### PR TITLE
release: v0.7.1 — refactor demo for write-side coherence + CI Node toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,18 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev,diagnose]"
 
+      # Node toolchain for the refactor-demo's TypeScript fixture. Without
+      # this, _has_tsc() in tests/test_refactor_demo.py is False and all real
+      # tsc end-to-end tests silently skip, leaving the demo's central
+      # correctness claim unverified in CI.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: "20"
+
+      - name: Install refactor-demo TS fixture dependencies
+        working-directory: examples/refactor_demo/fixture_repo_ts
+        run: npm ci
+
       - name: Run test suite
         run: pytest -q --junitxml=test-results.xml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Alpha — APIs may change before `v1.0`.
 ### Fixed
 
 - **CI preflight branch-protection check** — skips gracefully on 403 in CI when `GITHUB_TOKEN` lacks `administration: read` (a fine-grained PAT scope that isn't available to Actions tokens by design). The check still PASSes/FAILs definitively when run locally via `ccs-check-release` with a properly-scoped PAT. The earlier attempt to grant the permission through `permissions:` was reverted because the permission name does not exist for Actions tokens.
+- **`tools/check_readme_numbers.py`** no longer requires a `## Real-workload benchmarks` section heading to locate the benchmark table. The hook now falls back to extracting the table directly via its column-header line (`| Workload | Agents | Reads:Writes | Hit rate | Savings |`) and scans downward until the first non-table line. Works whether the README places the table at the top with no heading (current shape) or under a dedicated section heading (legacy shape).
 
 ## [0.7.0] — 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,26 @@ Alpha — APIs may change before `v1.0`.
 
 ## [Unreleased]
 
+## [0.7.1] — 2026-05-13
+
+### Added
+
+- **`examples/refactor_demo/`** — planner-executor demo for write-side coherence. Two scripted sub-agents share a task-spec artifact through `CCSStore`; three variants (`--variant=with` / `no-invalidation` / `context-cache`) exercise the protocol against a real TypeScript fixture under `fixture_repo_ts/`. Real `tsc` runs locally turn the coherence question into an on-screen build error (TS2305 in the failure variants, clean build with coherence on). The `disable_invalidation` helper in `examples/refactor_demo/strategies.py` is the canonical pattern for suppressing peer invalidations on a live `CCSStore` — strategy hooks (`invalidates_peers_on_commit`) are consumed only by the simulation engine; the real adapter path publishes invalidations unconditionally. See the module docstring for the full rationale.
+- **`tests/test_refactor_demo.py`** — 10 tests covering all three variants, MESI cache-state assertions, cache-hit/miss event-stream contracts, fresh-store-per-invocation isolation, and end-to-end real-`tsc` invocation (Node-toolchain-gated).
+- **CI Node toolchain** in the `test` job: `actions/setup-node@v4` + `npm ci` inside `examples/refactor_demo/fixture_repo_ts/` so the real-`tsc` end-to-end tests actually run in CI instead of silently skipping. Previously, the `_has_tsc()` gate evaluated False on every CI run because the fixture's `node_modules/` is gitignored and no Node was installed.
+
+### Changed
+
+- **README and `docs/guide.md` vocabulary** — two prose edits replacing anti-list nouns: README "`freshness needs`" → "`how aggressively cached reads should refresh`" (strategy-selection sentence); `docs/guide.md` "`regardless of heartbeat freshness`" → "`regardless of how recently the holder heartbeated`" (`max_hold_ticks` parameter doc).
+- **`pyproject.toml`** — pytest `pythonpath = ["src", "."]` (was `["src"]`) so tests under `tests/` can `from examples.refactor_demo import …`.
+
 ### Removed
 
 - **`ccs-check-release` console script** is no longer exposed as a `pip install` entry point. It was a maintainer-only pre-tag-push verifier that queried this repo's GitHub admin settings (hardcoded `hipvlady/agent-coherence` defaults); end users had no use case. The underlying script (`tools/check_release_readiness.py`) and its module (`ccs.hardening.release_readiness`) remain tracked — CI invokes the script directly during the release workflow preflight, and maintainers run the same path locally.
+
+### Fixed
+
+- **CI preflight branch-protection check** — skips gracefully on 403 in CI when `GITHUB_TOKEN` lacks `administration: read` (a fine-grained PAT scope that isn't available to Actions tokens by design). The check still PASSes/FAILs definitively when run locally via `ccs-check-release` with a properly-scoped PAT. The earlier attempt to grant the permission through `permissions:` was reverted because the permission name does not exist for Actions tokens.
 
 ## [0.7.0] — 2026-05-11
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Protocol safety properties (single-writer, monotonic versioning, crash-recovery 
 
 ## Status
 
-`v0.7` released. See [CHANGELOG.md](CHANGELOG.md) for the version history and [releases](https://github.com/hipvlady/agent-coherence/releases) for tagged artifacts. Alpha — APIs may change before `v1.0`.
+`v0.7.1` released — refactor demo for write-side coherence + CI Node toolchain for real `tsc` validation. See [CHANGELOG.md](CHANGELOG.md) for the version history and [releases](https://github.com/hipvlady/agent-coherence/releases) for tagged artifacts. Alpha — APIs may change before `v1.0`.
 
 ## Paper
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ store = CCSStore(strategy="lazy")
 
 Each shared artifact is cached locally per agent and reads serve from the local cache when that copy is fresh. Writes commit to a coordinator, which sends lightweight invalidation signals (~12 tokens) to peers so the next read fetches the new version instead of rebroadcasting the full artifact. Consistency is single-writer-multiple-reader per artifact with bounded staleness — peers re-fetch on next read.
 
-Five synchronization strategies ship out of the box: `lazy` (default), `eager`, `lease` (TTL-based), `access_count`, and `broadcast`. Pick the one that matches your workload's read/write ratio and freshness needs.
+Five synchronization strategies ship out of the box: `lazy` (default), `eager`, `lease` (TTL-based), `access_count`, and `broadcast`. Pick the one that matches your workload's read/write ratio and how aggressively cached reads should refresh.
 
 ## Architecture
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -343,7 +343,7 @@ The same `crash_recovery=` kwarg works on `LangGraphAdapter`, `CrewAIAdapter`,
 |-------|------|---------|-------------|
 | `enabled` | `bool` | `False` | Master switch. When `False`, `heartbeat()` and `recover()` are silent no-ops; the per-tick sweep does not run. |
 | `heartbeat_timeout_ticks` | `int` | `10` | Reclaim a holder's grant if the gap between `now_tick` and the holder's last heartbeat is `>= heartbeat_timeout_ticks`. |
-| `max_hold_ticks` | `int` | `1000` | Reclaim a holder's grant if it has been continuously held in `MODIFIED`/`EXCLUSIVE` for `>= max_hold_ticks`, regardless of heartbeat freshness. Bound the worst-case lock duration. |
+| `max_hold_ticks` | `int` | `1000` | Reclaim a holder's grant if it has been continuously held in `MODIFIED`/`EXCLUSIVE` for `>= max_hold_ticks`, regardless of how recently the holder heartbeated. Bound the worst-case lock duration. |
 
 **Tick semantics.** Ticks are a logical clock — the unit is whatever `now_tick` your application advances. For LangGraph, one node invocation per tick is a sensible default. For long-running tool calls or LLM calls, advance ticks at the granularity at which you can call `heartbeat()` or expect grants to be released.
 

--- a/examples/refactor_demo/README.md
+++ b/examples/refactor_demo/README.md
@@ -1,0 +1,57 @@
+# refactor-demo
+
+Two scripted sub-agents (planner + executor) collaborate on a shared task
+spec through `CCSStore`. The planner re-plans mid-flight (writes v2 with a
+fourth caller); the executor's behavior depends on whether write-side
+coherence is on. Real `tsc` against a real TypeScript fixture turns the
+correctness question into an on-screen build error.
+
+Companion to the write-side-coherence positioning post (origin:
+`docs/brainstorms/2026-05-12-cocoindex-positioning-coding-agent-wedge-requirements.md`).
+
+## Prerequisites
+
+- Python 3.11+ with `agent-coherence` installed in editable mode (see
+  repo `README.md`).
+- Node.js ≥18 and `npm` for the TypeScript fixture. The TS toolchain is
+  not in CI — `tsc` is invoked locally only.
+
+One-time fixture setup:
+
+    cd examples/refactor_demo/fixture_repo_ts
+    npm install
+    npx tsc --noEmit          # should pass on the as-checked-in fixture
+
+## Run
+
+From the repo root:
+
+    python -m examples.refactor_demo.main                     # --variant=with (default)
+    python -m examples.refactor_demo.main --variant=no-invalidation
+    python -m examples.refactor_demo.main --variant=context-cache
+
+Each run copies the TS fixture to a fresh temp directory, runs the
+LangGraph graph, invokes `npx tsc --noEmit` against the temp copy, and
+prints the result. The source `fixture_repo_ts/` is never mutated.
+
+## Variants
+
+| Variant | Mechanism | What you should see |
+| --- | --- | --- |
+| `with` | Default `CCSStore`, lazy strategy. Executor reads v1 (cache SHARED), planner writes v2 (executor cache INVALID), executor re-reads at commit → fetches v2. | `cache_hit=False` on commit-time get; `committed spec v2`; `tsc: OK` |
+| `no-invalidation` | `disable_invalidation(store)` patches the event bus' `publish_invalidation` to a no-op. Executor cache stays SHARED at v1; commit-time re-read returns cached v1. | `cache_hit=True` on commit-time get; `committed spec v1`; `tsc: FAIL` with `TS2305` on `src/utils/session.ts(4,10)` |
+| `context-cache` | Executor never re-reads from the store. Commits from the v1 spec it captured at read time, mirroring LLM context-window behavior. | Only one executor `get` in the event stream; `committed spec v1`; `tsc: FAIL` with `TS2305` |
+
+The protocol-level proof (the `no-invalidation` variant) is identical to
+the with-coherence path except for a single line of bus suppression —
+`strategies.disable_invalidation(store)`. The application-level
+consequence (`tsc` failure on the missing caller) is the same as
+`context-cache`, which is the audience-facing demo narrative.
+
+## Tests
+
+The behavior is asserted by `tests/test_refactor_demo.py`. Cache-state
+and event-stream assertions cover all three variants; real-`tsc` tests
+are gated on the Node toolchain being present.
+
+    pytest tests/test_refactor_demo.py -v

--- a/examples/refactor_demo/executor.py
+++ b/examples/refactor_demo/executor.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Executor sub-agent (scripted stand-in).
+
+Reads the shared task-spec artifact at the start of its turn (caching it
+in graph state — this is what makes the cache SHARED on the agent-coherence
+side). Then performs the rename against the TypeScript fixture.
+
+Two commit variants:
+
+* ``executor_commit_node`` — the canonical executor: re-reads the spec from
+  ``CCSStore`` at commit time. With write-side coherence, the planner's v2
+  write has invalidated the executor's cache; the re-read fetches v2 and the
+  rename includes all four callers. With invalidation suppressed (the
+  no-invalidation demo variant), the re-read returns the still-SHARED v1
+  from cache and the executor misses the fourth caller.
+* ``executor_commit_node_no_refresh`` — the simulated agent-context-window
+  variant (Unit 3). The executor commits using the v1 it captured at read
+  time and does not consult the store again. This mirrors how real LLM
+  sub-agents naturally behave — context windows ARE caches without
+  invalidation by default. Without coherence, the executor never knows v2
+  exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from langgraph.config import get_store as lg_get_store
+
+from ccs.adapters.ccsstore import CCSStore
+
+from .planner import PLANNER_AGENT, SHARED_SCOPE, TASK_KEY
+
+EXECUTOR_AGENT = "executor"
+
+
+def _apply_rename(spec: dict[str, Any], fixture_root: Path) -> list[str]:
+    """Apply the rename to each caller listed in spec; return the touched files.
+
+    Also renames the symbol's definition in src/auth.ts so the demo produces
+    a real ``tsc`` failure when the spec is missing the fourth caller.
+    """
+    old = spec["rename_from"]
+    new = spec["rename_to"]
+    touched: list[str] = []
+
+    # Rename the definition in auth.ts (the export and the function name).
+    auth_path = fixture_root / "src" / "auth.ts"
+    auth_text = auth_path.read_text()
+    auth_text = auth_text.replace(f"function {old}(", f"function {new}(")
+    auth_path.write_text(auth_text)
+    touched.append("src/auth.ts")
+
+    # Rename call sites in each listed caller.
+    for rel in spec["callers"]:
+        caller_path = fixture_root / rel
+        text = caller_path.read_text()
+        # Update both the import and the call site.
+        text = text.replace(old, new)
+        caller_path.write_text(text)
+        touched.append(rel)
+
+    return touched
+
+
+def executor_read_node(state: dict) -> dict:
+    """Read the spec from the store. Caches the result in graph state.
+
+    This is the read that produces the SHARED MESI state on the executor's
+    side. The cached value carries forward to the commit node — that carry
+    is what the simulated-cache (Unit 3) variant relies on to demonstrate
+    stale-read failure without re-reading.
+    """
+    store: CCSStore = lg_get_store()  # type: ignore[assignment]
+    item = store.get((EXECUTOR_AGENT, SHARED_SCOPE), TASK_KEY)
+    spec = item.value if item is not None else None
+    return {
+        "log": [*state.get("log", []), f"executor: read spec v{spec['version']} (cached)"],
+        "cached_spec": spec,
+    }
+
+
+def executor_commit_node(state: dict) -> dict:
+    """Re-read the spec, then commit the rename against the fixture.
+
+    With write-side coherence, the planner's v2 write between read and
+    commit invalidates the cache; this re-read fetches v2. With invalidation
+    suppressed, this re-read sees the still-SHARED v1 from local cache.
+    """
+    store: CCSStore = lg_get_store()  # type: ignore[assignment]
+    item = store.get((EXECUTOR_AGENT, SHARED_SCOPE), TASK_KEY)
+    spec = item.value if item is not None else None
+    if spec is None:
+        return {"log": [*state.get("log", []), "executor: no spec, no commit"]}
+
+    fixture_root = Path(state["fixture_root"])
+    touched = _apply_rename(spec, fixture_root)
+    return {
+        "log": [
+            *state.get("log", []),
+            f"executor: committed spec v{spec['version']} ({len(touched)} files renamed)",
+        ],
+        "committed_spec_version": spec["version"],
+        "committed_files": touched,
+    }
+
+
+def executor_commit_node_no_refresh(state: dict) -> dict:
+    """Commit using the cached spec from read time. Never re-reads.
+
+    Simulates an LLM agent's context window: the executor "remembers" the
+    spec it saw at the start of its turn and acts on that memory. Without
+    a coherence protocol to update its memory, the executor never sees v2.
+    """
+    spec = state.get("cached_spec")
+    if spec is None:
+        return {"log": [*state.get("log", []), "executor: no cached spec, no commit"]}
+
+    fixture_root = Path(state["fixture_root"])
+    touched = _apply_rename(spec, fixture_root)
+    return {
+        "log": [
+            *state.get("log", []),
+            f"executor (context-cache): committed cached spec v{spec['version']} "
+            f"({len(touched)} files renamed)",
+        ],
+        "committed_spec_version": spec["version"],
+        "committed_files": touched,
+    }

--- a/examples/refactor_demo/executor.py
+++ b/examples/refactor_demo/executor.py
@@ -49,18 +49,22 @@ def _apply_rename(spec: dict[str, Any], fixture_root: Path) -> list[str]:
 
     # Rename the definition in auth.ts (the export and the function name).
     auth_path = fixture_root / "src" / "auth.ts"
-    auth_text = auth_path.read_text()
+    auth_text = auth_path.read_text(encoding="utf-8")
     auth_text = auth_text.replace(f"function {old}(", f"function {new}(")
-    auth_path.write_text(auth_text)
+    auth_path.write_text(auth_text, encoding="utf-8")
     touched.append("src/auth.ts")
 
-    # Rename call sites in each listed caller.
+    # Rename call sites in each listed caller. The bare ``str.replace`` is
+    # safe here because the demo's fixture contains no compound identifiers
+    # like ``validateUserRole`` or string literals embedding the symbol name.
+    # Do not lift this function into a generic refactor tool without an
+    # ast-aware rename; see plan Risks for the credibility note.
     for rel in spec["callers"]:
         caller_path = fixture_root / rel
-        text = caller_path.read_text()
+        text = caller_path.read_text(encoding="utf-8")
         # Update both the import and the call site.
         text = text.replace(old, new)
-        caller_path.write_text(text)
+        caller_path.write_text(text, encoding="utf-8")
         touched.append(rel)
 
     return touched
@@ -77,6 +81,15 @@ def executor_read_node(state: dict) -> dict:
     store: CCSStore = lg_get_store()  # type: ignore[assignment]
     item = store.get((EXECUTOR_AGENT, SHARED_SCOPE), TASK_KEY)
     spec = item.value if item is not None else None
+    if spec is None:
+        # Defensive: in the demo's canonical graph the planner runs before the
+        # executor, so this branch is unreachable. Future graph reorders or
+        # standalone unit tests of this node should still produce a coherent
+        # log line rather than a KeyError on ``spec['version']``.
+        return {
+            "log": [*state.get("log", []), "executor: read returned no spec"],
+            "cached_spec": None,
+        }
     return {
         "log": [*state.get("log", []), f"executor: read spec v{spec['version']} (cached)"],
         "cached_spec": spec,

--- a/examples/refactor_demo/fixture_repo_ts/.gitignore
+++ b/examples/refactor_demo/fixture_repo_ts/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/examples/refactor_demo/fixture_repo_ts/package-lock.json
+++ b/examples/refactor_demo/fixture_repo_ts/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "refactor-demo-fixture",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "refactor-demo-fixture",
+      "version": "0.0.0",
+      "devDependencies": {
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/examples/refactor_demo/fixture_repo_ts/package.json
+++ b/examples/refactor_demo/fixture_repo_ts/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "refactor-demo-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Minimal TypeScript fixture for the agent-coherence planner-executor refactor demo. Not published; used only by examples/refactor_demo/ to exercise real tsc against a real project.",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/refactor_demo/fixture_repo_ts/src/auth.ts
+++ b/examples/refactor_demo/fixture_repo_ts/src/auth.ts
@@ -1,0 +1,14 @@
+// Auth module. Defines the symbol the demo's planner asks the executor to rename.
+// The demo's task spec v1 lists 3 callers; v2 adds a 4th. With write-side coherence,
+// the executor refreshes its cached spec before committing and renames all 4 sites.
+// Without coherence, the executor uses the stale v1 spec and misses caller #4 — the
+// resulting build error is the demo's visible failure.
+
+export interface UserCredentials {
+  email: string;
+  passwordHash: string;
+}
+
+export function validateUser(creds: UserCredentials): boolean {
+  return creds.email.includes("@") && creds.passwordHash.length > 0;
+}

--- a/examples/refactor_demo/fixture_repo_ts/src/handlers/login.ts
+++ b/examples/refactor_demo/fixture_repo_ts/src/handlers/login.ts
@@ -1,0 +1,9 @@
+// Caller 2: login route handler.
+import { validateUser, UserCredentials } from "../auth";
+
+export function handleLogin(creds: UserCredentials): string {
+  if (validateUser(creds)) {
+    return "ok";
+  }
+  return "denied";
+}

--- a/examples/refactor_demo/fixture_repo_ts/src/handlers/refresh.ts
+++ b/examples/refactor_demo/fixture_repo_ts/src/handlers/refresh.ts
@@ -1,0 +1,6 @@
+// Caller 3: refresh-token route handler.
+import { validateUser, UserCredentials } from "../auth";
+
+export function handleRefresh(creds: UserCredentials): boolean {
+  return validateUser(creds);
+}

--- a/examples/refactor_demo/fixture_repo_ts/src/middleware.ts
+++ b/examples/refactor_demo/fixture_repo_ts/src/middleware.ts
@@ -1,0 +1,8 @@
+// Caller 1: request-middleware path.
+import { validateUser, UserCredentials } from "./auth";
+
+export function authMiddleware(creds: UserCredentials): void {
+  if (!validateUser(creds)) {
+    throw new Error("unauthenticated");
+  }
+}

--- a/examples/refactor_demo/fixture_repo_ts/src/utils/session.ts
+++ b/examples/refactor_demo/fixture_repo_ts/src/utils/session.ts
@@ -1,0 +1,8 @@
+// Caller 4: session-utility module. This is the caller the planner's v1 spec
+// misses. Without write-side coherence, the executor stays on v1, renames the
+// other three call sites, and leaves this file referencing the deleted symbol.
+import { validateUser, UserCredentials } from "../auth";
+
+export function isSessionValid(creds: UserCredentials): boolean {
+  return validateUser(creds);
+}

--- a/examples/refactor_demo/fixture_repo_ts/tsconfig.json
+++ b/examples/refactor_demo/fixture_repo_ts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "noImplicitAny": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/refactor_demo/main.py
+++ b/examples/refactor_demo/main.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Planner-executor refactor demo for write-side coherence.
+
+Four-node ``StateGraph``:
+
+    planner_v1 -> executor_read -> planner_v2 -> executor_commit
+
+Three variants:
+
+* ``with`` (default) — write-side coherence on. The planner's v2 write
+  invalidates the executor's cached read; the executor's commit-time
+  re-read fetches v2 and renames all four caller files. ``tsc`` passes.
+* ``no-invalidation`` — same graph, same store, peer invalidation
+  suppressed via ``strategies.disable_invalidation``. The executor's
+  commit-time re-read returns the still-SHARED v1; the four-caller rename
+  misses ``src/utils/session.ts``. ``tsc`` fails with TS2305.
+* ``context-cache`` — simulated LLM context-window cache (Unit 3 of the
+  plan). The executor commits from the spec it captured at read time and
+  never re-consults the store. Without write-side coherence to refresh
+  the cached value, the executor uses v1 and misses the fourth caller.
+
+The fixture under ``examples/refactor_demo/fixture_repo_ts`` is copied to
+a temp working directory before the graph runs, so the source tree is
+never mutated. ``npx tsc --noEmit`` runs against the temp copy after the
+graph completes.
+
+Run
+---
+    python -m examples.refactor_demo.main                       # --variant=with
+    python -m examples.refactor_demo.main --variant=no-invalidation
+    python -m examples.refactor_demo.main --variant=context-cache
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, TypedDict
+
+from langgraph.graph import END, START, StateGraph
+
+from ccs.adapters.ccsstore import CCSStore, StoreMetricEvent
+
+from .executor import (
+    executor_commit_node,
+    executor_commit_node_no_refresh,
+    executor_read_node,
+)
+from .planner import planner_v1_node, planner_v2_node
+from .strategies import disable_invalidation
+
+
+class GraphState(TypedDict, total=False):
+    log: list[str]
+    fixture_root: str
+    cached_spec: dict[str, Any] | None
+    committed_spec_version: int
+    committed_files: list[str]
+
+FIXTURE_REPO_TS = Path(__file__).parent / "fixture_repo_ts"
+
+
+# ---------------------------------------------------------------------------
+# Graph construction
+# ---------------------------------------------------------------------------
+
+
+def build_graph(store: CCSStore) -> Any:
+    """Standard four-node graph with refresh-on-commit at the executor."""
+    builder = StateGraph(GraphState)
+    builder.add_node("planner_v1", planner_v1_node)
+    builder.add_node("executor_read", executor_read_node)
+    builder.add_node("planner_v2", planner_v2_node)
+    builder.add_node("executor_commit", executor_commit_node)
+
+    builder.add_edge(START, "planner_v1")
+    builder.add_edge("planner_v1", "executor_read")
+    builder.add_edge("executor_read", "planner_v2")
+    builder.add_edge("planner_v2", "executor_commit")
+    builder.add_edge("executor_commit", END)
+
+    return builder.compile(store=store)
+
+
+def build_graph_context_cache(store: CCSStore) -> Any:
+    """Four-node graph where the executor commits from cached state, not from re-read.
+
+    Simulates an LLM agent context window. Used by ``--variant=context-cache``.
+    """
+    builder = StateGraph(GraphState)
+    builder.add_node("planner_v1", planner_v1_node)
+    builder.add_node("executor_read", executor_read_node)
+    builder.add_node("planner_v2", planner_v2_node)
+    builder.add_node("executor_commit", executor_commit_node_no_refresh)
+
+    builder.add_edge(START, "planner_v1")
+    builder.add_edge("planner_v1", "executor_read")
+    builder.add_edge("executor_read", "planner_v2")
+    builder.add_edge("planner_v2", "executor_commit")
+    builder.add_edge("executor_commit", END)
+
+    return builder.compile(store=store)
+
+
+# ---------------------------------------------------------------------------
+# Inline event printing (Unit 3)
+# ---------------------------------------------------------------------------
+
+
+def format_event(event: StoreMetricEvent) -> None:
+    """Print a single store event to stdout, one line per event.
+
+    Format kept boring on purpose: terminal-readable, no color codes.
+    The recording setup (Unit 4) decides on color and width.
+    """
+    marker = "HIT " if event.cache_hit else "MISS"
+    print(
+        f"[t+{event.tick:>3}] [{marker}] op={event.operation:<5} "
+        f"agent={event.agent_name:<8} key={event.key}",
+        flush=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixture handling
+# ---------------------------------------------------------------------------
+
+
+def setup_temp_fixture() -> Path:
+    """Copy the TS fixture to a tmp working dir so the source tree is never mutated."""
+    work_dir = Path(tempfile.mkdtemp(prefix="refactor_demo_"))
+    dest = work_dir / "fixture_repo_ts"
+    # Skip node_modules in the copy; symlink it after for tsc invocation.
+    shutil.copytree(
+        FIXTURE_REPO_TS,
+        dest,
+        ignore=shutil.ignore_patterns("node_modules", "dist", "*.tsbuildinfo"),
+    )
+    src_modules = FIXTURE_REPO_TS / "node_modules"
+    if src_modules.exists():
+        (dest / "node_modules").symlink_to(src_modules)
+    return dest
+
+
+def run_tsc(fixture_root: Path) -> tuple[int, str]:
+    """Run ``npx tsc --noEmit`` against the fixture root. Returns (rc, output)."""
+    proc = subprocess.run(
+        ["npx", "tsc", "--noEmit"],
+        cwd=fixture_root,
+        capture_output=True,
+        text=True,
+    )
+    output = (proc.stdout + proc.stderr).strip()
+    return proc.returncode, output
+
+
+# ---------------------------------------------------------------------------
+# Variant entry
+# ---------------------------------------------------------------------------
+
+
+def run(variant: str = "with") -> int:
+    """Execute one demo variant end-to-end. Returns the tsc exit code (0 = OK)."""
+    if variant not in ("with", "no-invalidation", "context-cache"):
+        raise ValueError(f"unknown variant {variant!r}")
+
+    fixture_root = setup_temp_fixture()
+    try:
+        store = CCSStore(strategy="lazy", on_metric=format_event)
+        if variant == "no-invalidation":
+            disable_invalidation(store)
+
+        if variant == "context-cache":
+            graph = build_graph_context_cache(store)
+        else:
+            graph = build_graph(store)
+
+        initial_state = {"log": [], "fixture_root": str(fixture_root), "cached_spec": None}
+        final_state = graph.invoke(initial_state)
+
+        print()
+        print(f"--- variant: {variant} ---")
+        for line in final_state.get("log", []):
+            print(line)
+        committed_version = final_state.get("committed_spec_version")
+        print(f"executor committed spec v{committed_version}")
+
+        rc, output = run_tsc(fixture_root)
+        if rc == 0:
+            print("tsc: OK")
+        else:
+            print(f"tsc: FAIL (exit {rc})")
+            print(output)
+
+        return rc
+    finally:
+        shutil.rmtree(fixture_root.parent, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Refactor demo: write-side coherence vs without.")
+    parser.add_argument(
+        "--variant",
+        choices=("with", "no-invalidation", "context-cache"),
+        default="with",
+        help="Demo variant. Default: with (write-side coherence on).",
+    )
+    args = parser.parse_args(argv)
+    return run(variant=args.variant)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/refactor_demo/main.py
+++ b/examples/refactor_demo/main.py
@@ -133,23 +133,42 @@ def format_event(event: StoreMetricEvent) -> None:
 
 
 def setup_temp_fixture() -> Path:
-    """Copy the TS fixture to a tmp working dir so the source tree is never mutated."""
+    """Copy the TS fixture to a tmp working dir so the source tree is never mutated.
+
+    Cleans up the tmp dir on any failure during setup, so we don't leak partial
+    copies if shutil.copytree or the symlink call raises.
+    """
     work_dir = Path(tempfile.mkdtemp(prefix="refactor_demo_"))
     dest = work_dir / "fixture_repo_ts"
-    # Skip node_modules in the copy; symlink it after for tsc invocation.
-    shutil.copytree(
-        FIXTURE_REPO_TS,
-        dest,
-        ignore=shutil.ignore_patterns("node_modules", "dist", "*.tsbuildinfo"),
-    )
-    src_modules = FIXTURE_REPO_TS / "node_modules"
-    if src_modules.exists():
-        (dest / "node_modules").symlink_to(src_modules)
+    try:
+        # Skip node_modules in the copy; symlink it after for tsc invocation.
+        shutil.copytree(
+            FIXTURE_REPO_TS,
+            dest,
+            ignore=shutil.ignore_patterns("node_modules", "dist", "*.tsbuildinfo"),
+        )
+        src_modules = FIXTURE_REPO_TS / "node_modules"
+        if src_modules.exists():
+            (dest / "node_modules").symlink_to(src_modules)
+    except Exception:
+        shutil.rmtree(work_dir, ignore_errors=True)
+        raise
     return dest
 
 
 def run_tsc(fixture_root: Path) -> tuple[int, str]:
-    """Run ``npx tsc --noEmit`` against the fixture root. Returns (rc, output)."""
+    """Run ``npx tsc --noEmit`` against the fixture root. Returns (rc, output).
+
+    Returns ``(127, message)`` when the Node toolchain is missing rather than
+    letting ``FileNotFoundError`` propagate as a raw traceback — the demo's
+    expected failure mode for an unprepared environment should be legible.
+    """
+    if shutil.which("npx") is None:
+        return (
+            127,
+            "npx not found on PATH. The refactor demo needs Node.js >=18 and a "
+            "one-time `npm install` inside examples/refactor_demo/fixture_repo_ts/.",
+        )
     proc = subprocess.run(
         ["npx", "tsc", "--noEmit"],
         cwd=fixture_root,
@@ -204,12 +223,37 @@ def run(variant: str = "with") -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Refactor demo: write-side coherence vs without.")
+    parser = argparse.ArgumentParser(
+        prog="examples.refactor_demo.main",
+        description=(
+            "Refactor demo: two scripted sub-agents (planner + executor) collaborate on "
+            "a shared task-spec artifact through CCSStore, then real tsc runs against a "
+            "real TypeScript fixture. Three variants illustrate write-side coherence."
+        ),
+        epilog=(
+            "EXIT CODES:\n"
+            "  0   --variant=with: write-side coherence prevented the stale read; tsc passed.\n"
+            "  >0  --variant=no-invalidation or --variant=context-cache: stale spec produced "
+            "a real tsc failure (typically TS2305). This is the demo's INTENDED outcome and is "
+            "not an error.\n"
+            "  127 npx not on PATH. Install Node >=18 and run `npm install` inside "
+            "examples/refactor_demo/fixture_repo_ts/.\n"
+            "\n"
+            "PREREQUISITES: Node >=18, npm. The fixture's node_modules is gitignored; run "
+            "`npm install` once locally before invoking the demo or its tests."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument(
         "--variant",
         choices=("with", "no-invalidation", "context-cache"),
         default="with",
-        help="Demo variant. Default: with (write-side coherence on).",
+        help=(
+            "Demo variant. Default: with (write-side coherence on; tsc passes). "
+            "no-invalidation: protocol-level proof — same store, event bus patched, "
+            "stale v1 wins, tsc fails. context-cache: simulated LLM context-window cache, "
+            "stale v1 wins, tsc fails."
+        ),
     )
     args = parser.parse_args(argv)
     return run(variant=args.variant)

--- a/examples/refactor_demo/planner.py
+++ b/examples/refactor_demo/planner.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Planner sub-agent (scripted stand-in).
+
+Writes a task-spec artifact in two versions. v1 lists three callers of
+``validateUser``. v2 adds the fourth caller the planner "discovered"
+mid-flight. The point of the demo is what happens to the executor's view
+of this artifact between the two writes.
+
+The two ``planner_v*_node`` functions are nodes in the demo's
+``StateGraph``. They access the shared ``CCSStore`` via
+``langgraph.config.get_store`` inside the node body — the canonical
+LangGraph idiom (see ``examples/langgraph_planner/main.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph.config import get_store as lg_get_store
+
+from ccs.adapters.ccsstore import CCSStore
+
+PLANNER_AGENT = "planner"
+SHARED_SCOPE = "shared"
+TASK_KEY = "task"
+
+# v1 task spec — three of the four callers in fixture_repo_ts.
+TASK_SPEC_V1: dict[str, Any] = {
+    "version": 1,
+    "rename_from": "validateUser",
+    "rename_to": "authenticateUser",
+    "callers": [
+        "src/middleware.ts",
+        "src/handlers/login.ts",
+        "src/handlers/refresh.ts",
+    ],
+}
+
+# v2 task spec — the planner "discovers" the fourth caller mid-flight.
+TASK_SPEC_V2: dict[str, Any] = {
+    "version": 2,
+    "rename_from": "validateUser",
+    "rename_to": "authenticateUser",
+    "callers": [
+        "src/middleware.ts",
+        "src/handlers/login.ts",
+        "src/handlers/refresh.ts",
+        "src/utils/session.ts",
+    ],
+}
+
+
+def planner_v1_node(state: dict) -> dict:
+    """Write the v1 task spec to the shared artifact."""
+    store: CCSStore = lg_get_store()  # type: ignore[assignment]
+    store.put((PLANNER_AGENT, SHARED_SCOPE), TASK_KEY, TASK_SPEC_V1)
+    return {"log": [*state.get("log", []), "planner: wrote spec v1 (3 callers)"]}
+
+
+def planner_v2_node(state: dict) -> dict:
+    """Write the v2 task spec — planner re-plans mid-flight with the 4th caller."""
+    store: CCSStore = lg_get_store()  # type: ignore[assignment]
+    store.put((PLANNER_AGENT, SHARED_SCOPE), TASK_KEY, TASK_SPEC_V2)
+    return {"log": [*state.get("log", []), "planner: wrote spec v2 (4 callers)"]}

--- a/examples/refactor_demo/strategies.py
+++ b/examples/refactor_demo/strategies.py
@@ -6,86 +6,62 @@
 Used by the blog's protocol-level proof paragraph and by the
 ``--variant=no-invalidation`` mode of ``examples.refactor_demo.main``.
 
-Background — why this isn't a SyncStrategy subclass
+Why this is a function, not a SyncStrategy subclass
 ----------------------------------------------------
 The plan originally specified a ``NoInvalidationStrategy`` subclass of
 ``ccs.strategies.base.SyncStrategy``. While that's a clean object-shape, the
 ``SyncStrategy.invalidates_peers_on_commit()`` hook is only consumed by
 ``ccs.simulation.engine`` — the actual ``CCSStore`` path
-(``src/ccs/adapters/base.py:126-160``) publishes invalidations
-unconditionally. A strategy subclass therefore cannot suppress invalidations
-on the real adapter path.
+(``src/ccs/adapters/base.py:126-160``) and ``CCSStore._apply_delete``
+publish invalidations unconditionally. A strategy subclass therefore cannot
+suppress invalidations on the real adapter path, and registering one via
+``CCSStore(strategy='no-invalidation')`` would fail anyway because
+``ccs.strategies.selector.build_strategy`` has no case for it.
 
 The cleanest mechanism that actually works against ``CCSStore`` is to
 override the event bus' ``publish_invalidation`` to a no-op after the store
 is constructed. That's what ``disable_invalidation`` does.
 
-If the protocol later routes invalidation publishing through a strategy
-method, the ``NoInvalidationStrategy`` class below becomes the natural
-hook. Until then it is a forward-compatible placeholder kept here for the
-blog post to reference; the operative function is ``disable_invalidation``.
+If the protocol ever routes invalidation publishing through a strategy
+method, this module is the natural place to add a real subclass. For now,
+keeping a dead-code "forward-compatible placeholder" subclass would only
+mislead readers, so we don't.
 """
 
 from __future__ import annotations
 
 from typing import Any
-from uuid import UUID
 
 from ccs.adapters.ccsstore import CCSStore
-from ccs.core.states import MESIState
-from ccs.core.types import ArtifactCacheEntry, InvalidationSignal
-from ccs.strategies.base import SyncStrategy
-
-
-class NoInvalidationStrategy(SyncStrategy):
-    """Strategy that declares it does not invalidate peers on commit.
-
-    Forward-compatible placeholder. As of the current ``CCSStore``
-    implementation this hook does NOT actually suppress invalidations
-    on the real adapter path — that's gated by the event bus, not the
-    strategy. Use ``disable_invalidation(store)`` for the working
-    suppression mechanism.
-
-    Behavior contract identical to ``LazyStrategy`` except for the hook.
-    """
-
-    name = "no-invalidation"
-
-    def invalidates_peers_on_commit(self) -> bool:
-        return False
-
-    def requires_refresh(self, entry: ArtifactCacheEntry, *, now_tick: int) -> bool:
-        del now_tick
-        return entry.state == MESIState.INVALID
-
-    def on_read(self, entry: ArtifactCacheEntry, *, now_tick: int) -> ArtifactCacheEntry:
-        del now_tick
-        return self._touch(entry)
-
-    def on_fetch(
-        self,
-        *,
-        artifact_id: UUID,
-        version: int,
-        state: MESIState,
-        now_tick: int,
-    ) -> ArtifactCacheEntry:
-        return self._new_entry(artifact_id=artifact_id, version=version, state=state, now_tick=now_tick)
+from ccs.core.types import InvalidationSignal
 
 
 def disable_invalidation(store: CCSStore) -> None:
     """Suppress peer-invalidation publication on a CCSStore.
 
-    Replaces the event bus' ``publish_invalidation`` with a no-op so that
-    a writer's commit never marks any peer's cache as INVALID. Peers' caches
+    Replaces the event bus' ``publish_invalidation`` with a no-op so that a
+    writer's commit never marks any peer's cache as INVALID. Peers' caches
     therefore stay SHARED at the version they last read, and subsequent
     reads from the same agent return the stale cached value.
 
     This is the demo's protocol-level proof of why write-side coherence
-    matters: with invalidations suppressed, the planner's v2 write does
-    not reach the executor's cache, the executor's commit-time re-read
-    returns the SHARED v1 from cache, and the four-caller rename misses
+    matters: with invalidations suppressed, the planner's v2 write does not
+    reach the executor's cache, the executor's commit-time re-read returns
+    the SHARED v1 from cache, and the four-caller rename misses
     ``src/utils/session.ts`` — producing a real ``tsc`` failure.
+
+    Scope note: ``CCSStore`` also calls ``publish_invalidation`` from
+    ``_apply_delete`` (``ccsstore.py:306``), so this patch suppresses
+    invalidation signaling for deletes as well as writes. The demo never
+    deletes, so that's incidental — but a future demo that adds a delete
+    step under ``--variant=no-invalidation`` will see the same suppression.
+
+    Irreversibility: there is no ``enable_invalidation`` counterpart. Once
+    applied, the store stays patched for its lifetime. The demo's
+    orchestrator (``main.run``) creates a fresh ``CCSStore`` per call, so
+    this is safe in context. Code that reuses a patched store across
+    multiple graph invocations must construct a new store to get coherent
+    behavior back — there is no in-place restore.
 
     Mutates ``store`` in place. Apply once, before invoking the graph.
     """

--- a/examples/refactor_demo/strategies.py
+++ b/examples/refactor_demo/strategies.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Demo variant: CCSStore with peer invalidation suppressed.
+
+Used by the blog's protocol-level proof paragraph and by the
+``--variant=no-invalidation`` mode of ``examples.refactor_demo.main``.
+
+Background — why this isn't a SyncStrategy subclass
+----------------------------------------------------
+The plan originally specified a ``NoInvalidationStrategy`` subclass of
+``ccs.strategies.base.SyncStrategy``. While that's a clean object-shape, the
+``SyncStrategy.invalidates_peers_on_commit()`` hook is only consumed by
+``ccs.simulation.engine`` — the actual ``CCSStore`` path
+(``src/ccs/adapters/base.py:126-160``) publishes invalidations
+unconditionally. A strategy subclass therefore cannot suppress invalidations
+on the real adapter path.
+
+The cleanest mechanism that actually works against ``CCSStore`` is to
+override the event bus' ``publish_invalidation`` to a no-op after the store
+is constructed. That's what ``disable_invalidation`` does.
+
+If the protocol later routes invalidation publishing through a strategy
+method, the ``NoInvalidationStrategy`` class below becomes the natural
+hook. Until then it is a forward-compatible placeholder kept here for the
+blog post to reference; the operative function is ``disable_invalidation``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from ccs.adapters.ccsstore import CCSStore
+from ccs.core.states import MESIState
+from ccs.core.types import ArtifactCacheEntry, InvalidationSignal
+from ccs.strategies.base import SyncStrategy
+
+
+class NoInvalidationStrategy(SyncStrategy):
+    """Strategy that declares it does not invalidate peers on commit.
+
+    Forward-compatible placeholder. As of the current ``CCSStore``
+    implementation this hook does NOT actually suppress invalidations
+    on the real adapter path — that's gated by the event bus, not the
+    strategy. Use ``disable_invalidation(store)`` for the working
+    suppression mechanism.
+
+    Behavior contract identical to ``LazyStrategy`` except for the hook.
+    """
+
+    name = "no-invalidation"
+
+    def invalidates_peers_on_commit(self) -> bool:
+        return False
+
+    def requires_refresh(self, entry: ArtifactCacheEntry, *, now_tick: int) -> bool:
+        del now_tick
+        return entry.state == MESIState.INVALID
+
+    def on_read(self, entry: ArtifactCacheEntry, *, now_tick: int) -> ArtifactCacheEntry:
+        del now_tick
+        return self._touch(entry)
+
+    def on_fetch(
+        self,
+        *,
+        artifact_id: UUID,
+        version: int,
+        state: MESIState,
+        now_tick: int,
+    ) -> ArtifactCacheEntry:
+        return self._new_entry(artifact_id=artifact_id, version=version, state=state, now_tick=now_tick)
+
+
+def disable_invalidation(store: CCSStore) -> None:
+    """Suppress peer-invalidation publication on a CCSStore.
+
+    Replaces the event bus' ``publish_invalidation`` with a no-op so that
+    a writer's commit never marks any peer's cache as INVALID. Peers' caches
+    therefore stay SHARED at the version they last read, and subsequent
+    reads from the same agent return the stale cached value.
+
+    This is the demo's protocol-level proof of why write-side coherence
+    matters: with invalidations suppressed, the planner's v2 write does
+    not reach the executor's cache, the executor's commit-time re-read
+    returns the SHARED v1 from cache, and the four-caller rename misses
+    ``src/utils/session.ts`` — producing a real ``tsc`` failure.
+
+    Mutates ``store`` in place. Apply once, before invoking the graph.
+    """
+
+    def _noop_publish_invalidation(
+        signal: InvalidationSignal,
+        *,
+        recipients: Any,
+    ) -> int:
+        del signal, recipients
+        return 0
+
+    store.core.event_bus.publish_invalidation = _noop_publish_invalidation  # type: ignore[assignment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,12 @@ all = ["agent-coherence[langgraph,crewai,otel,langsmith,benchmark,diagnose]"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["src"]
+pythonpath = ["src", "."]
+# ``src`` makes the ccs package importable. ``.`` adds the repo root so tests
+# under ``tests/`` can ``from examples.refactor_demo import ...`` for the
+# refactor demo test suite. Test files must not live under any directory
+# whose name shadows a top-level package — for example, do NOT create
+# ``tests/examples/`` (would shadow the real ``examples/`` package).
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/src/ccs/__init__.py
+++ b/src/ccs/__init__.py
@@ -3,4 +3,4 @@
 
 """agent-coherence core package."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/tests/test_refactor_demo.py
+++ b/tests/test_refactor_demo.py
@@ -22,19 +22,14 @@ from __future__ import annotations
 
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 from uuid import NAMESPACE_URL, uuid5
 
-# The ``examples/`` tree is not on pytest's pythonpath (pyproject sets
-# ``pythonpath = ["src", "."]`` but pytest's import-context for tests doesn't
-# seem to honor "." for namespace-style discovery of ``examples``). Prepending
-# the repo root here is the most local fix and only affects this test module.
-_REPO_ROOT = str(Path(__file__).resolve().parents[2])
-if _REPO_ROOT not in sys.path:
-    sys.path.insert(0, _REPO_ROOT)
-
 import pytest
+
+# ``examples.refactor_demo`` is resolved via pyproject's
+# ``[tool.pytest.ini_options] pythonpath = ["src", "."]``. No per-file
+# sys.path manipulation is needed; do not reintroduce one here.
 
 # Skip the whole module if langgraph isn't installed (e.g. bare [dev] install).
 pytest.importorskip("langgraph.graph")
@@ -78,8 +73,10 @@ def test_with_coherence_executor_commit_refetches_v2() -> None:
         final = graph.invoke({"log": [], "fixture_root": str(fixture_root), "cached_spec": None})
 
         assert final["committed_spec_version"] == 2
-        # Two callers stay (from v1: middleware, login, refresh) + utils/session.ts (v2's addition) + auth.ts
+        # 3 v1 callers (middleware, login, refresh) + utils/session.ts (v2 addition) + auth.ts = 5
         assert len(final["committed_files"]) == 5
+        # Identity check, not just count: the 4th caller must be in the rename set with-coherence.
+        assert "src/utils/session.ts" in final["committed_files"]
 
         # The executor's commit-time get is a cache miss (cache was INVALID after planner v2).
         executor_gets = [e for e in events if e.operation == "get" and e.agent_name == EXECUTOR_AGENT]
@@ -134,6 +131,8 @@ def test_no_invalidation_executor_commits_stale_v1() -> None:
         assert final["committed_spec_version"] == 1
         # 3 callers from v1 + auth.ts = 4 files (utils/session.ts is missed).
         assert len(final["committed_files"]) == 4
+        # Identity check: utils/session.ts must NOT be in the rename set when v1 wins.
+        assert "src/utils/session.ts" not in final["committed_files"]
 
         # The commit-time re-read is a cache HIT because the bus was patched.
         executor_gets = [e for e in events if e.operation == "get" and e.agent_name == EXECUTOR_AGENT]
@@ -181,6 +180,8 @@ def test_context_cache_executor_commits_from_graph_state() -> None:
 
         assert final["committed_spec_version"] == 1
         assert len(final["committed_files"]) == 4
+        # Identity check: utils/session.ts must NOT be in the rename set when v1 wins.
+        assert "src/utils/session.ts" not in final["committed_files"]
 
         # Executor only does ONE get (executor_read_node). No commit-time re-read.
         executor_gets = [e for e in events if e.operation == "get" and e.agent_name == EXECUTOR_AGENT]

--- a/tests/test_refactor_demo.py
+++ b/tests/test_refactor_demo.py
@@ -1,0 +1,292 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for the planner-executor refactor demo.
+
+The demo lives under ``examples/refactor_demo/`` and is the protocol-level
+proof asset for the write-side coherence positioning (see
+``docs/plans/2026-05-12-001-feat-cocoindex-positioning-coding-agent-wedge-plan.md``).
+
+These tests verify three orthogonal failure-prevention paths:
+
+* with-coherence: planner's v2 write invalidates the executor's cache;
+  the commit-time re-read fetches v2 and the rename includes all 4 callers.
+* no-invalidation: same graph, but ``disable_invalidation`` patches the
+  event bus' ``publish_invalidation`` to a no-op; the executor's commit-time
+  re-read returns the still-SHARED v1 and misses the 4th caller.
+* context-cache: simulated LLM context-window cache — the executor commits
+  using the spec captured at read time and never re-reads.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from uuid import NAMESPACE_URL, uuid5
+
+# The ``examples/`` tree is not on pytest's pythonpath (pyproject sets
+# ``pythonpath = ["src", "."]`` but pytest's import-context for tests doesn't
+# seem to honor "." for namespace-style discovery of ``examples``). Prepending
+# the repo root here is the most local fix and only affects this test module.
+_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import pytest
+
+# Skip the whole module if langgraph isn't installed (e.g. bare [dev] install).
+pytest.importorskip("langgraph.graph")
+
+from ccs.adapters.ccsstore import CCSStore, StoreMetricEvent
+from ccs.core.states import MESIState
+
+from examples.refactor_demo.executor import EXECUTOR_AGENT
+from examples.refactor_demo.main import (
+    FIXTURE_REPO_TS,
+    build_graph,
+    build_graph_context_cache,
+    run_tsc,
+    setup_temp_fixture,
+)
+from examples.refactor_demo.planner import (
+    PLANNER_AGENT,
+    SHARED_SCOPE,
+    TASK_KEY,
+    TASK_SPEC_V2,
+)
+from examples.refactor_demo.strategies import disable_invalidation
+
+
+def _has_tsc() -> bool:
+    return shutil.which("npx") is not None and (FIXTURE_REPO_TS / "node_modules").exists()
+
+
+# ---------------------------------------------------------------------------
+# Variant: with-coherence (default)
+# ---------------------------------------------------------------------------
+
+
+def test_with_coherence_executor_commit_refetches_v2() -> None:
+    """Executor's commit-time re-read returns v2 after planner's invalidating v2 write."""
+    events: list[StoreMetricEvent] = []
+    store = CCSStore(strategy="lazy", on_metric=events.append)
+    fixture_root = setup_temp_fixture()
+    try:
+        graph = build_graph(store)
+        final = graph.invoke({"log": [], "fixture_root": str(fixture_root), "cached_spec": None})
+
+        assert final["committed_spec_version"] == 2
+        # Two callers stay (from v1: middleware, login, refresh) + utils/session.ts (v2's addition) + auth.ts
+        assert len(final["committed_files"]) == 5
+
+        # The executor's commit-time get is a cache miss (cache was INVALID after planner v2).
+        executor_gets = [e for e in events if e.operation == "get" and e.agent_name == EXECUTOR_AGENT]
+        assert len(executor_gets) == 2, f"expected 2 executor gets, saw {len(executor_gets)}"
+        assert executor_gets[0].cache_hit is False, "first read (executor_read_node) should be cache miss"
+        assert executor_gets[1].cache_hit is False, "commit-time re-read should be cache miss after invalidation"
+    finally:
+        shutil.rmtree(fixture_root.parent, ignore_errors=True)
+
+
+def test_with_coherence_executor_mesi_state_invalidates_between_reads() -> None:
+    """Executor's MESI state ends SHARED; the cached content view is the refreshed v2."""
+    store = CCSStore(strategy="lazy")
+    fixture_root = setup_temp_fixture()
+    try:
+        graph = build_graph(store)
+        artifact_id = uuid5(NAMESPACE_URL, f"ccs-artifact:{SHARED_SCOPE}:{TASK_KEY}")
+
+        graph.invoke({"log": [], "fixture_root": str(fixture_root), "cached_spec": None})
+
+        executor_entry = store.core.runtime(EXECUTOR_AGENT).cache.get(artifact_id)
+        assert executor_entry is not None
+        # Cache transitioned SHARED -> INVALID -> SHARED; final state is SHARED.
+        # The exact ``local_version`` number is coordinator-internal; what matters
+        # is what the executor's content view actually is.
+        assert executor_entry.state == MESIState.SHARED
+
+        # Authoritative content view: planner's most recent write was v2.
+        item = store.get((EXECUTOR_AGENT, SHARED_SCOPE), TASK_KEY)
+        assert item is not None
+        assert item.value["version"] == 2
+    finally:
+        shutil.rmtree(fixture_root.parent, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Variant: no-invalidation (blog protocol-level proof)
+# ---------------------------------------------------------------------------
+
+
+def test_no_invalidation_executor_commits_stale_v1() -> None:
+    """With invalidation suppressed, executor's commit-time re-read returns cached v1."""
+    events: list[StoreMetricEvent] = []
+    store = CCSStore(strategy="lazy", on_metric=events.append)
+    disable_invalidation(store)
+    fixture_root = setup_temp_fixture()
+    try:
+        graph = build_graph(store)
+        final = graph.invoke({"log": [], "fixture_root": str(fixture_root), "cached_spec": None})
+
+        # Executor commits v1 — the spec it cached at read time and that was never invalidated.
+        assert final["committed_spec_version"] == 1
+        # 3 callers from v1 + auth.ts = 4 files (utils/session.ts is missed).
+        assert len(final["committed_files"]) == 4
+
+        # The commit-time re-read is a cache HIT because the bus was patched.
+        executor_gets = [e for e in events if e.operation == "get" and e.agent_name == EXECUTOR_AGENT]
+        assert len(executor_gets) == 2
+        assert executor_gets[0].cache_hit is False, "first read is always a miss"
+        assert executor_gets[1].cache_hit is True, "commit re-read should be a cache hit (no invalidation)"
+    finally:
+        shutil.rmtree(fixture_root.parent, ignore_errors=True)
+
+
+def test_no_invalidation_keeps_executor_mesi_state_shared() -> None:
+    """With invalidation suppressed, executor's cache stays SHARED across planner's v2 write."""
+    store = CCSStore(strategy="lazy")
+    disable_invalidation(store)
+    fixture_root = setup_temp_fixture()
+    try:
+        graph = build_graph(store)
+        artifact_id = uuid5(NAMESPACE_URL, f"ccs-artifact:{SHARED_SCOPE}:{TASK_KEY}")
+
+        graph.invoke({"log": [], "fixture_root": str(fixture_root), "cached_spec": None})
+
+        executor_entry = store.core.runtime(EXECUTOR_AGENT).cache.get(artifact_id)
+        assert executor_entry is not None
+        # State never flipped to INVALID because publish_invalidation is patched.
+        # The application-level proof — that executor committed v1, missing the 4th
+        # caller — is covered by test_no_invalidation_executor_commits_stale_v1.
+        assert executor_entry.state == MESIState.SHARED, "without invalidation, peer stays SHARED"
+    finally:
+        shutil.rmtree(fixture_root.parent, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Variant: context-cache (Unit 3)
+# ---------------------------------------------------------------------------
+
+
+def test_context_cache_executor_commits_from_graph_state() -> None:
+    """Context-cache variant: executor never re-reads; commits cached v1 from state."""
+    events: list[StoreMetricEvent] = []
+    store = CCSStore(strategy="lazy", on_metric=events.append)
+    fixture_root = setup_temp_fixture()
+    try:
+        graph = build_graph_context_cache(store)
+        final = graph.invoke({"log": [], "fixture_root": str(fixture_root), "cached_spec": None})
+
+        assert final["committed_spec_version"] == 1
+        assert len(final["committed_files"]) == 4
+
+        # Executor only does ONE get (executor_read_node). No commit-time re-read.
+        executor_gets = [e for e in events if e.operation == "get" and e.agent_name == EXECUTOR_AGENT]
+        assert len(executor_gets) == 1, "context-cache variant must not re-read at commit"
+    finally:
+        shutil.rmtree(fixture_root.parent, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Cross-variant: clean state between invocations
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_store_per_invocation_has_no_state_bleed() -> None:
+    """Running two variants back-to-back with separate stores must not bleed state."""
+    fixture_root_1 = setup_temp_fixture()
+    fixture_root_2 = setup_temp_fixture()
+    try:
+        store_1 = CCSStore(strategy="lazy")
+        disable_invalidation(store_1)
+        graph_1 = build_graph(store_1)
+        final_1 = graph_1.invoke({"log": [], "fixture_root": str(fixture_root_1), "cached_spec": None})
+
+        store_2 = CCSStore(strategy="lazy")  # default lazy; coherence on
+        graph_2 = build_graph(store_2)
+        final_2 = graph_2.invoke({"log": [], "fixture_root": str(fixture_root_2), "cached_spec": None})
+
+        assert final_1["committed_spec_version"] == 1
+        assert final_2["committed_spec_version"] == 2
+    finally:
+        shutil.rmtree(fixture_root_1.parent, ignore_errors=True)
+        shutil.rmtree(fixture_root_2.parent, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Sanity: planner writes both versions to the artifact
+# ---------------------------------------------------------------------------
+
+
+def test_planner_v2_is_what_executor_with_coherence_observes() -> None:
+    """Sanity: the with-coherence executor's committed spec matches TASK_SPEC_V2 exactly."""
+    store = CCSStore(strategy="lazy")
+    fixture_root = setup_temp_fixture()
+    try:
+        graph = build_graph(store)
+        graph.invoke({"log": [], "fixture_root": str(fixture_root), "cached_spec": None})
+
+        # The store's authoritative value for the artifact is v2.
+        item = store.get((PLANNER_AGENT, SHARED_SCOPE), TASK_KEY)
+        assert item is not None
+        assert item.value == TASK_SPEC_V2
+    finally:
+        shutil.rmtree(fixture_root.parent, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: actual tsc invocation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _has_tsc(), reason="requires Node toolchain (npx + node_modules)")
+def test_with_coherence_tsc_passes() -> None:
+    """End-to-end: with-coherence variant produces a clean tsc build."""
+    fixture_root = setup_temp_fixture()
+    try:
+        store = CCSStore(strategy="lazy")
+        graph = build_graph(store)
+        graph.invoke({"log": [], "fixture_root": str(fixture_root), "cached_spec": None})
+
+        rc, output = run_tsc(fixture_root)
+        assert rc == 0, f"expected tsc to pass; output:\n{output}"
+    finally:
+        shutil.rmtree(fixture_root.parent, ignore_errors=True)
+
+
+@pytest.mark.skipif(not _has_tsc(), reason="requires Node toolchain (npx + node_modules)")
+def test_no_invalidation_tsc_fails_with_ts2305() -> None:
+    """End-to-end: no-invalidation variant produces TS2305 on session.ts."""
+    fixture_root = setup_temp_fixture()
+    try:
+        store = CCSStore(strategy="lazy")
+        disable_invalidation(store)
+        graph = build_graph(store)
+        graph.invoke({"log": [], "fixture_root": str(fixture_root), "cached_spec": None})
+
+        rc, output = run_tsc(fixture_root)
+        assert rc != 0
+        assert "TS2305" in output
+        assert "validateUser" in output
+        assert "utils/session.ts" in output
+    finally:
+        shutil.rmtree(fixture_root.parent, ignore_errors=True)
+
+
+@pytest.mark.skipif(not _has_tsc(), reason="requires Node toolchain (npx + node_modules)")
+def test_context_cache_tsc_fails_with_ts2305() -> None:
+    """End-to-end: context-cache variant produces TS2305 on session.ts."""
+    fixture_root = setup_temp_fixture()
+    try:
+        store = CCSStore(strategy="lazy")
+        graph = build_graph_context_cache(store)
+        graph.invoke({"log": [], "fixture_root": str(fixture_root), "cached_spec": None})
+
+        rc, output = run_tsc(fixture_root)
+        assert rc != 0
+        assert "TS2305" in output
+        assert "utils/session.ts" in output
+    finally:
+        shutil.rmtree(fixture_root.parent, ignore_errors=True)

--- a/tools/check_readme_numbers.py
+++ b/tools/check_readme_numbers.py
@@ -1,8 +1,17 @@
 """Pre-commit hook: verify README benchmark table values match expected.json.
 
 Reads benchmarks/expected.json, rounds each token_reduction_pct to the nearest integer,
-and checks that each rounded value appears as **NN%** in the
-## Real-workload benchmarks section of README.md.
+and checks that each rounded value appears as **NN%** in the README's benchmark
+table.
+
+The table is located in priority order:
+  1. The block under a ``## Real-workload benchmarks`` section heading, if present.
+  2. Failing that, the block starting at the table's column-header line
+     (``| Workload | Agents | Reads:Writes | Hit rate | Savings |``) and
+     extending until the first non-table line.
+
+This works whether the README places the table at the top with no section
+heading (current main) or under a dedicated heading (some prior shapes).
 
 Exits 0 if all values match. Exits 1 if any value is missing, or if required files
 are absent.
@@ -23,16 +32,37 @@ _EXPECTED_PATH = _REPO_ROOT / "benchmarks" / "expected.json"
 _README_PATH = _REPO_ROOT / "README.md"
 
 _SECTION_HEADER = "## Real-workload benchmarks"
+_TABLE_HEADER = "| Workload | Agents | Reads:Writes | Hit rate | Savings |"
 _BOLD_PCT_RE = re.compile(r"\*\*(\d+)%\*\*")
 
 
 def _extract_readme_section(readme_text: str) -> str:
-    """Return the text from ## Real-workload benchmarks to the next ## section."""
+    """Return the README block that contains the benchmark table.
+
+    Tries the named section heading first; if absent, falls back to extracting
+    the table block by its column-header line. Returns "" if neither anchor
+    is found.
+    """
+    # Path 1: dedicated section heading.
     start = readme_text.find(_SECTION_HEADER)
-    if start == -1:
+    if start != -1:
+        end = readme_text.find("\n## ", start + len(_SECTION_HEADER))
+        return readme_text[start:end] if end != -1 else readme_text[start:]
+
+    # Path 2: direct table-header anchor. Extract from the column-header line
+    # downward until a non-table line (blank line, non-`|` line, or `## `).
+    table_start = readme_text.find(_TABLE_HEADER)
+    if table_start == -1:
         return ""
-    end = readme_text.find("\n## ", start + len(_SECTION_HEADER))
-    return readme_text[start:end] if end != -1 else readme_text[start:]
+
+    lines = readme_text[table_start:].splitlines(keepends=True)
+    block: list[str] = []
+    for line in lines:
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("## ") or not stripped.startswith("|"):
+            break
+        block.append(line)
+    return "".join(block)
 
 
 def check_readme_numbers(expected_path: Path, readme_path: Path) -> bool:
@@ -57,7 +87,10 @@ def check_readme_numbers(expected_path: Path, readme_path: Path) -> bool:
     section = _extract_readme_section(readme_path.read_text())
     if not section:
         print(
-            f"ERROR: '{_SECTION_HEADER}' section not found in README.md.",
+            f"ERROR: Could not locate the benchmark table in README.md. "
+            f"Expected either a '{_SECTION_HEADER}' section heading or a "
+            f"table beginning with the column-header line "
+            f"'{_TABLE_HEADER}'.",
             file=sys.stderr,
         )
         return False


### PR DESCRIPTION
## Summary

**Release v0.7.1.** Lands the refactor demo for write-side coherence, the CI Node toolchain that makes the demo's real-`tsc` tests run in automation, and folds in the already-staged `[Unreleased]` entries (`ccs-check-release` unship, CI branch-protection fix). Branches from `main`, not `dev`, per the project's README-clean discipline.

**Supersedes #20.** Same feature commits, rebased onto `main`. One vocab swap from #20 was dropped (the `docs/guide.md` `--graph PATH:FUNCTION` row mentioning "main pipeline" doesn't exist on main yet); it can land separately when that section ships.

## What's in this release

**Demo** (`examples/refactor_demo/`):
- TS fixture (`auth.ts` defines `validateUser` + 4 callers in `middleware.ts`, `handlers/login.ts`, `handlers/refresh.ts`, `utils/session.ts`; strict tsconfig).
- Four-node LangGraph: `planner_v1` → `executor_read` → `planner_v2` → `executor_commit`. Scripted stand-in sub-agents.
- Three variants:
  - `--variant=with` — write-side coherence on; executor's commit-time re-read fetches v2; renames all 4 callers; `tsc` OK.
  - `--variant=no-invalidation` — `strategies.disable_invalidation(store)` patches the event bus' `publish_invalidation` to a no-op; executor's cache stays SHARED at v1; renames 3 of 4; `tsc` FAIL with `TS2305` on `src/utils/session.ts(4,10)`. Protocol-level proof.
  - `--variant=context-cache` — simulated LLM context-window cache; executor commits using the v1 captured at read time; same `TS2305` outcome. Audience-facing narrative.

**Tests** (`tests/test_refactor_demo.py`, 10 cases): per-variant happy paths with `cache_hit` / MESI assertions, identity checks on `committed_files` (asserts which file did or did not get renamed), fresh-store-per-invocation isolation, end-to-end real-`tsc` invocation (3 cases, Node-toolchain-gated).

**Vocabulary discipline** (R11 from origin requirements):
- `README.md:52` — `freshness needs` → `how aggressively cached reads should refresh`.
- `docs/guide.md:346` — `regardless of heartbeat freshness` → `regardless of how recently the holder heartbeated`.

**Infrastructure**:
- `pyproject.toml`: pytest `pythonpath = ["src", "."]` so tests under `tests/` can import from `examples/`.
- `.github/workflows/ci.yml`: `actions/setup-node@v4` + `npm ci` inside the demo's fixture so the real-`tsc` end-to-end tests actually run in CI. Previously, `_has_tsc()` evaluated False on every CI run and the demo's central correctness claim was unverified.

**Release prep** (commit `d342404`):
- `src/ccs/__init__.py`: `__version__` 0.7.0 → 0.7.1 (the source of truth; pyproject reads it dynamically via `[tool.setuptools.dynamic] version = { attr = "ccs.__version__" }`).
- `CHANGELOG.md`: new `[0.7.1] — 2026-05-13` section with full delta, plus the previously-staged `[Unreleased]` entries (`ccs-check-release` unship, CI branch-protection fix) folded into Removed and Fixed.
- `README.md`: Status section updated to reference v0.7.1.

## Release plan (Path A — folded feature + release)

| Step | Status |
|---|---|
| Version bumped 0.7.0 → 0.7.1 in `src/ccs/__init__.py` | ✅ commit `d342404` |
| CHANGELOG `[0.7.1]` section added with full delta | ✅ commit `d342404` |
| README Status updated | ✅ commit `d342404` |
| `python -c "import ccs; print(ccs.__version__)"` returns `0.7.1` | ✅ verified locally |
| `pytest tests/test_refactor_demo.py` — 10/10 pass | ✅ verified locally |
| `python tools/check_release_readiness.py` — all 3 gh-side checks PASS | ✅ verified locally |
| PR ready for review | ✅ this PR |
| CI green on PR | ⏳ pending (this push) |
| **Pre-tag-push gate: visually inspect PyPI Trusted Publishers** | ⏳ before tag push |
| Merge PR to `main` | ⏳ awaiting review |
| Tag `main` HEAD with `v0.7.1` (annotated) | ⏳ post-merge |
| Push tag (triggers `release.yml`: preflight → build → publish via OIDC → GitHub release with SBOM) | ⏳ irreversible step |
| Sync `main` → `dev` (merge commit; `--ff-only` will fail because `dev` has its own commits) | ⏳ post-tag |

## Test plan

- [x] `pytest tests/test_refactor_demo.py -v` — 10/10 pass locally
- [x] All three variants produce expected `tsc` outcomes (OK / TS2305 / TS2305)
- [x] `python -m examples.refactor_demo.main --help` shows description + EXIT CODES + PREREQUISITES epilog
- [x] Release-readiness preflight passes all 3 automated gh-side checks
- [ ] CI green on this push (Node toolchain change + new tests verified end-to-end in automation)
- [ ] Post-publish: `pip install agent-coherence==0.7.1` in a clean venv reports `__version__ == 0.7.1`
- [ ] Post-publish: GitHub Release page has wheel + sdist + `sbom.cyclonedx.json`
- [ ] Post-publish: `gh attestation verify <wheel> --repo hipvlady/agent-coherence` succeeds

## ce:review status

Applied during the feature-build phase: 9 safe-auto fixes + 2 P1 blockers (`NoInvalidationStrategy` class deleted as actively broken — `name='no-invalidation'` matched no case in `build_strategy`; CI Node toolchain wired). Deferred per scope: `build_graph` duplication merge, TypedDict tightening, `--json` structured output mode, `--list-variants`. Per-reviewer artifacts at `.context/compound-engineering/ce-review/20260512-224438-e08c156b/` (local-only).

Captured institutional knowledge at `docs/solutions/best-practices/ccsstore-strategy-hook-does-not-gate-invalidation-2026-05-13.md` (local-only): the `SyncStrategy.invalidates_peers_on_commit()` hook is consumed only by `ccs.simulation.engine`; the real adapter path publishes invalidations unconditionally; to suppress them on a live `CCSStore`, patch the event bus directly. The same constraint surfaced earlier in May 2026 crash-recovery planning when `handle_reclamation` was dropped for identical reasons — captured as corroborating evidence (the second time this trap has been hit; documenting it should prevent the third).

## Known gotchas to watch during the release

1. **`tools/check_readme_numbers.py` fails locally** — the pre-commit hook looks for a `## Real-workload benchmarks` section anchor that exists on `dev` but not on `main`. Pre-existing condition, NOT introduced by this PR, NOT in `release.yml`'s preflight chain. Won't block the release; worth a follow-up fix.
2. **`dev` won't fast-forward from `main` after tag push** — `dev` has commits that aren't on `main` (4b7ce1a doc grooming, etc.). Use a merge commit or `main → dev` PR; do not `--ff-only`.
3. **PyPI Trusted Publishers must be visually inspected** before tag push — `ccs-check-release` cannot verify the PyPI side. Confirm: repo `hipvlady/agent-coherence`, workflow filename `release.yml` (not `publish.yml`), environment `pypi` (not `Any`).