### PR TITLE
feat(v0.1.1 Unit 6): residual risk fixes — R10/R11/R12/R14/R21

### DIFF
--- a/src/ccs/adapters/claude_code/auth.py
+++ b/src/ccs/adapters/claude_code/auth.py
@@ -31,6 +31,7 @@ import hmac
 import logging
 import os
 import secrets
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -44,52 +45,90 @@ hex-encoded shared secret. Mode 0600 — owner-read-only."""
 SECRET_BYTES = 32
 """32 bytes of random entropy → 64-char hex token in the Authorization header."""
 
+ENSURE_SECRET_MAX_RETRIES = 5
+"""R11 (Unit 6): bound on the empty-file recovery loop in :func:`ensure_secret`.
+If we observe 'file exists but is empty' more than this many times in a row,
+something pathological is happening (a racer that creates but never writes,
+a misbehaving editor, disk-full mid-write); fail closed rather than risk
+clobbering valid secrets via O_TRUNC."""
+
+ENSURE_SECRET_RETRY_SLEEP_SEC = 0.020
+"""R11 (Unit 6): brief sleep between empty-file recovery attempts so a
+racer that has the file open but hasn't flushed its write yet gets a
+chance to make progress before we re-poll."""
+
 _BEARER_PREFIX = "Bearer "
 _HOST_ALLOWLIST: frozenset[str] = frozenset({"localhost", "127.0.0.1"})
+
+
+class EnsureSecretError(RuntimeError):
+    """R11 (Unit 6): ensure_secret could not converge — the file exists
+    but stays empty across ENSURE_SECRET_MAX_RETRIES attempts. The
+    coordinator startup path should treat this as fatal; the alternative
+    (O_TRUNC re-write of a file another process may have just populated)
+    risks clobbering a concurrent racer's valid secret and giving two
+    spawn-side processes different secrets for the same workspace."""
 
 
 def ensure_secret(coordinator_root: Path) -> str:
     """Generate-and-persist the shared secret if missing; otherwise load it.
 
     Idempotent: safe to call from every coordinator spawn. Returns the
-    hex-encoded secret. Raises OSError if the .coherence directory cannot
-    be created or the file cannot be written (graceful-degradation should
-    happen at the lifecycle layer, not here).
+    hex-encoded secret. Raises ``OSError`` if the ``.coherence`` directory
+    cannot be created (graceful-degradation should happen at the
+    lifecycle layer, not here). Raises :class:`EnsureSecretError` if a
+    ``hook.secret`` file exists but stays empty across
+    ``ENSURE_SECRET_MAX_RETRIES`` attempts — see R11 for the rationale
+    on failing closed instead of falling back to O_TRUNC.
+
+    R11 (Unit 6): the empty-file recovery branch is now a bounded
+    O_EXCL retry loop instead of the prior O_TRUNC re-write. The
+    O_TRUNC path could clobber a concurrent spawn's valid secret in
+    the narrow window between O_EXCL-create and write — both processes
+    would then walk away with DIFFERENT secrets for the same workspace,
+    which silently breaks all peer hooks until one coordinator restarts.
     """
     coherence_dir = coordinator_root / ".coherence"
     coherence_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     secret_path = coherence_dir / SECRET_FILENAME
 
-    if secret_path.is_file():
-        # Existing secret — load it. Don't rotate without explicit invalidation
-        # (see project_plugin_release_sequence.md: v0.1 secret persists across
-        # restarts; v0.2 may add rotation).
-        token = secret_path.read_text().strip()
-        if token:
-            return token
-        logger.warning("hook.secret exists but is empty; regenerating")
+    for attempt in range(ENSURE_SECRET_MAX_RETRIES):
+        # Fast path: file exists and is populated.
+        if secret_path.is_file():
+            token = secret_path.read_text().strip()
+            if token:
+                return token
 
-    # Generate fresh secret. Atomic create with mode 0600 via O_EXCL +
-    # explicit mode argument — no window where the file is mode 0644.
-    # If the file already exists at this point (race with another spawn),
-    # O_EXCL raises FileExistsError; we re-load and return the existing
-    # secret (last-writer-wins-but-content-identical from the user's POV).
-    token = secrets.token_hex(SECRET_BYTES)
-    try:
-        fd = os.open(str(secret_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-    except FileExistsError:
-        # Another concurrent spawn won the race. Re-read.
-        existing = secret_path.read_text().strip()
-        if existing:
-            return existing
-        # File was created by the racer but is somehow empty — fall through
-        # and retry generation (very narrow window where we can recover).
-        token = secrets.token_hex(SECRET_BYTES)
-        fd = os.open(str(secret_path), os.O_CREAT | os.O_TRUNC | os.O_WRONLY, 0o600)
-    with os.fdopen(fd, "w") as f:
-        f.write(token + "\n")
-    logger.info("generated shared secret at %s", secret_path)
-    return token
+        # Try the atomic O_EXCL create. Either we win (write our secret)
+        # or someone else owns the file (re-read on next iteration).
+        new_token = secrets.token_hex(SECRET_BYTES)
+        try:
+            fd = os.open(
+                str(secret_path),
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+        except FileExistsError:
+            # Another process owns the file. Brief sleep so they can
+            # finish writing, then loop back to the fast-path re-read.
+            if attempt + 1 < ENSURE_SECRET_MAX_RETRIES:
+                time.sleep(ENSURE_SECRET_RETRY_SLEEP_SEC)
+            continue
+        with os.fdopen(fd, "w") as f:
+            f.write(new_token + "\n")
+        logger.info("generated shared secret at %s", secret_path)
+        return new_token
+
+    # All retries observed the file existing but staying empty. We do
+    # NOT O_TRUNC over it — that would risk overwriting a concurrent
+    # racer's just-written secret. Fail closed; coordinator startup
+    # aborts with an actionable error.
+    raise EnsureSecretError(
+        f"hook.secret at {secret_path} exists but stayed empty across "
+        f"{ENSURE_SECRET_MAX_RETRIES} attempts; refusing to O_TRUNC over a "
+        f"file another process may be writing concurrently. Manually "
+        f"remove {secret_path} if it is genuinely stale."
+    )
 
 
 def load_secret(coordinator_root: Path) -> Optional[str]:

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -585,15 +585,24 @@ def _make_handler_class(coordinator: CoordinatorHTTPServer) -> type:
                     self._json(401, {"error": "missing or invalid bearer token"})
                     return
 
-                # Route
+                # Route. R12 (Unit 6): query string is intentionally
+                # separated from the route key so /status?detail=full
+                # dispatches to the same handler as /status, with the
+                # handler reading the detail parameter for tier gating.
+                raw_path = self.path
+                if "?" in raw_path:
+                    route_path, query = raw_path.split("?", 1)
+                else:
+                    route_path, query = raw_path, ""
+                self._query_string = query  # consumed by status handler
                 try:
-                    handler = _ROUTES.get((method, self.path))
+                    handler = _ROUTES.get((method, route_path))
                     if handler is None:
-                        self._json(404, {"error": f"unknown route {method} {self.path}"})
+                        self._json(404, {"error": f"unknown route {method} {route_path}"})
                         return
                     handler(self, coordinator)
                 except Exception as exc:
-                    logger.exception("unhandled error in handler for %s %s", method, self.path)
+                    logger.exception("unhandled error in handler for %s %s", method, route_path)
                     self._json(500, {"error": f"internal: {type(exc).__name__}"})
             finally:
                 coordinator.release_handler_slot()
@@ -1333,26 +1342,54 @@ def _handle_pre_grep(req, coordinator: CoordinatorHTTPServer) -> None:
 def _handle_status(req, coordinator: CoordinatorHTTPServer) -> None:
     """GET /status — drives the agent-coherence-status console script.
 
-    P2 ce-review fix #18 (kieran-python): batched the per-(session,
-    artifact) query loop. The previous version did
-    ``get_agent_state(artifact_id, agent_id)`` and a SECOND
-    ``get_artifact(artifact_id)`` per inner iteration — O(sessions ×
-    artifacts) SQLite round-trips per /status request. Now we
-    build a single ``{artifact_id: Artifact}`` lookup outside the loop
-    and call ``get_state_map(artifact_id)`` once per artifact (which
-    returns ``{agent_id: MESIState}`` in one query). Per-session
-    iteration becomes a dict lookup — O(artifacts) total queries.
+    R12 (Unit 6): three-tier disclosure model.
+
+    | tier      | query                | extra requirement              |
+    |-----------|----------------------|--------------------------------|
+    | minimal   | (none) or detail=minimal | none                       |
+    | metrics   | ?detail=metrics      | none — telemetry block only    |
+    | full      | ?detail=full         | ``Coherence-Local-Operator: true`` header opt-in |
+
+    ``minimal`` is the default and includes no absolute paths (workspace
+    root is reported as a sentinel ``.``). ``metrics`` returns only the
+    counter block — useful for operators scraping /status into a
+    dashboard without leaking workspace state. ``full`` is the legacy
+    everything-block plus absolute ``coordinator_root`` and ``coordinator_pid``,
+    gated by the explicit ``Coherence-Local-Operator: true`` header so a
+    same-user adversary (Adversary 1 in auth.py) cannot trivially grab
+    the operator's home-directory path. Bearer auth is enforced by the
+    dispatcher; the header is a SECOND factor specifically for the
+    elevated tier.
     """
-    # A4 + R10 (Unit 6): snapshot artifact_ids and _agent_names BEFORE
-    # iterating, to avoid `RuntimeError: dictionary changed size during
-    # iteration` racing against a concurrent register_session in another
-    # handler. The snapshot is now taken under the dedicated
-    # _agent_names_lock via the public accessor — no GIL reliance.
+    detail = _parse_detail_query(getattr(req, "_query_string", ""))
+    if detail == "full":
+        if req.headers.get("Coherence-Local-Operator", "").lower() != "true":
+            req._json(403, {
+                "error": (
+                    "detail=full requires the Coherence-Local-Operator: true "
+                    "opt-in header in addition to the Bearer secret (R12)."
+                ),
+            })
+            return
+
+    # Counter block — present at every tier so the telemetry-only
+    # consumer (?detail=metrics) doesn't pay for the artifact/session walk.
+    counters = {
+        "coordinator_uptime_s": coordinator.uptime_s,
+        "watchdog_timeouts_total": coordinator._watchdog_timeouts_total,
+        "watchdog_queue_overflows_total": coordinator._watchdog_queue_overflows_total,
+        "handler_concurrency_overflows_total": coordinator._server.handler_concurrency_overflows_total,
+        "in_flight_drain_timed_out": coordinator._in_flight_drain_timed_out,
+        "cold_start_duration_ms": coordinator.cold_start_duration_ms,
+    }
+    if detail == "metrics":
+        req._json(200, {"detail": "metrics", **counters})
+        return
+
+    # Artifacts + sessions — needed for minimal AND full tiers. Keep the
+    # P2 ce-review fix #18 batched-query pattern.
     artifact_ids_snapshot = list(coordinator.registry.artifact_ids())
     agent_names_snapshot = coordinator.agent_names_snapshot()
-
-    # Single-pass artifact resolution: one get_artifact per artifact id,
-    # cached in artifact_by_id for the inner-loop lookups below.
     artifact_by_id = {}
     for artifact_id in artifact_ids_snapshot:
         art = coordinator.registry.get_artifact(artifact_id)
@@ -1363,15 +1400,10 @@ def _handle_status(req, coordinator: CoordinatorHTTPServer) -> None:
         {"path": art.name, "version": art.version, "id": str(artifact_id)}
         for artifact_id, art in artifact_by_id.items()
     ]
-
-    # Single-pass per-artifact state map: one get_state_map per artifact
-    # (returns all agents' states for that artifact in one query). The
-    # session/artifact cross-product becomes a dict lookup.
     state_by_artifact = {
         artifact_id: coordinator.registry.get_state_map(artifact_id)
-        for artifact_id in artifact_by_id  # only artifacts we actually have
+        for artifact_id in artifact_by_id
     }
-
     sessions: list[dict] = []
     for agent_id, name in agent_names_snapshot:
         per_artifact: dict[str, str] = {}
@@ -1385,20 +1417,39 @@ def _handle_status(req, coordinator: CoordinatorHTTPServer) -> None:
             "states": per_artifact,
         })
 
-    # v0.1.1 KTD-G item 3 + KTD-J: surface watchdog / concurrency degradation
-    # via /status so silent degradation is observable. agent-coherence-status
-    # CLI consumes this block; operators reading bug reports can spot
-    # watchdog saturation immediately.
-    req._json(200, {
+    base = {
+        "detail": detail,
         "tracked_artifacts": tracked,
         "sessions": sessions,
-        "coordinator_uptime_s": coordinator.uptime_s,
-        "coordinator_pid": os.getpid(),
         "policy_summary": coordinator.policy.summary(),
-        "watchdog_timeouts_total": coordinator._watchdog_timeouts_total,
-        "watchdog_queue_overflows_total": coordinator._watchdog_queue_overflows_total,
-        "handler_concurrency_overflows_total": coordinator._server.handler_concurrency_overflows_total,
-    })
+        **counters,
+    }
+    if detail == "full":
+        base["coordinator_root"] = str(coordinator.coordinator_root)
+        base["coordinator_pid"] = os.getpid()
+    else:
+        # Minimal: replace absolute workspace path with sentinel "." so the
+        # default tier never leaks $HOME or directory layout.
+        base["coordinator_root"] = "."
+    req._json(200, base)
+
+
+def _parse_detail_query(query: str) -> str:
+    """R12 (Unit 6): map a raw ``?detail=...`` query string to one of
+    ``{minimal, metrics, full}``. Unknown values fall back to ``minimal``
+    so a typo never exposes more than the default tier."""
+    if not query:
+        return "minimal"
+    for part in query.split("&"):
+        if "=" not in part:
+            continue
+        key, _, value = part.partition("=")
+        if key.strip() == "detail":
+            v = value.strip().lower()
+            if v in ("minimal", "metrics", "full"):
+                return v
+            return "minimal"
+    return "minimal"
 
 
 _ROUTES: dict[tuple[str, str], Callable] = {

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -97,6 +97,13 @@ MAX_PATH_LEN = 1024
 """Cap on inbound path length to defend against memory/DoS and prose-injection
 attacks. 1024 covers nested-deep paths in any realistic project."""
 
+MAX_REQUEST_BODY_BYTES = 64 * 1024
+"""R21 (Unit 6): hard cap on the Content-Length the HTTP server is willing
+to read into memory. Matches MAX_POLICY_YAML_BYTES — generous for the
+~1 KB hook payloads we actually expect, tight enough that a hostile or
+buggy client cannot OOM the coordinator with a single oversized body.
+Validated BEFORE rfile.read so we never allocate the offending buffer."""
+
 _SESSION_ID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
                             re.IGNORECASE)
 """UUID4 shape. CC v2.1.131 fixtures (cc_hook_stdin/) confirm session_ids
@@ -576,6 +583,23 @@ def _make_handler_class(coordinator: CoordinatorHTTPServer) -> type:
                 return None
             if n <= 0:
                 return {}
+            # R21 (Unit 6): cap the body BEFORE rfile.read so a hostile or
+            # buggy client cannot allocate an oversized buffer in the
+            # coordinator process. Validates Content-Length only — chunked
+            # transfer encoding is not supported by http.server in any
+            # case, so a missing/zero Content-Length already short-circuits
+            # above.
+            if n > MAX_REQUEST_BODY_BYTES:
+                self._json(
+                    413,
+                    {
+                        "error": (
+                            f"request body exceeds {MAX_REQUEST_BODY_BYTES} bytes "
+                            f"(Content-Length={n})"
+                        )
+                    },
+                )
+                return None
             raw = self.rfile.read(n)
             try:
                 obj = json.loads(raw.decode("utf-8"))

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -223,6 +223,13 @@ class CoordinatorHTTPServer:
         self._last_request_at = self._started_at
         self._shutting_down = False
         self._agent_names: dict[UUID, str] = dict(agent_names or {})
+        # R10 (Unit 6): explicit lock around _agent_names mutation. CPython's
+        # GIL makes single-key dict assignment effectively atomic today, but
+        # the project standard is "don't rely on GIL" so the contract holds
+        # on PyPy / future free-threading builds and so the snapshot pattern
+        # at _handle_status (list(items()) under the lock) sees a consistent
+        # view. threading.Lock per pattern (NOT RLock — no nested acquisition).
+        self._agent_names_lock = threading.Lock()
         # v0.1.1 KTD-G item 3: surface watchdog/concurrency degradation
         # rather than letting it stay silent. Counters are read by
         # _handle_status; incremented in _run_or_degrade (timeouts +
@@ -408,11 +415,31 @@ class CoordinatorHTTPServer:
         return self._shutting_down
 
     def register_session(self, session_id: str) -> UUID:
-        """Idempotent session registration. Returns the deterministic agent UUID."""
+        """Idempotent session registration. Returns the deterministic agent UUID.
+
+        R10 (Unit 6): mutation is wrapped in ``_agent_names_lock`` so the
+        check-then-set is atomic w.r.t. concurrent registrations AND so
+        :meth:`agent_name_for` snapshots see a consistent dict — relying
+        on the GIL is forbidden by the project standard."""
         agent_id = session_to_agent_id(session_id)
-        if agent_id not in self._agent_names:
-            self._agent_names[agent_id] = session_to_agent_name(session_id)
+        with self._agent_names_lock:
+            if agent_id not in self._agent_names:
+                self._agent_names[agent_id] = session_to_agent_name(session_id)
         return agent_id
+
+    def agent_names_snapshot(self) -> list[tuple[UUID, str]]:
+        """R10 (Unit 6): return a stable list snapshot of (agent_id, name)
+        pairs taken under the lock — callers iterate over the snapshot
+        rather than the live dict so a concurrent register_session cannot
+        invalidate the iteration (RuntimeError: dictionary changed size)."""
+        with self._agent_names_lock:
+            return list(self._agent_names.items())
+
+    def agent_name_for(self, agent_id: UUID) -> Optional[str]:
+        """R10 (Unit 6): single-key read under the lock. Returns None if
+        the agent has never been registered."""
+        with self._agent_names_lock:
+            return self._agent_names.get(agent_id)
 
     def run_with_watchdog(self, fn: Callable[[], Any]) -> Any:
         """Run a callable under the 4s handler-side timeout. Raises
@@ -1316,11 +1343,13 @@ def _handle_status(req, coordinator: CoordinatorHTTPServer) -> None:
     returns ``{agent_id: MESIState}`` in one query). Per-session
     iteration becomes a dict lookup — O(artifacts) total queries.
     """
-    # A4: snapshot artifact_ids and _agent_names BEFORE iterating, to avoid
-    # `RuntimeError: dictionary changed size during iteration` racing against
-    # a concurrent register_session in another handler.
+    # A4 + R10 (Unit 6): snapshot artifact_ids and _agent_names BEFORE
+    # iterating, to avoid `RuntimeError: dictionary changed size during
+    # iteration` racing against a concurrent register_session in another
+    # handler. The snapshot is now taken under the dedicated
+    # _agent_names_lock via the public accessor — no GIL reliance.
     artifact_ids_snapshot = list(coordinator.registry.artifact_ids())
-    agent_names_snapshot = list(coordinator._agent_names.items())
+    agent_names_snapshot = coordinator.agent_names_snapshot()
 
     # Single-pass artifact resolution: one get_artifact per artifact id,
     # cached in artifact_by_id for the inner-loop lookups below.
@@ -1569,8 +1598,10 @@ def _last_writer_unix_ts(
 
 
 def _agent_id_to_session(coordinator: CoordinatorHTTPServer, agent_id: UUID) -> Optional[str]:
-    """Reverse the session_to_agent_id mapping via agent_names."""
-    name = coordinator._agent_names.get(agent_id)
+    """Reverse the session_to_agent_id mapping via agent_names. R10 (Unit 6):
+    routes through the lock-aware public accessor instead of reaching into
+    the private dict directly."""
+    name = coordinator.agent_name_for(agent_id)
     if name and name.startswith("claude-session-"):
         return name[len("claude-session-"):]
     return None
@@ -1579,9 +1610,19 @@ def _agent_id_to_session(coordinator: CoordinatorHTTPServer, agent_id: UUID) -> 
 def _append_policy_yaml(yaml_path: Path, new_paths: list[str]) -> tuple[list[str], list[dict]]:
     """Append valid patterns to a YAML file. Returns (added, rejected).
     Honors MAX_POLICY_YAML_BYTES — raises ValueError if the resulting file
-    would exceed the cap."""
+    would exceed the cap.
+
+    R14 (Unit 6): the read-modify-write is wrapped in an ``fcntl.flock``
+    exclusive lock on a sidecar ``<yaml_path>.lock`` file so two concurrent
+    /policy/track or /policy/untrack requests cannot interleave their
+    reads-and-writes and corrupt the YAML (e.g., both read the same
+    pre-state, both compute "previous + my_paths", second write loses the
+    first writer's additions). fcntl is POSIX-only; on the deferred
+    Windows path this is a no-op (lifecycle already disables the
+    coordinator on Windows per _FCNTL_AVAILABLE)."""
     yaml_path.parent.mkdir(parents=True, exist_ok=True)
-    # Validate each path the same way TrackedArtifactPolicy does.
+    # Validate each path the same way TrackedArtifactPolicy does. This
+    # validation is pure (no I/O) so it lives outside the lock window.
     added: list[str] = []
     rejected: list[dict] = []
     for p in new_paths:
@@ -1599,12 +1640,45 @@ def _append_policy_yaml(yaml_path: Path, new_paths: list[str]) -> tuple[list[str
     if not added:
         return added, rejected
 
-    existing = ""
-    if yaml_path.is_file():
-        existing = yaml_path.read_text()
-    new_lines = "\n".join(f"- {p}" for p in added)
-    new_content = (existing.rstrip("\n") + "\n" + new_lines + "\n") if existing else (new_lines + "\n")
-    if len(new_content.encode("utf-8")) > MAX_POLICY_YAML_BYTES:
-        raise ValueError(f"policy YAML cap of {MAX_POLICY_YAML_BYTES} bytes would be exceeded")
-    yaml_path.write_text(new_content)
-    return added, rejected
+    lock_path = yaml_path.with_suffix(yaml_path.suffix + ".lock")
+    try:
+        import fcntl as _fcntl
+        lock_fd: Optional[int] = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            _fcntl.flock(lock_fd, _fcntl.LOCK_EX)
+            existing = yaml_path.read_text() if yaml_path.is_file() else ""
+            new_lines = "\n".join(f"- {p}" for p in added)
+            new_content = (
+                (existing.rstrip("\n") + "\n" + new_lines + "\n") if existing
+                else (new_lines + "\n")
+            )
+            if len(new_content.encode("utf-8")) > MAX_POLICY_YAML_BYTES:
+                raise ValueError(
+                    f"policy YAML cap of {MAX_POLICY_YAML_BYTES} bytes would be exceeded"
+                )
+            yaml_path.write_text(new_content)
+            return added, rejected
+        finally:
+            try:
+                _fcntl.flock(lock_fd, _fcntl.LOCK_UN)
+            except OSError:
+                pass
+            try:
+                os.close(lock_fd)
+            except OSError:
+                pass
+    except ImportError:
+        # Windows fallback: no fcntl. Lifecycle already disables the
+        # coordinator on Windows, but degrade defensively if reached.
+        existing = yaml_path.read_text() if yaml_path.is_file() else ""
+        new_lines = "\n".join(f"- {p}" for p in added)
+        new_content = (
+            (existing.rstrip("\n") + "\n" + new_lines + "\n") if existing
+            else (new_lines + "\n")
+        )
+        if len(new_content.encode("utf-8")) > MAX_POLICY_YAML_BYTES:
+            raise ValueError(
+                f"policy YAML cap of {MAX_POLICY_YAML_BYTES} bytes would be exceeded"
+            )
+        yaml_path.write_text(new_content)
+        return added, rejected

--- a/src/ccs/cli/_coherence_client.py
+++ b/src/ccs/cli/_coherence_client.py
@@ -118,17 +118,30 @@ def resolve_endpoint(coordinator_root: Path) -> CoordinatorEndpoint:
     return CoordinatorEndpoint(port=port, bearer=bearer)
 
 
-def get(endpoint: CoordinatorEndpoint, path: str) -> dict[str, Any]:
+def get(
+    endpoint: CoordinatorEndpoint,
+    path: str,
+    *,
+    extra_headers: Optional[dict[str, str]] = None,
+) -> dict[str, Any]:
     """Authenticated GET. Raises :class:`CoordinatorUnavailable` on network
     error; raises :class:`urllib.error.HTTPError` for non-2xx so the caller
-    can format status codes explicitly."""
+    can format status codes explicitly.
+
+    R12 (Unit 6): ``extra_headers`` lets local-operator CLIs (e.g.,
+    ``agent-coherence-status``) add ``Coherence-Local-Operator: true``
+    for the elevated ``/status?detail=full`` tier without hard-coding
+    that header here."""
+    headers: dict[str, str] = {
+        "Authorization": f"Bearer {endpoint.bearer}",
+        "Host": "127.0.0.1",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
     req = urllib.request.Request(
         url=f"{endpoint.base_url}{path}",
         method="GET",
-        headers={
-            "Authorization": f"Bearer {endpoint.bearer}",
-            "Host": "127.0.0.1",
-        },
+        headers=headers,
     )
     return _execute(req)
 

--- a/src/ccs/cli/coherence_status.py
+++ b/src/ccs/cli/coherence_status.py
@@ -59,7 +59,16 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     try:
         endpoint = resolve_endpoint(Path(root))
-        payload = get(endpoint, "/status")
+        # R12 (Unit 6): agent-coherence-status is a local operator CLI
+        # running in the workspace it inspects, so it qualifies for the
+        # full tier. Pass the explicit Coherence-Local-Operator opt-in
+        # header so coordinator_pid and the absolute coordinator_root are
+        # included in the rendered table.
+        payload = get(
+            endpoint,
+            "/status?detail=full",
+            extra_headers={"Coherence-Local-Operator": "true"},
+        )
     except CoordinatorUnavailable as exc:
         err(f"agent-coherence-status: {exc}")
         return 0  # graceful — no coordinator is a normal state

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -1446,3 +1446,124 @@ def test_r21_body_at_cap_accepted(coordinator) -> None:
         # — but the body must have been READ, proving the cap let it through).
         assert resp.status in (200, 400)
     del client  # silence unused-var lint
+
+
+# ----------------------------------------------------------------------
+# R10 (Unit 6) — _agent_names mutation under threading.Lock
+# ----------------------------------------------------------------------
+
+
+def test_r10_agent_names_lock_serializes_concurrent_registration(
+    coordinator,
+) -> None:
+    """Eight threads concurrently call register_session with distinct
+    session ids; the resulting dict must contain exactly the union with
+    no torn entries (no missing keys, no overwrites)."""
+    expected: set[str] = set()
+    barrier = threading.Barrier(8)
+    lock = threading.Lock()
+
+    def churner(thread_idx: int) -> None:
+        barrier.wait()
+        for j in range(50):
+            sid = _sid(f"r10-{thread_idx}-{j}")
+            with lock:
+                expected.add(sid)
+            coordinator.register_session(sid)
+
+    threads = [threading.Thread(target=churner, args=(i,)) for i in range(8)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+
+    snapshot = coordinator.agent_names_snapshot()
+    names = {name for _, name in snapshot}
+    assert len(snapshot) >= len(expected)
+    for sid in expected:
+        assert f"claude-session-{sid}" in names, (
+            f"session {sid} missing from snapshot (lock failed to serialize)"
+        )
+
+
+def test_r10_status_snapshot_consistent_under_churn(
+    coordinator, client: _Client,
+) -> None:
+    """A reader calling /status while writers churn register_session must
+    NEVER see RuntimeError from a torn iteration. The lock-protected
+    snapshot is the contract."""
+    stop = threading.Event()
+    errors: list[Exception] = []
+
+    def writer() -> None:
+        i = 0
+        while not stop.is_set():
+            try:
+                coordinator.register_session(_sid(f"r10-churn-{i}"))
+            except Exception as e:
+                errors.append(e)
+            i += 1
+
+    writers = [threading.Thread(target=writer) for _ in range(4)]
+    for t in writers: t.start()
+    try:
+        for _ in range(20):
+            s, _ = client.get("/status")
+            assert s == 200, "status returned non-200 under register_session churn"
+    finally:
+        stop.set()
+        for t in writers: t.join(timeout=2.0)
+    assert not errors, f"writer threads hit errors: {errors[:3]}"
+
+
+def test_r10_agent_name_for_returns_none_for_unknown(coordinator) -> None:
+    """The single-key accessor returns None for an agent that has never
+    been registered, without raising."""
+    fake_id = uuid.uuid5(uuid.NAMESPACE_URL, "ccs-agent:claude-session-never-registered")
+    assert coordinator.agent_name_for(fake_id) is None
+
+
+# ----------------------------------------------------------------------
+# R14 (Unit 6) — _append_policy_yaml under fcntl.flock
+# ----------------------------------------------------------------------
+
+
+def test_r14_concurrent_policy_track_no_lost_writes(coordinator, client: _Client) -> None:
+    """Eight threads each POST /policy/track with one unique path; every
+    request that the coordinator accepts (status 200) must have its path
+    persisted in tracked.yaml — no read-modify-write interleaving losing
+    entries. R14's contract is about lost writes among ACCEPTED requests,
+    not about 503s from the KTD-G concurrency cap (which is a separate
+    pre-handler reject)."""
+    target_paths = [f"r14/path_{i}.md" for i in range(8)]
+    barrier = threading.Barrier(len(target_paths))
+    results: list[tuple[str, int]] = []
+    results_lock = threading.Lock()
+
+    def add_path(p: str) -> None:
+        barrier.wait()
+        s, _ = client.post("/policy/track", {"paths": [p]})
+        with results_lock:
+            results.append((p, s))
+
+    threads = [threading.Thread(target=add_path, args=(p,)) for p in target_paths]
+    for t in threads: t.start()
+    for t in threads: t.join()
+
+    accepted = [p for p, s in results if s == 200]
+    assert accepted, f"no requests succeeded — KTD-G cap may be too tight: {results}"
+
+    yaml_path = coordinator.coordinator_root / ".coherence" / "tracked.yaml"
+    text = yaml_path.read_text()
+    for p in accepted:
+        assert f"- {p}" in text, (
+            f"path {p!r} lost despite 200 response — fcntl.flock did not serialize"
+        )
+
+
+def test_r14_lock_file_created_next_to_yaml(coordinator, client: _Client) -> None:
+    """The fcntl lock uses a sidecar ``<yaml>.lock`` file; verify it
+    appears and stays present (the file is reused across calls)."""
+    client.post("/policy/track", {"paths": ["r14_sidecar.md"]})
+    lock_path = (
+        coordinator.coordinator_root / ".coherence" / "tracked.yaml.lock"
+    )
+    assert lock_path.is_file(), "tracked.yaml.lock sidecar was not created"

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -1365,3 +1365,84 @@ def test_i6_dispatch_decrements_even_when_handler_raises(
         assert coordinator._in_flight == 0
     finally:
         mod._ROUTES[("POST", "/hooks/pre-read")] = original
+
+
+# ----------------------------------------------------------------------
+# R21 (Unit 6) — MAX_REQUEST_BODY_BYTES cap before rfile.read
+# ----------------------------------------------------------------------
+
+
+def test_r21_request_body_overflow_returns_413(coordinator) -> None:
+    """A Content-Length header that exceeds MAX_REQUEST_BODY_BYTES must
+    be rejected with 413 BEFORE the coordinator reads the body into
+    memory — protects against single-request OOM by a hostile or buggy
+    client inside the trust boundary."""
+    import http.client
+    from ccs.adapters.claude_code.coordinator_server import MAX_REQUEST_BODY_BYTES
+    from ccs.adapters.claude_code.auth import load_secret
+
+    secret = load_secret(coordinator.coordinator_root)
+    assert secret is not None
+
+    # Build the request manually to control Content-Length precisely.
+    # We claim n+1 bytes but only send 1 byte — server must reject on
+    # header alone, not after reading the (oversized) body.
+    over_n = MAX_REQUEST_BODY_BYTES + 1
+    conn = http.client.HTTPConnection("127.0.0.1", coordinator.port, timeout=5)
+    try:
+        conn.request(
+            "POST", "/hooks/pre-read",
+            body=b"x",  # intentional mismatch — header says oversized, body is tiny
+            headers={
+                "Authorization": f"Bearer {secret}",
+                "Host": "127.0.0.1",
+                "Content-Type": "application/json",
+                "Content-Length": str(over_n),
+            },
+        )
+        resp = conn.getresponse()
+        assert resp.status == 413, (
+            f"expected 413 for oversized Content-Length={over_n}; got {resp.status}"
+        )
+        body = json.loads(resp.read().decode("utf-8"))
+        assert "exceeds" in body["error"].lower()
+        assert str(over_n) in body["error"]
+    finally:
+        conn.close()
+
+
+def test_r21_body_at_cap_accepted(coordinator) -> None:
+    """Boundary: a body at exactly MAX_REQUEST_BODY_BYTES (still well
+    over our real payload sizes) is accepted, not 413'd off."""
+    from ccs.adapters.claude_code.coordinator_server import MAX_REQUEST_BODY_BYTES
+    from ccs.adapters.claude_code.auth import load_secret
+
+    secret = load_secret(coordinator.coordinator_root)
+    assert secret is not None
+
+    # Craft a JSON object whose serialized length equals the cap. We pad
+    # the session_id label so the overall JSON hits the byte count.
+    base = {"session_id": _sid("r21"), "path": "CLAUDE.md", "pad": ""}
+    base_bytes = json.dumps(base).encode("utf-8")
+    pad_len = MAX_REQUEST_BODY_BYTES - len(base_bytes)
+    assert pad_len > 0
+    base["pad"] = "x" * pad_len
+    payload = json.dumps(base).encode("utf-8")
+    assert len(payload) == MAX_REQUEST_BODY_BYTES
+
+    client = _Client("127.0.0.1", coordinator.port, secret)
+    # Use the raw urllib client to ensure we control Content-Length.
+    url = f"http://127.0.0.1:{coordinator.port}/hooks/pre-read"
+    req = urlrequest.Request(
+        url, data=payload, method="POST",
+        headers={
+            "Authorization": f"Bearer {secret}",
+            "Host": "127.0.0.1",
+            "Content-Type": "application/json",
+        },
+    )
+    with urlrequest.urlopen(req, timeout=5) as resp:
+        # Server may 200 (fresh) or 400 (unknown extra fields are tolerated
+        # — but the body must have been READ, proving the cap let it through).
+        assert resp.status in (200, 400)
+    del client  # silence unused-var lint

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -416,6 +416,9 @@ def test_policy_untrack_persists_to_ignored_yaml(coordinator, client: _Client) -
 
 
 def test_status_includes_tracked_artifacts_and_sessions(client: _Client) -> None:
+    """Default (minimal) tier still surfaces tracked artifacts + sessions +
+    counters; operator-level fields (coordinator_pid, absolute root) move
+    to ``?detail=full`` per R12."""
     a_sid = _sid("A")
     client.post("/hooks/pre-read", {"session_id": a_sid, "path": "plan.md"})
     client.post("/hooks/pre-edit", {"session_id": a_sid, "path": "spec.md"})
@@ -427,8 +430,11 @@ def test_status_includes_tracked_artifacts_and_sessions(client: _Client) -> None
     sessions = {sess["agent_name"] for sess in b["sessions"]}
     assert f"claude-session-{a_sid}" in sessions
     assert b["coordinator_uptime_s"] > 0
-    assert isinstance(b["coordinator_pid"], int)
     assert "policy_summary" in b
+    # R12: minimal tier never leaks coordinator_pid or absolute root.
+    assert b.get("detail") == "minimal"
+    assert b.get("coordinator_root") == "."
+    assert "coordinator_pid" not in b
 
 
 # ----------------------------------------------------------------------
@@ -1646,6 +1652,79 @@ def test_r11_ensure_secret_fails_closed_when_empty_file_persists(
     assert "stayed empty" in str(exc.value)
     # The file must remain empty — we did NOT O_TRUNC over it.
     assert secret_path.stat().st_size == 0
+
+
+# ----------------------------------------------------------------------
+# R12 (Unit 6) — /status three-tier disclosure
+# ----------------------------------------------------------------------
+
+
+def test_r12_status_minimal_default_hides_coordinator_root_and_pid(
+    client: _Client,
+) -> None:
+    """The default (no query) response is the minimal tier — coordinator_root
+    is the sentinel "." and coordinator_pid is absent."""
+    s, b = client.get("/status")
+    assert s == 200
+    assert b["detail"] == "minimal"
+    assert b["coordinator_root"] == "."
+    assert "coordinator_pid" not in b
+
+
+def test_r12_status_full_requires_operator_header(client: _Client) -> None:
+    """?detail=full without the Coherence-Local-Operator: true opt-in header
+    must be rejected with 403 — Bearer auth alone is not sufficient for
+    the elevated tier."""
+    s, b = client.get("/status?detail=full")
+    assert s == 403
+    assert "operator" in b["error"].lower()
+
+
+def test_r12_status_full_with_operator_header_exposes_root_and_pid(
+    client: _Client, coordinator,
+) -> None:
+    """?detail=full + Coherence-Local-Operator: true returns the absolute
+    coordinator_root and coordinator_pid for legitimate operator inspection."""
+    s, b = client.request(
+        "GET", "/status?detail=full",
+        headers_override={"Coherence-Local-Operator": "true"},
+    )
+    assert s == 200
+    assert b["detail"] == "full"
+    assert b["coordinator_root"] == str(coordinator.coordinator_root)
+    assert isinstance(b["coordinator_pid"], int)
+    # Full tier also retains the artifact/session block.
+    assert "tracked_artifacts" in b
+    assert "sessions" in b
+
+
+def test_r12_status_metrics_returns_counters_only(client: _Client) -> None:
+    """?detail=metrics returns only the counter block — no artifact/session
+    walk, no leak of workspace state. Useful for dashboard scrapers."""
+    s, b = client.get("/status?detail=metrics")
+    assert s == 200
+    assert b["detail"] == "metrics"
+    assert "tracked_artifacts" not in b
+    assert "sessions" not in b
+    assert "policy_summary" not in b
+    # Counters must be present.
+    for k in (
+        "coordinator_uptime_s",
+        "watchdog_timeouts_total",
+        "handler_concurrency_overflows_total",
+        "in_flight_drain_timed_out",
+        "cold_start_duration_ms",
+    ):
+        assert k in b, f"counter {k} missing from metrics tier"
+
+
+def test_r12_status_unknown_detail_falls_back_to_minimal(client: _Client) -> None:
+    """A typo'd ?detail=value must NOT silently grant more access — it
+    falls back to minimal, never to full."""
+    s, b = client.get("/status?detail=fully")
+    assert s == 200
+    assert b["detail"] == "minimal"
+    assert "coordinator_pid" not in b
 
 
 def test_r11_ensure_secret_concurrent_threads_return_identical(

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -1567,3 +1567,109 @@ def test_r14_lock_file_created_next_to_yaml(coordinator, client: _Client) -> Non
         coordinator.coordinator_root / ".coherence" / "tracked.yaml.lock"
     )
     assert lock_path.is_file(), "tracked.yaml.lock sidecar was not created"
+
+
+# ----------------------------------------------------------------------
+# R11 (Unit 6) — ensure_secret bounded O_EXCL retry, fail-closed
+# ----------------------------------------------------------------------
+
+
+def test_r11_ensure_secret_recovers_from_empty_file_during_retries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If a stale empty hook.secret exists when ensure_secret runs (e.g.,
+    a previous coordinator crashed between O_EXCL-create and write), the
+    bounded retry loop must eventually populate it without clobbering
+    via O_TRUNC. We simulate this by pre-creating the empty file, then
+    letting ensure_secret retry through to a clean O_EXCL after we
+    unlink it from a sidecar 'racer' thread."""
+    import threading as _t
+    from ccs.adapters.claude_code import auth as _auth
+
+    coherence_dir = tmp_path / ".coherence"
+    coherence_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    secret_path = coherence_dir / _auth.SECRET_FILENAME
+
+    # Make the file exist but be empty (mimics crashed predecessor).
+    secret_path.touch(mode=0o600)
+    assert secret_path.stat().st_size == 0
+
+    # Speed up the test: shorter retry sleep, but keep retry count.
+    monkeypatch.setattr(_auth, "ENSURE_SECRET_RETRY_SLEEP_SEC", 0.020)
+
+    # Simulate a racer that unlinks the empty file mid-retry, allowing
+    # ensure_secret's next O_EXCL to succeed.
+    def racer() -> None:
+        time.sleep(0.040)
+        try:
+            secret_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    t = _t.Thread(target=racer)
+    t.start()
+    try:
+        token = _auth.ensure_secret(tmp_path)
+    finally:
+        t.join(timeout=2.0)
+    # Contract: ensure_secret returned a token (recovery from empty
+    # file succeeded). We intentionally do NOT re-read the file —
+    # the racer may have unlinked AFTER ensure_secret returned, which
+    # is fine for the in-process race but would race the assertion
+    # on slow CI runners.
+    assert token
+    assert len(token) == 64
+
+
+def test_r11_ensure_secret_fails_closed_when_empty_file_persists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If hook.secret stays empty across all retries, ensure_secret MUST
+    raise EnsureSecretError rather than O_TRUNC over it. The old behavior
+    would silently overwrite a concurrent racer's valid secret, leaving
+    two spawn-side processes with different secrets for the same
+    workspace — a silent total-protocol-break failure mode."""
+    from ccs.adapters.claude_code import auth as _auth
+
+    coherence_dir = tmp_path / ".coherence"
+    coherence_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    secret_path = coherence_dir / _auth.SECRET_FILENAME
+    secret_path.touch(mode=0o600)
+    assert secret_path.stat().st_size == 0
+
+    # Shorten retry sleep so the test finishes fast.
+    monkeypatch.setattr(_auth, "ENSURE_SECRET_RETRY_SLEEP_SEC", 0.001)
+    monkeypatch.setattr(_auth, "ENSURE_SECRET_MAX_RETRIES", 3)
+
+    with pytest.raises(_auth.EnsureSecretError) as exc:
+        _auth.ensure_secret(tmp_path)
+    assert "stayed empty" in str(exc.value)
+    # The file must remain empty — we did NOT O_TRUNC over it.
+    assert secret_path.stat().st_size == 0
+
+
+def test_r11_ensure_secret_concurrent_threads_return_identical(
+    tmp_path: Path,
+) -> None:
+    """Multiple threads spawning concurrently must all walk away with the
+    SAME secret (one wins O_EXCL, the others read what the winner wrote).
+    Thread-level test exercises the in-process race; the cross-process
+    case is identical at the syscall layer (O_EXCL is OS-enforced)."""
+    from ccs.adapters.claude_code.auth import ensure_secret
+
+    tokens: list[str] = []
+    tokens_lock = threading.Lock()
+    barrier = threading.Barrier(8)
+
+    def worker() -> None:
+        barrier.wait()
+        tok = ensure_secret(tmp_path)
+        with tokens_lock:
+            tokens.append(tok)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+    assert len(set(tokens)) == 1, (
+        f"concurrent ensure_secret returned different tokens: {set(tokens)}"
+    )

--- a/tests/test_claude_code_e2e.py
+++ b/tests/test_claude_code_e2e.py
@@ -198,13 +198,17 @@ def test_auth_rejects_request_with_wrong_bearer(live) -> None:
 
 
 def test_auth_accepts_request_with_correct_bearer(live) -> None:
-    """Correct token → 200 + valid JSON status."""
+    """Correct token → 200 + valid JSON status. R12 (Unit 6): default
+    tier no longer includes ``coordinator_pid`` (operator-elevated). The
+    e2e contract here is "Bearer auth gets you a 200 with the minimal
+    shape", not "Bearer auth gets you operator-level fields"."""
     _, port, secret = live
     status, body = _request(port, "/status", bearer=secret)
     assert status == 200
     payload = json.loads(body)
-    assert "coordinator_pid" in payload
+    assert payload["detail"] == "minimal"
     assert "tracked_artifacts" in payload
+    assert "coordinator_pid" not in payload  # gated by ?detail=full + opt-in header
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase B Unit 6 of the v0.1.1 marketplace cut — five residual-risk fixes. **Stacked on #29** (Unit 5) which stacks on #28 (Unit 4); after both ancestors merge this PR resolves to just the Unit 6 commits.

- **R21** ([678d6de](../../commit/678d6de)) — \`MAX_REQUEST_BODY_BYTES = 64 KB\` enforced in \`_read_json\` BEFORE \`rfile.read\`. A hostile or buggy client cannot OOM the coordinator with a single oversized body.
- **R10 + R14** ([def3742](../../commit/def3742)) — \`_agent_names\` mutation wrapped in \`threading.Lock\`; public \`agent_names_snapshot()\` / \`agent_name_for()\` accessors replace cross-module reach-into private dict. \`_append_policy_yaml\` serializes its read-modify-write under \`fcntl.flock\` on a sidecar \`tracked.yaml.lock\` so concurrent \`/policy/track\` requests can't interleave and lose writes.
- **R11** ([b072e38](../../commit/b072e38)) — \`ensure_secret\` empty-file recovery is now a bounded \`O_EXCL\` retry loop (default 5 attempts, brief sleeps) that fails closed with a new \`EnsureSecretError\` rather than \`O_TRUNC\`-overwriting a racer's just-written valid secret. The old \`O_TRUNC\` path could silently leave two spawn-side processes with different secrets for the same workspace.
- **R12** ([9f9b316](../../commit/9f9b316)) — \`/status\` now exposes three tiers: \`minimal\` (default, no absolute paths, no pid), \`metrics\` (counter block only), \`full\` (everything, requires \`Coherence-Local-Operator: true\` header in addition to Bearer). Unknown \`?detail=\` values fall back to minimal — typos cannot silently grant elevated access. \`agent-coherence-status\` CLI sends the opt-in header so the rendered table still shows pid + absolute root for legitimate local operators.

## Test plan

- [x] \`tests/test_claude_code_coordinator_server.py\` — +15 tests across R21 (2), R10 (3), R14 (2), R11 (3), R12 (5).
- [x] e2e regression — \`test_auth_accepts_request_with_correct_bearer\` updated for the new minimal-tier shape.
- [x] Full claude_code suite green locally at HEAD (304 passed).

Refs: \`docs/plans/2026-05-18-001-feat-claude-code-coherence-plugin-v0.1.1-plan.md\` Unit 6 / R10 / R11 / R12 / R14 / R21.