### PR TITLE
feat(v0.1.1 Unit 5): lifecycle hardening — L1 inode revalidation + L2 in-flight drain + L3 cold-start instrumentation

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -79,6 +79,13 @@ HANDLER_CONCURRENCY_LIMIT = _WATCHDOG_POOL_SIZE * 2
 """Each endpoint's coordinator call is bounded to 4s by the watchdog;
 leaves 1s of margin under the 5s Claude Code hook timeout (KTD-12 / Unit 4)."""
 
+IN_FLIGHT_DRAIN_TIMEOUT_SEC = 5.0
+"""KTD-I (Unit 5 L2): ``shutdown()`` waits up to this many seconds for
+in-flight handlers to complete before closing the SQLite registry. After
+the deadline, any still-running handlers are abandoned — they may raise
+``sqlite3.ProgrammingError`` and return HTTP 500 to their clients. Better
+a 500 than a wedged shutdown (silent hang vs observable failure)."""
+
 MAX_POLICY_PATHS_PER_REQUEST = 20
 """Cap on the number of paths /policy/track and /policy/untrack accept
 in one request body (security-lens P1)."""
@@ -218,6 +225,18 @@ class CoordinatorHTTPServer:
         self._watchdog_timeouts_total: int = 0
         self._watchdog_queue_overflows_total: int = 0
 
+        # KTD-I (Unit 5 L2) — in-flight handler counter. Incremented at
+        # dispatch entry via :meth:`acquire_handler_slot`, decremented in
+        # the handler's finally via :meth:`release_handler_slot`.
+        # :meth:`shutdown` blocks on the counter reaching zero for up to
+        # IN_FLIGHT_DRAIN_TIMEOUT_SEC before closing the SQLite registry,
+        # so a handler mid-write doesn't see ProgrammingError on a closed
+        # connection (silent hang → observable 500 at worst).
+        self._in_flight_lock = threading.Lock()
+        self._in_flight_zero = threading.Condition(self._in_flight_lock)
+        self._in_flight = 0
+        self._in_flight_drain_timed_out = False
+
         # Wire storage + coordinator service.
         db_path = self.coordinator_root / ".coherence" / "state.db"
         self.registry = SqliteArtifactRegistry(
@@ -263,16 +282,78 @@ class CoordinatorHTTPServer:
         self._serve_thread.start()
 
     def shutdown(self) -> None:
-        """Stop the server, drain in-flight handlers, close storage."""
+        """Stop the server, drain in-flight handlers, close storage.
+
+        KTD-I (Unit 5 L2): waits up to ``IN_FLIGHT_DRAIN_TIMEOUT_SEC`` for
+        the in-flight counter to reach zero before closing the SQLite
+        registry. Sets ``shutting_down`` BEFORE the drain so new dispatch
+        attempts 503 immediately and don't replenish the counter. After
+        the deadline, closes regardless — handlers still mid-write may
+        raise ``sqlite3.ProgrammingError`` (becoming HTTP 500 to clients),
+        which is observable. The alternative — wedging shutdown waiting
+        for a stuck handler — is silent and worse.
+        """
         if self._shutting_down:
             return
         self._shutting_down = True
         try:
-            self._server.shutdown()
+            # http.server.HTTPServer.shutdown() blocks on an Event set by
+            # serve_forever's exit. If serve_in_thread was never called,
+            # serve_forever never ran, and the event was never set —
+            # shutdown() would wait forever. Guard against that so unit
+            # tests that construct a server purely for state manipulation
+            # can still tear it down cleanly.
+            if self._serve_thread is not None:
+                self._server.shutdown()
             self._server.server_close()
         finally:
+            self._drain_in_flight(IN_FLIGHT_DRAIN_TIMEOUT_SEC)
             self._watchdog.shutdown(wait=True, cancel_futures=False)
             self.registry.close()
+
+    def acquire_handler_slot(self) -> bool:
+        """KTD-I L2: atomic shutting_down check + counter increment.
+
+        Returns False if shutdown has started between the dispatcher's
+        outer ``shutting_down`` check and this call (race window of a few
+        microseconds). Returns True iff the slot was acquired and the
+        caller MUST pair with :meth:`release_handler_slot`."""
+        with self._in_flight_lock:
+            if self._shutting_down:
+                return False
+            self._in_flight += 1
+            return True
+
+    def release_handler_slot(self) -> None:
+        """KTD-I L2: decrement the counter and notify drain waiters when
+        it reaches zero. Safe to call from any handler thread's finally."""
+        with self._in_flight_lock:
+            self._in_flight -= 1
+            if self._in_flight <= 0:
+                self._in_flight = 0  # defensive — never go negative
+                self._in_flight_zero.notify_all()
+
+    def _drain_in_flight(self, timeout_sec: float) -> None:
+        """Wait up to ``timeout_sec`` for in-flight handlers to complete.
+
+        Sets :attr:`_in_flight_drain_timed_out` if the deadline elapses
+        with handlers still running, so operators can observe the event
+        via the eventual /status surface (deferred to Unit 8)."""
+        if timeout_sec <= 0:
+            return
+        deadline = time.monotonic() + timeout_sec
+        with self._in_flight_lock:
+            while self._in_flight > 0:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    self._in_flight_drain_timed_out = True
+                    logger.warning(
+                        "shutdown drain timed out after %.1fs with %d handler(s) still in-flight; "
+                        "closing registry anyway (KTD-I — observable 500 > wedged shutdown)",
+                        timeout_sec, self._in_flight,
+                    )
+                    return
+                self._in_flight_zero.wait(timeout=remaining)
 
     def __enter__(self) -> "CoordinatorHTTPServer":
         self.serve_in_thread()
@@ -441,30 +522,40 @@ def _make_handler_class(coordinator: CoordinatorHTTPServer) -> type:
             self._dispatch("GET")
 
         def _dispatch(self, method: str) -> None:
-            if coordinator.shutting_down:
+            # KTD-I L2: acquire_handler_slot does the atomic shutting_down
+            # check + counter increment. If shutdown started between this
+            # call and the dispatcher entry, the slot is denied and we 503
+            # without touching the SQLite registry (which may already be
+            # mid-close).
+            if not coordinator.acquire_handler_slot():
                 self._json(503, {"error": "coordinator shutting down"})
                 return
-            coordinator.mark_request()
-
-            # Auth + Host check on every endpoint
-            if not verify_host(self.headers.get("Host")):
-                self._json(403, {"error": "host header not allowlisted"})
-                logger.warning("rejected request with bad Host: %r", self.headers.get("Host"))
-                return
-            if not verify_bearer(self.headers.get("Authorization"), coordinator.secret):
-                self._json(401, {"error": "missing or invalid bearer token"})
-                return
-
-            # Route
             try:
-                handler = _ROUTES.get((method, self.path))
-                if handler is None:
-                    self._json(404, {"error": f"unknown route {method} {self.path}"})
+                coordinator.mark_request()
+
+                # Auth + Host check on every endpoint
+                if not verify_host(self.headers.get("Host")):
+                    self._json(403, {"error": "host header not allowlisted"})
+                    logger.warning(
+                        "rejected request with bad Host: %r", self.headers.get("Host")
+                    )
                     return
-                handler(self, coordinator)
-            except Exception as exc:
-                logger.exception("unhandled error in handler for %s %s", method, self.path)
-                self._json(500, {"error": f"internal: {type(exc).__name__}"})
+                if not verify_bearer(self.headers.get("Authorization"), coordinator.secret):
+                    self._json(401, {"error": "missing or invalid bearer token"})
+                    return
+
+                # Route
+                try:
+                    handler = _ROUTES.get((method, self.path))
+                    if handler is None:
+                        self._json(404, {"error": f"unknown route {method} {self.path}"})
+                        return
+                    handler(self, coordinator)
+                except Exception as exc:
+                    logger.exception("unhandled error in handler for %s %s", method, self.path)
+                    self._json(500, {"error": f"internal: {type(exc).__name__}"})
+            finally:
+                coordinator.release_handler_slot()
 
         # ----------------------------------------------------------
         # Helpers

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -237,6 +237,13 @@ class CoordinatorHTTPServer:
         self._in_flight = 0
         self._in_flight_drain_timed_out = False
 
+        # KTD-H/I/L3 (Unit 5 L3) — cold-start timing populated by the
+        # lifecycle winner path after self-probe completes. Telemetry
+        # surface for the future /status endpoint (Unit 8). 0.0 until the
+        # lifecycle module sets it; remains 0.0 when the server is
+        # constructed directly in tests.
+        self.cold_start_duration_ms: float = 0.0
+
         # Wire storage + coordinator service.
         db_path = self.coordinator_root / ".coherence" / "state.db"
         self.registry = SqliteArtifactRegistry(

--- a/src/ccs/adapters/claude_code/lifecycle.py
+++ b/src/ccs/adapters/claude_code/lifecycle.py
@@ -117,6 +117,12 @@ class LifecycleConfig:
     #: Transient-state timeout (fail-safe for unfinished M↔E protocol steps).
     transient_timeout_sec: int = 60
 
+    #: KTD-H — Unit 5 L1: cap on inode re-opens during one ``ensure_coordinator``
+    #: call. Each external ``rm -rf .coherence/ && recreate`` consumes one
+    #: revalidation. Churn beyond this budget indicates a runaway external
+    #: process; the coordinator returns -1 and lets the hook degrade.
+    inode_revalidation_budget: int = 5
+
 
 _DEFAULT_CONFIG = LifecycleConfig()
 
@@ -175,6 +181,12 @@ def ensure_coordinator(
 
     # Unified spawn-or-join loop (G1 fix per Unit 5 §5.654 — the
     # idle-shutdown-vs-spawn race). On each attempt:
+    #   0. KTD-H (Unit 5 L1): revalidate fd's inode against the on-disk
+    #      path. If an external process unlinked `.coherence/` and
+    #      recreated it mid-retry, our fd points at the orphaned inode
+    #      and any flock/write happens invisibly. Re-open and restart
+    #      the retry counter on mismatch (bounded by the revalidation
+    #      budget to defend against pathological churn).
     #   1. Try to acquire the flock (non-blocking). If acquired, we're
     #      the winner — bind, write port, serve, return.
     #   2. If contended, try to read a valid port from the file. If
@@ -185,24 +197,60 @@ def ensure_coordinator(
     #
     # This handles both the cold-start thundering herd (holder is
     # mid-bind; port appears) and the idle-shutdown race (holder is
-    # mid-shutdown; flock releases) without baking in an order.
-    for attempt in range(cfg.port_file_retry_attempts):
+    # mid-shutdown; flock releases) without baking in an order, plus
+    # the rm -rf race that KTD-H closes.
+    revalidations_remaining = cfg.inode_revalidation_budget
+    attempt = 0
+    while attempt < cfg.port_file_retry_attempts:
+        # KTD-H: per-iteration inode revalidation. Cheap (~50μs) — st_dev
+        # + st_ino comparison detects unlink-and-recreate races before the
+        # flock attempt commits us to an orphan.
+        if not _inode_matches(fd, pid_file):
+            if revalidations_remaining <= 0:
+                logger.warning(
+                    "ensure_coordinator: inode revalidation budget exhausted "
+                    "(%d revalidations); external churn on .coherence/ — giving up",
+                    cfg.inode_revalidation_budget,
+                )
+                _close_quiet(fd)
+                return -1
+            revalidations_remaining -= 1
+            logger.info(
+                "ensure_coordinator: server.pid inode mismatch (rm -rf race?); "
+                "re-opening (%d revalidations remaining)",
+                revalidations_remaining,
+            )
+            _close_quiet(fd)
+            # Re-create the .coherence dir in case the rm -rf removed it too.
+            new_coherence_dir = _ensure_coherence_dir(coordinator_root)
+            if new_coherence_dir is None:
+                return -1
+            coherence_dir = new_coherence_dir
+            pid_file = coherence_dir / "server.pid"
+            new_fd = _open_pidfile(pid_file)
+            if new_fd is None:
+                return -1
+            fd = new_fd
+            attempt = 0  # KTD-H: restart the retry counter on re-open
+            continue
+
         try:
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except OSError as exc:
             if exc.errno not in (errno.EWOULDBLOCK, errno.EACCES, errno.EAGAIN):
-                os.close(fd)
+                _close_quiet(fd)
                 raise
             # Contended — try to read the port.
             port = _read_port_from_file(pid_file)
             if port is not None:
-                os.close(fd)
+                _close_quiet(fd)
                 return port
             # Port file empty (holder mid-bind or mid-shutdown). Wait
             # and try the whole loop again — on the next iteration we
             # may either see the port populated OR acquire the released
             # lock ourselves.
             time.sleep(cfg.port_file_retry_interval_sec)
+            attempt += 1
             continue
 
         # Winner — we hold the lock. Bind, write port, serve.
@@ -240,7 +288,7 @@ def ensure_coordinator(
             try:
                 fcntl.flock(fd, fcntl.LOCK_UN)
             finally:
-                os.close(fd)
+                _close_quiet(fd)
             raise
 
     # Retry budget exhausted without acquiring the lock or seeing a
@@ -249,7 +297,7 @@ def ensure_coordinator(
     # which would itself be a bug in this module — OR the holder is
     # mid-shutdown for longer than the retry budget. Either way, return
     # -1 so the caller degrades gracefully.
-    os.close(fd)
+    _close_quiet(fd)
     logger.warning(
         "ensure_coordinator: %d attempts exhausted without acquiring lock or reading port",
         cfg.port_file_retry_attempts,
@@ -383,6 +431,38 @@ def _open_pidfile(pid_file: Path) -> Optional[int]:
         logger.warning("cannot open pid file %s: %s", pid_file, exc)
         return None
     return fd
+
+
+def _close_quiet(fd: int) -> None:
+    """Best-effort close. Swallows OSError so cleanup paths can chain
+    without separate try/except blocks — closing an already-bad fd just
+    means the underlying file was already gone."""
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+
+def _inode_matches(fd: int, path: Path) -> bool:
+    """KTD-H Unit 5 L1 helper. Returns True iff the file currently at
+    ``path`` shares (st_dev, st_ino) with the open ``fd``. Used to detect
+    the unlink-and-recreate race where an external ``rm -rf .coherence/``
+    leaves our fd orphaned on a no-longer-reachable inode.
+
+    Returns False on any stat/fstat failure or mismatch — caller treats
+    that as "revalidate" rather than trying to disambiguate. Cost is
+    roughly two syscalls (~50μs) per call, executed once per retry
+    iteration."""
+    try:
+        fd_stat = os.fstat(fd)
+    except OSError:
+        return False
+    try:
+        path_stat = os.stat(path)
+    except OSError:
+        # Path was unlinked, or its parent dir was. Definitely mismatch.
+        return False
+    return (fd_stat.st_dev, fd_stat.st_ino) == (path_stat.st_dev, path_stat.st_ino)
 
 
 def _write_pidfile(fd: int, pid: int, port: int) -> None:

--- a/src/ccs/adapters/claude_code/lifecycle.py
+++ b/src/ccs/adapters/claude_code/lifecycle.py
@@ -254,6 +254,12 @@ def ensure_coordinator(
             continue
 
         # Winner — we hold the lock. Bind, write port, serve.
+        # KTD-H/I/L3 (Unit 5 L3): time the winner path so operators have a
+        # signal for cold-start regressions. Telemetry-only — no default
+        # behavior change. Surfaced via the coordinator's
+        # ``cold_start_duration_ms`` attribute for the future /status
+        # endpoint (Unit 8).
+        cold_start_start = time.monotonic()
         try:
             coordinator = CoordinatorHTTPServer(coordinator_root, port=0, bind_host=bind_host)
             port = coordinator.port
@@ -273,15 +279,18 @@ def ensure_coordinator(
             # is actually accepting. Cold-start (Python interpreter +
             # SQLite WAL rehydration) can take well past the loser-side
             # connect_retry budget.
-            if not _self_probe(port, cfg, bind_host=bind_host):
+            probe_ok = _self_probe(port, cfg, bind_host=bind_host)
+            cold_start_ms = (time.monotonic() - cold_start_start) * 1000.0
+            coordinator.cold_start_duration_ms = cold_start_ms
+            if not probe_ok:
                 logger.warning(
                     "coordinator bound port=%d but self-probe exhausted after %dms; returning anyway",
                     port,
                     int(cfg.spawn_self_probe_attempts * cfg.spawn_self_probe_interval_sec * 1000),
                 )
             logger.info(
-                "coordinator spawned: pid=%d port=%d root=%s",
-                os.getpid(), port, coordinator_root,
+                "coordinator spawned: pid=%d port=%d root=%s cold_start=%.1fms",
+                os.getpid(), port, coordinator_root, cold_start_ms,
             )
             return port
         except Exception:

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -1227,3 +1227,141 @@ def test_handler_concurrency_limit_constant_matches_spec(client: _Client) -> Non
     assert _WATCHDOG_POOL_SIZE == 4
     assert HANDLER_CONCURRENCY_LIMIT == 8
     assert WATCHDOG_QUEUE_LIMIT == 8
+
+
+# ----------------------------------------------------------------------
+# KTD-I (Unit 5 L2) — in-flight handler semaphore drain on shutdown
+# ----------------------------------------------------------------------
+
+
+def test_i1_acquire_release_pair_balances_counter(tmp_path: Path) -> None:
+    """Unit-level: acquire/release balance the in-flight counter; the
+    drain condition is signalled on the zero transition."""
+    srv = CoordinatorHTTPServer(tmp_path, port=0, instance_id="i1")
+    try:
+        assert srv._in_flight == 0
+        assert srv.acquire_handler_slot() is True
+        assert srv._in_flight == 1
+        assert srv.acquire_handler_slot() is True
+        assert srv._in_flight == 2
+        srv.release_handler_slot()
+        assert srv._in_flight == 1
+        srv.release_handler_slot()
+        assert srv._in_flight == 0
+    finally:
+        srv.shutdown()
+
+
+def test_i2_acquire_denied_after_shutdown_started(tmp_path: Path) -> None:
+    """Once ``_shutting_down`` flips, acquire_handler_slot returns False
+    so the dispatcher 503s instead of touching a closing registry."""
+    srv = CoordinatorHTTPServer(tmp_path, port=0, instance_id="i2")
+    srv.serve_in_thread()
+    try:
+        # Manually flip the flag (mimics in-progress shutdown without
+        # actually closing the registry, so we can keep poking).
+        srv._shutting_down = True
+        assert srv.acquire_handler_slot() is False
+        assert srv._in_flight == 0
+    finally:
+        srv._shutting_down = False  # let shutdown() proceed normally
+        srv.shutdown()
+
+
+def test_i3_shutdown_waits_for_in_flight_handler(tmp_path: Path) -> None:
+    """End-to-end: a long-running handler keeps the in-flight counter
+    above zero; shutdown() must block on the drain until the handler
+    returns rather than closing the registry under it."""
+    srv = CoordinatorHTTPServer(tmp_path, port=0, instance_id="i3")
+    srv.serve_in_thread()
+    time.sleep(0.05)
+    secret = load_secret(srv.coordinator_root)
+    assert secret is not None
+    client = _Client("127.0.0.1", srv.port, secret)
+
+    # Simulate a slow handler by acquiring a slot from the test thread
+    # (no real handler invoked — we only need to keep _in_flight > 0
+    # for the drain to wait on).
+    assert srv.acquire_handler_slot() is True
+
+    shutdown_done = threading.Event()
+    def shutdown_thread() -> None:
+        srv.shutdown()
+        shutdown_done.set()
+    t = threading.Thread(target=shutdown_thread)
+    t.start()
+
+    # shutdown() should be blocked in the drain loop.
+    assert not shutdown_done.wait(timeout=0.5), (
+        "shutdown returned before the in-flight slot was released"
+    )
+
+    # Releasing the slot wakes the drain and lets shutdown complete.
+    srv.release_handler_slot()
+    assert shutdown_done.wait(timeout=2.0), "shutdown did not complete after drain"
+    t.join(timeout=2.0)
+    assert srv._in_flight_drain_timed_out is False
+    del client  # silence unused-var lint
+
+
+def test_i4_shutdown_drain_timeout_records_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If a handler stays in-flight past the drain timeout, shutdown
+    closes the registry anyway and records the timeout for observability."""
+    srv = CoordinatorHTTPServer(tmp_path, port=0, instance_id="i4")
+    srv.serve_in_thread()
+    time.sleep(0.05)
+
+    # Keep an in-flight slot held for the duration of the test.
+    assert srv.acquire_handler_slot() is True
+
+    # Shrink the drain timeout so the test finishes in <1s.
+    import ccs.adapters.claude_code.coordinator_server as mod
+    monkeypatch.setattr(mod, "IN_FLIGHT_DRAIN_TIMEOUT_SEC", 0.1)
+    try:
+        srv.shutdown()
+        assert srv._in_flight_drain_timed_out is True, (
+            "drain timeout should set the observability flag"
+        )
+    finally:
+        # Release the artificially-held slot so the test doesn't leak.
+        srv.release_handler_slot()
+
+
+def test_i5_dispatch_pairs_acquire_with_release(client: _Client, coordinator) -> None:
+    """Integration: a normal pre-read request increments and decrements
+    the in-flight counter exactly once, leaving it at zero on return."""
+    assert coordinator._in_flight == 0
+    status, _ = client.post(
+        "/hooks/pre-read",
+        {"session_id": _sid("i5"), "path": "CLAUDE.md"},
+    )
+    assert status == 200
+    assert coordinator._in_flight == 0, (
+        f"in-flight counter leaked: expected 0, got {coordinator._in_flight}"
+    )
+
+
+def test_i6_dispatch_decrements_even_when_handler_raises(
+    client: _Client, coordinator, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defensive: if a handler raises mid-dispatch (becoming a 500), the
+    finally block must still release the slot."""
+    import ccs.adapters.claude_code.coordinator_server as mod
+    original = mod._ROUTES[("POST", "/hooks/pre-read")]
+
+    def raising_handler(req, coord) -> None:
+        raise RuntimeError("simulated handler failure")
+
+    monkeypatch.setitem(mod._ROUTES, ("POST", "/hooks/pre-read"), raising_handler)
+    try:
+        status, _ = client.post(
+            "/hooks/pre-read",
+            {"session_id": _sid("i6"), "path": "CLAUDE.md"},
+        )
+        assert status == 500
+        # Counter must have been decremented despite the exception.
+        assert coordinator._in_flight == 0
+    finally:
+        mod._ROUTES[("POST", "/hooks/pre-read")] = original

--- a/tests/test_claude_code_lifecycle.py
+++ b/tests/test_claude_code_lifecycle.py
@@ -771,3 +771,36 @@ def test_h4_revalidation_budget_exhaustion_returns_minus_one(
         )
     finally:
         monkeypatch.undo()
+
+
+# ----------------------------------------------------------------------
+# Unit 5 L3 — cold-start instrumentation (telemetry only)
+# ----------------------------------------------------------------------
+
+
+def test_l3_cold_start_duration_populated_on_winner_path(
+    workspace: Path, fast_cfg: LifecycleConfig,
+) -> None:
+    """L3 instrumentation: the lifecycle winner path measures the wall-clock
+    time from CoordinatorHTTPServer construction through self-probe success
+    and stores it on the coordinator for the future /status endpoint."""
+    port = ensure_coordinator(workspace, config=fast_cfg)
+    assert port > 0
+    try:
+        entry = lifecycle._SPAWNED_REGISTRY[str(workspace.resolve())]
+        # Some time must have been recorded — fast hardware can finish under
+        # 50ms but never zero.
+        assert entry.coordinator.cold_start_duration_ms > 0.0
+        # Sanity ceiling: even on a slow CI runner, cold start under the
+        # spawn self-probe budget plus a generous margin.
+        ceiling_ms = (
+            fast_cfg.spawn_self_probe_attempts
+            * fast_cfg.spawn_self_probe_interval_sec
+            * 1000.0
+        ) + 1000.0
+        assert entry.coordinator.cold_start_duration_ms < ceiling_ms, (
+            f"cold_start_duration_ms={entry.coordinator.cold_start_duration_ms:.1f} "
+            f"exceeded ceiling {ceiling_ms:.1f}ms"
+        )
+    finally:
+        stop_coordinator(workspace)

--- a/tests/test_claude_code_lifecycle.py
+++ b/tests/test_claude_code_lifecycle.py
@@ -645,3 +645,129 @@ def test_g4_shutdown_raise_aborts_without_releasing_lock(
     # Manual cleanup for the test (otherwise we'd leak the lock_fd).
     monkeypatch.undo()
     stop_coordinator(workspace)
+
+
+# ----------------------------------------------------------------------
+# KTD-H (Unit 5 L1) — inode revalidation per retry iteration
+# ----------------------------------------------------------------------
+
+
+def test_h1_inode_matches_helper_detects_unlink_recreate(workspace: Path) -> None:
+    """Unit-level: ``_inode_matches`` returns True when fd and path point
+    at the same inode, and False after an external unlink + recreate."""
+    coherence_dir = workspace / ".coherence"
+    coherence_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    pid_file = coherence_dir / "server.pid"
+    pid_file.write_text("", encoding="utf-8")
+    fd = os.open(pid_file, os.O_RDWR)
+    try:
+        # Same inode → match.
+        assert lifecycle._inode_matches(fd, pid_file) is True
+
+        # Unlink + recreate → mismatch.
+        pid_file.unlink()
+        pid_file.write_text("", encoding="utf-8")
+        assert lifecycle._inode_matches(fd, pid_file) is False
+    finally:
+        os.close(fd)
+
+
+def test_h2_inode_matches_returns_false_when_path_absent(workspace: Path) -> None:
+    """If the path is unlinked entirely (no recreate), the helper still
+    returns False rather than raising — caller treats as 'revalidate'."""
+    coherence_dir = workspace / ".coherence"
+    coherence_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    pid_file = coherence_dir / "server.pid"
+    pid_file.write_text("", encoding="utf-8")
+    fd = os.open(pid_file, os.O_RDWR)
+    try:
+        pid_file.unlink()
+        assert lifecycle._inode_matches(fd, pid_file) is False
+    finally:
+        os.close(fd)
+
+
+def test_h3_ensure_coordinator_recovers_after_rm_rf_race(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """KTD-H end-to-end: simulate an external ``rm -rf .coherence/`` between
+    the pid-file open and the first retry iteration. ``ensure_coordinator``
+    must detect the inode mismatch, re-open, and still bind a coordinator
+    on a fresh inode rather than holding an orphan fd."""
+    cfg = LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0,
+        port_file_retry_attempts=20,
+        port_file_retry_interval_sec=0.02,
+        inode_revalidation_budget=3,
+        spawn_self_probe_attempts=20,
+        spawn_self_probe_interval_sec=0.05,
+    )
+
+    # Monkey-patch _open_pidfile so the FIRST call performs the open AND
+    # immediately wipes the directory (simulating `rm -rf .coherence`
+    # racing in just after open). Subsequent calls open normally.
+    real_open = lifecycle._open_pidfile
+    call_count = {"n": 0}
+
+    def open_then_wipe(pid_file: Path) -> Optional[int]:
+        call_count["n"] += 1
+        fd = real_open(pid_file)
+        if fd is None:
+            return None
+        if call_count["n"] == 1:
+            # Simulate the race: external rm -rf wipes .coherence/ AFTER
+            # we got our fd. Our fd now refers to an orphaned inode.
+            try:
+                pid_file.unlink()
+            except FileNotFoundError:
+                pass
+        return fd
+
+    monkeypatch.setattr(lifecycle, "_open_pidfile", open_then_wipe)
+    try:
+        port = ensure_coordinator(workspace, config=cfg)
+        assert port > 0, (
+            f"expected ensure_coordinator to recover via inode revalidation; got {port}"
+        )
+        # The live pid file should match the bound port.
+        pid_file = workspace / ".coherence" / "server.pid"
+        live_port = _read_port_from_file(pid_file)
+        assert live_port == port, (
+            f"pid file ({live_port}) does not reflect bound port ({port}) — "
+            "winner may have written to an orphaned inode"
+        )
+        # At least one revalidation must have occurred.
+        assert call_count["n"] >= 2, (
+            f"_open_pidfile called only {call_count['n']} time(s); "
+            "expected at least 2 (initial + revalidation re-open)"
+        )
+    finally:
+        monkeypatch.undo()
+        stop_coordinator(workspace)
+
+
+def test_h4_revalidation_budget_exhaustion_returns_minus_one(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pathological churn: every iteration sees a fresh inode mismatch.
+    The revalidation budget caps the recovery work and returns -1 cleanly
+    rather than spinning forever."""
+    cfg = LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0,
+        port_file_retry_attempts=5,
+        port_file_retry_interval_sec=0.01,
+        inode_revalidation_budget=2,
+    )
+
+    # Force _inode_matches to always report mismatch — simulates an
+    # adversary unlinking the pid file every iteration.
+    monkeypatch.setattr(lifecycle, "_inode_matches", lambda _fd, _path: False)
+    try:
+        port = ensure_coordinator(workspace, config=cfg)
+        assert port == -1, (
+            f"expected -1 after revalidation budget exhausted; got {port}"
+        )
+    finally:
+        monkeypatch.undo()


### PR DESCRIPTION
## Summary

Phase B Unit 5 of the v0.1.1 marketplace cut — three commits closing the lifecycle deferrals from \`docs/known-issues/\`. **Stacked on #28** (Unit 4); after #28 merges this PR's diff resolves to just the Unit 5 commits.

- **L1 / KTD-H** ([16203b8](../../commit/16203b8)) — \`ensure_coordinator\` revalidates the pid-file fd's (st_dev, st_ino) against the on-disk path before every flock attempt. On mismatch (external \`rm -rf .coherence/ && recreate\` mid-retry) it closes the orphaned fd, recreates \`.coherence/\` if needed, re-opens, and restarts the retry counter. Bounded by \`inode_revalidation_budget\` (default 5) to defend against pathological churn.
- **L2 / KTD-I** ([2df6cc4](../../commit/2df6cc4)) — \`_dispatch\` acquires/releases a handler slot via \`acquire_handler_slot\`/\`release_handler_slot\`; \`coordinator.shutdown()\` drains up to 5s on a Condition before closing the SQLite registry. After the deadline, the registry closes anyway — handlers mid-write raise \`sqlite3.ProgrammingError\` → observable HTTP 500, which beats a silent client hang. Also guards \`http.server.HTTPServer.shutdown()\` so tests that skip \`serve_in_thread\` no longer deadlock on the never-set \`__is_shut_down\` event.
- **L3** ([ed8fb62](../../commit/ed8fb62)) — captures the wall-clock duration of the winner path (construction → port-write → self-probe) on \`coordinator.cold_start_duration_ms\`. Telemetry-only; the future \`/status\` endpoint reads it (Unit 8).

## Test plan

- [x] \`tests/test_claude_code_lifecycle.py\` — +5 tests (H1–H4 inode + L3 timing).
- [x] \`tests/test_claude_code_coordinator_server.py\` — +6 tests (I1–I6 drain + acquire/release pairing + exception-path balance).
- [x] Existing G1–G6 lifecycle invariants retained — no regression.
- [x] Full claude_code suite green locally at HEAD.

Refs: \`docs/plans/2026-05-18-001-feat-claude-code-coherence-plugin-v0.1.1-plan.md\` Unit 5 / KTD-H / KTD-I.