### PR TITLE
fix(ci): release.yml preflight needs administration:read for branch-protection check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,15 @@ jobs:
     runs-on: ubuntu-latest
 
     # ``gh api`` calls into the same repo for environment / branch /
-    # tag protection lookups. ``contents: read`` is enough; the
-    # default ``GITHUB_TOKEN`` is auto-exposed to ``gh``.
+    # tag protection lookups. ``administration: read`` is required for
+    # ``repos/{owner}/{repo}/branches/{branch}/protection`` — the
+    # default ``GITHUB_TOKEN`` cannot read branch protection metadata
+    # without it. The other two checks (pypi env, tag ruleset) work
+    # with ``contents: read`` alone but we grant both scopes uniformly
+    # because all three checks fire from the same script invocation.
     permissions:
       contents: read
+      administration: read
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4


### PR DESCRIPTION
## Summary

The first `v0.7.0` tag push failed at the **preflight** step of `release.yml` with `HTTP 403: Resource not accessible by integration`. The build, publish, and github-release jobs were skipped (correct fail-closed behavior), so **no artefacts shipped to PyPI and no GitHub release was created**. Recoverable.

## Root cause

`tools/check_release_readiness.py` calls three GitHub APIs, one of which requires elevated permissions on `GITHUB_TOKEN`:

| API | Required permission |
|---|---|
| `repos/{owner}/{repo}/environments/pypi` | `contents: read` (default) |
| **`repos/{owner}/{repo}/branches/main/protection`** | **`administration: read`** |
| `repos/{owner}/{repo}/rulesets` | `contents: read` (default) |

The workflow's preflight job declared only `contents: read`, so the middle call returned 403 and the job exited 1. The check passes locally because a developer's PAT has admin scope by default.

## Fix

One-line YAML change: add `administration: read` to the preflight job's permissions block. Other jobs (`build`, `publish` with `id-token: write`, `github-release` with `contents: write`) are unchanged.

## Test plan

- [x] `pytest tests/test_release_readiness.py` — 16/16 pass
- [x] Local `python tools/check_release_readiness.py` — all three checks PASS
- [ ] CI on this PR validates the workflow YAML parses
- [ ] After merge: re-tag `v0.7.0` on `main` and re-push → preflight passes and the release pipeline completes through publish + github-release

## Recovery sequence after merge

```bash
git checkout main && git pull
git tag -a v0.7.0 -m "Release v0.7.0 — ccs-diagnose CLI + supply-chain hardening"
git push origin v0.7.0
```

The deleted `v0.7.0` tag has already been removed from `origin` (admin-bypassed the ruleset); re-pushing after this merge is the same workflow trigger as the first attempt.
