### PR TITLE
[codex] docs(readme): add direction paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,12 @@ arXiv:[2603.15183](https://arxiv.org/abs/2603.15183)
 
 </details>
 
+Debugging multi-agent failures often comes down to which agent saw what state when.
+CCSStore tracks every read and write through MESI state transitions — the trace of
+who-saw-what is already in the system, even without a UI for it. If you've hit a
+stale-read bug in a multi-agent workflow, I'd like to hear about it —
+[open an issue](https://github.com/hipvlady/agent-coherence/issues/new).
+
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
## What changed
Added a short paragraph near the bottom of the README that signals the roadmap direction around debugging multi-agent stale reads and invites users to open an issue with real-world examples.

## Why
The README already documents MESI state tracking and event logging, but it did not yet connect that capability to the longer-term debugging story or invite user reports about stale-read failures.

## Impact
Readers now get a clearer sense of where CCSStore is headed and have a direct call to action for sharing failure cases.

## Validation
- Reviewed the README diff
- Ran `git diff --check`