### PR TITLE
fix(tests): launch-gate harness — isolation + timeout headroom + degenerate-on-timeout

### DIFF
--- a/tests/integration/test_warn_mode_behavior_change.py
+++ b/tests/integration/test_warn_mode_behavior_change.py
@@ -112,6 +112,12 @@ PLUGIN_REPO = Path("/Users/vladparakhin/projects/agent-coherence-plugin")
 CLAUDE_BIN = Path("/Users/vladparakhin/.npm-global/bin/claude")
 HARD_GATE_THRESHOLD = 0.70
 MIN_N_FOR_LAUNCH = 40
+# Per-scenario wall-clock cap. The harness docstring notes ~5min/scenario
+# under realistic conditions (dominated by OTHER user-installed plugins
+# firing on every hook event). Setting the timeout to exactly that figure
+# guarantees borderline scenarios trip it, so we give 2× headroom and
+# treat a timeout as a DEGENERATE classification (see _run_scenario).
+SCENARIO_TIMEOUT_SEC = 600
 
 
 # ----------------------------------------------------------------------
@@ -299,24 +305,39 @@ def _run_scenario(scenario: dict[str, Any], tmp_root: Path) -> ScenarioResult:
             transcript_path = transcript_dir / f"{scenario['id']}.stream.jsonl"
             try:
                 env = {**os.environ, "PATH": f"{CLAUDE_BIN.parent}:{os.environ.get('PATH','')}"}
-                proc = subprocess.run(
-                    [
-                        str(CLAUDE_BIN),
-                        "--plugin-dir", str(PLUGIN_REPO),
-                        "--include-hook-events",
-                        "--output-format", "stream-json",
-                        "--print",
-                        "--verbose",
-                        "--permission-mode", "bypassPermissions",
-                        "--model", "haiku",
-                        scenario["prompt"],
-                    ],
-                    cwd=workspace,
-                    env=env,
-                    capture_output=True,
-                    text=True,
-                    timeout=300,
-                )
+                try:
+                    proc = subprocess.run(
+                        [
+                            str(CLAUDE_BIN),
+                            "--plugin-dir", str(PLUGIN_REPO),
+                            "--include-hook-events",
+                            "--output-format", "stream-json",
+                            "--print",
+                            "--verbose",
+                            "--permission-mode", "bypassPermissions",
+                            "--model", "haiku",
+                            scenario["prompt"],
+                        ],
+                        cwd=workspace,
+                        env=env,
+                        capture_output=True,
+                        text=True,
+                        timeout=SCENARIO_TIMEOUT_SEC,
+                    )
+                except subprocess.TimeoutExpired:
+                    # A claude invocation that exceeds the per-scenario
+                    # wall-clock budget is treated as DEGENERATE rather
+                    # than crashing the whole gate run — preserves the
+                    # signal from the other N-1 scenarios and surfaces
+                    # via the degenerate_rate < 10% instrumentation gate.
+                    return ScenarioResult(
+                        scenario_id=scenario["id"],
+                        category=scenario["category"],
+                        phpmac_shape=scenario["seed"].get("phpmac_shape", False),
+                        verdict=Verdict.DEGENERATE,
+                        warning_seen=False,
+                        notes=f"claude timeout after {SCENARIO_TIMEOUT_SEC}s",
+                    )
                 transcript_path.write_text(proc.stdout)
                 # Score IN-MEMORY immediately
                 verdict, warning_seen, ac_text = _classify(

--- a/tests/integration/test_warn_mode_behavior_change.py
+++ b/tests/integration/test_warn_mode_behavior_change.py
@@ -309,6 +309,16 @@ def _run_scenario(scenario: dict[str, Any], tmp_root: Path) -> ScenarioResult:
                     proc = subprocess.run(
                         [
                             str(CLAUDE_BIN),
+                            # `--setting-sources project` skips the user-level
+                            # settings.json, which is where the OTHER plugins
+                            # (hookify, claude-mem, compound-engineering, etc.)
+                            # are configured. Without this, those plugins'
+                            # hooks fire on every event in the test session
+                            # and dominate wall-clock time (measured 26× slower
+                            # in 2026-05-18 calibration). `--plugin-dir` still
+                            # loads the agent-coherence plugin under test —
+                            # the two flags are orthogonal.
+                            "--setting-sources", "project",
                             "--plugin-dir", str(PLUGIN_REPO),
                             "--include-hook-events",
                             "--output-format", "stream-json",


### PR DESCRIPTION
## Summary

The `launch_gate` / `launch_gate_pilot` harness in
`tests/integration/test_warn_mode_behavior_change.py` couldn't
complete a clean run end-to-end. Two distinct defects, both surfaced
during the 2026-05-18 pre-v0.1.1 launch-gate execution:

1. **Per-scenario timeout exactly matched expected scenario wall time.**
   The harness docstring acknowledges scenarios take ~5min wall-clock,
   and the previous `subprocess.run(..., timeout=300)` line was 300s on
   the nose. The first scenario in the pilot run hit it, raised
   `subprocess.TimeoutExpired`, and crashed the entire N=40 attempt.

2. **Other user-installed plugins dominated wall time.**
   The harness docstring already names hookify, claude-mem, and
   compound-engineering as the wall-clock dominant — their hooks fire
   on every event in the spawned claude session. Measured calibration
   on a no-op `pong` prompt: **4:08 → 9.6s** when their user-level
   settings are skipped. That's the 26× speedup that turned a 36-min
   pilot into a 1:36 pilot.

## Changes

- `SCENARIO_TIMEOUT_SEC = 600` (2× headroom over the ~5min expected
  scenario wall-clock).
- `subprocess.TimeoutExpired` caught in `_run_scenario` → returns a
  `Verdict.DEGENERATE` result with the timeout reason in `notes`. A
  flaky/slow harness now surfaces via the existing
  `degenerate_rate < 0.10` instrumentation gate instead of crashing
  the test.
- `--setting-sources project` passed to the spawned `claude` CLI to
  skip the user-level `settings.json` where OTHER plugins are
  registered. `--plugin-dir <PLUGIN_REPO>` is orthogonal — it still
  loads the `agent-coherence` plugin under test.

Mechanics-only change. No effect on the gate's scoring semantics or
the 0.70 hard-gate threshold.

## Validation — full N=40 × 2 consecutive runs (post-fix, 2026-05-18)

| Run | re-read | acknowledged | ignored | degenerate | score | degenerate_rate | wall |
|---|---|---|---|---|---|---|---|
| #1 | 35 | 3 | 0 | 2 | **100%** | 5% | 14:36 |
| #2 | 33 | 7 | 0 | 0 | **100%** | 0% | 17:07 |

Both gates clear by a wide margin (score ≥70%; degenerate_rate <10%);
no `ignored` verdicts across N=80 total trials.

## Test plan

- [x] `pytest -m launch_gate_pilot` — passes, 4/4 classified, 1:36 wall
- [x] `pytest -m launch_gate` — passes consecutively, 80/80 classified across two runs
- [x] Default `pytest -q` unchanged (`launch_gate*` markers still in `addopts` deselect list)