### PR TITLE
fix(ci): branch-protection check skips gracefully on 403 in CI; revert invalid permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,15 +27,15 @@ jobs:
     runs-on: ubuntu-latest
 
     # ``gh api`` calls into the same repo for environment / branch /
-    # tag protection lookups. ``administration: read`` is required for
-    # ``repos/{owner}/{repo}/branches/{branch}/protection`` — the
-    # default ``GITHUB_TOKEN`` cannot read branch protection metadata
-    # without it. The other two checks (pypi env, tag ruleset) work
-    # with ``contents: read`` alone but we grant both scopes uniformly
-    # because all three checks fire from the same script invocation.
+    # tag protection lookups. ``contents: read`` is enough; the
+    # default ``GITHUB_TOKEN`` is auto-exposed to ``gh``. Note: the
+    # branch-protection endpoint requires admin scope (not available
+    # to GITHUB_TOKEN at any permission level — admin scope is a
+    # PAT-only capability). The preflight script handles that 403
+    # gracefully as a [WARN] skipped check; operators verify branch
+    # protection locally with `ccs-check-release` before tag push.
     permissions:
       contents: read
-      administration: read
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4

--- a/src/ccs/hardening/release_readiness.py
+++ b/src/ccs/hardening/release_readiness.py
@@ -50,11 +50,20 @@ __all__ = [
 
 @dataclass(frozen=True)
 class CheckResult:
-    """One automated-check outcome — name, pass/fail, human-readable detail."""
+    """One automated-check outcome.
+
+    ``ok=True``  → check passed.
+    ``ok=False`` → check failed (hard block on the release path).
+    ``ok=True``  + ``skipped=True`` → check could not be verified from this
+        execution context (e.g. CI's ``GITHUB_TOKEN`` lacks the scope to
+        read branch protection rules); operators must verify manually with
+        a PAT. Treated as a warning, not a release blocker.
+    """
 
     name: str
     ok: bool
     detail: str
+    skipped: bool = False
 
 
 def _gh_api(path: str) -> tuple[int, str, str]:
@@ -106,18 +115,39 @@ def check_branch_protection(owner: str, repo: str, branch: str) -> CheckResult:
     A 200 response means *some* protection is in place. The script does
     not assert on the rule shape because GitHub returns different
     fields by plan tier (free / team / enterprise).
+
+    The ``repos/{owner}/{repo}/branches/{branch}/protection`` endpoint
+    requires admin scope. GitHub Actions' default ``GITHUB_TOKEN``
+    cannot reach it and returns ``HTTP 403: Resource not accessible by
+    integration`` — that is a CI-context limitation, not a real
+    configuration failure. We treat 403 as ``skipped`` (warning) so a
+    CI preflight run does not fail-closed when the actual protection
+    rules are in place but unreadable from this token.
     """
+    name = f"Branch protection on '{branch}'"
     rc, _, err = _gh_api(f"repos/{owner}/{repo}/branches/{branch}/protection")
     if rc == 0:
         return CheckResult(
-            name=f"Branch protection on '{branch}'",
+            name=name,
             ok=True,
             detail="protection rules retrieved successfully",
         )
+    err_text = err.strip()
+    # gh exits non-zero on 403; the stderr contains the HTTP code and message.
+    if "403" in err_text and "Resource not accessible by integration" in err_text:
+        return CheckResult(
+            name=name,
+            ok=True,
+            skipped=True,
+            detail=(
+                "could not verify from CI (GITHUB_TOKEN lacks admin scope); "
+                "verify locally with `ccs-check-release` before tag push"
+            ),
+        )
     return CheckResult(
-        name=f"Branch protection on '{branch}'",
+        name=name,
         ok=False,
-        detail=err.strip() or f"gh api returned {rc}",
+        detail=err_text or f"gh api returned {rc}",
     )
 
 
@@ -223,7 +253,12 @@ def format_report(results: Sequence[CheckResult]) -> str:
     lines = ["Automated release-readiness checks:", ""]
     width = max((len(r.name) for r in results), default=0)
     for r in results:
-        status = "PASS" if r.ok else "FAIL"
+        if r.skipped:
+            status = "WARN"
+        elif r.ok:
+            status = "PASS"
+        else:
+            status = "FAIL"
         lines.append(f"  [{status}] {r.name:<{width}}  {r.detail}")
     lines.append("")
     lines.append("Manual verification still required (cannot be automated):")

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -105,6 +105,39 @@ def test_branch_protection_check_fails_on_404(
     assert result.ok is False
 
 
+def test_branch_protection_check_skips_on_403_integration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GitHub Actions GITHUB_TOKEN cannot read branch protection (requires
+    admin scope, PAT-only). We treat 403 as a [WARN] skipped check so the
+    preflight does not fail-closed in CI; operators verify locally."""
+    monkeypatch.setattr(
+        release_readiness,
+        "_gh_api",
+        _gh_stub(1, "", "HTTP 403: Resource not accessible by integration"),
+    )
+    result = release_readiness.check_branch_protection("o", "r", "main")
+    assert result.ok is True
+    assert result.skipped is True
+    assert "verify locally" in result.detail
+
+
+def test_branch_protection_check_fails_on_other_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the specific 'Resource not accessible by integration' 403 is
+    treated as a skip — other 403s (e.g. token revoked, repo private) are
+    still hard failures."""
+    monkeypatch.setattr(
+        release_readiness,
+        "_gh_api",
+        _gh_stub(1, "", "HTTP 403: Forbidden"),
+    )
+    result = release_readiness.check_branch_protection("o", "r", "main")
+    assert result.ok is False
+    assert result.skipped is False
+
+
 def _ruleset_routes(
     owner: str,
     repo: str,


### PR DESCRIPTION
## Summary

The previous fix (PR #17) added `administration: read` to `release.yml`'s preflight permissions. That scope **does not exist** in GitHub Actions' [GITHUB_TOKEN permission list](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) — the workflow file fails YAML validation and zero jobs schedule. That's why the second `v0.7.0` tag push run completed in seconds with no jobs and a "workflow file issue" annotation.

Worse: even if `administration: read` were a valid scope, GITHUB_TOKEN still cannot read `repos/{owner}/{repo}/branches/{branch}/protection` — that endpoint requires admin scope on the underlying token, which is a PAT-only capability.

## Root cause

The branch-protection check fundamentally can't run from GitHub Actions' default token. The right answer is graceful degradation in the check itself.

## Fix

- `check_branch_protection` returns a new tri-state when gh returns `HTTP 403: Resource not accessible by integration` (the exact CI error): `CheckResult(ok=True, skipped=True, detail="could not verify from CI ... verify locally with ccs-check-release before tag push")`. Distinguishable from other 403s (token revoked, repo private) which remain hard failures.
- `format_report` renders skipped checks as `[WARN]`.
- `main()` already returns `0` when `all(r.ok for r in results)` — `skipped=True` rides under `ok=True`, so CI preflight stops fail-closing on this specific 403.
- Revert the invalid `administration: read` line; workflow permissions return to `contents: read`.
- Workflow comment rewritten to document the GITHUB_TOKEN limit and the `[WARN]` semantics.

## Test plan

- [x] `pytest tests/test_release_readiness.py` — 18/18 (added 2 new tests: 403+integration → skipped, generic 403 → failed)
- [x] Local `ccs-check-release` — all three checks still PASS (PAT has admin scope; the WARN path is CI-specific)
- [ ] CI on this PR — workflow YAML validation passes
- [ ] After merge: re-tag v0.7.0; preflight reports `[WARN] Branch protection on 'main'` and the release pipeline proceeds through build → publish → github-release

## After merge

Re-tag and re-push:

```bash
git checkout main && git pull
git tag -a v0.7.0 -m "Release v0.7.0 — ccs-diagnose CLI + supply-chain hardening"
git push origin v0.7.0
```

The deleted `v0.7.0` tag was already removed from origin. PyPI publisher is correctly configured (workflow `release.yml`, env `pypi`).
