### PR TITLE
feat: crash-recovery for stale stable-state grants (coordinator-side, integrating to dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ codebase-review workload.
 - 📄 [Paper on arXiv (2603.15183)](https://arxiv.org/abs/2603.15183) — formal protocol, TLA+ verification, simulation results
 - 📊 [Real benchmarks](#real-workload-benchmarks) — measured on actual LangGraph graphs
 - 🔧 [User guide](docs/guide.md) — strategies, telemetry, examples
+- 🔍 [Why coherence matters](docs/why-coherence-matters.md) — the gap across LangGraph, CrewAI, AutoGen, and Claude Agent SDK, with citations
 
 ---
 

--- a/benchmarks/scenarios/crash_recovery_validation.yaml
+++ b/benchmarks/scenarios/crash_recovery_validation.yaml
@@ -1,0 +1,71 @@
+# Crash-recovery validation scenario (Unit 5, R9).
+#
+# Single combined scenario exercising all three reclamation shapes in one run:
+#   - agent_0 holds EXCLUSIVE on artifact_0, killed at tick 5, never restored.
+#     Models jingchang0623 (OOM-kill) → reclaim_heartbeat.
+#   - agent_1 holds MODIFIED on artifact_1, killed at tick 10, restored at
+#     tick 30 (driver test issues a stale commit() afterwards).
+#     Models jessieibarra (checkpoint-restore-then-commit) → reclaim_heartbeat,
+#     then late commit() raises CoherenceError carrying reclamation context.
+#   - agent_2 holds EXCLUSIVE on artifact_2 from tick 0; stays alive
+#     (continues heartbeating), never commits, never releases.
+#     Models the live-but-stuck shape → reclaim_max_hold at ~tick 400.
+#   - agent_3 acquires nothing initially; the driver test issues a write on
+#     artifact_0 after the run to confirm reclamation unblocks the artifact.
+#
+# Initial M∪E grants are seeded by the driver test (engine has no per-agent
+# write knob); see tests/test_crash_recovery.py::test_combined_validation_scenario.
+# Failure events handle kills/restore deterministically via the YAML schema.
+#
+# duration_ticks=600 > max_hold_ticks=400 so the live-but-stuck sweep fires.
+# max_hold_ticks=400 > LeaseStrategy.ttl_ticks=300 (R11 composition rule).
+
+simulation:
+  duration_ticks: 600
+  num_agents: 4
+  seed: 20260507
+  action_probability: 0.0  # Driver test owns all M∪E setup; engine action loop is silent.
+network:
+  latency_ticks: 0
+  message_loss_rate: 0.0
+scenario:
+  name: crash-recovery-validation
+  workload: custom
+  action_probability: 0.0
+  write_probability: 0.0
+artifacts:
+  - id: artifact_0
+    size_tokens: 256
+    volatility: 0.0
+    initial_version: 1
+    mutable: true
+  - id: artifact_1
+    size_tokens: 256
+    volatility: 0.0
+    initial_version: 1
+    mutable: true
+  - id: artifact_2
+    size_tokens: 256
+    volatility: 0.0
+    initial_version: 1
+    mutable: true
+strategies:
+  eager: {}
+  lazy:
+    check_interval_ticks: 100
+  lease:
+    default_ttl_ticks: 300
+  access_count:
+    max_accesses: 100
+transient:
+  timeout_ticks: 100
+context_semantics:
+  model: conditional_injection
+crash_recovery:
+  enabled: true
+  heartbeat_timeout_ticks: 8
+  max_hold_ticks: 400
+failure_events:
+  - {tick: 5, action: kill, agent: agent_0}
+  - {tick: 10, action: kill, agent: agent_1}
+  - {tick: 30, action: restore, agent: agent_1}

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -6,13 +6,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, TypeAlias
 from uuid import UUID, uuid4
 
 from ccs.core.states import MESIState, TransientState
 from ccs.core.types import Artifact
 
 CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
+
+ReclamationSlot: TypeAlias = tuple[str, int]  # (trigger, tick)
+_M_OR_E_STATES: frozenset[MESIState] = frozenset({MESIState.MODIFIED, MESIState.EXCLUSIVE})
 
 
 @dataclass
@@ -27,7 +30,7 @@ class ArtifactRecord:
     last_writer: Optional[UUID] = None
     version_history: dict[int, str] = field(default_factory=dict)
     granted_at_tick_by_agent: dict[UUID, int] = field(default_factory=dict)
-    last_reclamation_by_agent: dict[UUID, tuple[str, int]] = field(default_factory=dict)
+    last_reclamation_by_agent: dict[UUID, ReclamationSlot] = field(default_factory=dict)
 
 
 class ArtifactRegistry:
@@ -150,15 +153,15 @@ class ArtifactRegistry:
         # keeping the hot path branch-free preserves R5 byte-identity (these are dict mutations
         # only, never serialized) and avoids subtle flag-on/flag-off divergence.
         record = self._records[artifact_id]
-        m_or_e = {MESIState.MODIFIED, MESIState.EXCLUSIVE}
-        new_in_me = state in m_or_e
-        prev_in_me = from_state in m_or_e
+        new_in_me = state in _M_OR_E_STATES
+        prev_in_me = from_state in _M_OR_E_STATES
         if new_in_me:
             if not prev_in_me:
                 # Set granted_at_tick on M∪E acquire only; M↔E transitions preserve the
                 # original grant tick (the agent has continuously held some M∪E grant).
                 record.granted_at_tick_by_agent[agent_id] = tick
-                # Slot clears on M∪E acquire ONLY (not on SHARED) — preserves jessieibarra path.
+                # Slot clears on M∪E acquire ONLY (not on SHARED) — preserves the
+                # checkpoint-restore diagnostic across SHARED re-fetches.
                 record.last_reclamation_by_agent.pop(agent_id, None)
         elif prev_in_me:
             record.granted_at_tick_by_agent.pop(agent_id, None)
@@ -181,7 +184,7 @@ class ArtifactRegistry:
 
     def get_last_reclamation(
         self, agent_id: UUID, artifact_id: UUID
-    ) -> tuple[str, int] | None:
+    ) -> ReclamationSlot | None:
         """Return the most recent reclamation slot for an (agent, artifact) pair, if any."""
         record = self._records.get(artifact_id)
         if record is None:

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -123,36 +123,18 @@ class ArtifactRegistry:
         content_hash: str | None = None,
     ) -> None:
         """Set MESI state for one agent/artifact pair."""
-        from_state = self._records[artifact_id].state_by_agent.get(agent_id, MESIState.INVALID)
-        self._records[artifact_id].state_by_agent[agent_id] = state
-        if self._state_log is not None:
-            self._seq += 1
-            entry = {
-                "tick": tick,
-                "artifact_id": str(artifact_id),
-                "agent_id": str(agent_id),
-                "agent_name": self._agent_names.get(agent_id) if self._agent_names is not None else None,
-                "from_state": from_state.name,
-                "to_state": state.name,
-                "trigger": trigger,
-                "version": self._records[artifact_id].artifact.version,
-                "content_hash": content_hash,
-                "sequence_number": self._seq,
-                "instance_id": self._instance_id,
-                "schema_version": CCS_STATE_LOG_SCHEMA_VERSION,
-            }
-            try:
-                self._state_log(entry)
-            except Exception:
-                # Sequence number is reserved on success, not on attempt.
-                # Roll back so the next successful emission does not create a phantom gap.
-                self._seq -= 1
-                raise
-
-        # Crash-recovery bookkeeping (no log emit, no serialization). Runs unconditionally —
-        # keeping the hot path branch-free preserves R5 byte-identity (these are dict mutations
-        # only, never serialized) and avoids subtle flag-on/flag-off divergence.
         record = self._records[artifact_id]
+        from_state = record.state_by_agent.get(agent_id, MESIState.INVALID)
+        record.state_by_agent[agent_id] = state
+
+        # Crash-recovery bookkeeping (no log emit, no serialization). Runs
+        # unconditionally and BEFORE the log emit so a state_log raise cannot
+        # leave state_by_agent and granted_at_tick_by_agent inconsistent
+        # (review fix COR-01 / REL-01: previously, a failed log emit left an
+        # M∪E entry without a granted_at_tick slot, defeating max-hold reclaim).
+        # Keeping the hot path branch-free preserves R5 byte-identity (these
+        # are dict mutations only, never serialized) and avoids subtle
+        # flag-on/flag-off divergence.
         new_in_me = state in _M_OR_E_STATES
         prev_in_me = from_state in _M_OR_E_STATES
         if new_in_me:
@@ -165,6 +147,30 @@ class ArtifactRegistry:
                 record.last_reclamation_by_agent.pop(agent_id, None)
         elif prev_in_me:
             record.granted_at_tick_by_agent.pop(agent_id, None)
+
+        if self._state_log is not None:
+            self._seq += 1
+            entry = {
+                "tick": tick,
+                "artifact_id": str(artifact_id),
+                "agent_id": str(agent_id),
+                "agent_name": self._agent_names.get(agent_id) if self._agent_names is not None else None,
+                "from_state": from_state.name,
+                "to_state": state.name,
+                "trigger": trigger,
+                "version": record.artifact.version,
+                "content_hash": content_hash,
+                "sequence_number": self._seq,
+                "instance_id": self._instance_id,
+                "schema_version": CCS_STATE_LOG_SCHEMA_VERSION,
+            }
+            try:
+                self._state_log(entry)
+            except Exception:
+                # Sequence number is reserved on success, not on attempt.
+                # Roll back so the next successful emission does not create a phantom gap.
+                self._seq -= 1
+                raise
 
     def record_heartbeat(self, agent_id: UUID, now_tick: int) -> None:
         """Record an agent's heartbeat tick using max(prev, incoming) (R12 monotonicity)."""

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -26,6 +26,8 @@ class ArtifactRecord:
     transient_tick_by_agent: dict[UUID, int] = field(default_factory=dict)
     last_writer: Optional[UUID] = None
     version_history: dict[int, str] = field(default_factory=dict)
+    granted_at_tick_by_agent: dict[UUID, int] = field(default_factory=dict)
+    last_reclamation_by_agent: dict[UUID, tuple[str, int]] = field(default_factory=dict)
 
 
 class ArtifactRegistry:
@@ -45,6 +47,7 @@ class ArtifactRegistry:
                 "pass instance_id=str(uuid4()) or route through CCSStore which manages it automatically"
             )
         self._records: dict[UUID, ArtifactRecord] = {}
+        self._heartbeat_by_agent: dict[UUID, int] = {}
         self._state_log = state_log
         self._agent_names = agent_names
         self._instance_id: str = instance_id if instance_id is not None else str(uuid4())
@@ -142,6 +145,55 @@ class ArtifactRegistry:
                 # Roll back so the next successful emission does not create a phantom gap.
                 self._seq -= 1
                 raise
+
+        # Crash-recovery bookkeeping (no log emit, no serialization). Runs unconditionally —
+        # keeping the hot path branch-free preserves R5 byte-identity (these are dict mutations
+        # only, never serialized) and avoids subtle flag-on/flag-off divergence.
+        record = self._records[artifact_id]
+        m_or_e = {MESIState.MODIFIED, MESIState.EXCLUSIVE}
+        new_in_me = state in m_or_e
+        prev_in_me = from_state in m_or_e
+        if new_in_me:
+            if not prev_in_me:
+                # Set granted_at_tick on M∪E acquire only; M↔E transitions preserve the
+                # original grant tick (the agent has continuously held some M∪E grant).
+                record.granted_at_tick_by_agent[agent_id] = tick
+                # Slot clears on M∪E acquire ONLY (not on SHARED) — preserves jessieibarra path.
+                record.last_reclamation_by_agent.pop(agent_id, None)
+        elif prev_in_me:
+            record.granted_at_tick_by_agent.pop(agent_id, None)
+
+    def record_heartbeat(self, agent_id: UUID, now_tick: int) -> None:
+        """Record an agent's heartbeat tick using max(prev, incoming) (R12 monotonicity)."""
+        prev = self._heartbeat_by_agent.get(agent_id)
+        if prev is None or now_tick > prev:
+            self._heartbeat_by_agent[agent_id] = now_tick
+
+    def last_heartbeat_tick(self, agent_id: UUID) -> int | None:
+        """Return the last recorded heartbeat tick for an agent, if any."""
+        return self._heartbeat_by_agent.get(agent_id)
+
+    def record_last_reclamation(
+        self, agent_id: UUID, artifact_id: UUID, trigger: str, tick: int
+    ) -> None:
+        """Record the most recent reclamation slot for an (agent, artifact) pair."""
+        self._records[artifact_id].last_reclamation_by_agent[agent_id] = (trigger, tick)
+
+    def get_last_reclamation(
+        self, agent_id: UUID, artifact_id: UUID
+    ) -> tuple[str, int] | None:
+        """Return the most recent reclamation slot for an (agent, artifact) pair, if any."""
+        record = self._records.get(artifact_id)
+        if record is None:
+            return None
+        return record.last_reclamation_by_agent.get(agent_id)
+
+    def granted_at_tick(self, agent_id: UUID, artifact_id: UUID) -> int | None:
+        """Return the tick at which agent acquired its current M/E grant on artifact, if any."""
+        record = self._records.get(artifact_id)
+        if record is None:
+            return None
+        return record.granted_at_tick_by_agent.get(agent_id)
 
     def get_agent_transient(self, artifact_id: UUID, agent_id: UUID) -> TransientState | None:
         """Return transient state for one agent/artifact pair if present."""

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -404,7 +404,12 @@ class CoordinatorService:
                 continue
 
             last_hb = self.registry.last_heartbeat_tick(agent_id)
-            heartbeat_stale = last_hb is None or (current_tick - last_hb) > heartbeat_timeout_ticks
+            # Heartbeat uses `>=` to match max-hold's `>=` (review fix ADV-02).
+            # An effective timeout of exactly heartbeat_timeout_ticks means a
+            # grant is reclaimed when (current_tick - last_hb) reaches the
+            # threshold, not the tick after. Matches the 'at least this many
+            # ticks since last heartbeat' framing in CrashRecoveryConfig docs.
+            heartbeat_stale = last_hb is None or (current_tick - last_hb) >= heartbeat_timeout_ticks
 
             if heartbeat_stale:
                 trigger = "reclaim_heartbeat"

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -258,6 +258,12 @@ class CoordinatorService:
         self.registry.remove_artifact(artifact_id)
         return signals
 
+    def record_heartbeat(self, *, agent_id: UUID, now_tick: int) -> None:
+        """Record an agent's heartbeat tick (R12: max(prev, incoming))."""
+        if now_tick < 0:
+            raise ValueError("now_tick must be >= 0")
+        self.registry.record_heartbeat(agent_id, now_tick)
+
     def enforce_transient_timeouts(self, *, current_tick: int, timeout_ticks: int) -> int:
         """Force expired transient entries to INVALID as fail-safe recovery."""
         if timeout_ticks < 1:

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -71,9 +71,11 @@ def _validate_crash_recovery_config(
         return
 
     if ttl is None:
-        # Built-in strategies other than LeaseStrategy expose no TTL — silent-accept
-        # is correct for those. A custom strategy ought to expose ttl_ticks; warn so
-        # the integrator notices.
+        # Built-in non-lease strategies (lazy, eager, access_count, broadcast) and
+        # any custom strategy without a ttl_ticks attribute cannot be statically
+        # validated against R11. Silent-accept matches the spec's design choice
+        # for the common case; the warn-on-non-int branch below catches the
+        # narrower "attribute exists but isn't an int" foot-gun.
         return
 
     warnings.warn(

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -59,7 +59,20 @@ def _validate_crash_recovery_config(
         return
 
     ttl = getattr(strategy, "ttl_ticks", None)
-    if isinstance(ttl, int) and ttl > 0:
+
+    # Built-in non-lease strategies (lazy, eager, access_count, broadcast) and
+    # any custom strategy without a ttl_ticks attribute cannot be statically
+    # validated against R11. Silent-accept matches the spec's design choice
+    # for the common case.
+    if ttl is None:
+        return
+
+    # Integer ttl (including 0 and negatives): apply the rule. Review fix
+    # ADV-02 / ADV-03: previously this branch required ttl > 0, which silently
+    # dropped ttl=0 into the "non-integer" warning path with misleading text.
+    # Now any int ttl is checked, and the warn-on-non-integer branch below
+    # only fires for genuinely non-integer attributes (string, float, etc.).
+    if isinstance(ttl, int):
         if crash_recovery.max_hold_ticks <= ttl:
             raise ValueError(
                 f"crash_recovery composition violation: "
@@ -68,14 +81,6 @@ def _validate_crash_recovery_config(
                 f"(strategy={type(strategy).__name__}); "
                 f"sweep at lease TTL boundary races strategy refresh."
             )
-        return
-
-    if ttl is None:
-        # Built-in non-lease strategies (lazy, eager, access_count, broadcast) and
-        # any custom strategy without a ttl_ticks attribute cannot be statically
-        # validated against R11. Silent-accept matches the spec's design choice
-        # for the common case; the warn-on-non-int branch below catches the
-        # narrower "attribute exists but isn't an int" foot-gun.
         return
 
     warnings.warn(

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import warnings
+from dataclasses import dataclass
 from uuid import UUID
 
 from ccs.core.exceptions import CoherenceError
@@ -14,6 +16,73 @@ from ccs.core.states import MESIState, TransientState
 from ccs.core.types import Artifact, FetchRequest, FetchResponse, InvalidationSignal
 
 from .registry import ArtifactRegistry
+
+
+@dataclass(frozen=True)
+class CrashRecoveryConfig:
+    """Configuration knobs for the stable-grant reclamation sweep.
+
+    The sweep ships disabled by default (R10) and is gated on the TLA+
+    amendment before any default-on flip.
+
+    Attributes:
+        enabled: Master flag. When ``False`` (default), the sweep is never
+            invoked and no heartbeat is required.
+        heartbeat_timeout_ticks: Sweep reclaims any M∪E grant whose holder
+            has not heartbeated within this many ticks.
+        max_hold_ticks: Sweep reclaims any M∪E grant held for at least this
+            many ticks regardless of heartbeat. Must be ``>`` the longest
+            inspectable strategy lease TTL when ``enabled=True`` (R11).
+    """
+
+    enabled: bool = False
+    heartbeat_timeout_ticks: int = 10
+    max_hold_ticks: int = 1000
+
+
+def _validate_crash_recovery_config(
+    crash_recovery: CrashRecoveryConfig,
+    strategy: object,
+) -> None:
+    """Fail-fast composition check (R11).
+
+    When the sweep is enabled, ``max_hold_ticks`` must exceed the strategy's
+    inspectable lease TTL strictly. Equal is rejected because a sweep at the
+    TTL boundary races the strategy's own refresh logic.
+
+    Strategies without an introspectable ``ttl_ticks`` attribute (lazy,
+    eager, access-count, broadcast) cannot be statically validated against
+    the rule; we emit a ``RuntimeWarning`` so a custom strategy with a
+    non-inspectable TTL is at least surfaced, but do not refuse startup.
+    """
+    if not crash_recovery.enabled:
+        return
+
+    ttl = getattr(strategy, "ttl_ticks", None)
+    if isinstance(ttl, int) and ttl > 0:
+        if crash_recovery.max_hold_ticks <= ttl:
+            raise ValueError(
+                f"crash_recovery composition violation: "
+                f"max_hold_ticks={crash_recovery.max_hold_ticks} must be > "
+                f"strategy.ttl_ticks={ttl} "
+                f"(strategy={type(strategy).__name__}); "
+                f"sweep at lease TTL boundary races strategy refresh."
+            )
+        return
+
+    if ttl is None:
+        # Built-in strategies other than LeaseStrategy expose no TTL — silent-accept
+        # is correct for those. A custom strategy ought to expose ttl_ticks; warn so
+        # the integrator notices.
+        return
+
+    warnings.warn(
+        f"crash_recovery: strategy {type(strategy).__name__} exposes a "
+        f"non-integer ttl_ticks={ttl!r}; composition rule (R11) cannot be "
+        f"statically verified.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
 
 
 class CoordinatorService:

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -148,6 +148,13 @@ class CoordinatorService:
         artifact = self._require_artifact(artifact_id)
         agent_state = self.registry.get_agent_state(artifact_id, agent_id)
         if agent_state not in {MESIState.EXCLUSIVE, MESIState.MODIFIED}:
+            reclamation = self.registry.get_last_reclamation(agent_id, artifact_id)
+            if reclamation is not None:
+                trigger, reclaimed_at_tick = reclamation
+                raise CoherenceError(
+                    f"commit_not_allowed agent={agent_id} artifact={artifact_id} "
+                    f"state={agent_state} reclaimed_by={trigger} at_tick={reclaimed_at_tick}"
+                )
             raise CoherenceError(
                 f"commit_not_allowed agent={agent_id} artifact={artifact_id} state={agent_state}"
             )
@@ -284,6 +291,75 @@ class CoordinatorService:
                 expired += 1
 
         return expired
+
+    def enforce_stable_grant_timeouts(
+        self,
+        *,
+        current_tick: int,
+        heartbeat_timeout_ticks: int,
+        max_hold_ticks: int,
+    ) -> int:
+        """Reclaim stale stable-state (M∪E) grants whose holders are gone or over-held.
+
+        Trigger order (first match wins):
+          1. ``reclaim_heartbeat`` — agent's last heartbeat is older than
+             ``heartbeat_timeout_ticks``, or the agent has never heartbeated.
+          2. ``reclaim_max_hold`` — agent's grant is at least ``max_hold_ticks``
+             old. Skipped if ``granted_at_tick`` is missing (defensive).
+
+        Pairs with a non-empty transient slot are skipped so the transient sweep
+        (which must run first) owns those entries — preserves R4 sweep ordering.
+
+        Returns the number of grants reclaimed.
+        """
+        if heartbeat_timeout_ticks < 1:
+            raise ValueError("heartbeat_timeout_ticks must be >= 1")
+        if max_hold_ticks < 1:
+            raise ValueError("max_hold_ticks must be >= 1")
+
+        m_or_e = {MESIState.MODIFIED, MESIState.EXCLUSIVE}
+        snapshot: list[tuple[UUID, UUID, MESIState]] = [
+            (artifact_id, agent_id, mesi)
+            for artifact_id in self.registry.artifact_ids()
+            for agent_id, mesi in self.registry.get_state_map(artifact_id).items()
+            if mesi in m_or_e
+        ]
+
+        reclaimed = 0
+        for artifact_id, agent_id, _mesi in snapshot:
+            # Live read — agents that entered transient since the snapshot are owned by
+            # the transient sweep, not this one (R4).
+            if self.registry.get_agent_transient(artifact_id, agent_id) is not None:
+                continue
+
+            last_hb = self.registry.last_heartbeat_tick(agent_id)
+            heartbeat_stale = last_hb is None or (current_tick - last_hb) > heartbeat_timeout_ticks
+
+            if heartbeat_stale:
+                trigger = "reclaim_heartbeat"
+            else:
+                granted_at = self.registry.granted_at_tick(agent_id, artifact_id)
+                if granted_at is None:
+                    # Defensive: an M∪E holder without a granted_at slot should not exist.
+                    continue
+                if (current_tick - granted_at) >= max_hold_ticks:
+                    trigger = "reclaim_max_hold"
+                else:
+                    continue
+
+            self.registry.set_agent_state(
+                artifact_id,
+                agent_id,
+                MESIState.INVALID,
+                trigger=trigger,
+                tick=current_tick,
+                content_hash=None,
+            )
+            self.registry.record_last_reclamation(agent_id, artifact_id, trigger, current_tick)
+            self._validate_single_writer(artifact_id)
+            reclaimed += 1
+
+        return reclaimed
 
     def _validate_single_writer(self, artifact_id: UUID) -> None:
         check_single_writer(self.registry.get_state_map(artifact_id))

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -83,7 +83,7 @@ def _validate_crash_recovery_config(
         f"non-integer ttl_ticks={ttl!r}; composition rule (R11) cannot be "
         f"statically verified.",
         RuntimeWarning,
-        stacklevel=2,
+        stacklevel=3,
     )
 
 

--- a/src/ccs/simulation/engine.py
+++ b/src/ccs/simulation/engine.py
@@ -93,10 +93,15 @@ class SimulationEngine:
         self._agent_ids = [UUID(int=i + 1) for i in range(int(simulation["num_agents"]))]
         # Failure-injection bookkeeping. _alive_agents is the set of agents that
         # heartbeat and may issue actions on a given tick; _busy_agents is the
-        # set in a fixed-window busy state (no heartbeat, no actions). On init
-        # all agents are alive; failure events flip them.
+        # set in a fixed-window busy state (no heartbeat, no actions);
+        # _killed_agents is the set permanently sidelined by a `kill` event
+        # (cleared only by an explicit `restore`). On init all agents are alive;
+        # failure events flip them. _killed_agents is tracked separately from
+        # _busy_agents so that a busy auto-expiry never silently resurrects a
+        # killed agent (review finding ADV-01 / COR-03).
         self._alive_agents: set[UUID] = set(self._agent_ids)
         self._busy_agents: set[UUID] = set()
+        self._killed_agents: set[UUID] = set()
         self._busy_until: dict[UUID, int] = {}
         self._agent_id_by_name: dict[str, UUID] = {
             f"agent_{i}": agent_id for i, agent_id in enumerate(self._agent_ids)
@@ -206,9 +211,15 @@ class SimulationEngine:
         reached: those agents flip back to alive without a ``restore`` event.
         """
         # Auto-expire busy windows first so an event firing at the same tick
-        # observes the agent as live again.
+        # observes the agent as live again. Killed agents are NEVER restored
+        # by busy auto-expiry — only an explicit `restore` event clears a kill
+        # (review ADV-01: prevents busy×kill silent resurrection).
         if self._busy_until:
-            expired = [a for a, u in self._busy_until.items() if now_tick >= u]
+            expired = [
+                a
+                for a, u in self._busy_until.items()
+                if now_tick >= u and a not in self._killed_agents
+            ]
             for agent_id in expired:
                 self._busy_until.pop(agent_id, None)
                 self._busy_agents.discard(agent_id)
@@ -217,11 +228,18 @@ class SimulationEngine:
         for event in self._failure_events_by_tick.get(now_tick, ()):
             if event.action == "kill":
                 self._alive_agents.discard(event.agent_id)
-                self._busy_agents.add(event.agent_id)
+                self._busy_agents.discard(event.agent_id)
+                self._busy_until.pop(event.agent_id, None)
+                self._killed_agents.add(event.agent_id)
             elif event.action == "busy":
                 if event.until_tick is None:
                     raise ValueError(
                         f"failure_event(action='busy') missing until_tick at tick={event.tick}"
+                    )
+                if event.agent_id in self._killed_agents:
+                    raise ValueError(
+                        f"failure_event(action='busy') on killed agent at tick={event.tick}; "
+                        "issue a 'restore' before scheduling busy on a killed agent"
                     )
                 self._alive_agents.discard(event.agent_id)
                 self._busy_agents.add(event.agent_id)
@@ -230,6 +248,7 @@ class SimulationEngine:
                 self._alive_agents.add(event.agent_id)
                 self._busy_agents.discard(event.agent_id)
                 self._busy_until.pop(event.agent_id, None)
+                self._killed_agents.discard(event.agent_id)
             else:  # pragma: no cover — schema validator already rejects this.
                 raise ValueError(f"unsupported failure-event action '{event.action}'")
 
@@ -259,11 +278,17 @@ class SimulationEngine:
         agent_velocity = scenario.get("agent_velocity")
 
         for agent_id in self._agent_ids:
-            # Skip agents that are killed (not in _alive_agents) or in a busy
-            # window. Filter is applied BEFORE action selection so RNG state
+            # Skip agents that are killed, in a busy window, or otherwise not
+            # alive. Filter is applied BEFORE action selection so RNG state
             # is unaffected for live agents and a killed agent never reaches
-            # _perform_read / _perform_write.
-            if agent_id not in self._alive_agents or agent_id in self._busy_agents:
+            # _perform_read / _perform_write. Each set is consulted explicitly
+            # (defense in depth) — _killed_agents and _busy_agents are now
+            # disjoint after review fix ADV-01.
+            if (
+                agent_id not in self._alive_agents
+                or agent_id in self._busy_agents
+                or agent_id in self._killed_agents
+            ):
                 continue
             if agent_velocity is not None:
                 for _ in range(int(agent_velocity)):

--- a/src/ccs/simulation/engine.py
+++ b/src/ccs/simulation/engine.py
@@ -11,7 +11,11 @@ from uuid import UUID
 
 from ccs.agent.runtime import AgentRuntime
 from ccs.coordinator.registry import ArtifactRegistry
-from ccs.coordinator.service import CoordinatorService
+from ccs.coordinator.service import (
+    CoordinatorService,
+    CrashRecoveryConfig,
+    _validate_crash_recovery_config,
+)
 from ccs.core.clock import LogicalClock
 from ccs.core.states import MESIState
 from ccs.core.types import Artifact, InvalidationSignal
@@ -25,6 +29,19 @@ from .metrics import SimulationMetrics, StrategyComparisonReport
 
 _INVALIDATION_SIGNAL_TOKENS = 12
 _POINTER_UPDATE_TOKENS = 8
+
+
+def _build_crash_recovery_config(scenario_config: Mapping[str, Any]) -> CrashRecoveryConfig:
+    """Read optional ``crash_recovery`` block from scenario; default to safe values."""
+    block = scenario_config.get("crash_recovery") or {}
+    defaults = CrashRecoveryConfig()
+    return CrashRecoveryConfig(
+        enabled=bool(block.get("enabled", defaults.enabled)),
+        heartbeat_timeout_ticks=int(
+            block.get("heartbeat_timeout_ticks", defaults.heartbeat_timeout_ticks)
+        ),
+        max_hold_ticks=int(block.get("max_hold_ticks", defaults.max_hold_ticks)),
+    )
 
 
 class SimulationEngine:
@@ -53,6 +70,8 @@ class SimulationEngine:
             lease_ttl_ticks=int(lease_cfg.get("default_ttl_ticks", 300)),
             access_count_max_accesses=int(access_count_cfg.get("max_accesses", 100)),
         )
+        self._crash_recovery = _build_crash_recovery_config(scenario_config)
+        _validate_crash_recovery_config(self._crash_recovery, self._strategy)
         self._monitor = ConsistencyMonitor(self._strategy)
         self._network = NetworkSimulator(
             latency_ticks=int(scenario_config["network"]["latency_ticks"]),

--- a/src/ccs/simulation/engine.py
+++ b/src/ccs/simulation/engine.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
-from typing import Any, Mapping, Sequence
+from typing import Any, Literal, Mapping, Sequence
 from uuid import UUID
 
 from ccs.agent.runtime import AgentRuntime
@@ -37,7 +37,7 @@ class _FailureEvent:
     """Internal canonical form of a parsed failure_events entry."""
 
     tick: int
-    action: str  # kill | busy | restore
+    action: Literal["kill", "busy", "restore"]
     agent_id: UUID
     until_tick: int | None = None
 
@@ -144,19 +144,19 @@ class SimulationEngine:
             self._deliver_messages()
             self._execute_actions_for_tick()
             if self._strategy.broadcasts_every_tick():
-                self._broadcast_all_to_all(now_tick=self._clock.now())
+                self._broadcast_all_to_all(now_tick=now)
             self._transient_state_timeouts += self._coordinator.enforce_transient_timeouts(
-                current_tick=self._clock.now(),
+                current_tick=now,
                 timeout_ticks=timeout_ticks,
             )
             if self._crash_recovery.enabled:
                 # R5: flag-off path must be byte-identical to v0.5 baseline.
                 # Guard at the call site so no heartbeat / sweep entries land
                 # in the state-log when the feature is disabled.
-                self._emit_heartbeats_for_alive_agents(now_tick=self._clock.now())
+                self._emit_heartbeats_for_alive_agents(now_tick=now)
                 self._stable_grant_reclamations += (
                     self._coordinator.enforce_stable_grant_timeouts(
-                        current_tick=self._clock.now(),
+                        current_tick=now,
                         heartbeat_timeout_ticks=self._crash_recovery.heartbeat_timeout_ticks,
                         max_hold_ticks=self._crash_recovery.max_hold_ticks,
                     )
@@ -219,7 +219,10 @@ class SimulationEngine:
                 self._alive_agents.discard(event.agent_id)
                 self._busy_agents.add(event.agent_id)
             elif event.action == "busy":
-                assert event.until_tick is not None
+                if event.until_tick is None:
+                    raise ValueError(
+                        f"failure_event(action='busy') missing until_tick at tick={event.tick}"
+                    )
                 self._alive_agents.discard(event.agent_id)
                 self._busy_agents.add(event.agent_id)
                 self._busy_until[event.agent_id] = event.until_tick

--- a/src/ccs/simulation/engine.py
+++ b/src/ccs/simulation/engine.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import random
+from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 from uuid import UUID
 
@@ -29,6 +30,16 @@ from .metrics import SimulationMetrics, StrategyComparisonReport
 
 _INVALIDATION_SIGNAL_TOKENS = 12
 _POINTER_UPDATE_TOKENS = 8
+
+
+@dataclass(frozen=True)
+class _FailureEvent:
+    """Internal canonical form of a parsed failure_events entry."""
+
+    tick: int
+    action: str  # kill | busy | restore
+    agent_id: UUID
+    until_tick: int | None = None
 
 
 def _build_crash_recovery_config(scenario_config: Mapping[str, Any]) -> CrashRecoveryConfig:
@@ -80,6 +91,19 @@ class SimulationEngine:
         )
 
         self._agent_ids = [UUID(int=i + 1) for i in range(int(simulation["num_agents"]))]
+        # Failure-injection bookkeeping. _alive_agents is the set of agents that
+        # heartbeat and may issue actions on a given tick; _busy_agents is the
+        # set in a fixed-window busy state (no heartbeat, no actions). On init
+        # all agents are alive; failure events flip them.
+        self._alive_agents: set[UUID] = set(self._agent_ids)
+        self._busy_agents: set[UUID] = set()
+        self._busy_until: dict[UUID, int] = {}
+        self._agent_id_by_name: dict[str, UUID] = {
+            f"agent_{i}": agent_id for i, agent_id in enumerate(self._agent_ids)
+        }
+        self._failure_events_by_tick: dict[int, list[_FailureEvent]] = (
+            self._parse_failure_events(scenario_config.get("failure_events"))
+        )
         self._artifact_ids: list[UUID] = []
         self._artifact_specs_by_id: dict[UUID, dict[str, Any]] = {}
         self._register_artifacts()
@@ -108,12 +132,15 @@ class SimulationEngine:
         self._tokens_invalidation = 0
         self._context_injections = 0
         self._transient_state_timeouts = 0
+        self._stable_grant_reclamations = 0
 
     def run(self) -> SimulationMetrics:
         """Run one deterministic simulation and return collected metrics."""
         duration_ticks = int(self._config["simulation"]["duration_ticks"])
         timeout_ticks = int(self._config.get("transient", {}).get("timeout_ticks", 5))
         for _ in range(duration_ticks):
+            now = self._clock.now()
+            self._apply_failure_events_for_tick(now)
             self._deliver_messages()
             self._execute_actions_for_tick()
             if self._strategy.broadcasts_every_tick():
@@ -122,11 +149,91 @@ class SimulationEngine:
                 current_tick=self._clock.now(),
                 timeout_ticks=timeout_ticks,
             )
+            if self._crash_recovery.enabled:
+                # R5: flag-off path must be byte-identical to v0.5 baseline.
+                # Guard at the call site so no heartbeat / sweep entries land
+                # in the state-log when the feature is disabled.
+                self._emit_heartbeats_for_alive_agents(now_tick=self._clock.now())
+                self._stable_grant_reclamations += (
+                    self._coordinator.enforce_stable_grant_timeouts(
+                        current_tick=self._clock.now(),
+                        heartbeat_timeout_ticks=self._crash_recovery.heartbeat_timeout_ticks,
+                        max_hold_ticks=self._crash_recovery.max_hold_ticks,
+                    )
+                )
             self._clock.advance()
 
         # Drain messages that become due exactly at final tick.
         self._deliver_messages()
         return self._build_metrics(duration_ticks)
+
+    # ---- Failure-event injection ----------------------------------------
+
+    def _parse_failure_events(
+        self, raw_events: Any
+    ) -> dict[int, list[_FailureEvent]]:
+        """Parse and resolve agent-name references for ``failure_events``.
+
+        Validation of structure and value ranges is done by the scenario
+        validator. Here we only resolve agent names against the engine's
+        registered agent set and bucket events by tick (preserving order).
+        """
+        if not raw_events:
+            return {}
+        bucketed: dict[int, list[_FailureEvent]] = {}
+        for event in raw_events:
+            agent_name = str(event["agent"])
+            if agent_name not in self._agent_id_by_name:
+                raise ValueError(
+                    f"failure_events: unknown agent name '{agent_name}'; "
+                    f"valid names: {sorted(self._agent_id_by_name)}"
+                )
+            tick = int(event["tick"])
+            until_tick = event.get("until_tick")
+            parsed = _FailureEvent(
+                tick=tick,
+                action=str(event["action"]),
+                agent_id=self._agent_id_by_name[agent_name],
+                until_tick=int(until_tick) if until_tick is not None else None,
+            )
+            bucketed.setdefault(tick, []).append(parsed)
+        return bucketed
+
+    def _apply_failure_events_for_tick(self, now_tick: int) -> None:
+        """Apply kill/busy/restore events scheduled for ``now_tick``.
+
+        Also auto-expires ``busy`` windows whose ``until_tick`` has been
+        reached: those agents flip back to alive without a ``restore`` event.
+        """
+        # Auto-expire busy windows first so an event firing at the same tick
+        # observes the agent as live again.
+        if self._busy_until:
+            expired = [a for a, u in self._busy_until.items() if now_tick >= u]
+            for agent_id in expired:
+                self._busy_until.pop(agent_id, None)
+                self._busy_agents.discard(agent_id)
+                self._alive_agents.add(agent_id)
+
+        for event in self._failure_events_by_tick.get(now_tick, ()):
+            if event.action == "kill":
+                self._alive_agents.discard(event.agent_id)
+                self._busy_agents.add(event.agent_id)
+            elif event.action == "busy":
+                assert event.until_tick is not None
+                self._alive_agents.discard(event.agent_id)
+                self._busy_agents.add(event.agent_id)
+                self._busy_until[event.agent_id] = event.until_tick
+            elif event.action == "restore":
+                self._alive_agents.add(event.agent_id)
+                self._busy_agents.discard(event.agent_id)
+                self._busy_until.pop(event.agent_id, None)
+            else:  # pragma: no cover — schema validator already rejects this.
+                raise ValueError(f"unsupported failure-event action '{event.action}'")
+
+    def _emit_heartbeats_for_alive_agents(self, *, now_tick: int) -> None:
+        """Emit one heartbeat per alive agent for ``now_tick``."""
+        for agent_id in self._alive_agents:
+            self._coordinator.record_heartbeat(agent_id=agent_id, now_tick=now_tick)
 
     def _register_artifacts(self) -> None:
         for artifact_cfg in self._config["artifacts"]:
@@ -149,6 +256,12 @@ class SimulationEngine:
         agent_velocity = scenario.get("agent_velocity")
 
         for agent_id in self._agent_ids:
+            # Skip agents that are killed (not in _alive_agents) or in a busy
+            # window. Filter is applied BEFORE action selection so RNG state
+            # is unaffected for live agents and a killed agent never reaches
+            # _perform_read / _perform_write.
+            if agent_id not in self._alive_agents or agent_id in self._busy_agents:
+                continue
             if agent_velocity is not None:
                 for _ in range(int(agent_velocity)):
                     self._execute_single_action(agent_id=agent_id, now_tick=now)
@@ -427,6 +540,7 @@ class SimulationEngine:
             tokens_invalidation=self._tokens_invalidation,
             context_injections=self._context_injections,
             transient_state_timeouts=self._transient_state_timeouts,
+            stable_grant_reclamations=self._stable_grant_reclamations,
         )
 
 

--- a/src/ccs/simulation/metrics.py
+++ b/src/ccs/simulation/metrics.py
@@ -40,6 +40,7 @@ class SimulationMetrics:
     tokens_invalidation: int
     context_injections: int
     transient_state_timeouts: int = 0
+    stable_grant_reclamations: int = 0
 
     @property
     def synchronization_tokens(self) -> int:

--- a/src/ccs/simulation/scenarios.py
+++ b/src/ccs/simulation/scenarios.py
@@ -287,6 +287,56 @@ def _validate_crash_recovery(crash_recovery: dict[str, Any], path: Path) -> None
         )
 
 
+_SUPPORTED_FAILURE_ACTIONS = {"kill", "busy", "restore"}
+
+
+def _validate_failure_events(failure_events: Any, path: Path) -> None:
+    """Validate optional ``failure_events`` top-level list.
+
+    Each entry: ``{tick, action, agent, [until_tick]}``.
+      - ``action`` ∈ {kill, busy, restore}
+      - ``tick`` integer >= 0
+      - ``agent`` non-empty string (cross-checked against agent set at engine init)
+      - ``until_tick`` required for ``busy`` and must be > ``tick``;
+        forbidden for ``kill`` and ``restore``.
+    """
+    if failure_events is None:
+        return
+    if not isinstance(failure_events, list):
+        raise ScenarioValidationError(str(path), "'failure_events' must be a list")
+    for idx, event in enumerate(failure_events):
+        prefix = f"failure_events[{idx}]"
+        if not isinstance(event, dict):
+            raise ScenarioValidationError(str(path), f"'{prefix}' must be a mapping")
+        _require_int(event.get("tick"), path=path, field=f"{prefix}.tick", min_value=0)
+        action = event.get("action")
+        if action not in _SUPPORTED_FAILURE_ACTIONS:
+            raise ScenarioValidationError(
+                str(path),
+                f"'{prefix}.action' must be one of: {', '.join(sorted(_SUPPORTED_FAILURE_ACTIONS))}",
+            )
+        agent = event.get("agent")
+        if not isinstance(agent, str) or not agent.strip():
+            raise ScenarioValidationError(str(path), f"'{prefix}.agent' must be a non-empty string")
+        until_tick = event.get("until_tick")
+        if action == "busy":
+            if until_tick is None:
+                raise ScenarioValidationError(
+                    str(path), f"'{prefix}.until_tick' is required when action='busy'"
+                )
+            _require_int(until_tick, path=path, field=f"{prefix}.until_tick", min_value=0)
+            if int(until_tick) <= int(event["tick"]):
+                raise ScenarioValidationError(
+                    str(path), f"'{prefix}.until_tick' must be > {prefix}.tick"
+                )
+        else:
+            if until_tick is not None:
+                raise ScenarioValidationError(
+                    str(path),
+                    f"'{prefix}.until_tick' is only valid when action='busy'",
+                )
+
+
 def _validate_context_semantics(context_semantics: dict[str, Any], path: Path) -> None:
     model = context_semantics.get("model")
     if model not in _SUPPORTED_CONTEXT_MODELS:
@@ -338,6 +388,7 @@ def validate_scenario(data: dict[str, Any], scenario_path: str | Path) -> dict[s
     _validate_transient(transient, path)
     _validate_context_semantics(context_semantics, path)
     _validate_crash_recovery(crash_recovery, path)
+    _validate_failure_events(normalized.get("failure_events"), path)
 
     return _populate_runtime_aliases(normalized)
 

--- a/src/ccs/simulation/scenarios.py
+++ b/src/ccs/simulation/scenarios.py
@@ -76,6 +76,7 @@ def _normalize_legacy_keys(data: dict[str, Any]) -> dict[str, Any]:
     strategies = data.setdefault("strategies", {})
     transient = data.setdefault("transient", {})
     context_semantics = data.setdefault("context_semantics", {})
+    data.setdefault("crash_recovery", {})
 
     if "num_agents" not in simulation and "agents" in simulation:
         simulation["num_agents"] = simulation["agents"]
@@ -266,6 +267,26 @@ def _validate_transient(transient: dict[str, Any], path: Path) -> None:
     )
 
 
+def _validate_crash_recovery(crash_recovery: dict[str, Any], path: Path) -> None:
+    """Validate optional ``crash_recovery`` block; absent or empty ⇒ defaults."""
+    if "enabled" in crash_recovery:
+        _require_bool(crash_recovery["enabled"], path=path, field="crash_recovery.enabled")
+    if "heartbeat_timeout_ticks" in crash_recovery:
+        _require_int(
+            crash_recovery["heartbeat_timeout_ticks"],
+            path=path,
+            field="crash_recovery.heartbeat_timeout_ticks",
+            min_value=1,
+        )
+    if "max_hold_ticks" in crash_recovery:
+        _require_int(
+            crash_recovery["max_hold_ticks"],
+            path=path,
+            field="crash_recovery.max_hold_ticks",
+            min_value=1,
+        )
+
+
 def _validate_context_semantics(context_semantics: dict[str, Any], path: Path) -> None:
     model = context_semantics.get("model")
     if model not in _SUPPORTED_CONTEXT_MODELS:
@@ -307,6 +328,7 @@ def validate_scenario(data: dict[str, Any], scenario_path: str | Path) -> dict[s
     strategies = _require_mapping(normalized, path, "strategies")
     transient = _require_mapping(normalized, path, "transient")
     context_semantics = _require_mapping(normalized, path, "context_semantics")
+    crash_recovery = _require_mapping(normalized, path, "crash_recovery")
 
     _validate_simulation(simulation, path)
     _validate_network(network, path)
@@ -315,6 +337,7 @@ def validate_scenario(data: dict[str, Any], scenario_path: str | Path) -> dict[s
     _validate_strategies(strategies, path)
     _validate_transient(transient, path)
     _validate_context_semantics(context_semantics, path)
+    _validate_crash_recovery(crash_recovery, path)
 
     return _populate_runtime_aliases(normalized)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -440,6 +440,54 @@ def test_validate_crash_recovery_config_skips_non_lease_strategy() -> None:
     _validate_crash_recovery_config(cfg, LazyStrategy())
 
 
+# Review fix ADV-03: ttl_ticks=0 was silently routed to the warning path
+# (with misleading "non-integer" text) and skipped R11 entirely. Now it's
+# treated like any other int ttl and validated against max_hold_ticks.
+
+
+class _ZeroTTLStrategy:
+    """Test fixture: strategy that exposes ttl_ticks=0 (degenerate case)."""
+
+    ttl_ticks = 0
+
+
+class _StringTTLStrategy:
+    """Test fixture: strategy with a non-integer ttl_ticks attribute."""
+
+    ttl_ticks = "300"
+
+
+def test_validate_crash_recovery_config_zero_ttl_passes_when_max_hold_positive() -> None:
+    """ADV-03: ttl_ticks=0 with max_hold_ticks=1 passes R11 (1 > 0). No warning."""
+    import warnings as _w  # local import keeps top-of-file unchanged
+    cfg = CrashRecoveryConfig(enabled=True, max_hold_ticks=1)
+    with _w.catch_warnings():
+        _w.simplefilter("error")  # Any warning fails the test.
+        _validate_crash_recovery_config(cfg, _ZeroTTLStrategy())
+
+
+def test_validate_crash_recovery_config_zero_ttl_rejects_zero_max_hold() -> None:
+    """ADV-03: ttl_ticks=0 with max_hold_ticks=0 IS a R11 violation (0 not > 0)."""
+    # max_hold_ticks=0 is normally rejected by the int-validator at sweep time,
+    # but the composition rule must still flag this combination at construction.
+    cfg = CrashRecoveryConfig(enabled=True, max_hold_ticks=0)
+    with pytest.raises(ValueError, match="max_hold_ticks=0"):
+        _validate_crash_recovery_config(cfg, _ZeroTTLStrategy())
+
+
+def test_validate_crash_recovery_config_non_integer_ttl_warns() -> None:
+    """ADV-03: only genuinely non-integer ttl_ticks (e.g., string) triggers the warn path."""
+    import warnings as _w
+    cfg = CrashRecoveryConfig(enabled=True, max_hold_ticks=300)
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        _validate_crash_recovery_config(cfg, _StringTTLStrategy())
+    runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    assert len(runtime_warnings) == 1
+    assert "non-integer" in str(runtime_warnings[0].message)
+    assert "'300'" in str(runtime_warnings[0].message) or '"300"' in str(runtime_warnings[0].message)
+
+
 # Review fix COR-01 / REL-01: bookkeeping must run before the log emit so a
 # state_log raise leaves state_by_agent and granted_at_tick_by_agent
 # consistent. Without this fix, max-hold reclamation silently misses live

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -438,3 +438,80 @@ def test_validate_crash_recovery_config_skips_non_lease_strategy() -> None:
     cfg = CrashRecoveryConfig(enabled=True, max_hold_ticks=300)
     # LazyStrategy exposes no ttl_ticks attribute.
     _validate_crash_recovery_config(cfg, LazyStrategy())
+
+
+# Review fix COR-01 / REL-01: bookkeeping must run before the log emit so a
+# state_log raise leaves state_by_agent and granted_at_tick_by_agent
+# consistent. Without this fix, max-hold reclamation silently misses live
+# agents whose granted_at_tick slot was never written.
+
+from ccs.core.types import Artifact  # noqa: E402
+
+
+def test_set_agent_state_failed_log_emit_keeps_bookkeeping_consistent() -> None:
+    """COR-01: log emit raise must NOT leave state_by_agent inconsistent with bookkeeping.
+
+    With the fix, bookkeeping runs BEFORE the log emit. So if the log raises:
+    - state_by_agent shows the new state (pre-existing semantics — not changed)
+    - granted_at_tick_by_agent has the M∪E entry (NEW — was missing before fix)
+    - The next sweep can correctly evaluate max-hold for the agent.
+    """
+    seen = [0]
+
+    def flaky_log(entry):
+        seen[0] += 1
+        # Fail on every call — first M∪E acquire's log emit raises.
+        raise RuntimeError("simulated log emit failure")
+
+    registry = ArtifactRegistry(
+        state_log=flaky_log, agent_names=None, instance_id="test-instance"
+    )
+    artifact = Artifact(name="x", version=1)
+    registry.register_artifact(artifact, content="v1")
+    agent_id = uuid4()
+
+    with pytest.raises(RuntimeError, match="simulated log emit failure"):
+        registry.set_agent_state(
+            artifact.id, agent_id, MESIState.EXCLUSIVE, trigger="write", tick=42
+        )
+
+    # State mutation survived (pre-existing behavior, unchanged):
+    assert registry.get_agent_state(artifact.id, agent_id) == MESIState.EXCLUSIVE
+    # Bookkeeping is now CONSISTENT with that state — granted_at_tick is recorded:
+    assert registry.granted_at_tick(agent_id, artifact.id) == 42
+
+
+def test_set_agent_state_failed_log_emit_consistent_for_me_exit_too() -> None:
+    """COR-01 mirror case: log raise on M∪E exit still clears the slot."""
+    fail_on_call = 3
+    seen = [0]
+
+    def flaky_log(entry):
+        seen[0] += 1
+        if seen[0] >= fail_on_call:
+            raise RuntimeError("simulated log emit failure")
+
+    registry = ArtifactRegistry(
+        state_log=flaky_log, agent_names=None, instance_id="test-instance"
+    )
+    artifact = Artifact(name="x", version=1)
+    registry.register_artifact(artifact, content="v1")
+    agent_id = uuid4()
+
+    # Calls 1 & 2 succeed (acquire EXCLUSIVE, internal step). Call 3 fails.
+    registry.set_agent_state(
+        artifact.id, agent_id, MESIState.EXCLUSIVE, trigger="write", tick=10
+    )
+    registry.set_agent_state(
+        artifact.id, agent_id, MESIState.MODIFIED, trigger="commit", tick=11
+    )
+    # granted_at_tick survives the M↔E transition (preserved at acquire).
+    assert registry.granted_at_tick(agent_id, artifact.id) == 10
+
+    with pytest.raises(RuntimeError, match="simulated log emit failure"):
+        registry.set_agent_state(
+            artifact.id, agent_id, MESIState.INVALID, trigger="reclaim", tick=20
+        )
+    # Bookkeeping cleanup ran even though log emit raised.
+    assert registry.get_agent_state(artifact.id, agent_id) == MESIState.INVALID
+    assert registry.granted_at_tick(agent_id, artifact.id) is None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -391,3 +391,50 @@ def test_set_agent_state_bookkeeping_emits_no_extra_log_entries() -> None:
     # Exactly 3 log entries total; bookkeeping itself produced none.
     assert len(entries) - entries_before == 3
     assert registry._seq - seq_before == 3
+
+
+# ---- Unit 3: CrashRecoveryConfig + composition fail-fast --------------------
+
+from ccs.coordinator.service import (  # noqa: E402
+    CrashRecoveryConfig,
+    _validate_crash_recovery_config,
+)
+from ccs.strategies.lazy import LazyStrategy  # noqa: E402
+from ccs.strategies.lease import LeaseStrategy  # noqa: E402
+
+
+def test_crash_recovery_config_defaults_are_safe() -> None:
+    cfg = CrashRecoveryConfig()
+    assert cfg.enabled is False
+    assert cfg.heartbeat_timeout_ticks == 10
+    assert cfg.max_hold_ticks == 1000
+
+
+def test_validate_crash_recovery_config_disabled_always_accepts() -> None:
+    # Even an obviously bad max_hold_ticks vs ttl is fine when disabled.
+    cfg = CrashRecoveryConfig(enabled=False, max_hold_ticks=10)
+    _validate_crash_recovery_config(cfg, LeaseStrategy(ttl_ticks=300))
+
+
+def test_validate_crash_recovery_config_rejects_equal_ttl() -> None:
+    cfg = CrashRecoveryConfig(enabled=True, max_hold_ticks=300)
+    with pytest.raises(ValueError, match="max_hold_ticks=300"):
+        _validate_crash_recovery_config(cfg, LeaseStrategy(ttl_ticks=300))
+
+
+def test_validate_crash_recovery_config_rejects_below_ttl() -> None:
+    cfg = CrashRecoveryConfig(enabled=True, max_hold_ticks=100)
+    with pytest.raises(ValueError):
+        _validate_crash_recovery_config(cfg, LeaseStrategy(ttl_ticks=300))
+
+
+def test_validate_crash_recovery_config_accepts_above_ttl() -> None:
+    cfg = CrashRecoveryConfig(enabled=True, max_hold_ticks=300)
+    _validate_crash_recovery_config(cfg, LeaseStrategy(ttl_ticks=200))
+
+
+def test_validate_crash_recovery_config_skips_non_lease_strategy() -> None:
+    """Strategies without ttl_ticks (lazy/eager/etc.) silent-accept (R11 skip rule)."""
+    cfg = CrashRecoveryConfig(enabled=True, max_hold_ticks=300)
+    # LazyStrategy exposes no ttl_ticks attribute.
+    _validate_crash_recovery_config(cfg, LazyStrategy())

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -242,3 +242,152 @@ def test_peer_transient_lifecycle_set_on_write_and_cleared_on_invalidate_ack() -
         issued_at_tick=6,
     )
     assert svc.registry.get_agent_transient(artifact.id, peer) is None
+
+
+# --- Crash-recovery Unit 1: heartbeat + grant-slot bookkeeping ---
+
+
+def test_record_heartbeat_returns_last_seen_tick() -> None:
+    svc = _service()
+    agent = uuid4()
+
+    svc.record_heartbeat(agent_id=agent, now_tick=5)
+
+    assert svc.registry.last_heartbeat_tick(agent) == 5
+
+
+def test_record_heartbeat_returns_max_of_seen_ticks() -> None:
+    """R12 monotonicity: out-of-order delivery must not regress the heartbeat."""
+    svc = _service()
+    agent = uuid4()
+
+    svc.record_heartbeat(agent_id=agent, now_tick=10)
+    svc.record_heartbeat(agent_id=agent, now_tick=8)
+
+    assert svc.registry.last_heartbeat_tick(agent) == 10
+
+
+def test_record_heartbeat_rejects_negative_tick() -> None:
+    svc = _service()
+    with pytest.raises(ValueError):
+        svc.record_heartbeat(agent_id=uuid4(), now_tick=-1)
+
+
+def test_last_heartbeat_tick_returns_none_when_unknown() -> None:
+    svc = _service()
+    assert svc.registry.last_heartbeat_tick(uuid4()) is None
+
+
+def test_record_heartbeat_does_not_emit_state_log_entry() -> None:
+    """R5 byte-identity: heartbeat must NOT emit log entries or bump _seq."""
+    entries: list[dict] = []
+    registry = ArtifactRegistry(state_log=entries.append, instance_id="inst-1")
+    svc = CoordinatorService(registry)
+    seq_before = registry._seq
+
+    svc.record_heartbeat(agent_id=uuid4(), now_tick=42)
+
+    assert entries == []
+    assert registry._seq == seq_before
+
+
+def test_invalid_to_exclusive_populates_granted_at_tick() -> None:
+    svc = _service()
+    agent = uuid4()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+
+    svc.registry.set_agent_state(
+        artifact.id, agent, MESIState.EXCLUSIVE, trigger="test", tick=7
+    )
+
+    assert svc.registry.granted_at_tick(agent, artifact.id) == 7
+
+
+def test_exclusive_to_modified_preserves_granted_at_tick() -> None:
+    svc = _service()
+    agent = uuid4()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+
+    svc.registry.set_agent_state(
+        artifact.id, agent, MESIState.EXCLUSIVE, trigger="test", tick=3
+    )
+    svc.registry.set_agent_state(
+        artifact.id, agent, MESIState.MODIFIED, trigger="test", tick=9
+    )
+
+    # E→M stays within M∪E — the original grant tick must be preserved (R8 diagnostic context).
+    assert svc.registry.granted_at_tick(agent, artifact.id) == 3
+
+
+def test_modified_to_invalid_clears_granted_at_tick() -> None:
+    svc = _service()
+    agent = uuid4()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+
+    svc.registry.set_agent_state(
+        artifact.id, agent, MESIState.MODIFIED, trigger="test", tick=3
+    )
+    svc.registry.set_agent_state(
+        artifact.id, agent, MESIState.INVALID, trigger="test", tick=9
+    )
+
+    assert svc.registry.granted_at_tick(agent, artifact.id) is None
+
+
+def test_reclamation_slot_survives_shared_acquire_then_clears_on_exclusive() -> None:
+    """jessieibarra path: SHARED re-fetch by a reclaimed agent must NOT clear the slot.
+    Slot clears ONLY on M∪E re-acquire."""
+    svc = _service()
+    agent = uuid4()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+
+    # Seed a reclamation slot via the helper (simulates Unit 2's sweep result).
+    svc.registry.record_last_reclamation(agent, artifact.id, "reclaim_max_hold", 200)
+    assert svc.registry.get_last_reclamation(agent, artifact.id) == ("reclaim_max_hold", 200)
+
+    # INVALID → SHARED: slot must SURVIVE.
+    svc.registry.set_agent_state(
+        artifact.id, agent, MESIState.SHARED, trigger="fetch", tick=210
+    )
+    assert svc.registry.get_last_reclamation(agent, artifact.id) == ("reclaim_max_hold", 200)
+
+    # SHARED → EXCLUSIVE (M∪E acquire, prev not in M∪E): slot now clears.
+    svc.registry.set_agent_state(
+        artifact.id, agent, MESIState.EXCLUSIVE, trigger="write", tick=220
+    )
+    assert svc.registry.get_last_reclamation(agent, artifact.id) is None
+
+
+def test_reclamation_slot_untouched_by_set_agent_transient() -> None:
+    """Slot-clear bookkeeping fires only on stable transitions through set_agent_state."""
+    svc = _service()
+    agent = uuid4()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    svc.registry.record_last_reclamation(agent, artifact.id, "reclaim_heartbeat", 100)
+
+    svc.registry.set_agent_transient(
+        artifact.id, agent, TransientState.IED, entered_tick=105
+    )
+    assert svc.registry.get_last_reclamation(agent, artifact.id) == ("reclaim_heartbeat", 100)
+
+    svc.registry.clear_agent_transient(artifact.id, agent)
+    assert svc.registry.get_last_reclamation(agent, artifact.id) == ("reclaim_heartbeat", 100)
+
+
+def test_set_agent_state_bookkeeping_emits_no_extra_log_entries() -> None:
+    """R5 byte-identity: dict mutations on set_agent_state must NOT add state-log entries."""
+    entries: list[dict] = []
+    registry = ArtifactRegistry(state_log=entries.append, instance_id="inst-1")
+    svc = CoordinatorService(registry)
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    agent = uuid4()
+    entries_before = len(entries)
+    seq_before = registry._seq
+
+    registry.set_agent_state(artifact.id, agent, MESIState.EXCLUSIVE, trigger="t", tick=1)
+    registry.set_agent_state(artifact.id, agent, MESIState.MODIFIED, trigger="t", tick=2)
+    registry.set_agent_state(artifact.id, agent, MESIState.INVALID, trigger="t", tick=3)
+
+    # Exactly 3 log entries total; bookkeeping itself produced none.
+    assert len(entries) - entries_before == 3
+    assert registry._seq - seq_before == 3

--- a/tests/test_crash_recovery.py
+++ b/tests/test_crash_recovery.py
@@ -561,3 +561,36 @@ def test_combined_validation_scenario_exercises_all_three_reclaim_shapes(
     gaps, mismatches = validate_log(log_path, schema_version="ccs.state_log.v2")
     assert gaps == []
     assert mismatches == []
+
+
+# Review fix ADV-02: heartbeat staleness uses `>=` to match max-hold's `>=`.
+# Previously heartbeat used strict `>`, so the effective heartbeat timeout was
+# N+1 ticks (one tick later than the documented 'at least N ticks since last
+# heartbeat' framing). Boundary test locks the new semantic.
+
+
+def test_heartbeat_stale_boundary_at_exact_timeout() -> None:
+    """ADV-02: at gap == heartbeat_timeout_ticks, the grant IS reclaimed.
+
+    Last heartbeat at tick 5, timeout 10, current tick 15 → gap 10 == 10 → reclaim.
+    Under the old `>` operator, gap 10 was NOT reclaimed (would have needed gap 11).
+    """
+    svc = _service()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    agent_a = uuid4()
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=agent_a, requested_at_tick=0))
+    svc.record_heartbeat(agent_id=agent_a, now_tick=5)
+
+    # Gap = 14 - 5 = 9, just below threshold → no reclaim.
+    n_below = svc.enforce_stable_grant_timeouts(
+        current_tick=14, heartbeat_timeout_ticks=10, max_hold_ticks=1000
+    )
+    assert n_below == 0
+    assert svc.registry.get_agent_state(artifact.id, agent_a) == MESIState.EXCLUSIVE
+
+    # Gap = 15 - 5 = 10 == threshold → reclaim.
+    n_at = svc.enforce_stable_grant_timeouts(
+        current_tick=15, heartbeat_timeout_ticks=10, max_hold_ticks=1000
+    )
+    assert n_at == 1
+    assert svc.registry.get_agent_state(artifact.id, agent_a) == MESIState.INVALID

--- a/tests/test_crash_recovery.py
+++ b/tests/test_crash_recovery.py
@@ -451,9 +451,18 @@ def test_combined_validation_scenario_exercises_all_three_reclaim_shapes(
         log_fh.write(json.dumps(entry) + "\n")
 
     engine._registry._state_log = _emit  # noqa: SLF001 — test-only capture hook
-    # Reset _seq so log entries start at 1 even though no log was attached
-    # at registry construction; without this the first entry observed by the
-    # capture lambda begins at the post-construction _seq value, not 1.
+    # Reset _seq so log entries start at 1 even though no log was attached at
+    # registry construction; without this the first entry observed by the
+    # capture lambda begins at the post-construction _seq value, not 1, and
+    # validate_log() reports a gap. Capture the pre-poke value first to make
+    # the brittleness explicit: if construction starts to emit entries on its
+    # own, this assertion will catch the silent regression instead of letting
+    # the reset mask it.
+    pre_poke_seq = engine._registry._seq  # noqa: SLF001
+    assert pre_poke_seq == 0, (
+        f"registry _seq was {pre_poke_seq} at capture-hook attach time; "
+        f"construction now emits state-log entries — re-evaluate this reset"
+    )
     engine._registry._seq = 0  # noqa: SLF001
 
     artifact_0 = engine._artifact_ids[0]
@@ -494,16 +503,16 @@ def test_combined_validation_scenario_exercises_all_three_reclaim_shapes(
     heartbeat_entries = [e for e in reclaim_entries if e["trigger"] == "reclaim_heartbeat"]
     max_hold_entries = [e for e in reclaim_entries if e["trigger"] == "reclaim_max_hold"]
 
-    assert metrics.stable_grant_reclamations >= 3, (
-        f"expected ≥3 reclamations (one per agent_0/agent_1/agent_2); "
+    assert metrics.stable_grant_reclamations == 3, (
+        f"expected exactly 3 reclamations (one per agent_0/agent_1/agent_2); "
         f"got {metrics.stable_grant_reclamations}"
     )
-    assert len(heartbeat_entries) >= 2, (
-        f"expected ≥2 reclaim_heartbeat entries (agent_0 + agent_1); "
+    assert len(heartbeat_entries) == 2, (
+        f"expected exactly 2 reclaim_heartbeat entries (agent_0 + agent_1); "
         f"got {len(heartbeat_entries)}"
     )
-    assert len(max_hold_entries) >= 1, (
-        f"expected ≥1 reclaim_max_hold entry (agent_2 live-but-stuck); "
+    assert len(max_hold_entries) == 1, (
+        f"expected exactly 1 reclaim_max_hold entry (agent_2 live-but-stuck); "
         f"got {len(max_hold_entries)}"
     )
 

--- a/tests/test_crash_recovery.py
+++ b/tests/test_crash_recovery.py
@@ -594,3 +594,128 @@ def test_heartbeat_stale_boundary_at_exact_timeout() -> None:
     )
     assert n_at == 1
     assert svc.registry.get_agent_state(artifact.id, agent_a) == MESIState.INVALID
+
+
+# Review fix T-02: defensive `granted_at_tick is None` branch in the sweep
+# is unreachable under correct lifecycle but must remain functional. Test
+# manually clears the slot to exercise the defensive `continue`.
+
+
+def test_sweep_skips_me_holder_with_missing_granted_at_slot() -> None:
+    """T-02: defensive branch — M∪E holder lacking granted_at slot is skipped, not crashed.
+
+    Under correct lifecycle this state shouldn't exist. We manually pop the slot
+    after fetch to simulate the defensive case (e.g., a bug elsewhere clearing
+    the dict). The sweep must not raise; it must continue past the orphan entry.
+    """
+    svc = _service()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    agent_a = uuid4()
+
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=agent_a, requested_at_tick=0))
+    assert svc.registry.granted_at_tick(agent_a, artifact.id) == 0
+
+    # Fresh heartbeat — heartbeat path will not fire.
+    svc.record_heartbeat(agent_id=agent_a, now_tick=100)
+
+    # Manually corrupt: clear the granted_at slot for an agent still in EXCLUSIVE.
+    svc.registry._records[artifact.id].granted_at_tick_by_agent.pop(agent_a, None)
+
+    # Sweep at tick 100 with max_hold=10: would normally trigger reclaim_max_hold,
+    # but the missing slot causes the defensive `continue` — no reclaim, no crash.
+    n = svc.enforce_stable_grant_timeouts(
+        current_tick=100, heartbeat_timeout_ticks=200, max_hold_ticks=10
+    )
+    assert n == 0
+    assert svc.registry.get_agent_state(artifact.id, agent_a) == MESIState.EXCLUSIVE
+
+
+# Review fix T-06: double-run determinism for the R9 combined scenario.
+# The scenario is fully deterministic (seed, action_probability=0.0, no
+# network latency) — running twice must produce identical outputs.
+
+
+def test_combined_validation_scenario_is_deterministic_across_runs() -> None:
+    """T-06: a crash-recovery-enabled scenario with a kill event produces
+    identical metrics + state-log fingerprints across two runs.
+
+    Determinism is the load-bearing assumption behind the seed presence; this
+    test proves it by direct comparison and exercises the reclamation path
+    (kill at tick 5 with heartbeat_timeout_ticks=8 forces reclaim_heartbeat
+    around tick 13) so the test would catch any non-determinism in the sweep.
+    """
+    from ccs.simulation.engine import SimulationEngine
+
+    def _build_scenario() -> dict:
+        return {
+            "simulation": {
+                "duration_ticks": 25,
+                "num_agents": 2,
+                "seed": 42,
+                "action_probability": 0.0,
+                "actions_per_tick": 1,
+            },
+            "network": {"latency_ticks": 0, "message_loss_rate": 0.0},
+            "scenario": {
+                "name": "determinism-check",
+                "workload": "read_heavy",
+                "action_probability": 0.0,
+                "write_probability": 0.0,
+                "agent_velocity": None,
+                "revocation_tick": None,
+            },
+            "artifacts": [
+                {"id": "plan.md", "size_tokens": 100, "volatility": 0.0,
+                 "initial_version": 1, "mutable": True},
+            ],
+            "strategies": {
+                "eager": {},
+                "lazy": {"check_interval_ticks": 100},
+                "lease": {"default_ttl_ticks": 5},
+                "access_count": {"max_accesses": 4},
+                "exec_count": {"max_operations": 4},
+            },
+            "transient": {"timeout_ticks": 100},
+            "context_semantics": {"model": "conditional_injection"},
+            "crash_recovery": {
+                "enabled": True,
+                "heartbeat_timeout_ticks": 8,
+                "max_hold_ticks": 1000,
+            },
+            "failure_events": [
+                {"tick": 5, "action": "kill", "agent": "agent_0"},
+            ],
+        }
+
+    def _run_once() -> tuple[int, list[tuple[str, str, str]]]:
+        engine = SimulationEngine(_build_scenario(), strategy_name="lazy", seed=42)
+        # Pre-seed agent_0 with EXCLUSIVE on the artifact at tick 0 so the
+        # kill at tick 5 leaves a stale grant the sweep can reclaim.
+        agent_0 = engine._agent_id_by_name["agent_0"]
+        artifact_id = engine._artifact_ids[0]
+        engine._coordinator.fetch(
+            FetchRequest(artifact_id=artifact_id, requesting_agent_id=agent_0,
+                         requested_at_tick=0)
+        )
+        log: list[dict] = []
+        # _seq is reset because the pre-seed fetch already emitted entries —
+        # we want to compare the post-pre-seed log only.
+        assert engine._registry._seq >= 0
+        engine._registry._state_log = log.append
+        pre_seed_seq = engine._registry._seq
+        engine._registry._seq = 0
+        metrics = engine.run()
+        fingerprint = [(e["from_state"], e["to_state"], e["trigger"]) for e in log]
+        return metrics.stable_grant_reclamations, fingerprint, pre_seed_seq
+
+    count_a, fp_a, seq_a = _run_once()
+    count_b, fp_b, seq_b = _run_once()
+
+    # Sanity: the kill event drove at least one reclamation, otherwise the
+    # determinism check would be trivially-empty.
+    assert count_a >= 1, "test setup must exercise the reclaim path"
+    assert seq_a == seq_b, "pre-seed sequence number must be identical"
+    assert count_a == count_b
+    assert fp_a == fp_b
+    # Stronger: the reclamation must appear in the fingerprint.
+    assert any(t == "reclaim_heartbeat" for _, _, t in fp_a)

--- a/tests/test_crash_recovery.py
+++ b/tests/test_crash_recovery.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for crash-recovery: stable-grant sweep + reclamation-aware commit error."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.service import CoordinatorService
+from ccs.core.exceptions import CoherenceError
+from ccs.core.invariants import check_monotonic_version, check_single_writer
+from ccs.core.states import MESIState, TransientState
+from ccs.core.types import FetchRequest
+from ccs.validation import validate_log
+
+
+def _service() -> CoordinatorService:
+    return CoordinatorService(ArtifactRegistry())
+
+
+# ---------------------------------------------------------------------------
+# Sweep happy paths
+# ---------------------------------------------------------------------------
+
+def test_heartbeat_stale_exclusive_is_reclaimed() -> None:
+    """R1: agent A holds EXCLUSIVE; heartbeat older than threshold; sweep reclaims."""
+    entries: list[dict] = []
+    registry = ArtifactRegistry(state_log=entries.append, instance_id="inst-1")
+    svc = CoordinatorService(registry)
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    agent_a = uuid4()
+
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=agent_a, requested_at_tick=1))
+    assert registry.get_agent_state(artifact.id, agent_a) == MESIState.EXCLUSIVE
+    svc.record_heartbeat(agent_id=agent_a, now_tick=1)
+
+    n = svc.enforce_stable_grant_timeouts(
+        current_tick=20, heartbeat_timeout_ticks=10, max_hold_ticks=1000
+    )
+
+    assert n == 1
+    assert registry.get_agent_state(artifact.id, agent_a) == MESIState.INVALID
+    last_entry = entries[-1]
+    assert last_entry["trigger"] == "reclaim_heartbeat"
+    assert last_entry["content_hash"] is None
+    assert last_entry["to_state"] == "INVALID"
+
+
+def test_max_hold_modified_is_reclaimed_with_fresh_heartbeat() -> None:
+    """R2: MODIFIED, fresh heartbeat, granted_at older than max_hold_ticks → reclaim_max_hold."""
+    entries: list[dict] = []
+    registry = ArtifactRegistry(state_log=entries.append, instance_id="inst-1")
+    svc = CoordinatorService(registry)
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    agent_a = uuid4()
+
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=agent_a, requested_at_tick=0))
+    # Drive A into MODIFIED via commit at tick 10 — sets granted_at_tick=10 (E→M preserves
+    # original grant, which is tick 0; commit changes the state to MODIFIED but stays in M∪E,
+    # so granted_at remains 0 from the initial fetch).
+    svc.commit(agent_id=agent_a, artifact_id=artifact.id, content="v2", issued_at_tick=10)
+    assert registry.get_agent_state(artifact.id, agent_a) == MESIState.MODIFIED
+
+    granted_at = registry.granted_at_tick(agent_a, artifact.id)
+    assert granted_at is not None
+    version_before = registry.get_artifact(artifact.id).version
+
+    # Fresh heartbeat — heartbeat trigger must NOT fire.
+    svc.record_heartbeat(agent_id=agent_a, now_tick=granted_at + 500)
+
+    n = svc.enforce_stable_grant_timeouts(
+        current_tick=granted_at + 500,
+        heartbeat_timeout_ticks=100,
+        max_hold_ticks=400,
+    )
+
+    assert n == 1
+    assert registry.get_agent_state(artifact.id, agent_a) == MESIState.INVALID
+    assert registry.get_artifact(artifact.id).version == version_before
+    last_entry = entries[-1]
+    assert last_entry["trigger"] == "reclaim_max_hold"
+
+
+def test_trigger_ordering_heartbeat_wins_over_max_hold() -> None:
+    """A grant violating BOTH conditions reports reclaim_heartbeat (first match)."""
+    entries: list[dict] = []
+    registry = ArtifactRegistry(state_log=entries.append, instance_id="inst-1")
+    svc = CoordinatorService(registry)
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    agent_a = uuid4()
+
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=agent_a, requested_at_tick=0))
+    svc.record_heartbeat(agent_id=agent_a, now_tick=0)
+
+    n = svc.enforce_stable_grant_timeouts(
+        current_tick=10_000, heartbeat_timeout_ticks=10, max_hold_ticks=100
+    )
+
+    assert n == 1
+    assert entries[-1]["trigger"] == "reclaim_heartbeat"
+
+
+# ---------------------------------------------------------------------------
+# Sweep edge cases
+# ---------------------------------------------------------------------------
+
+def test_agent_in_transient_eia_is_not_reclaimed() -> None:
+    svc = _service()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    agent_a = uuid4()
+
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=agent_a, requested_at_tick=0))
+    # Push A into transient EIA without changing its EXCLUSIVE state.
+    svc.registry.set_agent_transient(
+        artifact.id, agent_a, TransientState.EIA, entered_tick=1
+    )
+
+    n = svc.enforce_stable_grant_timeouts(
+        current_tick=1000, heartbeat_timeout_ticks=10, max_hold_ticks=100
+    )
+
+    assert n == 0
+    assert svc.registry.get_agent_state(artifact.id, agent_a) == MESIState.EXCLUSIVE
+
+
+def test_shared_holder_is_untouched() -> None:
+    svc = _service()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    a, b = uuid4(), uuid4()
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=a, requested_at_tick=0))
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=b, requested_at_tick=1))
+    # Both now SHARED.
+    assert svc.registry.get_agent_state(artifact.id, a) == MESIState.SHARED
+    assert svc.registry.get_agent_state(artifact.id, b) == MESIState.SHARED
+
+    n = svc.enforce_stable_grant_timeouts(
+        current_tick=10_000, heartbeat_timeout_ticks=10, max_hold_ticks=100
+    )
+
+    assert n == 0
+    assert svc.registry.get_agent_state(artifact.id, a) == MESIState.SHARED
+    assert svc.registry.get_agent_state(artifact.id, b) == MESIState.SHARED
+
+
+def test_grant_within_both_timeouts_is_no_op() -> None:
+    entries: list[dict] = []
+    registry = ArtifactRegistry(state_log=entries.append, instance_id="inst-1")
+    svc = CoordinatorService(registry)
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    agent_a = uuid4()
+
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=agent_a, requested_at_tick=5))
+    svc.record_heartbeat(agent_id=agent_a, now_tick=5)
+    seq_before = registry._seq
+
+    n = svc.enforce_stable_grant_timeouts(
+        current_tick=10, heartbeat_timeout_ticks=10, max_hold_ticks=100
+    )
+
+    assert n == 0
+    assert registry._seq == seq_before  # No log entries emitted.
+    assert registry.get_agent_state(artifact.id, agent_a) == MESIState.EXCLUSIVE
+
+
+# ---------------------------------------------------------------------------
+# Safety (R3)
+# ---------------------------------------------------------------------------
+
+def test_peer_can_acquire_exclusive_after_reclamation() -> None:
+    """R3: after reclamation of A, peer B's write() succeeds; single-writer holds."""
+    svc = _service()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    a, b = uuid4(), uuid4()
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=a, requested_at_tick=0))
+    svc.record_heartbeat(agent_id=a, now_tick=0)
+
+    svc.enforce_stable_grant_timeouts(
+        current_tick=100, heartbeat_timeout_ticks=10, max_hold_ticks=1000
+    )
+    assert svc.registry.get_agent_state(artifact.id, a) == MESIState.INVALID
+
+    svc.write(agent_id=b, artifact_id=artifact.id, issued_at_tick=101)
+    assert svc.registry.get_agent_state(artifact.id, b) == MESIState.EXCLUSIVE
+    # Single-writer holds throughout.
+    check_single_writer(svc.registry.get_state_map(artifact.id))
+
+
+def test_monotonic_version_unchanged_across_sweep() -> None:
+    """R3: version unchanged for reclaimed grants (reclamation is state-only)."""
+    svc = _service()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    a = uuid4()
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=a, requested_at_tick=0))
+
+    v_before = svc.registry.get_artifact(artifact.id).version
+    svc.enforce_stable_grant_timeouts(
+        current_tick=100, heartbeat_timeout_ticks=10, max_hold_ticks=1000
+    )
+    v_after = svc.registry.get_artifact(artifact.id).version
+    assert v_before == v_after
+    check_monotonic_version(v_before, v_after)
+
+
+# ---------------------------------------------------------------------------
+# Sweep ordering (R4)
+# ---------------------------------------------------------------------------
+
+def test_transient_sweep_first_then_stable_skips_invalid() -> None:
+    """R4: transient sweep reclaims first; stable sweep sees INVALID and skips. One log entry."""
+    entries: list[dict] = []
+    registry = ArtifactRegistry(state_log=entries.append, instance_id="inst-1")
+    svc = CoordinatorService(registry)
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    a = uuid4()
+
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=a, requested_at_tick=0))
+    # Push A into transient EIA at tick 1 while keeping EXCLUSIVE state.
+    registry.set_agent_transient(artifact.id, a, TransientState.EIA, entered_tick=1)
+    # No heartbeat — A would also fail the heartbeat trigger.
+
+    entries_at_setup = len(entries)
+
+    transient_n = svc.enforce_transient_timeouts(current_tick=1000, timeout_ticks=10)
+    assert transient_n == 1
+    # State is now INVALID, transient cleared.
+    assert registry.get_agent_state(artifact.id, a) == MESIState.INVALID
+    assert registry.get_agent_transient(artifact.id, a) is None
+    # Exactly one new entry from the transient sweep, with trigger="timeout".
+    assert len(entries) == entries_at_setup + 1
+    assert entries[-1]["trigger"] == "timeout"
+
+    # Stable sweep now sees A in INVALID — should skip entirely.
+    stable_n = svc.enforce_stable_grant_timeouts(
+        current_tick=1000, heartbeat_timeout_ticks=10, max_hold_ticks=100
+    )
+    assert stable_n == 0
+    assert len(entries) == entries_at_setup + 1  # No new entry.
+
+
+# ---------------------------------------------------------------------------
+# Observability (R6)
+# ---------------------------------------------------------------------------
+
+def test_state_log_validates_clean_after_reclamation(tmp_path: Path) -> None:
+    """R6: validate_log reports no gaps; sequence numbers contiguous."""
+    log_path = tmp_path / "state_log.jsonl"
+    fh = log_path.open("w", encoding="utf-8")
+
+    def emit(entry: dict) -> None:
+        fh.write(json.dumps(entry) + "\n")
+
+    registry = ArtifactRegistry(state_log=emit, instance_id="inst-r6")
+    svc = CoordinatorService(registry)
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    a, b = uuid4(), uuid4()
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=a, requested_at_tick=0))
+    svc.record_heartbeat(agent_id=a, now_tick=0)
+    svc.enforce_stable_grant_timeouts(
+        current_tick=100, heartbeat_timeout_ticks=10, max_hold_ticks=1000
+    )
+    svc.write(agent_id=b, artifact_id=artifact.id, issued_at_tick=101)
+    fh.close()
+
+    gaps, mismatches = validate_log(log_path, schema_version="ccs.state_log.v2")
+    assert gaps == []
+    assert mismatches == []
+
+
+# ---------------------------------------------------------------------------
+# Reclamation-aware commit error (R8)
+# ---------------------------------------------------------------------------
+
+def test_commit_after_heartbeat_reclamation_includes_diagnostic_message() -> None:
+    """R8 (jingchang0623): late commit after reclaim_heartbeat carries trigger and tick."""
+    svc = _service()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    a = uuid4()
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=a, requested_at_tick=0))
+    svc.record_heartbeat(agent_id=a, now_tick=0)
+
+    svc.enforce_stable_grant_timeouts(
+        current_tick=100, heartbeat_timeout_ticks=10, max_hold_ticks=1000
+    )
+
+    with pytest.raises(CoherenceError) as exc_info:
+        svc.commit(agent_id=a, artifact_id=artifact.id, content="v2", issued_at_tick=101)
+
+    msg = str(exc_info.value)
+    assert "reclaimed_by=reclaim_heartbeat" in msg
+    assert "at_tick=100" in msg
+
+
+def test_commit_after_max_hold_reclamation_then_shared_fetch_still_diagnostic() -> None:
+    """R8 (jessieibarra): slot survives SHARED re-fetch.
+
+    A holds MODIFIED; sweep reclaims via reclaim_max_hold; A fetches and gets SHARED;
+    A's stale commit STILL raises with the reclamation context.
+    """
+    svc = _service()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    a, b = uuid4(), uuid4()
+
+    # Drive A to MODIFIED.
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=a, requested_at_tick=0))
+    svc.commit(agent_id=a, artifact_id=artifact.id, content="v2", issued_at_tick=1)
+    assert svc.registry.get_agent_state(artifact.id, a) == MESIState.MODIFIED
+
+    # Heartbeat fresh — only max-hold should fire.
+    svc.record_heartbeat(agent_id=a, now_tick=500)
+    svc.enforce_stable_grant_timeouts(
+        current_tick=500, heartbeat_timeout_ticks=1000, max_hold_ticks=10
+    )
+    assert svc.registry.get_agent_state(artifact.id, a) == MESIState.INVALID
+    assert svc.registry.get_last_reclamation(a, artifact.id) == ("reclaim_max_hold", 500)
+
+    # B acquires + fetches so subsequent A-fetch grants SHARED, not EXCLUSIVE.
+    svc.write(agent_id=b, artifact_id=artifact.id, issued_at_tick=501)
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=a, requested_at_tick=502))
+    assert svc.registry.get_agent_state(artifact.id, a) == MESIState.SHARED
+
+    # Slot survives SHARED transition.
+    assert svc.registry.get_last_reclamation(a, artifact.id) == ("reclaim_max_hold", 500)
+
+    with pytest.raises(CoherenceError) as exc_info:
+        svc.commit(agent_id=a, artifact_id=artifact.id, content="v3", issued_at_tick=503)
+    msg = str(exc_info.value)
+    assert "reclaimed_by=reclaim_max_hold" in msg
+    assert "at_tick=500" in msg
+
+
+def test_commit_on_unrelated_invalid_uses_original_message_format() -> None:
+    """R5: agent never held a grant; rejection message has no reclaimed_by= field."""
+    svc = _service()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    a = uuid4()
+    # A is implicitly INVALID (never registered any state) — commit should reject without diagnostic.
+
+    with pytest.raises(CoherenceError) as exc_info:
+        svc.commit(agent_id=a, artifact_id=artifact.id, content="v2")
+
+    msg = str(exc_info.value)
+    assert "commit_not_allowed" in msg
+    assert "reclaimed_by=" not in msg
+    assert "at_tick=" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Re-reclamation
+# ---------------------------------------------------------------------------
+
+def test_re_reclamation_after_reacquire_reflects_only_most_recent() -> None:
+    """A reclaimed → re-acquires EXCLUSIVE (slot cleared) → reclaimed again with new trigger."""
+    svc = _service()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    a = uuid4()
+
+    # First reclamation: heartbeat-stale.
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=a, requested_at_tick=0))
+    svc.record_heartbeat(agent_id=a, now_tick=0)
+    svc.enforce_stable_grant_timeouts(
+        current_tick=100, heartbeat_timeout_ticks=10, max_hold_ticks=10_000
+    )
+    assert svc.registry.get_last_reclamation(a, artifact.id) == ("reclaim_heartbeat", 100)
+
+    # A re-acquires EXCLUSIVE — slot must be cleared on M∪E acquire.
+    svc.write(agent_id=a, artifact_id=artifact.id, issued_at_tick=200)
+    assert svc.registry.get_agent_state(artifact.id, a) == MESIState.EXCLUSIVE
+    assert svc.registry.get_last_reclamation(a, artifact.id) is None
+
+    # Second reclamation: max-hold (heartbeat fresh this time).
+    svc.record_heartbeat(agent_id=a, now_tick=10_000)
+    svc.enforce_stable_grant_timeouts(
+        current_tick=10_000, heartbeat_timeout_ticks=10_000, max_hold_ticks=100
+    )
+    assert svc.registry.get_last_reclamation(a, artifact.id) == ("reclaim_max_hold", 10_000)
+
+    # Late commit reflects only the most recent reclamation.
+    with pytest.raises(CoherenceError) as exc_info:
+        svc.commit(agent_id=a, artifact_id=artifact.id, content="v2", issued_at_tick=10_001)
+    msg = str(exc_info.value)
+    assert "reclaimed_by=reclaim_max_hold" in msg
+    assert "at_tick=10000" in msg
+    assert "reclaim_heartbeat" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def test_invalid_heartbeat_timeout_raises() -> None:
+    svc = _service()
+    with pytest.raises(ValueError):
+        svc.enforce_stable_grant_timeouts(
+            current_tick=10, heartbeat_timeout_ticks=0, max_hold_ticks=100
+        )
+
+
+def test_invalid_max_hold_raises() -> None:
+    svc = _service()
+    with pytest.raises(ValueError):
+        svc.enforce_stable_grant_timeouts(
+            current_tick=10, heartbeat_timeout_ticks=10, max_hold_ticks=0
+        )

--- a/tests/test_crash_recovery.py
+++ b/tests/test_crash_recovery.py
@@ -407,3 +407,148 @@ def test_invalid_max_hold_raises() -> None:
         svc.enforce_stable_grant_timeouts(
             current_tick=10, heartbeat_timeout_ticks=10, max_hold_ticks=0
         )
+
+
+# ---------------------------------------------------------------------------
+# Unit 5: combined validation-scenario driver test (R9)
+# ---------------------------------------------------------------------------
+
+
+def test_combined_validation_scenario_exercises_all_three_reclaim_shapes(
+    tmp_path: Path,
+) -> None:
+    """R9: one scenario exercises OOM-kill, checkpoint-restore-then-commit,
+    and live-but-stuck max-hold shapes in a single repeatable run.
+
+    Setup:
+      - agent_0 holds EXCLUSIVE on artifact_0; killed at tick 5 (YAML);
+        expected: reclaim_heartbeat. agent_3 then writes artifact_0.
+      - agent_1 holds MODIFIED on artifact_1; killed at tick 10 (YAML),
+        restored at tick 30 (YAML); driver simulates the stale post-restore
+        commit() and asserts CoherenceError carries reclaimed_by/at_tick.
+      - agent_2 holds EXCLUSIVE on artifact_2; stays alive (heartbeats every
+        tick); never commits. With max_hold_ticks=400, sweep reclaims via
+        reclaim_max_hold around tick 400.
+
+    YAML drives kill/restore deterministically; driver seeds the M∪E grants
+    (engine has no per-agent grant config) and issues post-run probes.
+    """
+    from ccs.core.types import FetchRequest as _FR
+    from ccs.simulation.engine import SimulationEngine
+    from ccs.simulation.scenarios import load_scenario
+
+    scenario = load_scenario("benchmarks/scenarios/crash_recovery_validation.yaml")
+    engine = SimulationEngine(scenario, strategy_name="lazy")
+
+    # Wire a state-log capture into the engine's registry so we can audit
+    # reclamation entries and run validate_log on a JSONL dump afterwards.
+    log_entries: list[dict] = []
+    log_path = tmp_path / "state_log.jsonl"
+    log_fh = log_path.open("w", encoding="utf-8")
+
+    def _emit(entry: dict) -> None:
+        log_entries.append(entry)
+        log_fh.write(json.dumps(entry) + "\n")
+
+    engine._registry._state_log = _emit  # noqa: SLF001 — test-only capture hook
+    # Reset _seq so log entries start at 1 even though no log was attached
+    # at registry construction; without this the first entry observed by the
+    # capture lambda begins at the post-construction _seq value, not 1.
+    engine._registry._seq = 0  # noqa: SLF001
+
+    artifact_0 = engine._artifact_ids[0]
+    artifact_1 = engine._artifact_ids[1]
+    artifact_2 = engine._artifact_ids[2]
+    agent_0 = engine._agent_id_by_name["agent_0"]
+    agent_1 = engine._agent_id_by_name["agent_1"]
+    agent_2 = engine._agent_id_by_name["agent_2"]
+    agent_3 = engine._agent_id_by_name["agent_3"]
+
+    # Seed initial M∪E grants at tick 0 — drive directly through the coordinator.
+    engine._coordinator.fetch(  # agent_0 → EXCLUSIVE on artifact_0
+        _FR(artifact_id=artifact_0, requesting_agent_id=agent_0, requested_at_tick=0)
+    )
+    engine._coordinator.fetch(  # agent_1 → EXCLUSIVE on artifact_1
+        _FR(artifact_id=artifact_1, requesting_agent_id=agent_1, requested_at_tick=0)
+    )
+    engine._coordinator.commit(  # promote agent_1 to MODIFIED on artifact_1
+        agent_id=agent_1, artifact_id=artifact_1, content="v2", issued_at_tick=0
+    )
+    engine._coordinator.fetch(  # agent_2 → EXCLUSIVE on artifact_2
+        _FR(artifact_id=artifact_2, requesting_agent_id=agent_2, requested_at_tick=0)
+    )
+
+    assert engine._registry.get_agent_state(artifact_0, agent_0) == MESIState.EXCLUSIVE
+    assert engine._registry.get_agent_state(artifact_1, agent_1) == MESIState.MODIFIED
+    assert engine._registry.get_agent_state(artifact_2, agent_2) == MESIState.EXCLUSIVE
+
+    # Run the simulation. The engine's per-tick loop applies failure events,
+    # heartbeats _alive_agents, and runs the stable-grant sweep each tick.
+    metrics = engine.run()
+
+    # ---- Reclamation count + per-trigger breakdown ----
+    reclaim_entries = [
+        e for e in log_entries
+        if e.get("trigger") in {"reclaim_heartbeat", "reclaim_max_hold"}
+    ]
+    heartbeat_entries = [e for e in reclaim_entries if e["trigger"] == "reclaim_heartbeat"]
+    max_hold_entries = [e for e in reclaim_entries if e["trigger"] == "reclaim_max_hold"]
+
+    assert metrics.stable_grant_reclamations >= 3, (
+        f"expected ≥3 reclamations (one per agent_0/agent_1/agent_2); "
+        f"got {metrics.stable_grant_reclamations}"
+    )
+    assert len(heartbeat_entries) >= 2, (
+        f"expected ≥2 reclaim_heartbeat entries (agent_0 + agent_1); "
+        f"got {len(heartbeat_entries)}"
+    )
+    assert len(max_hold_entries) >= 1, (
+        f"expected ≥1 reclaim_max_hold entry (agent_2 live-but-stuck); "
+        f"got {len(max_hold_entries)}"
+    )
+
+    # ---- Per-agent state checks ----
+    assert engine._registry.get_agent_state(artifact_0, agent_0) == MESIState.INVALID
+    assert engine._registry.get_agent_state(artifact_1, agent_1) == MESIState.INVALID
+    assert engine._registry.get_agent_state(artifact_2, agent_2) == MESIState.INVALID
+
+    # ---- Post-reclamation peer write (jingchang0623 unblocks) ----
+    engine._coordinator.write(
+        agent_id=agent_3, artifact_id=artifact_0, issued_at_tick=599
+    )
+    assert engine._registry.get_agent_state(artifact_0, agent_3) == MESIState.EXCLUSIVE
+    check_single_writer(engine._registry.get_state_map(artifact_0))
+
+    # ---- jessieibarra path: agent_1's late commit raises with diagnostic ----
+    reclaim_for_a1 = engine._registry.get_last_reclamation(agent_1, artifact_1)
+    assert reclaim_for_a1 is not None
+    a1_trigger, a1_tick = reclaim_for_a1
+    assert a1_trigger == "reclaim_heartbeat"
+
+    with pytest.raises(CoherenceError) as exc_info:
+        engine._coordinator.commit(
+            agent_id=agent_1,
+            artifact_id=artifact_1,
+            content="late-restored-content",
+            issued_at_tick=599,
+        )
+    msg = str(exc_info.value)
+    assert "reclaimed_by=reclaim_heartbeat" in msg
+    assert f"at_tick={a1_tick}" in msg
+
+    # ---- Single-writer + monotonic version invariants on every artifact ----
+    for artifact_id in engine._artifact_ids:
+        check_single_writer(engine._registry.get_state_map(artifact_id))
+        # Reclamation does not bump version; commit by agent_1 (tick 0) bumped
+        # artifact_1 from v1 → v2, and agent_3's post-run write left
+        # artifact_0 at v1 (write request without commit). Just spot-check
+        # version is positive and the helper accepts the trivial pair.
+        version = engine._registry.get_artifact(artifact_id).version
+        assert version >= 1
+        check_monotonic_version(version, version)
+
+    # ---- State-log validation: no gaps, no schema mismatches (R6) ----
+    log_fh.close()
+    gaps, mismatches = validate_log(log_path, schema_version="ccs.state_log.v2")
+    assert gaps == []
+    assert mismatches == []

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -224,3 +224,281 @@ def test_engine_flag_off_state_log_is_byte_identical_with_or_without_block() -> 
 
     assert log_without_block == log_with_disabled_block
     assert len(log_without_block) > 0  # sanity: we actually captured something
+
+
+# ---- Unit 4: failure-event injection + sweep wiring -------------------------
+
+from ccs.core.states import MESIState  # noqa: E402
+from ccs.core.types import FetchRequest  # noqa: E402
+
+
+def _failure_scenario(*, num_agents: int = 2, duration: int = 50) -> dict:
+    """Minimal scenario for failure-event integration tests.
+
+    Single small artifact, deterministic action knobs, no network latency.
+    Action knobs are very low — tests drive state via direct registry/coordinator
+    calls when they need precise control over MESI lifecycle.
+    """
+    return {
+        "simulation": {
+            "duration_ticks": duration,
+            "num_agents": num_agents,
+            "seed": 7,
+            "action_probability": 0.0,
+            "actions_per_tick": 1,
+        },
+        "network": {"latency_ticks": 0, "message_loss_rate": 0.0},
+        "scenario": {
+            "name": "failure-injection",
+            "workload": "read_heavy",
+            "action_probability": 0.0,
+            "write_probability": 0.0,
+            "agent_velocity": None,
+            "revocation_tick": None,
+        },
+        "artifacts": [
+            {"id": "plan.md", "size_tokens": 100, "volatility": 0.0, "initial_version": 1, "mutable": True},
+        ],
+        "strategies": {
+            "eager": {},
+            "lazy": {"check_interval_ticks": 100},
+            "lease": {"default_ttl_ticks": 5},
+            "access_count": {"max_accesses": 4},
+            "exec_count": {"max_operations": 4},
+        },
+        "transient": {"timeout_ticks": 100},
+        "context_semantics": {"model": "conditional_injection"},
+    }
+
+
+def _capture_state_log(engine: SimulationEngine) -> list[dict]:
+    log: list[dict] = []
+    engine._registry._state_log = log.append
+    return log
+
+
+def test_failure_event_kill_triggers_heartbeat_reclaim() -> None:
+    """R1 / OOM-kill shape: A acquires E, is killed, sweep reclaims, B can write.
+
+    A is granted EXCLUSIVE on artifact_0 at tick 0. A `kill` event fires at
+    tick 5. After heartbeat_timeout_ticks elapse with no heartbeat, the
+    sweep reclaims A's grant via ``reclaim_heartbeat``. Agent B's subsequent
+    write succeeds.
+    """
+    scenario = _failure_scenario(num_agents=2, duration=30)
+    scenario["crash_recovery"] = {
+        "enabled": True,
+        "heartbeat_timeout_ticks": 5,
+        "max_hold_ticks": 1000,
+    }
+    scenario["failure_events"] = [
+        {"tick": 5, "action": "kill", "agent": "agent_0"},
+    ]
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=1)
+    log = _capture_state_log(engine)
+
+    artifact_id = engine._artifact_ids[0]
+    agent_a = engine._agent_id_by_name["agent_0"]
+    agent_b = engine._agent_id_by_name["agent_1"]
+
+    # Pre-grant EXCLUSIVE to A at tick 0.
+    engine._coordinator.fetch(
+        FetchRequest(artifact_id=artifact_id, requesting_agent_id=agent_a, requested_at_tick=0)
+    )
+    assert engine._registry.get_agent_state(artifact_id, agent_a) == MESIState.EXCLUSIVE
+
+    engine.run()
+
+    assert engine._stable_grant_reclamations >= 1
+    reclaim_entries = [e for e in log if e.get("trigger") == "reclaim_heartbeat"]
+    assert len(reclaim_entries) >= 1
+    # B can now write because A's grant was reclaimed.
+    engine._coordinator.write(agent_id=agent_b, artifact_id=artifact_id, issued_at_tick=29)
+    assert engine._registry.get_agent_state(artifact_id, agent_b) == MESIState.EXCLUSIVE
+
+
+def test_failure_event_alive_agent_max_hold_reclaim() -> None:
+    """R2 / max-hold-alive shape: live agent never commits; max_hold reclaims.
+
+    A acquires MODIFIED at tick 10, then continues to be heartbeated by the
+    engine (it stays in ``_alive_agents``). After ``max_hold_ticks`` ticks
+    pass with no commit, the sweep reclaims via ``reclaim_max_hold``.
+    """
+    scenario = _failure_scenario(num_agents=1, duration=60)
+    scenario["crash_recovery"] = {
+        "enabled": True,
+        "heartbeat_timeout_ticks": 1000,  # heartbeat trigger never fires
+        "max_hold_ticks": 30,
+    }
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=1)
+    log = _capture_state_log(engine)
+
+    artifact_id = engine._artifact_ids[0]
+    agent_a = engine._agent_id_by_name["agent_0"]
+
+    engine._coordinator.fetch(
+        FetchRequest(artifact_id=artifact_id, requesting_agent_id=agent_a, requested_at_tick=0)
+    )
+    engine._coordinator.commit(
+        agent_id=agent_a, artifact_id=artifact_id, content="v2", issued_at_tick=10
+    )
+    assert engine._registry.get_agent_state(artifact_id, agent_a) == MESIState.MODIFIED
+
+    engine.run()
+
+    reclaim_entries = [e for e in log if e.get("trigger") == "reclaim_max_hold"]
+    assert len(reclaim_entries) >= 1
+    assert engine._stable_grant_reclamations >= 1
+
+
+def test_busy_agent_during_sync_compute_is_falsely_reclaimed() -> None:
+    """Documents the false-reclaim-under-sync-compute shape (Carryover risk #3).
+
+    Agent A acquires EXCLUSIVE; at tick 5, a ``busy`` event fires with
+    ``until_tick = 5 + heartbeat_timeout_ticks + 1``. Inside the busy window
+    A does NOT heartbeat and does NOT act. The sweep is expected to reclaim
+    A via ``reclaim_heartbeat`` because the engine cannot distinguish
+    "blocked on long sync compute" from "crashed". This test passes by
+    DEMONSTRATING the failure mode, not by avoiding it.
+    """
+    heartbeat_timeout = 4
+    busy_start = 5
+    busy_until = busy_start + heartbeat_timeout + 2
+    scenario = _failure_scenario(num_agents=1, duration=busy_until + 5)
+    scenario["crash_recovery"] = {
+        "enabled": True,
+        "heartbeat_timeout_ticks": heartbeat_timeout,
+        "max_hold_ticks": 1000,
+    }
+    scenario["failure_events"] = [
+        {"tick": busy_start, "action": "busy", "agent": "agent_0", "until_tick": busy_until},
+    ]
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=1)
+    log = _capture_state_log(engine)
+
+    artifact_id = engine._artifact_ids[0]
+    agent_a = engine._agent_id_by_name["agent_0"]
+
+    engine._coordinator.fetch(
+        FetchRequest(artifact_id=artifact_id, requesting_agent_id=agent_a, requested_at_tick=0)
+    )
+
+    engine.run()
+
+    reclaim_entries = [e for e in log if e.get("trigger") == "reclaim_heartbeat"]
+    assert len(reclaim_entries) >= 1, (
+        "expected the sync-compute busy window to trigger a false-positive heartbeat reclaim"
+    )
+    assert engine._stable_grant_reclamations >= 1
+
+
+def test_killed_agent_does_not_act() -> None:
+    """A killed agent must never reach _perform_read or _perform_write."""
+    scenario = _failure_scenario(num_agents=2, duration=30)
+    # Force every alive agent to act every tick.
+    scenario["scenario"]["action_probability"] = 1.0
+    scenario["scenario"]["write_probability"] = 0.5
+    scenario["failure_events"] = [
+        {"tick": 5, "action": "kill", "agent": "agent_0"},
+    ]
+
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=3)
+    agent_a = engine._agent_id_by_name["agent_0"]
+    agent_b = engine._agent_id_by_name["agent_1"]
+
+    seen_agents: list = []
+    original = engine._execute_single_action
+
+    def _spy(*, agent_id, now_tick):
+        if now_tick >= 5:
+            seen_agents.append((now_tick, agent_id))
+        return original(agent_id=agent_id, now_tick=now_tick)
+
+    engine._execute_single_action = _spy  # type: ignore[assignment]
+    engine.run()
+
+    # After tick 5 (kill takes effect at start of tick 5), A must never act.
+    post_kill_a = [t for t, aid in seen_agents if aid == agent_a]
+    post_kill_b = [t for t, aid in seen_agents if aid == agent_b]
+    assert post_kill_a == [], f"killed agent acted at ticks {post_kill_a}"
+    assert post_kill_b, "control: live agent should still be acting"
+
+
+def test_metrics_include_stable_grant_reclamations_field() -> None:
+    """R5: existing baseline scenarios get the new field defaulted to 0."""
+    metrics = SimulationEngine(_scenario(), strategy_name="lazy", seed=5).run()
+    payload = metrics.to_dict()
+    assert "stable_grant_reclamations" in payload
+    assert payload["stable_grant_reclamations"] == 0
+
+
+def test_baseline_state_log_byte_identical_with_disabled_flag_after_unit4() -> None:
+    """R5: with crash_recovery disabled, state-log is identical to v0.5 baseline.
+
+    Identical to the Unit 3 byte-identity test but exercises the Unit 4
+    code paths now that the sweep call site exists. The flag-off guard at
+    the call site MUST keep the heartbeat / sweep entries out of the log.
+    """
+
+    def _run_and_capture(crash_recovery_block: dict | None) -> list[dict]:
+        scenario = _scenario()
+        if crash_recovery_block is not None:
+            scenario["crash_recovery"] = crash_recovery_block
+        engine = SimulationEngine(scenario, strategy_name="lazy", seed=42)
+        log: list[dict] = []
+        engine._registry._state_log = log.append
+        engine.run()
+        artifact_id_map: dict[str, str] = {}
+        for entry in log:
+            entry["instance_id"] = "<inst>"
+            aid = entry.get("artifact_id")
+            if aid is not None:
+                aid_str = str(aid)
+                placeholder = artifact_id_map.setdefault(
+                    aid_str, f"<artifact-{len(artifact_id_map)}>"
+                )
+                entry["artifact_id"] = placeholder
+        return log
+
+    log_without_block = _run_and_capture(None)
+    log_with_disabled_block = _run_and_capture(
+        {"enabled": False, "heartbeat_timeout_ticks": 5, "max_hold_ticks": 50}
+    )
+    assert log_without_block == log_with_disabled_block
+    assert len(log_without_block) > 0
+
+
+def test_failure_event_unknown_agent_name_raises() -> None:
+    scenario = _failure_scenario(num_agents=1, duration=10)
+    scenario["failure_events"] = [
+        {"tick": 1, "action": "kill", "agent": "agent_999"},
+    ]
+    with pytest.raises(ValueError, match="unknown agent name"):
+        SimulationEngine(scenario, strategy_name="lazy", seed=1)
+
+
+def test_busy_window_auto_expires_without_restore_event() -> None:
+    """`busy` with `until_tick` flips back to alive automatically."""
+    scenario = _failure_scenario(num_agents=1, duration=20)
+    scenario["scenario"]["action_probability"] = 1.0
+    scenario["failure_events"] = [
+        {"tick": 2, "action": "busy", "agent": "agent_0", "until_tick": 6},
+    ]
+
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=1)
+    agent_a = engine._agent_id_by_name["agent_0"]
+
+    seen: list[int] = []
+    original = engine._execute_single_action
+
+    def _spy(*, agent_id, now_tick):
+        if agent_id == agent_a:
+            seen.append(now_tick)
+        return original(agent_id=agent_id, now_tick=now_tick)
+
+    engine._execute_single_action = _spy  # type: ignore[assignment]
+    engine.run()
+
+    # During [2, 6) A is busy; from tick 6 onward A is alive again.
+    assert all(t < 2 or t >= 6 for t in seen), seen
+    assert any(t >= 6 for t in seen), "agent should resume acting after busy window"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -579,3 +579,39 @@ def test_kill_then_busy_then_restore_round_trip() -> None:
     assert agent_a in engine._alive_agents
     assert agent_a not in engine._killed_agents
     assert agent_a not in engine._busy_agents
+
+
+# Review fix T-05: restore-after-kill is asserted to clear killed state but
+# was never directly verified to re-enable heartbeat emission. Test below
+# confirms that after restore, the engine emits heartbeats for the agent.
+
+
+def test_restore_after_kill_resumes_heartbeat_emission() -> None:
+    """T-05: a `restore` event must re-enable heartbeat emission for the agent.
+
+    Before restore, _emit_heartbeats_for_alive_agents skips the killed agent
+    (it's not in _alive_agents). After restore, the agent is in _alive_agents
+    again and the next tick's emission updates last_heartbeat_tick.
+    """
+    scenario = _failure_scenario(num_agents=1, duration=20)
+    scenario["crash_recovery"] = {
+        "enabled": True,
+        "heartbeat_timeout_ticks": 50,  # generous so no reclaim disturbs the test
+        "max_hold_ticks": 1000,
+    }
+    scenario["failure_events"] = [
+        {"tick": 3, "action": "kill", "agent": "agent_0"},
+        {"tick": 12, "action": "restore", "agent": "agent_0"},
+    ]
+
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=1)
+    agent_a = engine._agent_id_by_name["agent_0"]
+    engine.run()
+
+    # last_heartbeat_tick must reflect a tick AFTER the restore (12), proving
+    # that emission resumed. Run completes at duration_ticks=20, so the last
+    # heartbeat should be at tick 19 (last tick before clock.advance to 20).
+    last_hb = engine._registry.last_heartbeat_tick(agent_a)
+    assert last_hb is not None
+    assert last_hb >= 12, f"heartbeat should have resumed after restore, got {last_hb}"
+    assert last_hb <= 19, f"heartbeat must not exceed final tick, got {last_hb}"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -502,3 +502,80 @@ def test_busy_window_auto_expires_without_restore_event() -> None:
     # During [2, 6) A is busy; from tick 6 onward A is alive again.
     assert all(t < 2 or t >= 6 for t in seen), seen
     assert any(t >= 6 for t in seen), "agent should resume acting after busy window"
+
+
+def test_busy_then_kill_does_not_resurrect_at_busy_until_tick() -> None:
+    """Review ADV-01: busy at tick T0 with until_tick=U, then kill at T1 < U.
+
+    The busy auto-expiry at U must NOT silently resurrect the killed agent.
+    Without the fix, agent_0 would re-enter `_alive_agents` at tick U.
+    """
+    busy_until = 12
+    scenario = _failure_scenario(num_agents=1, duration=busy_until + 5)
+    scenario["failure_events"] = [
+        {"tick": 2, "action": "busy", "agent": "agent_0", "until_tick": busy_until},
+        {"tick": 5, "action": "kill", "agent": "agent_0"},
+    ]
+
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=1)
+    agent_a = engine._agent_id_by_name["agent_0"]
+    engine.run()
+
+    # After the run completes, the killed agent must remain killed and never
+    # be in _alive_agents — the busy auto-expiry at tick=busy_until must not
+    # have resurrected it.
+    assert agent_a in engine._killed_agents
+    assert agent_a not in engine._alive_agents
+    assert agent_a not in engine._busy_agents
+    assert agent_a not in engine._busy_until
+
+
+def test_kill_then_restore_brings_agent_back_alive() -> None:
+    """A `restore` event after `kill` must clear the killed state."""
+    scenario = _failure_scenario(num_agents=1, duration=20)
+    scenario["failure_events"] = [
+        {"tick": 3, "action": "kill", "agent": "agent_0"},
+        {"tick": 8, "action": "restore", "agent": "agent_0"},
+    ]
+
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=1)
+    agent_a = engine._agent_id_by_name["agent_0"]
+    engine.run()
+
+    assert agent_a not in engine._killed_agents
+    assert agent_a in engine._alive_agents
+
+
+def test_busy_on_killed_agent_raises() -> None:
+    """Review ADV-01: scheduling busy on a killed agent must fail loudly.
+
+    Strict semantics — silent no-op would mask operator misconfiguration.
+    """
+    scenario = _failure_scenario(num_agents=1, duration=20)
+    scenario["failure_events"] = [
+        {"tick": 3, "action": "kill", "agent": "agent_0"},
+        {"tick": 6, "action": "busy", "agent": "agent_0", "until_tick": 12},
+    ]
+
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=1)
+    with pytest.raises(ValueError, match="busy.*killed agent"):
+        engine.run()
+
+
+def test_kill_then_busy_then_restore_round_trip() -> None:
+    """kill → restore → busy is the supported way to reuse a killed agent."""
+    scenario = _failure_scenario(num_agents=1, duration=20)
+    scenario["failure_events"] = [
+        {"tick": 3, "action": "kill", "agent": "agent_0"},
+        {"tick": 6, "action": "restore", "agent": "agent_0"},
+        {"tick": 9, "action": "busy", "agent": "agent_0", "until_tick": 14},
+    ]
+
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=1)
+    agent_a = engine._agent_id_by_name["agent_0"]
+    engine.run()
+
+    # Final state: alive again after the busy window auto-expires.
+    assert agent_a in engine._alive_agents
+    assert agent_a not in engine._killed_agents
+    assert agent_a not in engine._busy_agents

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -135,3 +135,92 @@ def test_pointer_model_reduces_eager_broadcast_token_cost() -> None:
     conditional = SimulationEngine(_scenario_with_model("conditional_injection"), strategy_name="eager", seed=31).run()
 
     assert pointer.tokens_broadcast <= conditional.tokens_broadcast
+
+
+# ---- Unit 3: crash_recovery config plumbing ---------------------------------
+
+import pytest  # noqa: E402
+
+from ccs.coordinator.service import CrashRecoveryConfig  # noqa: E402
+
+
+def test_engine_uses_default_crash_recovery_config_when_block_absent() -> None:
+    engine = SimulationEngine(_scenario(), strategy_name="lazy", seed=5)
+    assert engine._crash_recovery == CrashRecoveryConfig()
+    assert engine._crash_recovery.enabled is False
+
+
+def test_engine_reads_crash_recovery_block_from_scenario() -> None:
+    scenario = _scenario()
+    scenario["crash_recovery"] = {
+        "enabled": False,
+        "heartbeat_timeout_ticks": 7,
+        "max_hold_ticks": 77,
+    }
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=5)
+    assert engine._crash_recovery.heartbeat_timeout_ticks == 7
+    assert engine._crash_recovery.max_hold_ticks == 77
+
+
+def test_engine_fail_fast_when_max_hold_at_lease_ttl_boundary() -> None:
+    scenario = _scenario()
+    scenario["strategies"]["lease"] = {"default_ttl_ticks": 300}
+    scenario["crash_recovery"] = {"enabled": True, "max_hold_ticks": 300}
+    with pytest.raises(ValueError, match="max_hold_ticks"):
+        SimulationEngine(scenario, strategy_name="lease", seed=5)
+
+
+def test_engine_fail_fast_accepts_max_hold_above_ttl() -> None:
+    scenario = _scenario()
+    scenario["strategies"]["lease"] = {"default_ttl_ticks": 200}
+    scenario["crash_recovery"] = {"enabled": True, "max_hold_ticks": 300}
+    # No raise.
+    SimulationEngine(scenario, strategy_name="lease", seed=5)
+
+
+def test_engine_flag_off_state_log_is_byte_identical_with_or_without_block() -> None:
+    """R5: the flag-off path must produce a state-log identical to the v0.5 baseline.
+
+    We compare two runs of the same scenario+strategy+seed:
+      - Run A: no ``crash_recovery`` block (legacy v0.5 shape).
+      - Run B: explicit ``crash_recovery: { enabled: false, ... }`` block with
+        knobs the sweep would otherwise read.
+
+    Today this is preventive (Unit 4 will add the sweep call site). The
+    contract: when ``enabled=False`` the engine MUST never invoke the sweep
+    or emit heartbeats, so the state-log is identical to a run with the
+    block omitted entirely.
+    """
+
+    def _run_and_capture(crash_recovery_block: dict | None) -> list[dict]:
+        scenario = _scenario()
+        if crash_recovery_block is not None:
+            scenario["crash_recovery"] = crash_recovery_block
+        engine = SimulationEngine(scenario, strategy_name="lazy", seed=42)
+        # Wire a state_log onto the registry post-construction. Construction
+        # already populated _instance_id, so it's safe to attach the callback.
+        log: list[dict] = []
+        engine._registry._state_log = log.append
+        engine.run()
+        # Normalize per-run uuid4 fields (instance_id, artifact_id) to
+        # deterministic placeholders. artifact_id is fresh on every Artifact
+        # construction; first-seen order maps to a stable placeholder.
+        artifact_id_map: dict[str, str] = {}
+        for entry in log:
+            entry["instance_id"] = "<inst>"
+            aid = entry.get("artifact_id")
+            if aid is not None:
+                aid_str = str(aid)
+                placeholder = artifact_id_map.setdefault(
+                    aid_str, f"<artifact-{len(artifact_id_map)}>"
+                )
+                entry["artifact_id"] = placeholder
+        return log
+
+    log_without_block = _run_and_capture(None)
+    log_with_disabled_block = _run_and_capture(
+        {"enabled": False, "heartbeat_timeout_ticks": 5, "max_hold_ticks": 50}
+    )
+
+    assert log_without_block == log_with_disabled_block
+    assert len(log_without_block) > 0  # sanity: we actually captured something

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -113,3 +113,76 @@ def test_load_scenario_rejects_revocation_tick_out_of_range(tmp_path: Path) -> N
     with pytest.raises(ScenarioValidationError):
         load_scenario(str(scenario_path))
 
+
+
+def _minimal_scenario_payload() -> dict:
+    return {
+        "simulation": {"duration_ticks": 10, "num_agents": 2, "seed": 1},
+        "network": {"latency_ticks": 1, "message_loss_rate": 0.0},
+        "scenario": {
+            "name": "valid",
+            "workload": "custom",
+            "action_probability": 0.5,
+            "write_probability": 0.2,
+        },
+        "artifacts": [{"id": "plan.md", "size_tokens": 1024}],
+        "strategies": {},
+        "transient": {"timeout_ticks": 5},
+        "context_semantics": {"model": "pointer"},
+    }
+
+
+def test_load_scenario_without_crash_recovery_block_uses_defaults(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "no-cr.yaml"
+    payload = _minimal_scenario_payload()
+    _write_yaml(scenario_path, payload)
+
+    config = load_scenario(str(scenario_path))
+    # Block is normalized to an empty mapping; engine reads defaults from CrashRecoveryConfig.
+    assert config["crash_recovery"] == {}
+
+
+def test_load_scenario_with_crash_recovery_block_parses(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "with-cr.yaml"
+    payload = _minimal_scenario_payload()
+    payload["crash_recovery"] = {
+        "enabled": True,
+        "heartbeat_timeout_ticks": 5,
+        "max_hold_ticks": 50,
+    }
+    _write_yaml(scenario_path, payload)
+
+    config = load_scenario(str(scenario_path))
+    assert config["crash_recovery"]["enabled"] is True
+    assert config["crash_recovery"]["heartbeat_timeout_ticks"] == 5
+    assert config["crash_recovery"]["max_hold_ticks"] == 50
+
+
+def test_load_scenario_rejects_zero_heartbeat_timeout(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "bad-cr-hb.yaml"
+    payload = _minimal_scenario_payload()
+    payload["crash_recovery"] = {"heartbeat_timeout_ticks": 0}
+    _write_yaml(scenario_path, payload)
+
+    with pytest.raises(ScenarioValidationError, match="heartbeat_timeout_ticks"):
+        load_scenario(str(scenario_path))
+
+
+def test_load_scenario_rejects_non_bool_enabled(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "bad-cr-enabled.yaml"
+    payload = _minimal_scenario_payload()
+    payload["crash_recovery"] = {"enabled": "yes"}
+    _write_yaml(scenario_path, payload)
+
+    with pytest.raises(ScenarioValidationError, match="enabled"):
+        load_scenario(str(scenario_path))
+
+
+def test_load_scenario_rejects_negative_max_hold(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "bad-cr-mh.yaml"
+    payload = _minimal_scenario_payload()
+    payload["crash_recovery"] = {"max_hold_ticks": -1}
+    _write_yaml(scenario_path, payload)
+
+    with pytest.raises(ScenarioValidationError, match="max_hold_ticks"):
+        load_scenario(str(scenario_path))

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -186,3 +186,64 @@ def test_load_scenario_rejects_negative_max_hold(tmp_path: Path) -> None:
 
     with pytest.raises(ScenarioValidationError, match="max_hold_ticks"):
         load_scenario(str(scenario_path))
+
+
+# ---- Unit 4: failure_events schema -----------------------------------------
+
+
+def test_load_scenario_accepts_failure_events_block(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "ok-fe.yaml"
+    payload = _minimal_scenario_payload()
+    payload["failure_events"] = [
+        {"tick": 5, "action": "kill", "agent": "agent_0"},
+        {"tick": 10, "action": "busy", "agent": "agent_1", "until_tick": 20},
+        {"tick": 30, "action": "restore", "agent": "agent_0"},
+    ]
+    _write_yaml(scenario_path, payload)
+
+    config = load_scenario(str(scenario_path))
+    assert len(config["failure_events"]) == 3
+
+
+def test_load_scenario_rejects_unknown_failure_action(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "bad-fe-action.yaml"
+    payload = _minimal_scenario_payload()
+    payload["failure_events"] = [{"tick": 1, "action": "explode", "agent": "agent_0"}]
+    _write_yaml(scenario_path, payload)
+
+    with pytest.raises(ScenarioValidationError, match="action"):
+        load_scenario(str(scenario_path))
+
+
+def test_load_scenario_rejects_busy_without_until_tick(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "bad-fe-busy.yaml"
+    payload = _minimal_scenario_payload()
+    payload["failure_events"] = [{"tick": 1, "action": "busy", "agent": "agent_0"}]
+    _write_yaml(scenario_path, payload)
+
+    with pytest.raises(ScenarioValidationError, match="until_tick"):
+        load_scenario(str(scenario_path))
+
+
+def test_load_scenario_rejects_kill_with_until_tick(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "bad-fe-kill-until.yaml"
+    payload = _minimal_scenario_payload()
+    payload["failure_events"] = [
+        {"tick": 1, "action": "kill", "agent": "agent_0", "until_tick": 5}
+    ]
+    _write_yaml(scenario_path, payload)
+
+    with pytest.raises(ScenarioValidationError, match="until_tick"):
+        load_scenario(str(scenario_path))
+
+
+def test_load_scenario_rejects_busy_until_tick_not_after_tick(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "bad-fe-window.yaml"
+    payload = _minimal_scenario_payload()
+    payload["failure_events"] = [
+        {"tick": 5, "action": "busy", "agent": "agent_0", "until_tick": 5}
+    ]
+    _write_yaml(scenario_path, payload)
+
+    with pytest.raises(ScenarioValidationError, match="until_tick"):
+        load_scenario(str(scenario_path))


### PR DESCRIPTION
## Status — merging to `dev`, not production-ready

This PR is being merged into `dev` (integration branch) rather than `main` because the **feature is not fully functional end-to-end yet**. Production readiness requires three deferred follow-ups, none of which are in scope here:

| Gap | Why it blocks default-on | Tracking |
|---|---|---|
| **Adapter heartbeat plumbing** | LangGraph / CrewAI / AutoGen / CCSStore don't yet call `coordinator.record_heartbeat(...)` or expose `recover()`. Without that, real-adapter use of `enabled=True` would false-reclaim immediately under any normal compute. | `docs/plans/2026-05-07-002-feat-adapter-heartbeat-plumbing-plan.md` (planned, not started) |
| **TLA+ amendment (origin Gate 1)** | Invariants I1–I7 in `docs/specs/crash-recovery.md` need formal verification before the flag flips default-on. | Separate backlog item |
| **End-user durability narrative** | Operator-facing docs explaining the "coherence ≠ durability" contract (D3 discards uncommitted MODIFIED). | Origin Carryover Risk #4 |

**What this PR ships safely to dev:** the coordinator-side machinery behind `crash_recovery.enabled=False` (default). Existing scenarios produce byte-identical state-transition logs to the v0.5 baseline (R5/I7). No behavioral change for any current consumer until an operator opts in.

The branching strategy that drives this choice is documented in the local `CLAUDE.md` (gitignored): feature work integrates to `dev`; `dev → main` is a separate release merge.

**Note on diff scope:** the PR includes a 1-line `README.md` addition that exists on `main` but not yet on `dev` (a "coherence gap evidence brief" link from a prior `main`-side commit). It will collapse out automatically once `main → dev` is synced; included here only because of the merge-base differential. All other diff content is the crash-recovery work.

---

## Summary

Coordinator-side crash recovery for stale `MODIFIED` / `EXCLUSIVE` MESI grants. `enforce_transient_timeouts` already handles transient states; this adds `enforce_stable_grant_timeouts` for stable-state grants held by crashed or livelocked agents. Ships behind a feature flag (`enabled=False` default).

Closes the liveness gap behind backlog item C: two validated leads (jingchang0623 OOM-kill cron, jessieibarra checkpoint-restore short-circuit) at pain=7 each.

## Implementation (12 commits)

| Phase | Commits | Net |
|---|---:|---|
| 6 implementation units | 6 | Coordinator + simulation wiring + benchmark scenario; 269 tests |
| Code-review polish (safe-auto) | 1 | 9 fixes, no behavior change |
| Code-review P1 fixes | 2 | `kill`×`busy` resurrection bug; log-fail bookkeeping inconsistency |
| Code-review P2 fixes | 2 | `>` vs `>=` operator asymmetry; `ttl_ticks=0` silent-skip |
| Manual test additions | 1 | Coverage for defensive branch, restore-resumes-heartbeat, double-run determinism |

**Total:** +1900 / −16 lines (after review-driven additions). 282 tests passing (was 223 pre-branch — +59 tests).

## Key behavior

- **Hybrid liveness signal:** per-agent heartbeat (catches hard crashes) + per-grant max-hold (catches livelocks).
- **Trigger ordering:** `reclaim_heartbeat` checked first; both conditions use `>=` for symmetry.
- **Sweep ordering:** transient sweep runs first, stable sweep takes its snapshot afterward; a given (agent, artifact) is reclaimed by at most one sweep per tick.
- **Reclamation-aware commit:** stale agents calling `commit()` get `reclaimed_by=<trigger> at_tick=<n>` in the error message; the slot survives a `SHARED` transition (jessieibarra path) and clears only on M∪E re-acquire.
- **Tick monotonicity (R12):** `record_heartbeat` uses `max(prev, incoming)` — out-of-order delivery is harmless.
- **Composition fail-fast (R11):** refuses `enabled=True` startup when a strategy with inspectable `ttl_ticks` would have `max_hold_ticks <= ttl_ticks`. Distinguishes `ttl=None` (silent accept), integer `ttl` (validate, including `ttl=0`), and non-integer `ttl` (`RuntimeWarning`).
- **First-class `_killed_agents`:** failure-injection vocabulary distinguishes `kill` (permanent until explicit `restore`) from `busy` (auto-expires); `busy` on a killed agent raises strict `ValueError`.

## Test plan

- [x] 282 tests passing (was 223 pre-branch — +59 across 5 files)
- [x] Architecture boundary check (`tools/check_architecture.py`) clean
- [x] README benchmark numbers up-to-date (no benchmark drift)
- [x] **R5 byte-identity preserved:** state-transition log byte-identical to v0.5 baseline when `enabled=False` (instance-id-normalized regression test)
- [x] **R6 observability:** `validate_log` reports no gaps or schema mismatches under the new code paths
- [x] **R8 jessieibarra path:** dedicated test asserts the reclamation slot survives `INVALID → SHARED` and a late `commit()` raises with the diagnostic message
- [x] **R9 combined scenario:** `benchmarks/scenarios/crash_recovery_validation.yaml` exercises OOM-kill (`reclaim_heartbeat`), checkpoint-restore-then-commit (`reclaim_heartbeat` + diagnostic message), AND live-but-stuck max-hold (`reclaim_max_hold`) in one deterministic run
- [x] Trigger ordering, sweep ordering, `granted_at_tick` lifecycle, `kill`/`busy`/`restore` semantics
- [x] Boundary tests for heartbeat-stale at exact timeout (`>=`)
- [x] Log-emit-failure consistency: state and bookkeeping stay aligned when `state_log` raises
- [x] Double-run determinism for the combined scenario

## Code review summary

11 reviewers ran (correctness, testing, maintainability, project-standards, agent-native, learnings + adversarial, performance, api-contract, reliability, kieran-python). Verdict went from "Ready with fixes" to "Ready to merge to dev" after the gated-auto P1/P2 fixes and manual test additions landed.

| Class | Count | Status |
|---|---:|---|
| safe_auto applied | 9 | committed |
| gated_auto P1 fixed | 2 | committed (`kill`×`busy` resurrection; log-fail bookkeeping) |
| gated_auto P2 fixed | 2 | committed (`>`/`>=` asymmetry; `ttl_ticks=0` silent-skip) |
| manual tests added | 4 | committed |
| advisory (informational) | 7 | left in report; included in this PR's notes |

## Notes for reviewers

- All planning artifacts (`docs/brainstorms/`, `docs/plans/`, `docs/specs/`) are gitignored locally per the repo's `.git/info/exclude` policy. They are NOT in this PR. The spec doc (`docs/specs/crash-recovery.md`) lives on the author's clone.
- Default behavior is unchanged: `crash_recovery.enabled=False` is the default; existing scenarios produce byte-identical state logs to the v0.5 baseline.
- The `stable_grant_reclamations` field added to `SimulationMetrics` is a metric-schema addition (intentional). On flag-off scenarios it's always `0`.
- `benchmarks/expected.json` is NOT regenerated — its schema is LangGraph workload token counts, unrelated to `SimulationMetrics`.
- The `dev → main` promotion will happen after the adapter plumbing PR lands and the TLA+ amendment is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)