### PR TITLE
docs(security): correct PEP 740 verification guidance (remove broken gh attestation verify)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -76,17 +76,31 @@ prefer `requirements-diagnose.txt` for reproducible installs.
 Each wheel published to PyPI ships with a Sigstore-backed PEP 740 attestation
 tied to the GitHub Actions workflow that built it. To verify before installing:
 
-    # Using pypi-attestations:
     pip install pypi-attestations
     pypi-attestations verify --provenance \
         --repo hipvlady/agent-coherence \
         --workflow release.yml \
         agent_coherence-X.Y.Z-py3-none-any.whl
 
-    # Or using gh:
-    gh attestation verify <wheel> --repo hipvlady/agent-coherence
-
 The PyPI page also displays the verified provenance in the release sidebar.
+You can also inspect the raw signed attestation directly:
+
+    curl -s \
+      https://pypi.org/integrity/agent-coherence/X.Y.Z/agent_coherence-X.Y.Z-py3-none-any.whl/provenance \
+      | python3 -m json.tool
+
+The `publisher` block in each attestation bundle should report
+`{kind: GitHub, repository: hipvlady/agent-coherence, workflow: release.yml, environment: pypi}`.
+A publisher mismatch is the signature of a Trusted Publisher misconfiguration —
+do not install if the values diverge from those above.
+
+> **Note on `gh attestation verify`.** That command queries GitHub's SLSA
+> build-provenance attestation store, which the current release workflow does
+> not populate. It will return HTTP 404 against this package's wheels. The
+> PEP 740 attestation lives on PyPI; use `pypi-attestations verify` or the
+> raw `curl` inspection above. A future release-workflow enhancement could
+> add an `actions/attest-build-provenance` step to also publish SLSA
+> attestations to GitHub, at which point `gh attestation verify` would work.
 
 ## CycloneDX SBOM
 


### PR DESCRIPTION
## Summary

\`docs/security.md\` instructed end users to verify the PEP 740 attestation with \`gh attestation verify <wheel> --repo hipvlady/agent-coherence\`. That command queries GitHub's SLSA build-provenance attestation store, which \`release.yml\` does NOT populate — it only generates PEP 740 attestations via \`pypa/gh-action-pypi-publish\` (\`attestations: true\`), which live on PyPI. The command returns HTTP 404 in every case.

Surfaced during the v0.7.1 post-publish verification: the \`gh attestation verify\` step 404'd, but the attestation is in fact present — verifiable via \`pypi-attestations verify\` or by fetching \`https://pypi.org/integrity/agent-coherence/X.Y.Z/<wheel>/provenance\` directly. The returned bundle's \`publisher\` block correctly reports \`{kind: GitHub, repository: hipvlady/agent-coherence, workflow: release.yml, environment: pypi}\`.

## What changed

- **Removed** the \`# Or using gh:\` example block in the "Verifying release attestations (PEP 740)" section.
- **Added** a \`curl\` example that fetches the raw signed attestation directly. Lower-level than \`pypi-attestations verify\`, but works with no extra installs and surfaces the publisher metadata explicitly — useful for verifying there's no Trusted Publisher drift (the silent-failure mode documented at \`docs/solutions/integration-issues/pypi-trusted-publisher-workflow-drift-2026-05-11.md\`).
- **Added** an explicit note explaining why \`gh attestation verify\` doesn't work for this package, and what would need to change in the workflow for it to work (add \`actions/attest-build-provenance\` to also publish SLSA attestations to GitHub's store).

The \`pypi-attestations verify\` example (the canonical PEP 740 verifier) stays as the primary recommended path.

## Test plan

- [x] Verified the curl path works on v0.7.1 in production: returns a well-formed bundle with the correct publisher metadata
- [x] Verified \`pypi-attestations verify\` is the right tool — it's listed by PyPI's own docs at https://docs.pypi.org/attestations/
- [x] Verified \`gh attestation verify\` returns 404 for v0.7.1 wheels (the actual current state)
- [ ] No CI required — docs-only change to a tracked public-facing file

## Related

- Procedure-side memory (\`project_release_procedure.md\`) had the same misleading guidance; corrected at the memory layer in the same session.
- Original misleading reference: introduced in the v0.7.0 cycle as part of the supply-chain hardening unit; the goal was right ("document attestation verification") but the chosen command was the wrong one for this attestation type.