### PR TITLE
chore(release): unship ccs-check-release as a public console script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `agent-coherence` are documented here. The format follows
 
 Alpha — APIs may change before `v1.0`.
 
+## [Unreleased]
+
+### Removed
+
+- **`ccs-check-release` console script** is no longer exposed as a `pip install` entry point. It was a maintainer-only pre-tag-push verifier that queried this repo's GitHub admin settings (hardcoded `hipvlady/agent-coherence` defaults); end users had no use case. The underlying script (`tools/check_release_readiness.py`) and its module (`ccs.hardening.release_readiness`) remain tracked — CI invokes the script directly during the release workflow preflight, and maintainers run the same path locally.
+
 ## [0.7.0] — 2026-05-11
 
 ### Added

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -660,7 +660,6 @@ All bundled CLIs are installed as console scripts when you
 | `ccs-simulate` | — | Run a protocol-only simulation scenario from a YAML file |
 | `ccs-compare` | — | Compare two or more strategies on the same scenario |
 | `ccs-check-architecture` | — | Verify the four-layer architecture boundary (also runs in CI) |
-| `ccs-check-release` | — | Verify PyPI Trusted Publishers + branch/tag protection before a `v*` tag push |
 
 Run any command with `--help` for the full option list.
 
@@ -681,20 +680,14 @@ when you want protocol-only numbers without spinning up a real LangGraph
 graph. See [REPRODUCE.md](REPRODUCE.md) for the simulation methodology behind
 the paper's headline numbers.
 
-### `ccs-check-architecture` and `ccs-check-release`
+### `ccs-check-architecture`
 
 ```bash
 # Architecture boundary check — fails non-zero if any layer imports upward
 ccs-check-architecture
-
-# Pre-release verification — fails non-zero if PyPI Trusted Publishers,
-# branch protection on main, or v* tag protection are missing
-ccs-check-release
 ```
 
-Both are designed for CI gating. `ccs-check-architecture` runs on every push;
-`ccs-check-release` runs as a preflight job before any wheel is built for a
-`v*` tag.
+Designed for CI gating; runs on every push. The companion script `tools/check_release_readiness.py` (also runs in CI as the release-workflow preflight) is maintainer-only and intentionally not exposed as a console script — it queries this repo's GitHub admin settings and has no end-user use case.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,13 @@ dependencies = ["pyyaml>=6.0"]
 ccs-simulate = "ccs.cli.simulate:main"
 ccs-compare = "ccs.cli.compare:main"
 ccs-check-architecture = "ccs.hardening.architecture:main"
-ccs-check-release = "ccs.hardening.release_readiness:main"
 ccs-benchmark = "ccs.cli.benchmark:main"
 ccs-diagnose = "ccs.cli.diagnose:main"
+# Note: ccs-check-release is intentionally NOT exposed as a public console
+# script. It's a maintainer-only pre-tag-push verifier that queries this
+# repo's GitHub admin settings (hardcoded defaults to hipvlady/agent-coherence).
+# End users have no use case. CI invokes it directly via
+# `python tools/check_release_readiness.py`. Maintainers run the same path.
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0"]


### PR DESCRIPTION
## Summary

`ccs-check-release` was a maintainer-only pre-tag-push verifier that landed in v0.7.0 as a `pip install` console script. End users have no use case for it — it queries this repo's GitHub admin settings (hardcoded `hipvlady/agent-coherence` defaults) to verify branch protection on `main`, the `v*` tag ruleset, and the `pypi` GitHub environment. Forks would need `--owner --repo` flags overriding the defaults.

Same conceptual artifact class as `SECURITY.md` (repo-root, local-only — maintainer ops doc) and `scripts/configure-release-protections.sh` (local-only — maintainer setup script). Both are kept off the public surface; `ccs-check-release` was the odd one out.

## Changes

- **Remove** `ccs-check-release` from `[project.scripts]` in `pyproject.toml`. Inline comment explains why the slot is intentionally empty.
- **Keep tracked** (no change): `tools/check_release_readiness.py` script, `src/ccs/hardening/release_readiness.py` module, `tests/test_release_readiness.py`. CI's release-workflow preflight uses `python tools/check_release_readiness.py` (line 50 of `release.yml`); the console-script entry point was never on its path. Maintainers run the same path locally.
- **Update** `docs/guide.md` Command-line tools table — drop the `ccs-check-release` row; reword the `ccs-check-architecture` section so the companion script is mentioned as maintainer-only.
- **CHANGELOG.md** — new `## [Unreleased]` section with `### Removed` entry.

## Test plan

- [x] Editable reinstall: only 5 `ccs-*` scripts on PATH (`ccs-diagnose`, `ccs-benchmark`, `ccs-simulate`, `ccs-compare`, `ccs-check-architecture`)
- [x] `python tools/check_release_readiness.py` still runs and all three checks PASS locally
- [x] `pytest tests/test_release_readiness.py tests/test_supply_chain_artifacts.py` — 41/41 pass

## Note

Breaking change in the sense that anyone who scripted against the v0.7.0 console script will need to switch to `python -m ccs.hardening.release_readiness` or `python tools/check_release_readiness.py`. The audience is approximately one person — me — so the impact is bounded.
