### PR TITLE
feat(v0.1.1 Unit 9): agent-coherence-migrate-rules — permissions.deny migration helper (R19)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ agent-coherence-coordinator = "ccs.cli.coherence_coordinator:main"
 agent-coherence-status = "ccs.cli.coherence_status:main"
 agent-coherence-track = "ccs.cli.coherence_track:main"
 agent-coherence-untrack = "ccs.cli.coherence_untrack:main"
+# Unit 9 (R19): scans workspace CLAUDE.md for prose tool-class rules
+# ("use rg, not grep", "never sudo") and proposes permissions.deny
+# entries. Flag-only by default; --apply writes to settings.local.json
+# after a confirmation prompt.
+agent-coherence-migrate-rules = "ccs.cli.coherence_migrate_rules:main"
 # Phase E.0 probe 2A surfaced that CC v2.1.131 rejects hooks.json URLs
 # containing ${COHERENCE_PORT} at LOAD TIME. HTTP-type hooks are not viable;
 # the plugin uses command-type hooks that invoke this client, which reads

--- a/src/ccs/cli/coherence_migrate_rules.py
+++ b/src/ccs/cli/coherence_migrate_rules.py
@@ -1,0 +1,449 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""``agent-coherence-migrate-rules`` — propose ``permissions.deny`` entries
+from prose rules in CLAUDE.md.
+
+Per the v0.1.1 plan (Unit 9, R19): many operators have tool-class rules
+written as prose in CLAUDE.md ("use rg, not grep", "never use sudo",
+"avoid python -c"). The model often violates these because prose rules
+are advisory at best — the runtime cannot enforce them.
+
+``permissions.deny`` in ``.claude/settings.local.json`` is the
+configuration-level enforcement equivalent. The CLI scans the workspace
+CLAUDE.md for prose patterns that map cleanly to ``Bash(...)`` deny
+entries and proposes the JSON to copy-paste. With ``--apply``, it writes
+the entries to ``.claude/settings.local.json`` after a confirmation
+prompt.
+
+This is BEST-EFFORT pattern matching. False positives (proposing a deny
+that shouldn't fire) waste operator time but cause no harm — the operator
+reviews before pasting. False negatives (missing a rule) are the same as
+not running the helper. The exit-codes are tuned for shell-scriptability:
+
+- 0: completed successfully (proposals printed, or --apply succeeded,
+  or no rules detected)
+- 1: workspace root could not be resolved
+- 2: --apply confirmation declined, or settings.json could not be written
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional, Sequence
+
+from ccs.adapters.claude_code.resolver import find_coordinator_root
+
+
+@dataclass(frozen=True)
+class _RuleRule:
+    """One detection rule. Matches one or more regex against CLAUDE.md
+    and proposes ``Bash(...)`` deny entries on hit."""
+
+    name: str
+    triggers: tuple[re.Pattern[str], ...]
+    deny_entries: tuple[str, ...]
+    explanation: str
+
+
+def _re(pattern: str) -> re.Pattern[str]:
+    return re.compile(pattern, re.IGNORECASE | re.MULTILINE)
+
+
+# Detection rules — heuristic, best-effort. Order matters: more specific
+# triggers should appear first so they win when both match.
+_RULES: tuple[_RuleRule, ...] = (
+    _RuleRule(
+        name="grep_to_rg",
+        triggers=(
+            _re(r"use\s+rg\b"),
+            _re(r"\brg\b\s+instead\s+of\s+\bgrep\b"),
+            _re(r"prefer\s+\brg\b"),
+            _re(r"prefer\s+ripgrep"),
+        ),
+        deny_entries=("Bash(grep:*)", "Bash(grep *)"),
+        explanation=(
+            "CLAUDE.md prefers `rg` over `grep`. The runtime cannot stop "
+            "the model from invoking `grep` unless `permissions.deny` "
+            "enforces it. Allow `rg` separately if not already permitted."
+        ),
+    ),
+    _RuleRule(
+        name="no_python_dash_c",
+        triggers=(
+            _re(r"(don'?t|do not|avoid|never)\s+use\s+python3?\s*-c"),
+            _re(r"no\s+python3?\s*-c"),
+        ),
+        deny_entries=("Bash(python -c *)", "Bash(python3 -c *)"),
+        explanation=(
+            "CLAUDE.md restricts `python -c` / `python3 -c` invocations "
+            "(typically for security or auditability)."
+        ),
+    ),
+    _RuleRule(
+        name="no_perl_dash_e",
+        triggers=(
+            _re(r"(don'?t|do not|avoid|never)\s+(use\s+)?perl\s*-e"),
+            _re(r"no\s+perl\s*-e"),
+        ),
+        deny_entries=("Bash(perl -e *)",),
+        explanation="CLAUDE.md restricts `perl -e` eval invocations.",
+    ),
+    _RuleRule(
+        name="no_ruby_dash_e",
+        triggers=(
+            _re(r"(don'?t|do not|avoid|never)\s+(use\s+)?ruby\s*-e"),
+            _re(r"no\s+ruby\s*-e"),
+        ),
+        deny_entries=("Bash(ruby -e *)",),
+        explanation="CLAUDE.md restricts `ruby -e` eval invocations.",
+    ),
+    _RuleRule(
+        name="no_sudo",
+        triggers=(
+            _re(r"(don'?t|do not|avoid|never)\s+use\s+sudo"),
+            _re(r"no\s+sudo\b"),
+            _re(r"never\s+sudo"),
+        ),
+        deny_entries=("Bash(sudo *)",),
+        explanation=(
+            "CLAUDE.md prohibits sudo invocations. `permissions.deny` "
+            "is the load-bearing enforcement — prose alone cannot stop "
+            "the model from suggesting sudo commands."
+        ),
+    ),
+    _RuleRule(
+        name="cat_for_files",
+        triggers=(
+            _re(r"(don'?t|do not|avoid|never)\s+use\s+cat\s+(to\s+read|for\s+(reading\s+)?files?)"),
+            _re(r"use\s+(the\s+)?Read\s+tool[\s,]+(not|instead\s+of)\s+cat"),
+        ),
+        deny_entries=("Bash(cat:*)",),
+        explanation=(
+            "CLAUDE.md routes file reads through the Read tool. Denying "
+            "`cat` at the permissions layer keeps the coherence layer "
+            "informed of every read (KTD-N's H4 routing mitigation)."
+        ),
+    ),
+    _RuleRule(
+        name="sed_for_files",
+        triggers=(
+            _re(r"(don'?t|do not|avoid|never)\s+use\s+sed\s+(to\s+edit|for\s+editing\s+files?)"),
+            _re(r"use\s+(the\s+)?Edit\s+tool[\s,]+(not|instead\s+of)\s+sed"),
+        ),
+        deny_entries=("Bash(sed:*)",),
+        explanation=(
+            "CLAUDE.md routes edits through the Edit tool. Denying "
+            "`sed` at the permissions layer keeps the single-writer "
+            "invariant safe."
+        ),
+    ),
+    _RuleRule(
+        name="awk_for_files",
+        triggers=(
+            _re(r"(don'?t|do not|avoid|never)\s+use\s+awk\s+(to\s+(read|edit)|for\s+(reading|editing)\s+files?)"),
+        ),
+        deny_entries=("Bash(awk:*)",),
+        explanation="CLAUDE.md restricts `awk` for file reads/edits.",
+    ),
+)
+
+
+@dataclass
+class _DetectedRule:
+    name: str
+    matched_text: str
+    deny_entries: tuple[str, ...]
+    explanation: str
+
+
+@dataclass
+class _Report:
+    claude_md_path: Path
+    detected: list[_DetectedRule] = field(default_factory=list)
+    # Deny entries already present in settings.local.json — we don't
+    # propose duplicates.
+    already_present: set[str] = field(default_factory=set)
+
+    @property
+    def proposed_entries(self) -> list[str]:
+        seen: set[str] = set()
+        out: list[str] = []
+        for rule in self.detected:
+            for entry in rule.deny_entries:
+                if entry in self.already_present or entry in seen:
+                    continue
+                seen.add(entry)
+                out.append(entry)
+        return out
+
+
+def _read_claude_md(workspace: Path) -> Optional[str]:
+    """Read CLAUDE.md from the workspace root. Returns None if absent —
+    detection has nothing to do but the CLI still exits 0 to keep the
+    helper safe to script in setup wizards."""
+    path = workspace / "CLAUDE.md"
+    if not path.is_file():
+        return None
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _existing_deny_entries(workspace: Path) -> set[str]:
+    """Read .claude/settings.local.json (and ./settings.json for completeness)
+    and return the union of existing ``permissions.deny`` entries so we
+    don't propose duplicates."""
+    out: set[str] = set()
+    for rel in (".claude/settings.local.json", ".claude/settings.json"):
+        path = workspace / rel
+        if not path.is_file():
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        deny = ((data or {}).get("permissions") or {}).get("deny") or []
+        if isinstance(deny, list):
+            out.update(str(x) for x in deny if isinstance(x, str))
+    return out
+
+
+def detect_rules(workspace: Path) -> _Report:
+    """Run the heuristic detector against ``<workspace>/CLAUDE.md``.
+
+    Public entry point — kept stable so the function can be re-used by
+    tests and by any future ``ce-work`` automation. Workspace is the
+    coordinator root (typically the repo root)."""
+    report = _Report(claude_md_path=workspace / "CLAUDE.md")
+    text = _read_claude_md(workspace)
+    if text is None:
+        return report
+    report.already_present = _existing_deny_entries(workspace)
+    for rule in _RULES:
+        match: Optional[re.Match[str]] = None
+        for trigger in rule.triggers:
+            match = trigger.search(text)
+            if match is not None:
+                break
+        if match is None:
+            continue
+        # Pull a short snippet around the match for the operator
+        # so they can verify the detection isn't a false positive.
+        start = max(0, match.start() - 40)
+        end = min(len(text), match.end() + 40)
+        snippet = text[start:end].strip().replace("\n", " ")
+        report.detected.append(_DetectedRule(
+            name=rule.name,
+            matched_text=snippet,
+            deny_entries=rule.deny_entries,
+            explanation=rule.explanation,
+        ))
+    return report
+
+
+def _format_proposed_settings_json(entries: list[str]) -> str:
+    """Render a minimal copy-paste-ready settings.local.json fragment."""
+    return json.dumps(
+        {"permissions": {"deny": entries}},
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="agent-coherence-migrate-rules",
+        description=(
+            "Propose permissions.deny entries from prose rules in CLAUDE.md. "
+            "Default is flag-only — prints proposals; use --apply to write "
+            "them into .claude/settings.local.json after a confirmation prompt."
+        ),
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Override the workspace root (default: walk up from cwd to git root).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "Write proposed entries into .claude/settings.local.json "
+            "after a confirmation prompt. Without this flag, the CLI "
+            "prints proposals only."
+        ),
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help=(
+            "Skip the --apply confirmation prompt. Useful for setup "
+            "wizards and CI smoke runs."
+        ),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    root_arg = args.root if args.root is not None else find_coordinator_root()
+    if root_arg is None:
+        print(
+            "agent-coherence-migrate-rules: not in a git repository",
+            file=sys.stderr,
+        )
+        return 1
+    root = Path(root_arg).resolve()
+
+    report = detect_rules(root)
+
+    if not report.claude_md_path.is_file():
+        print(
+            f"agent-coherence-migrate-rules: no CLAUDE.md at {report.claude_md_path}; "
+            "nothing to migrate.",
+            flush=True,
+        )
+        return 0
+
+    if not report.detected:
+        print(
+            "agent-coherence-migrate-rules: no tool-class rule patterns "
+            f"detected in {report.claude_md_path}.",
+            flush=True,
+        )
+        return 0
+
+    print("Detected tool-class rules in CLAUDE.md:")
+    print()
+    for rule in report.detected:
+        print(f"  [{rule.name}]")
+        print(f"    matched: …{rule.matched_text}…")
+        print(f"    why: {rule.explanation}")
+        print(f"    proposed deny: {list(rule.deny_entries)}")
+        print()
+
+    proposed = report.proposed_entries
+    if not proposed:
+        print(
+            "All matching deny entries are already present in "
+            ".claude/settings*.json — nothing to add.",
+            flush=True,
+        )
+        return 0
+
+    print("Proposed .claude/settings.local.json fragment:")
+    print()
+    print(_format_proposed_settings_json(proposed))
+    print()
+
+    if not args.apply:
+        print(
+            "Copy the fragment above into .claude/settings.local.json "
+            "(merging with any existing permissions.deny entries), or "
+            "re-run with --apply to write it automatically.",
+            flush=True,
+        )
+        return 0
+
+    return _apply_entries(root, proposed, prompt_for_confirmation=not args.yes)
+
+
+def _apply_entries(
+    workspace: Path, proposed: list[str], *, prompt_for_confirmation: bool
+) -> int:
+    """Merge ``proposed`` into ``.claude/settings.local.json``'s
+    ``permissions.deny`` list and write back atomically.
+
+    Returns 0 on success, 2 if the operator declined the prompt or if
+    the file could not be written."""
+    settings_path = workspace / ".claude" / "settings.local.json"
+    if prompt_for_confirmation:
+        try:
+            print(
+                f"Apply {len(proposed)} deny entr"
+                f"{'y' if len(proposed) == 1 else 'ies'} to {settings_path}? [y/N] ",
+                end="", flush=True,
+            )
+            answer = input().strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            print("agent-coherence-migrate-rules: aborted by user", file=sys.stderr)
+            return 2
+        if answer not in ("y", "yes"):
+            print("agent-coherence-migrate-rules: not applying", file=sys.stderr)
+            return 2
+
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    if settings_path.is_file():
+        try:
+            data = json.loads(settings_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            print(
+                f"agent-coherence-migrate-rules: existing {settings_path} is not valid JSON ({exc}); "
+                "refusing to overwrite.",
+                file=sys.stderr,
+            )
+            return 2
+        if not isinstance(data, dict):
+            print(
+                f"agent-coherence-migrate-rules: existing {settings_path} root is not an object; "
+                "refusing to overwrite.",
+                file=sys.stderr,
+            )
+            return 2
+    else:
+        data = {}
+
+    permissions = data.setdefault("permissions", {})
+    if not isinstance(permissions, dict):
+        print(
+            f"agent-coherence-migrate-rules: existing permissions key in {settings_path} "
+            "is not an object; refusing to overwrite.",
+            file=sys.stderr,
+        )
+        return 2
+    deny = permissions.setdefault("deny", [])
+    if not isinstance(deny, list):
+        print(
+            f"agent-coherence-migrate-rules: existing permissions.deny in {settings_path} "
+            "is not a list; refusing to overwrite.",
+            file=sys.stderr,
+        )
+        return 2
+    seen = {x for x in deny if isinstance(x, str)}
+    appended = 0
+    for entry in proposed:
+        if entry not in seen:
+            deny.append(entry)
+            seen.add(entry)
+            appended += 1
+
+    try:
+        settings_path.write_text(
+            json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        print(
+            f"agent-coherence-migrate-rules: could not write {settings_path}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+    print(
+        f"agent-coherence-migrate-rules: appended {appended} entry/ies to {settings_path}",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_claude_code_migrate_rules.py
+++ b/tests/test_claude_code_migrate_rules.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for the Unit 9 ``agent-coherence-migrate-rules`` CLI (R19).
+
+The detector is heuristic — these tests pin the load-bearing positive
+detections (grep→rg, sudo, python -c, perl -e, ruby -e, cat/sed/awk for
+files) and the false-positive negative cases (prose that mentions a
+tool but doesn't restrict it must NOT propose a deny entry)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ccs.cli import coherence_migrate_rules
+from ccs.cli.coherence_migrate_rules import detect_rules
+
+
+# ----------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """A workspace with a .git marker so find_coordinator_root resolves."""
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+def _write_claude_md(workspace: Path, body: str) -> None:
+    (workspace / "CLAUDE.md").write_text(body, encoding="utf-8")
+
+
+# ----------------------------------------------------------------------
+# Detection — positive cases (each rule type)
+# ----------------------------------------------------------------------
+
+
+def test_detect_grep_to_rg_canonical_prose(workspace: Path) -> None:
+    _write_claude_md(workspace, "## Style\n\n- Use rg instead of grep for all searches.\n")
+    report = detect_rules(workspace)
+    assert any(r.name == "grep_to_rg" for r in report.detected)
+    assert "Bash(grep:*)" in report.proposed_entries
+
+
+def test_detect_no_sudo_canonical_prose(workspace: Path) -> None:
+    _write_claude_md(workspace, "Operator commandments:\n- Never use sudo.\n")
+    report = detect_rules(workspace)
+    assert any(r.name == "no_sudo" for r in report.detected)
+    assert "Bash(sudo *)" in report.proposed_entries
+
+
+def test_detect_no_python_dash_c(workspace: Path) -> None:
+    _write_claude_md(workspace, "Don't use python -c for scripting; write a .py file.")
+    report = detect_rules(workspace)
+    assert any(r.name == "no_python_dash_c" for r in report.detected)
+    assert "Bash(python -c *)" in report.proposed_entries
+    assert "Bash(python3 -c *)" in report.proposed_entries
+
+
+def test_detect_no_perl_dash_e(workspace: Path) -> None:
+    _write_claude_md(workspace, "Avoid perl -e one-liners — they are unreviewable.")
+    report = detect_rules(workspace)
+    assert any(r.name == "no_perl_dash_e" for r in report.detected)
+    assert "Bash(perl -e *)" in report.proposed_entries
+
+
+def test_detect_no_ruby_dash_e(workspace: Path) -> None:
+    _write_claude_md(workspace, "Don't use ruby -e in this codebase.")
+    report = detect_rules(workspace)
+    assert any(r.name == "no_ruby_dash_e" for r in report.detected)
+    assert "Bash(ruby -e *)" in report.proposed_entries
+
+
+def test_detect_cat_for_files(workspace: Path) -> None:
+    _write_claude_md(workspace, "Use the Read tool, not cat, for reading files.")
+    report = detect_rules(workspace)
+    assert any(r.name == "cat_for_files" for r in report.detected)
+    assert "Bash(cat:*)" in report.proposed_entries
+
+
+def test_detect_sed_for_files(workspace: Path) -> None:
+    _write_claude_md(workspace, "Use the Edit tool instead of sed for editing files.")
+    report = detect_rules(workspace)
+    assert any(r.name == "sed_for_files" for r in report.detected)
+
+
+# ----------------------------------------------------------------------
+# Detection — negative cases (false-positive resistance)
+# ----------------------------------------------------------------------
+
+
+def test_no_detection_when_claude_md_is_neutral_prose(workspace: Path) -> None:
+    """CLAUDE.md that mentions tools without restricting them must not
+    propose denies. A naive substring search would hit on every project."""
+    _write_claude_md(
+        workspace,
+        "## Setup\n\n"
+        "Run `npm test` after editing TypeScript files. "
+        "Logs are appended to ./logs/build.log. "
+        "Use grep on the logs to find errors during local debugging.\n",
+    )
+    report = detect_rules(workspace)
+    assert report.detected == []
+
+
+def test_no_detection_for_descriptive_python_mention(workspace: Path) -> None:
+    """A CLAUDE.md that says "we run `python -c 'import x'` in CI" without
+    a restriction phrase must NOT flag python -c — restriction phrases are
+    the trigger ("don't", "no", "avoid", "never")."""
+    _write_claude_md(
+        workspace,
+        "CI runs python -c 'import this' as a smoke check.",
+    )
+    report = detect_rules(workspace)
+    assert not any(r.name == "no_python_dash_c" for r in report.detected)
+
+
+def test_no_claude_md_at_all_returns_empty_report(workspace: Path) -> None:
+    """Idempotent over missing CLAUDE.md — the helper is safe to run in
+    a fresh project."""
+    report = detect_rules(workspace)
+    assert report.detected == []
+
+
+# ----------------------------------------------------------------------
+# Deduplication: entries already in settings*.json
+# ----------------------------------------------------------------------
+
+
+def test_already_present_entries_are_not_re_proposed(workspace: Path) -> None:
+    """If permissions.deny already lists Bash(sudo *), don't propose it
+    again — but still detect the rule (so the operator sees the match)."""
+    _write_claude_md(workspace, "Never use sudo.\n")
+    claude_dir = workspace / ".claude"
+    claude_dir.mkdir(parents=True)
+    (claude_dir / "settings.local.json").write_text(json.dumps({
+        "permissions": {"deny": ["Bash(sudo *)"]},
+    }))
+    report = detect_rules(workspace)
+    assert any(r.name == "no_sudo" for r in report.detected)
+    assert "Bash(sudo *)" not in report.proposed_entries
+
+
+# ----------------------------------------------------------------------
+# CLI integration
+# ----------------------------------------------------------------------
+
+
+def test_cli_no_claude_md_exits_0_with_message(
+    workspace: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = coherence_migrate_rules.main(["--root", str(workspace)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "no CLAUDE.md" in captured.out
+
+
+def test_cli_no_rules_detected_exits_0_with_message(
+    workspace: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_claude_md(workspace, "## Setup\n\nRun the tests.\n")
+    rc = coherence_migrate_rules.main(["--root", str(workspace)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "no tool-class rule patterns detected" in captured.out
+
+
+def test_cli_prints_proposed_settings_fragment_by_default(
+    workspace: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_claude_md(workspace, "Never use sudo. Use rg instead of grep.")
+    rc = coherence_migrate_rules.main(["--root", str(workspace)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    # The rendered fragment is JSON; parse it to confirm shape.
+    json_start = captured.out.index("{")
+    json_end = captured.out.rindex("}") + 1
+    fragment = json.loads(captured.out[json_start:json_end])
+    deny = fragment["permissions"]["deny"]
+    assert "Bash(sudo *)" in deny
+    assert "Bash(grep:*)" in deny
+    # Default mode is flag-only — verify settings.local.json was NOT written.
+    assert not (workspace / ".claude" / "settings.local.json").exists()
+
+
+def test_cli_apply_with_yes_writes_settings_local(
+    workspace: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_claude_md(workspace, "Never use sudo. Use rg instead of grep.")
+    rc = coherence_migrate_rules.main([
+        "--root", str(workspace), "--apply", "--yes",
+    ])
+    captured = capsys.readouterr()
+    assert rc == 0
+    settings_path = workspace / ".claude" / "settings.local.json"
+    assert settings_path.is_file()
+    data = json.loads(settings_path.read_text())
+    deny = data["permissions"]["deny"]
+    assert "Bash(sudo *)" in deny
+    assert "Bash(grep:*)" in deny
+
+
+def test_cli_apply_merges_with_existing_deny_list(
+    workspace: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--apply must MERGE, not overwrite — operator-curated deny entries
+    persist alongside the new proposals."""
+    _write_claude_md(workspace, "Never use sudo.")
+    claude_dir = workspace / ".claude"
+    claude_dir.mkdir(parents=True)
+    (claude_dir / "settings.local.json").write_text(json.dumps({
+        "permissions": {"deny": ["Bash(curl evil.example.com:*)"]},
+        "allow": ["Bash(rg *)"],  # unrelated key — must survive
+    }))
+    rc = coherence_migrate_rules.main([
+        "--root", str(workspace), "--apply", "--yes",
+    ])
+    captured = capsys.readouterr()
+    assert rc == 0
+    data = json.loads((claude_dir / "settings.local.json").read_text())
+    deny = data["permissions"]["deny"]
+    assert "Bash(curl evil.example.com:*)" in deny  # preserved
+    assert "Bash(sudo *)" in deny  # newly appended
+    assert data["allow"] == ["Bash(rg *)"]  # unrelated key preserved
+
+
+def test_cli_apply_refuses_to_overwrite_malformed_settings(
+    workspace: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """If settings.local.json is malformed JSON or has the wrong shape,
+    --apply MUST refuse and exit 2 — operator-curated state takes priority
+    over the helper's heuristics."""
+    _write_claude_md(workspace, "Never use sudo.")
+    claude_dir = workspace / ".claude"
+    claude_dir.mkdir(parents=True)
+    (claude_dir / "settings.local.json").write_text("{ not valid json")
+    rc = coherence_migrate_rules.main([
+        "--root", str(workspace), "--apply", "--yes",
+    ])
+    assert rc == 2
+
+
+def test_cli_no_root_exits_1(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Outside a git repo with no --root flag, exit 1."""
+    monkeypatch.chdir(tmp_path)
+    rc = coherence_migrate_rules.main([])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "not in a git repository" in captured.err


### PR DESCRIPTION
## Summary

Phase C Unit 9 of the v0.1.1 marketplace cut — closes R19. Adds the \`agent-coherence-migrate-rules\` CLI which scans the workspace CLAUDE.md for prose tool-class rules ("use rg, not grep", "never sudo", "avoid python -c") and proposes \`permissions.deny\` entries that enforce them at the configuration layer.

Why this matters: per the v0.2 Phase 0 falsifiability experiment, runtime hook denies are routable around via alternative tools (the H4 finding). \`permissions.deny\` is structurally stronger — it fires before the model can choose which tool to invoke. The helper lowers the ergonomic cost of moving prose rules into enforceable config so the marketplace cohort isn't stuck with advisory-only rules.

## CLI surface

- Default: **flag-only**. Prints detected matches with explanatory snippets + a copy-paste-ready settings.local.json fragment. Exits 0.
- \`--apply\`: writes proposed entries to \`.claude/settings.local.json\` after a confirmation prompt.
- \`--yes\`: skips the confirmation prompt (for setup wizards / CI smoke).
- Merges with existing \`permissions.deny\` entries — operator-curated state always wins, malformed JSON refuses overwrite.

Detected patterns: grep→rg, python -c, perl -e, ruby -e, sudo, cat for files, sed for files, awk for files.

## Test plan

- [x] 18 tests cover positive detections for every rule type.
- [x] False-positive resistance — neutral prose mentioning a tool without restricting it must NOT propose a deny ("CI runs python -c 'import this'" stays clean).
- [x] Already-present entries are not re-proposed.
- [x] \`--apply\` merges (preserves operator-curated entries + unrelated keys); malformed JSON exits 2 instead of overwriting.
- [x] No CLAUDE.md / no rules detected → exit 0 with diagnostic message.
- [x] Outside a git repo → exit 1.

Refs: \`docs/plans/2026-05-18-001-feat-claude-code-coherence-plugin-v0.1.1-plan.md\` Unit 9, R19, KTD-E v0.2 deferral rationale.