### PR TITLE
feat(v0.1.1 Unit 8): KTD-J counters + /status three-tier CLI + --self-test + --prepare-for-migration

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1612,6 +1612,96 @@ def _parse_detail_query(query: str) -> str:
     return "minimal"
 
 
+def _handle_prepare_for_migration(req, coordinator: CoordinatorHTTPServer) -> None:
+    """POST /admin/prepare-for-migration — release-all-grants then schedule shutdown.
+
+    Unit 8 (Decision 1, locked 2026-05-18): operator runs
+    ``agent-coherence-coordinator --prepare-for-migration`` before
+    switching the Python/Node backend. This endpoint backs the CLI:
+
+    1. Snapshot every (agent, artifact) pair currently in MODIFIED or
+       EXCLUSIVE state.
+    2. Invalidate each — agents lose their write grants cleanly so the
+       new backend cannot inherit silent stale-grant state.
+    3. Schedule shutdown via a background thread (a small delay so this
+       response can flush to the CLI before the serve loop tears down).
+    4. Return {released, errors, shutdown_scheduled_in_ms}.
+
+    Requires the same elevated-tier signal as /status?detail=full:
+    Bearer + ``Coherence-Local-Operator: true`` header. The CLI sets
+    both; a same-user adversary trying to crash the coordinator needs
+    to read hook.secret AND know the magic header — the same bar as
+    /status?detail=full's pid disclosure.
+    """
+    if req.headers.get("Coherence-Local-Operator", "").lower() != "true":
+        req._json(403, {
+            "error": (
+                "prepare-for-migration requires the Coherence-Local-Operator: "
+                "true opt-in header (operator-only endpoint)."
+            ),
+        })
+        return
+
+    now = monotonic_seconds()
+    released = 0
+    errors: list[dict[str, str]] = []
+
+    # Snapshot artifacts + per-artifact state maps under the registry's
+    # own consistency guarantees, then invalidate each M/E grant. We do
+    # NOT hold any lock across invalidations — service.invalidate is
+    # designed for one-at-a-time use, and the per-artifact write
+    # serialization in the registry is sufficient.
+    for artifact_id in list(coordinator.registry.artifact_ids()):
+        state_map = coordinator.registry.get_state_map(artifact_id)
+        for agent_id, state in list(state_map.items()):
+            if state not in (MESIState.MODIFIED, MESIState.EXCLUSIVE):
+                continue
+            artifact = coordinator.registry.get_artifact(artifact_id)
+            if artifact is None:
+                continue
+            try:
+                coordinator.service.invalidate(
+                    agent_id=agent_id,
+                    artifact_id=artifact_id,
+                    new_version=artifact.version,
+                    issuer_agent_id=agent_id,
+                    issued_at_tick=now,
+                )
+                released += 1
+            except CoherenceError as exc:
+                errors.append({
+                    "artifact_id": str(artifact_id),
+                    "agent_id": str(agent_id),
+                    "reason": str(exc),
+                })
+
+    # Schedule shutdown. Background thread gives this response time to
+    # flush before serve_forever exits. 100ms is enough for the kernel
+    # to drain the response socket but short enough that the CLI's poll
+    # observes the port-down transition without long idle waits.
+    SHUTDOWN_DELAY_MS = 100
+
+    def _scheduled_shutdown() -> None:
+        time.sleep(SHUTDOWN_DELAY_MS / 1000.0)
+        try:
+            coordinator.shutdown()
+        except Exception:  # pragma: no cover — best-effort cleanup
+            logger.exception("scheduled shutdown after prepare-for-migration failed")
+
+    threading.Thread(
+        target=_scheduled_shutdown,
+        name="prepare-for-migration-shutdown",
+        daemon=True,
+    ).start()
+
+    req._json(200, {
+        "ok": True,
+        "released": released,
+        "errors": errors,
+        "shutdown_scheduled_in_ms": SHUTDOWN_DELAY_MS,
+    })
+
+
 _ROUTES: dict[tuple[str, str], Callable] = {
     ("POST", "/hooks/pre-read"): _handle_pre_read,
     ("POST", "/hooks/pre-edit"): _handle_pre_edit,
@@ -1626,6 +1716,7 @@ _ROUTES: dict[tuple[str, str], Callable] = {
     ("POST", "/policy/track"): _handle_policy_track,
     ("POST", "/policy/untrack"): _handle_policy_untrack,
     ("GET", "/status"): _handle_status,
+    ("POST", "/admin/prepare-for-migration"): _handle_prepare_for_migration,
 }
 
 
@@ -1643,6 +1734,9 @@ _ENDPOINT_COUNTER_NAMES: dict[tuple[str, str], str] = {
     ("POST", "/policy/track"): "policy_track_total",
     ("POST", "/policy/untrack"): "policy_untrack_total",
     ("GET", "/status"): "status_total",
+    # /admin/prepare-for-migration intentionally not counted — it
+    # initiates shutdown, so counting it would never be observable via
+    # subsequent /status calls (coordinator is already down).
 }
 
 

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -104,6 +104,21 @@ to read into memory. Matches MAX_POLICY_YAML_BYTES — generous for the
 buggy client cannot OOM the coordinator with a single oversized body.
 Validated BEFORE rfile.read so we never allocate the offending buffer."""
 
+
+def _resolve_coordinator_version() -> str:
+    """KTD-J (Unit 8): surface the package version via /status so operators
+    pasting status output into bug reports always include which build
+    they're running. Reads ``ccs.__version__`` lazily so test fixtures
+    that import this module before ``ccs`` is fully loaded don't crash."""
+    try:
+        from ccs import __version__ as _v
+        return _v
+    except Exception:  # pragma: no cover — defensive against import order
+        return "unknown"
+
+
+_COORDINATOR_VERSION: str = _resolve_coordinator_version()
+
 _SESSION_ID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
                             re.IGNORECASE)
 """UUID4 shape. CC v2.1.131 fixtures (cc_hook_stdin/) confirm session_ids
@@ -257,6 +272,60 @@ class CoordinatorHTTPServer:
         # lifecycle module sets it; remains 0.0 when the server is
         # constructed directly in tests.
         self.cold_start_duration_ms: float = 0.0
+
+        # KTD-J (Unit 8) — telemetry counters. CACHE, not persistent
+        # state: reset to 0 on coordinator respawn (do NOT persist in
+        # state.db per the plan rationale). Plain ints — CPython's
+        # GIL guarantees atomicity for ``+= 1``; the contract is
+        # "advisory, not auditable", so a missed increment on a
+        # future free-threading build is acceptable.
+        #
+        # Per-endpoint request counters — drive operator visibility
+        # into which hooks fire and how often. Surfaced via
+        # /status?detail=full and /status?detail=metrics.
+        self._endpoint_counters: dict[str, int] = {
+            "pre_read_total": 0,
+            "pre_edit_total": 0,
+            "post_edit_total": 0,
+            "session_stop_total": 0,
+            "pre_bash_total": 0,
+            "pre_grep_total": 0,
+            "policy_track_total": 0,
+            "policy_untrack_total": 0,
+            "status_total": 0,
+        }
+        self._endpoint_counters_lock = threading.Lock()
+
+        # KTD-J product-signal counters. These shape v0.2 / hosted-tier
+        # decisions, so each has documented economic meaning.
+        #
+        # intra_task_acquire_release_total: how often a session acquired
+        # EXCLUSIVE and released within the same dispatch chain. Sizes
+        # the hosted-tier upsell argument (signal that fine-grained
+        # write protection is exercised, not idle).
+        #
+        # stale_warning_emitted_total: how often /hooks/pre-read or
+        # /hooks/pre-bash returned a stale-summary response. Denominator
+        # for the operator-computed re-read rate.
+        #
+        # stale_warning_reread_total: how often the agent re-read after
+        # a stale warning (heuristic: same session re-reads same path
+        # within HANDLER_TIMEOUT_SEC × 4 of receiving a stale warning).
+        # Numerator for re-read rate; operator computes the ratio at
+        # query time.
+        self._intra_task_acquire_release_total: int = 0
+        self._stale_warning_emitted_total: int = 0
+        self._stale_warning_reread_total: int = 0
+
+        # KTD-J re-read detection: a stale warning marks an (agent, artifact)
+        # pair as "warned"; the next pre-read on that pair consumes the
+        # marker and bumps :attr:`_stale_warning_reread_total`. The set
+        # cannot grow without bound — any subsequent pre-read clears the
+        # entry, and a worst-case scenario of one entry per active
+        # (agent, artifact) pair is the same upper bound as the registry's
+        # own state map.
+        self._stale_warned_pairs: set[tuple[UUID, UUID]] = set()
+        self._stale_warned_pairs_lock = threading.Lock()
 
         # Wire storage + coordinator service.
         db_path = self.coordinator_root / ".coherence" / "state.db"
@@ -441,6 +510,60 @@ class CoordinatorHTTPServer:
         with self._agent_names_lock:
             return self._agent_names.get(agent_id)
 
+    def increment_endpoint_counter(self, name: str) -> None:
+        """KTD-J (Unit 8): bump a per-endpoint counter. Names match the
+        keys in ``_endpoint_counters`` (e.g., ``pre_read_total``). Unknown
+        names are silently ignored — counters are advisory; a typo in a
+        future endpoint dispatch must not crash the request."""
+        with self._endpoint_counters_lock:
+            if name in self._endpoint_counters:
+                self._endpoint_counters[name] += 1
+
+    def endpoint_counters_snapshot(self) -> dict[str, int]:
+        """KTD-J (Unit 8): stable snapshot of per-endpoint counters.
+        Taken under the lock so concurrent increments cannot tear the
+        view."""
+        with self._endpoint_counters_lock:
+            return dict(self._endpoint_counters)
+
+    def increment_intra_task_acquire_release(self) -> None:
+        """KTD-J product-signal counter. Increment when a session's
+        EXCLUSIVE grant is released within the same dispatch chain that
+        acquired it (post-edit on the same artifact as the pre-edit).
+        Documents how often fine-grained write protection actually fires
+        — feeds the v0.2 / hosted-tier upsell case."""
+        # CPython GIL guarantees atomicity of += on a plain int; no
+        # explicit lock needed for this advisory counter.
+        self._intra_task_acquire_release_total += 1
+
+    def increment_stale_warning_emitted(self) -> None:
+        """KTD-J: denominator counter for operator-computed re-read rate."""
+        self._stale_warning_emitted_total += 1
+
+    def increment_stale_warning_reread(self) -> None:
+        """KTD-J: numerator counter for operator-computed re-read rate."""
+        self._stale_warning_reread_total += 1
+
+    def mark_stale_warned(self, agent_id: UUID, artifact_id: UUID) -> None:
+        """KTD-J: stamp an (agent, artifact) pair as having received a
+        stale warning. The next pre-read on the same pair consumes the
+        marker via :meth:`consume_stale_marker` and bumps the re-read
+        counter."""
+        with self._stale_warned_pairs_lock:
+            self._stale_warned_pairs.add((agent_id, artifact_id))
+
+    def consume_stale_marker(self, agent_id: UUID, artifact_id: UUID) -> bool:
+        """KTD-J: returns True (and clears the marker) if a stale warning
+        had been emitted for this (agent, artifact) pair since the last
+        consumption. Returns False otherwise. Used by pre-read entry to
+        bump the re-read counter exactly once per warning cycle."""
+        with self._stale_warned_pairs_lock:
+            pair = (agent_id, artifact_id)
+            if pair in self._stale_warned_pairs:
+                self._stale_warned_pairs.remove(pair)
+                return True
+            return False
+
     def run_with_watchdog(self, fn: Callable[[], Any]) -> Any:
         """Run a callable under the 4s handler-side timeout. Raises
         :class:`FuturesTimeout` on timeout (caller decides degradation)."""
@@ -600,6 +723,13 @@ def _make_handler_class(coordinator: CoordinatorHTTPServer) -> type:
                     if handler is None:
                         self._json(404, {"error": f"unknown route {method} {route_path}"})
                         return
+                    # KTD-J (Unit 8): bump the per-endpoint counter BEFORE
+                    # invoking the handler so timeouts/exceptions still
+                    # show up in operator-visible counters. Contract:
+                    # counts attempted requests, not successful ones.
+                    counter_name = _ENDPOINT_COUNTER_NAMES.get((method, route_path))
+                    if counter_name is not None:
+                        coordinator.increment_endpoint_counter(counter_name)
                     handler(self, coordinator)
                 except Exception as exc:
                     logger.exception("unhandled error in handler for %s %s", method, route_path)
@@ -717,6 +847,13 @@ def _handle_pre_read(req, coordinator: CoordinatorHTTPServer) -> None:
             )
             return {"status": "fresh"}
 
+        # KTD-J (Unit 8): if a prior pre-read on this exact (agent,
+        # artifact) pair emitted a stale warning, count THIS call as the
+        # re-read. Increment whether the re-read returns fresh or stale —
+        # the agent attempted the read either way.
+        if coordinator.consume_stale_marker(agent_id, artifact_id):
+            coordinator.increment_stale_warning_reread()
+
         artifact = coordinator.registry.get_artifact(artifact_id)
         agent_state = coordinator.registry.get_agent_state(artifact_id, agent_id)
 
@@ -761,6 +898,10 @@ def _handle_pre_read(req, coordinator: CoordinatorHTTPServer) -> None:
             trigger="post_stale_read", tick=now, content_hash=content_hash,
         )
         resp = _payloads.build_stale_response(summary)
+        # KTD-J (Unit 8): bump the stale-warning emission counter +
+        # mark the pair so a follow-up pre-read counts as a re-read.
+        coordinator.increment_stale_warning_emitted()
+        coordinator.mark_stale_warned(agent_id, artifact_id)
         # A1: if THIS session has pending preemption notices, prepend them
         # to the additionalContext so X learns about Y's revocation alongside
         # the stale-read warning.
@@ -960,6 +1101,10 @@ def _handle_post_edit(req, coordinator: CoordinatorHTTPServer) -> None:
                 )
                 return {"ok": False, "reason": reason, "preempted": True}
             return {"ok": False, "reason": str(exc)}
+        # KTD-J (Unit 8): successful commit means an EXCLUSIVE grant was
+        # acquired (pre-edit) and released (post-edit) within this same
+        # turn → sizes the hosted-tier upsell case.
+        coordinator.increment_intra_task_acquire_release()
         return {"ok": True}
 
     _run_or_degrade(req, coordinator, work)
@@ -1235,6 +1380,9 @@ def _handle_pre_bash(req, coordinator: CoordinatorHTTPServer) -> None:
         if stale_summaries:
             resp["status"] = "stale"
             resp["stale_paths"] = [s["path"] for s in stale_summaries]
+            # KTD-J (Unit 8): one increment per stale RESPONSE, regardless
+            # of how many paths the response summarizes.
+            coordinator.increment_stale_warning_emitted()
         else:
             resp["status"] = "fresh"
         return resp
@@ -1332,6 +1480,8 @@ def _handle_pre_grep(req, coordinator: CoordinatorHTTPServer) -> None:
         if stale_summaries:
             resp["status"] = "stale"
             resp["stale_paths"] = [s["path"] for s in stale_summaries]
+            # KTD-J (Unit 8): one increment per stale pre-grep response.
+            coordinator.increment_stale_warning_emitted()
         else:
             resp["status"] = "fresh"
         return resp
@@ -1373,14 +1523,24 @@ def _handle_status(req, coordinator: CoordinatorHTTPServer) -> None:
             return
 
     # Counter block — present at every tier so the telemetry-only
-    # consumer (?detail=metrics) doesn't pay for the artifact/session walk.
+    # consumer (?detail=metrics) doesn't pay for the artifact/session
+    # walk. KTD-J (Unit 8) adds per-endpoint + product-signal counters
+    # alongside the existing watchdog/concurrency counters.
     counters = {
         "coordinator_uptime_s": coordinator.uptime_s,
+        "coordinator_backend": "python",
+        "coordinator_version": _COORDINATOR_VERSION,
         "watchdog_timeouts_total": coordinator._watchdog_timeouts_total,
         "watchdog_queue_overflows_total": coordinator._watchdog_queue_overflows_total,
         "handler_concurrency_overflows_total": coordinator._server.handler_concurrency_overflows_total,
         "in_flight_drain_timed_out": coordinator._in_flight_drain_timed_out,
         "cold_start_duration_ms": coordinator.cold_start_duration_ms,
+        # KTD-J per-endpoint counters (snapshot taken under lock).
+        "endpoint_counters": coordinator.endpoint_counters_snapshot(),
+        # KTD-J product-signal counters.
+        "intra_task_acquire_release_total": coordinator._intra_task_acquire_release_total,
+        "stale_warning_emitted_total": coordinator._stale_warning_emitted_total,
+        "stale_warning_reread_total": coordinator._stale_warning_reread_total,
     }
     if detail == "metrics":
         req._json(200, {"detail": "metrics", **counters})
@@ -1466,6 +1626,23 @@ _ROUTES: dict[tuple[str, str], Callable] = {
     ("POST", "/policy/track"): _handle_policy_track,
     ("POST", "/policy/untrack"): _handle_policy_untrack,
     ("GET", "/status"): _handle_status,
+}
+
+
+# KTD-J (Unit 8): route → counter-name lookup. Used by ``_dispatch`` to
+# bump per-endpoint counters BEFORE invoking the handler (contract:
+# counts attempted requests, not successful ones, so a timeout or
+# exception still shows up in operator-visible /status output).
+_ENDPOINT_COUNTER_NAMES: dict[tuple[str, str], str] = {
+    ("POST", "/hooks/pre-read"): "pre_read_total",
+    ("POST", "/hooks/pre-edit"): "pre_edit_total",
+    ("POST", "/hooks/post-edit"): "post_edit_total",
+    ("POST", "/hooks/session-stop"): "session_stop_total",
+    ("POST", "/hooks/pre-bash"): "pre_bash_total",
+    ("POST", "/hooks/pre-grep"): "pre_grep_total",
+    ("POST", "/policy/track"): "policy_track_total",
+    ("POST", "/policy/untrack"): "policy_untrack_total",
+    ("GET", "/status"): "status_total",
 }
 
 

--- a/src/ccs/cli/coherence_coordinator.py
+++ b/src/ccs/cli/coherence_coordinator.py
@@ -84,6 +84,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Suppress the 'port=N' line on stdout (still exits 0 on success).",
     )
     parser.add_argument(
+        "--prepare-for-migration",
+        action="store_true",
+        help=(
+            "Atomically release all EXCLUSIVE/MODIFIED grants and shut "
+            "down the coordinator for this workspace. RUN THIS before "
+            "switching the coherence backend between Python and Node — "
+            "see the v0.1.1 migration runbook."
+        ),
+    )
+    parser.add_argument(
         "--_daemonized",
         action="store_true",
         help=argparse.SUPPRESS,  # hidden — internal detached-worker flag
@@ -110,6 +120,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args._daemonized:
         return _run_daemonized(root)
 
+    # Unit 8 (Decision 1): release-all-grants + shutdown for backend
+    # switch safety. Routed through the running coordinator so we
+    # invalidate every M/E grant from the same process that owns the
+    # SQLite registry (the operator's CLI invocation may not be that
+    # process when the coordinator was detached on a prior session).
+    if args.prepare_for_migration:
+        return _run_prepare_for_migration(root, quiet=args.quiet)
+
     # Test mode: keep the legacy in-process behavior so test_claude_code_cli
     # can spawn + assert in the same Python process. Not for users.
     if args.no_detach:
@@ -132,6 +150,107 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     # No live coordinator — fork a detached child to run it.
     return _spawn_detached(root, quiet=args.quiet)
+
+
+def _run_prepare_for_migration(root: Path, *, quiet: bool) -> int:
+    """Unit 8: backend-switch safety entry point.
+
+    Connects to the running coordinator, posts /admin/prepare-for-migration
+    with the operator opt-in header, then polls the pid file + TCP probe
+    until the coordinator is genuinely gone. Returns 0 on clean
+    shutdown, 0 also when no coordinator was running (idempotent — safe
+    to script as a pre-switch step that may or may not find a live
+    coordinator), 2 on any error reaching the coordinator.
+    """
+    from ccs.cli._coherence_client import (
+        CoordinatorUnavailable,
+        resolve_endpoint,
+    )
+    import urllib.error as _urlerr
+
+    pid_file = root / ".coherence" / "server.pid"
+    if not pid_file.exists():
+        if not quiet:
+            print("prepare-for-migration: no coordinator running (idempotent no-op)", flush=True)
+        return 0
+
+    try:
+        endpoint = resolve_endpoint(root)
+    except CoordinatorUnavailable as exc:
+        # The pid file existed but the coordinator isn't reachable — it
+        # may have died uncleanly. Nothing to release in the registry
+        # via HTTP; idempotent no-op.
+        if not quiet:
+            print(
+                f"prepare-for-migration: coordinator not reachable ({exc}); "
+                "treating as clean — nothing to release.",
+                flush=True,
+            )
+        return 0
+
+    try:
+        resp = _post_with_operator_header(endpoint, "/admin/prepare-for-migration", {})
+    except _urlerr.HTTPError as exc:
+        err(f"agent-coherence-coordinator: prepare-for-migration HTTP {exc.code}")
+        return 2
+
+    if not resp.get("ok"):
+        err(f"agent-coherence-coordinator: prepare-for-migration returned {resp!r}")
+        return 2
+
+    released = int(resp.get("released", 0))
+    errors = resp.get("errors") or []
+
+    # Poll until the coordinator is no longer TCP-reachable. The server-
+    # side schedules shutdown ~100ms after responding, then the in-flight
+    # drain + serve_forever exit add a bit more — 5s budget is generous.
+    cfg = LifecycleConfig()
+    poll_deadline = time.monotonic() + 5.0
+    while time.monotonic() < poll_deadline:
+        port = _read_port_from_file(pid_file)
+        if port is None or not _tcp_probe(port, cfg):
+            break
+        time.sleep(0.1)
+    else:
+        err(
+            "agent-coherence-coordinator: prepare-for-migration: "
+            "coordinator failed to shut down within 5s after release"
+        )
+        return 2
+
+    if not quiet:
+        print(
+            f"prepare-for-migration: released {released} grant(s); "
+            f"coordinator shutdown clean.",
+            flush=True,
+        )
+        if errors:
+            print(f"  errors: {errors}", flush=True)
+    return 0
+
+
+def _post_with_operator_header(endpoint, path: str, body: dict) -> dict:
+    """POST with the Coherence-Local-Operator: true opt-in. Mirrors the
+    pattern used by agent-coherence-status for the elevated /status?detail=full
+    tier; agent-coherence-coordinator now needs the same for the
+    /admin/prepare-for-migration endpoint."""
+    import json as _json
+    import urllib.request as _urlrequest
+
+    payload = _json.dumps(body).encode("utf-8")
+    req = _urlrequest.Request(
+        url=f"{endpoint.base_url}{path}",
+        data=payload,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {endpoint.bearer}",
+            "Host": "127.0.0.1",
+            "Content-Type": "application/json",
+            "Coherence-Local-Operator": "true",
+        },
+    )
+    with _urlrequest.urlopen(req, timeout=5) as resp:
+        return _json.loads(resp.read().decode("utf-8") or "{}")
 
 
 def _run_daemonized(root: Path) -> int:

--- a/src/ccs/cli/coherence_status.py
+++ b/src/ccs/cli/coherence_status.py
@@ -10,6 +10,15 @@ Exit codes:
 - 0: status fetched and printed (including "no coordinator running")
 - 1: not in a git repo
 - 2: coordinator running but returned an error
+- 3: --self-test exercised but the smoke scenario failed
+
+KTD-J (Unit 8): ``--self-test`` runs an end-to-end smoke against a real
+coordinator. Two synthetic sessions exercise the stale-read warning
+path; the smoke fails if (a) the coordinator is unreachable, (b) the
+stale-warning response shape is wrong, or (c) counters do not increment
+in the expected pattern. README's post-install step points operators at
+this command so silent install regressions are caught locally before
+they reach a real agent session.
 """
 
 from __future__ import annotations
@@ -61,6 +70,19 @@ def build_parser() -> argparse.ArgumentParser:
             "operator view used by /agent-coherence status."
         ),
     )
+    # KTD-J (Unit 8): post-install smoke. Drives a two-session stale-read
+    # scenario against a real coordinator; exits non-zero if the smoke
+    # detects a regression. README's "After install:" step calls this.
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help=(
+            "Run an end-to-end smoke against a live coordinator. "
+            "Validates pre-read/pre-edit/post-edit chain, stale-warning "
+            "emission, and counter increments. Exits 0 on success, 3 on "
+            "failure with an actionable diagnostic on stderr."
+        ),
+    )
     return parser
 
 
@@ -71,6 +93,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if root is None:
         err("agent-coherence-status: not in a git repository")
         return 1
+
+    if args.self_test:
+        return _run_self_test(Path(root))
 
     try:
         endpoint = resolve_endpoint(Path(root))
@@ -102,6 +127,127 @@ def main(argv: Sequence[str] | None = None) -> int:
         _render_metrics(payload)
     else:
         _render_table(payload)
+    return 0
+
+
+def _run_self_test(root: Path) -> int:
+    """KTD-J (Unit 8): end-to-end smoke against a live coordinator.
+
+    Two synthetic sessions A and B drive the stale-read warning path:
+
+    1. A pre-reads ``plan.md`` (tracked by default policy) — fresh, seeds v1.
+    2. B pre-edits ``plan.md`` — acquires EXCLUSIVE.
+    3. B post-edits — commits v2, releases EXCLUSIVE.
+    4. A pre-reads ``plan.md`` again — stale warning fires.
+    5. Verify ``status: stale`` + ``hookSpecificOutput.additionalContext``
+       prose contains the path.
+    6. Verify ``stale_warning_emitted_total`` incremented in ``/status``.
+
+    Returns 0 on success, 3 on any verification failure. Diagnostics
+    print to stderr so the README's post-install step ("run
+    ``agent-coherence-status --self-test``") gives the operator an
+    actionable error rather than a stack trace.
+    """
+    from ccs.cli._coherence_client import post as _post
+    import uuid as _uuid
+
+    try:
+        endpoint = resolve_endpoint(root)
+    except CoordinatorUnavailable as exc:
+        err(
+            f"agent-coherence-status --self-test: coordinator unreachable "
+            f"({exc}). Spawn one first by running any hook (or "
+            f"``agent-coherence-coordinator``)."
+        )
+        return 3
+
+    # Deterministic-but-distinct UUIDs so re-runs against the same
+    # workspace produce predictable agent-name surfaces.
+    ns = _uuid.UUID("11111111-2222-4333-8444-555555555555")
+    sid_a = str(_uuid.uuid5(ns, "self-test-A"))
+    sid_b = str(_uuid.uuid5(ns, "self-test-B"))
+    path = "plan.md"  # part of DEFAULT_TRACKED_PATTERNS
+
+    def _step(name: str, body: dict[str, Any]) -> Optional[dict[str, Any]]:
+        try:
+            return _post(endpoint, name, body)
+        except urllib.error.HTTPError as exc:
+            err(f"--self-test: {name} returned HTTP {exc.code}")
+            return None
+
+    # Step 1 — A's first read seeds the artifact.
+    r1 = _step("/hooks/pre-read", {
+        "session_id": sid_a, "path": path,
+        "content_hash": "a" * 64,
+    })
+    if r1 is None or r1.get("status") != "fresh":
+        err(f"--self-test: expected fresh on first pre-read, got {r1!r}")
+        return 3
+
+    # Step 2 — B pre-edits.
+    r2 = _step("/hooks/pre-edit", {"session_id": sid_b, "path": path})
+    if r2 is None or not r2.get("ok", True):
+        err(f"--self-test: pre-edit failed: {r2!r}")
+        return 3
+
+    # Step 3 — B commits.
+    r3 = _step("/hooks/post-edit", {
+        "session_id": sid_b, "path": path,
+        "content_hash": "b" * 64, "success": True,
+    })
+    if r3 is None or not r3.get("ok"):
+        err(f"--self-test: post-edit failed: {r3!r}")
+        return 3
+
+    # Step 4 — A re-reads → expect stale.
+    r4 = _step("/hooks/pre-read", {"session_id": sid_a, "path": path})
+    if r4 is None:
+        return 3
+    if r4.get("status") != "stale":
+        err(
+            f"--self-test: expected stale warning on A's re-read after B's "
+            f"commit, got {r4.get('status')!r} (full response: {r4!r}). "
+            f"This usually means the hooks aren't wired or the coordinator "
+            f"is running a stale build."
+        )
+        return 3
+    out = r4.get("hookSpecificOutput") or {}
+    ctx = out.get("additionalContext", "")
+    if path not in ctx:
+        err(
+            f"--self-test: stale-warning prose did not mention {path}: "
+            f"{ctx!r}"
+        )
+        return 3
+
+    # Step 5 — counters reflect the activity.
+    try:
+        status = get(
+            endpoint, "/status?detail=metrics",
+            extra_headers={"Coherence-Local-Operator": "true"},
+        )
+    except urllib.error.HTTPError as exc:
+        err(f"--self-test: /status returned HTTP {exc.code}")
+        return 3
+    if status.get("stale_warning_emitted_total", 0) < 1:
+        err(
+            "--self-test: stale_warning_emitted_total did not increment "
+            "(coordinator KTD-J counters appear to be inert)."
+        )
+        return 3
+    eps = status.get("endpoint_counters") or {}
+    if eps.get("pre_read_total", 0) < 2 or eps.get("post_edit_total", 0) < 1:
+        err(
+            f"--self-test: endpoint counters did not reflect the four-step "
+            f"scenario: {eps!r}"
+        )
+        return 3
+
+    print("agent-coherence-status --self-test: OK", flush=True)
+    print(
+        f"  pre-read fresh → pre-edit → post-edit commit → pre-read STALE "
+        f"({path}) — all four steps observed."
+    )
     return 0
 
 

--- a/src/ccs/cli/coherence_status.py
+++ b/src/ccs/cli/coherence_status.py
@@ -46,6 +46,21 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Emit the raw JSON response instead of the rendered table.",
     )
+    # KTD-J (Unit 8): --detail mirrors the /status three-tier disclosure
+    # model. Default 'full' so the local-operator CLI keeps surfacing pid
+    # + absolute root + all counters; 'metrics' for dashboard scrapers
+    # that want only the counter block; 'minimal' for a redacted view
+    # safe to paste in bug reports.
+    parser.add_argument(
+        "--detail",
+        choices=["minimal", "full", "metrics"],
+        default="full",
+        help=(
+            "Disclosure tier (default: full). 'minimal' redacts coordinator_pid "
+            "and absolute paths; 'metrics' returns counters only; 'full' is the "
+            "operator view used by /agent-coherence status."
+        ),
+    )
     return parser
 
 
@@ -59,14 +74,14 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     try:
         endpoint = resolve_endpoint(Path(root))
-        # R12 (Unit 6): agent-coherence-status is a local operator CLI
-        # running in the workspace it inspects, so it qualifies for the
-        # full tier. Pass the explicit Coherence-Local-Operator opt-in
-        # header so coordinator_pid and the absolute coordinator_root are
-        # included in the rendered table.
+        # R12 (Unit 6) + KTD-J (Unit 8): the detail tier is selected via
+        # --detail. Only 'full' needs the Coherence-Local-Operator opt-in
+        # header; the lower tiers degrade by design if the header is
+        # missing, but we always set it from this CLI since it's a
+        # legitimate local operator.
         payload = get(
             endpoint,
-            "/status?detail=full",
+            f"/status?detail={args.detail}",
             extra_headers={"Coherence-Local-Operator": "true"},
         )
     except CoordinatorUnavailable as exc:
@@ -83,7 +98,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(_json.dumps(payload, indent=2), flush=True)
         return 0
 
-    _render_table(payload)
+    if args.detail == "metrics":
+        _render_metrics(payload)
+    else:
+        _render_table(payload)
     return 0
 
 
@@ -94,8 +112,17 @@ def _render_table(payload: dict[str, Any]) -> None:
     policy = payload.get("policy_summary", {})
     uptime = payload.get("coordinator_uptime_s", 0.0)
     pid = payload.get("coordinator_pid", 0)
+    backend = payload.get("coordinator_backend", "python")
+    version = payload.get("coordinator_version", "")
 
-    print(f"Coordinator: pid={pid} uptime={uptime:.0f}s")
+    header_bits: list[str] = []
+    if pid:
+        header_bits.append(f"pid={pid}")
+    header_bits.append(f"uptime={uptime:.0f}s")
+    header_bits.append(f"backend={backend}")
+    if version:
+        header_bits.append(f"version={version}")
+    print("Coordinator: " + " ".join(header_bits))
     print()
 
     # Policy section first — distinguishes "what's eligible to be tracked"
@@ -134,20 +161,79 @@ def _render_table(payload: dict[str, Any]) -> None:
 
     if not sessions:
         print("No active sessions.")
+    else:
+        print("Sessions:")
+        for s in sessions:
+            sid = s.get("agent_id", "?")
+            name = s.get("agent_name", "")
+            per_artifact = s.get("states", {})
+            print(f"  {sid[:8]}  {name}")
+            if not per_artifact:
+                print("    (no held grants)")
+                continue
+            path_w = max(len(p) for p in per_artifact)
+            for path, state in sorted(per_artifact.items()):
+                print(f"    {path:<{path_w}}  {state}")
+
+    # KTD-J (Unit 8): counters section. Only printed when the payload
+    # actually carries counter data — the minimal tier strips them.
+    _render_counter_block(payload)
+
+
+def _render_counter_block(payload: dict[str, Any]) -> None:
+    """KTD-J counter block, printed after the artifacts/sessions section
+    of the full-tier table. No-op if the payload doesn't carry counters
+    (e.g., minimal tier responses)."""
+    endpoint_counters = payload.get("endpoint_counters") or {}
+    has_endpoint_counters = any(v for v in endpoint_counters.values())
+    keys_present = [
+        k for k in (
+            "intra_task_acquire_release_total",
+            "stale_warning_emitted_total",
+            "stale_warning_reread_total",
+            "watchdog_timeouts_total",
+            "watchdog_queue_overflows_total",
+            "handler_concurrency_overflows_total",
+            "cold_start_duration_ms",
+        ) if k in payload
+    ]
+    if not has_endpoint_counters and not keys_present:
         return
 
-    print("Sessions:")
-    for s in sessions:
-        sid = s.get("agent_id", "?")
-        name = s.get("agent_name", "")
-        per_artifact = s.get("states", {})
-        print(f"  {sid[:8]}  {name}")
-        if not per_artifact:
-            print("    (no held grants)")
-            continue
-        path_w = max(len(p) for p in per_artifact)
-        for path, state in sorted(per_artifact.items()):
-            print(f"    {path:<{path_w}}  {state}")
+    print()
+    print("Counters:")
+    if endpoint_counters:
+        # Stable order so operator-facing output is diff-friendly.
+        for name in (
+            "pre_read_total",
+            "pre_edit_total",
+            "post_edit_total",
+            "session_stop_total",
+            "pre_bash_total",
+            "pre_grep_total",
+            "policy_track_total",
+            "policy_untrack_total",
+            "status_total",
+        ):
+            value = endpoint_counters.get(name, 0)
+            print(f"  {name:<40}  {value}")
+    for name in keys_present:
+        value = payload.get(name, 0)
+        if isinstance(value, float):
+            value_str = f"{value:.1f}"
+        else:
+            value_str = str(value)
+        print(f"  {name:<40}  {value_str}")
+
+
+def _render_metrics(payload: dict[str, Any]) -> None:
+    """KTD-J `--detail metrics` rendering — counter block only, no
+    artifact/session detail. Used by dashboard scrapers that want a
+    consistent counter format without parsing JSON."""
+    backend = payload.get("coordinator_backend", "python")
+    version = payload.get("coordinator_version", "")
+    print(f"Coordinator metrics: backend={backend} version={version}")
+    _render_counter_block(payload)
 
 
 if __name__ == "__main__":

--- a/tests/test_claude_code_cli.py
+++ b/tests/test_claude_code_cli.py
@@ -344,6 +344,68 @@ def test_self_test_returns_3_when_no_coordinator_running(
 
 
 # ----------------------------------------------------------------------
+# Unit 8 — agent-coherence-coordinator --prepare-for-migration
+# ----------------------------------------------------------------------
+
+
+def test_prepare_for_migration_no_coordinator_running_is_noop(
+    git_workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Idempotent: --prepare-for-migration on a workspace with no
+    .coherence/server.pid is a no-op exit 0 so it's safe to script
+    as a pre-switch step that may not always find a live coordinator."""
+    rc = coherence_coordinator.main([
+        "--root", str(git_workspace), "--prepare-for-migration",
+    ])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "no coordinator running" in captured.out
+
+
+def test_prepare_for_migration_releases_grants_and_shuts_down(
+    live_coordinator, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Decision 1 contract: with an EXCLUSIVE grant held by some agent
+    on some tracked artifact, --prepare-for-migration releases the
+    grant (state transitions away from M/E) and the coordinator's HTTP
+    server is no longer reachable when the command returns."""
+    import socket
+    workspace, port = live_coordinator
+
+    # Set up an EXCLUSIVE grant via the real HTTP path so registry
+    # state matches what a real client would have written.
+    from ccs.cli._coherence_client import resolve_endpoint, post as _post
+    endpoint = resolve_endpoint(workspace)
+    sid = "11111111-2222-4111-8111-aaaaaaaaaaaa"
+    _post(endpoint, "/hooks/pre-edit", {"session_id": sid, "path": "plan.md"})
+
+    # Now drive the migration helper.
+    rc = coherence_coordinator.main([
+        "--root", str(workspace), "--prepare-for-migration",
+    ])
+    captured = capsys.readouterr()
+    assert rc == 0, (
+        f"prepare-for-migration failed: stdout={captured.out!r} "
+        f"stderr={captured.err!r}"
+    )
+    # Output should report at least one released grant.
+    assert "released" in captured.out
+
+    # Coordinator must no longer be TCP-reachable.
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(0.5)
+    try:
+        sock.connect(("127.0.0.1", port))
+        sock.close()
+        pytest.fail(
+            f"coordinator at port={port} still accepting connections after "
+            "--prepare-for-migration"
+        )
+    except OSError:
+        pass  # expected — connection refused after shutdown
+
+
+# ----------------------------------------------------------------------
 # coherence_track + coherence_untrack — validation + happy path
 # ----------------------------------------------------------------------
 

--- a/tests/test_claude_code_cli.py
+++ b/tests/test_claude_code_cli.py
@@ -313,6 +313,36 @@ def test_status_full_default_includes_counters_below_sessions(
     assert "pre_read_total" in captured.out
 
 
+def test_self_test_passes_against_live_coordinator(
+    live_coordinator, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """KTD-J --self-test smoke: full pre-read → pre-edit → post-edit →
+    stale pre-read chain must report OK against a healthy coordinator."""
+    workspace, port = live_coordinator
+    rc = coherence_status.main(["--root", str(workspace), "--self-test"])
+    captured = capsys.readouterr()
+    assert rc == 0, (
+        f"--self-test failed unexpectedly: stdout={captured.out!r} "
+        f"stderr={captured.err!r}"
+    )
+    assert "OK" in captured.out
+    assert "pre-read STALE" in captured.out
+
+
+def test_self_test_returns_3_when_no_coordinator_running(
+    git_workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """If the coordinator isn't running, --self-test exits 3 with an
+    actionable diagnostic — operators can distinguish 'no coordinator'
+    from 'coordinator broken'."""
+    rc = coherence_status.main([
+        "--root", str(git_workspace), "--self-test",
+    ])
+    captured = capsys.readouterr()
+    assert rc == 3
+    assert "coordinator unreachable" in captured.err or "coordinator" in captured.err
+
+
 # ----------------------------------------------------------------------
 # coherence_track + coherence_untrack — validation + happy path
 # ----------------------------------------------------------------------

--- a/tests/test_claude_code_cli.py
+++ b/tests/test_claude_code_cli.py
@@ -262,6 +262,57 @@ def test_status_json_mode_emits_raw_payload(
     assert data["coordinator_pid"] == os.getpid()
 
 
+def test_status_detail_metrics_renders_counter_block(
+    live_coordinator, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """KTD-J (Unit 8): --detail metrics returns the counter block only —
+    no artifact/session walk in the output."""
+    workspace, port = live_coordinator
+    rc = coherence_status.main([
+        "--root", str(workspace), "--detail", "metrics",
+    ])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Coordinator metrics:" in captured.out
+    assert "backend=python" in captured.out
+    # Endpoint counter block must be present (zero-valued is fine on a
+    # fresh coordinator with no hook traffic yet).
+    assert "Counters:" in captured.out
+    assert "pre_read_total" in captured.out
+    assert "intra_task_acquire_release_total" in captured.out
+    # No artifact/session block in metrics mode.
+    assert "Observed artifacts" not in captured.out
+    assert "Sessions:" not in captured.out
+
+
+def test_status_detail_minimal_redacts_pid(
+    live_coordinator, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--detail minimal must not surface pid in the rendered output."""
+    workspace, port = live_coordinator
+    rc = coherence_status.main([
+        "--root", str(workspace), "--detail", "minimal",
+    ])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Coordinator:" in captured.out
+    # pid is not in the minimal tier so the header omits it.
+    assert f"pid={os.getpid()}" not in captured.out
+
+
+def test_status_full_default_includes_counters_below_sessions(
+    live_coordinator, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The default --detail=full table rendering now includes a Counters
+    section after the artifacts/sessions block."""
+    workspace, port = live_coordinator
+    rc = coherence_status.main(["--root", str(workspace)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Counters:" in captured.out
+    assert "pre_read_total" in captured.out
+
+
 # ----------------------------------------------------------------------
 # coherence_track + coherence_untrack — validation + happy path
 # ----------------------------------------------------------------------

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -1455,6 +1455,165 @@ def test_r21_body_at_cap_accepted(coordinator) -> None:
 
 
 # ----------------------------------------------------------------------
+# KTD-J (Unit 8) — telemetry counters
+# ----------------------------------------------------------------------
+
+
+def test_j1_per_endpoint_counters_increment_on_dispatch(client: _Client, coordinator) -> None:
+    """5 pre-reads + 3 pre-edits + 3 post-edits + 1 session-stop must show
+    up in the per-endpoint counter block of /status?detail=full."""
+    for i in range(5):
+        client.post(
+            "/hooks/pre-read",
+            {"session_id": _sid(f"j1-{i}"), "path": "plan.md"},
+        )
+    for i in range(3):
+        client.post(
+            "/hooks/pre-edit",
+            {"session_id": _sid(f"j1-edit-{i}"), "path": f"path_{i}.md"},
+        )
+    for i in range(3):
+        client.post(
+            "/hooks/post-edit",
+            {
+                "session_id": _sid(f"j1-edit-{i}"),
+                "path": f"path_{i}.md",
+                "content_hash": _hash(f"h{i}"),
+                "success": True,
+            },
+        )
+    client.post(
+        "/hooks/session-stop", {"session_id": _sid("j1-stop")}
+    )
+
+    s, b = client.request(
+        "GET", "/status?detail=metrics",
+    )
+    assert s == 200
+    counters = b["endpoint_counters"]
+    assert counters["pre_read_total"] == 5
+    assert counters["pre_edit_total"] == 3
+    assert counters["post_edit_total"] == 3
+    assert counters["session_stop_total"] == 1
+
+
+def test_j2_status_counter_request_itself_increments(client: _Client, coordinator) -> None:
+    """A /status call counts itself — the increment fires before the
+    handler runs."""
+    _, b1 = client.get("/status")
+    _, b2 = client.get("/status")
+    assert (
+        b2["endpoint_counters"]["status_total"]
+        > b1["endpoint_counters"]["status_total"]
+    )
+
+
+def test_j3_counters_reset_to_zero_on_fresh_coordinator(tmp_path: Path) -> None:
+    """Counters are CACHE, not persistent state. A fresh coordinator
+    instance starts with zeros even when state.db already exists."""
+    srv = CoordinatorHTTPServer(tmp_path, port=0, instance_id="j3")
+    try:
+        snap = srv.endpoint_counters_snapshot()
+        assert all(v == 0 for v in snap.values())
+        assert srv._intra_task_acquire_release_total == 0
+        assert srv._stale_warning_emitted_total == 0
+        assert srv._stale_warning_reread_total == 0
+    finally:
+        srv.shutdown()
+
+
+def test_j4_stale_emitted_and_reread_counters_track_warning_cycle(
+    client: _Client, coordinator,
+) -> None:
+    """Two-session stale scenario: A reads, B writes, A re-reads → stale
+    warning fires (emitted=1). A reads again with the same artifact →
+    that's the re-read (reread=1)."""
+    a = _sid("j4-A"); b = _sid("j4-B")
+    client.post("/hooks/pre-read",
+                {"session_id": a, "path": "plan.md", "content_hash": _hash("h1")})
+    client.post("/hooks/pre-edit", {"session_id": b, "path": "plan.md"})
+    client.post("/hooks/post-edit", {"session_id": b, "path": "plan.md",
+                                     "content_hash": _hash("h2"), "success": True})
+    # A re-reads — stale warning fires.
+    s, body = client.post("/hooks/pre-read",
+                          {"session_id": a, "path": "plan.md"})
+    assert body["status"] == "stale"
+    # A re-reads again (the re-read after the warning).
+    client.post("/hooks/pre-read",
+                {"session_id": a, "path": "plan.md"})
+
+    _, status_body = client.get("/status?detail=metrics")
+    assert status_body["stale_warning_emitted_total"] >= 1
+    assert status_body["stale_warning_reread_total"] >= 1
+
+
+def test_j5_intra_task_acquire_release_increments_on_successful_post_edit(
+    client: _Client, coordinator,
+) -> None:
+    """A pre-edit followed by a successful post-edit on a tracked path
+    must bump the intra-task acquire-release counter exactly once.
+    Untracked paths fast-path through pre-edit/post-edit without
+    acquiring E, so the counter is the load-bearing signal that fine-
+    grained write protection was actually exercised."""
+    sid = _sid("j5")
+    before = coordinator._intra_task_acquire_release_total
+    # plan.md matches the default tracked policy.
+    client.post("/hooks/pre-edit", {"session_id": sid, "path": "plan.md"})
+    client.post("/hooks/post-edit",
+                {"session_id": sid, "path": "plan.md",
+                 "content_hash": _hash("j5"), "success": True})
+    assert coordinator._intra_task_acquire_release_total == before + 1
+
+
+def test_j6_failed_post_edit_does_not_increment_acquire_release(
+    client: _Client, coordinator,
+) -> None:
+    """If post-edit reports failure, the counter does NOT increment —
+    the contract is 'fine-grained write protection actually used', not
+    'attempted'."""
+    sid = _sid("j6")
+    before = coordinator._intra_task_acquire_release_total
+    client.post("/hooks/pre-edit", {"session_id": sid, "path": "plan.md"})
+    client.post("/hooks/post-edit",
+                {"session_id": sid, "path": "plan.md",
+                 "content_hash": _hash("j6"), "success": False})
+    assert coordinator._intra_task_acquire_release_total == before
+
+
+def test_j7_status_exposes_coordinator_backend_and_version(client: _Client) -> None:
+    """KTD-J: /status shape includes coordinator_backend + coordinator_version
+    for cross-implementation operator observability."""
+    _, b = client.get("/status?detail=metrics")
+    assert b["coordinator_backend"] == "python"
+    assert isinstance(b["coordinator_version"], str)
+    assert b["coordinator_version"]  # non-empty
+
+
+def test_j8_counters_increment_even_when_handler_raises(
+    client: _Client, coordinator, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Contract per the plan: per-endpoint counters count ATTEMPTED
+    requests, not successful ones. A handler that raises mid-dispatch
+    (becoming a 500) must still leave the counter incremented."""
+    import ccs.adapters.claude_code.coordinator_server as mod
+    original = mod._ROUTES[("POST", "/hooks/pre-read")]
+    def raising(req, coord):
+        raise RuntimeError("simulated handler failure")
+    monkeypatch.setitem(mod._ROUTES, ("POST", "/hooks/pre-read"), raising)
+    try:
+        before = coordinator.endpoint_counters_snapshot()["pre_read_total"]
+        status, _ = client.post(
+            "/hooks/pre-read",
+            {"session_id": _sid("j8"), "path": "j8.md"},
+        )
+        assert status == 500
+        after = coordinator.endpoint_counters_snapshot()["pre_read_total"]
+        assert after == before + 1, "counter must increment even on handler exception"
+    finally:
+        mod._ROUTES[("POST", "/hooks/pre-read")] = original
+
+
+# ----------------------------------------------------------------------
 # R10 (Unit 6) — _agent_names mutation under threading.Lock
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Phase B Unit 8 of the v0.1.1 marketplace cut — four commits delivering the telemetry + CLI surfaces the v0.1.1 plan calls for, plus the backend-migration operator entry point.

- **KTD-J counters** ([8ce4788](../../commit/8ce4788)) — per-endpoint counters (pre_read_total, pre_edit_total, post_edit_total, session_stop_total, pre_bash_total, pre_grep_total, policy_track_total, policy_untrack_total, status_total) wired in \`_dispatch\` BEFORE handler invocation (counts attempted requests, not successful ones). KTD-J product-signal counters: intra_task_acquire_release_total (bumped on successful post-edit), stale_warning_emitted_total (one increment per stale RESPONSE, at pre-read/pre-bash/pre-grep emission sites), stale_warning_reread_total (via per-(agent, artifact) marker set). \`/status\` response shape adds coordinator_backend, coordinator_version, endpoint_counters dict, and the three product-signal counters.

- **CLI \`--detail\` + counter rendering** ([8e95cd3](../../commit/8e95cd3)) — \`agent-coherence-status --detail=minimal|full|metrics\` mirrors the R12 three-tier disclosure model. New Counters: section at the bottom of the full-tier table (stable order, floats with one decimal). \`--detail metrics\` renders a single-line header + counter block for dashboard scrapers. Fixed control-flow bug where the no-sessions branch's \`return\` skipped the counter block.

- **\`--self-test\` smoke** ([eed8051](../../commit/eed8051)) — the post-install validation Go/No-Go gate G5 requires. Four-step scenario (A pre-reads → B pre-edits → B post-edits → A re-reads expects STALE) against a live coordinator; verifies response shape and counter increments. Exit 0 on pass, 3 with operator diagnostic on fail. README's post-install instruction will point here.

- **\`--prepare-for-migration\`** ([b815a45](../../commit/b815a45)) — Decision 1 ships its operator entry point. New POST /admin/prepare-for-migration endpoint snapshots every M/E grant, invalidates each, then schedules coordinator.shutdown() ~100ms later. \`agent-coherence-coordinator --prepare-for-migration\` posts with the Coherence-Local-Operator: true opt-in header and polls until the coordinator is TCP-unreachable. Idempotent: no pid file → no-op exit 0.

## Test plan

- [x] \`tests/test_claude_code_coordinator_server.py\` — 8 new KTD-J counter tests (per-endpoint dispatch, /status self-counting, zero-on-fresh-spawn, stale emit→reread cycle, intra-task acquire/release on success-only, backend/version surfacing, counter increment on handler raise).
- [x] \`tests/test_claude_code_cli.py\` — 3 new \`--detail\` rendering tests, 2 \`--self-test\` tests (live coordinator pass + no-coordinator exit 3), 2 \`--prepare-for-migration\` tests (idempotent no-op + grant-release-and-shutdown).
- [x] Full claude_code surface: **197 passed** locally at HEAD.
- [x] Existing e2e + lifecycle + bash_path_detector suites still green.

Refs: \`docs/plans/2026-05-18-001-feat-claude-code-coherence-plugin-v0.1.1-plan.md\` Unit 8, KTD-J, Decision 1, Go/No-Go gate G5.