### PR TITLE
fix(review): COR-01 shutdown ordering + COR-02 _seq rollback on COMMIT failure

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -393,11 +393,24 @@ class CoordinatorHTTPServer:
             # shutdown() would wait forever. Guard against that so unit
             # tests that construct a server purely for state manipulation
             # can still tear it down cleanly.
+            #
+            # COR-01: order is shutdown → drain → server_close → registry.close.
+            # _server.shutdown() stops the serve_forever accept loop but does
+            # NOT close in-flight handler threads (they own their accepted
+            # sockets and finish writing on their own). Drain those slots
+            # BEFORE server_close + registry.close, so the registry remains
+            # open while a handler is still mid-transaction. Closing the
+            # listening socket is independent of accepted-connection sockets
+            # but keeping it open through the drain matches the canonical
+            # shutdown ordering and removes a refactor footgun.
             if self._serve_thread is not None:
                 self._server.shutdown()
-            self._server.server_close()
         finally:
             self._drain_in_flight(IN_FLIGHT_DRAIN_TIMEOUT_SEC)
+            try:
+                self._server.server_close()
+            except Exception:  # noqa: BLE001 - best-effort cleanup
+                logger.exception("server_close raised during shutdown")
             self._watchdog.shutdown(wait=True, cancel_futures=False)
             self.registry.close()
 

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -530,6 +530,9 @@ class SqliteArtifactRegistry:
         does not create a phantom gap.
         """
         with self._lock:
+            # COR-02: initialised outside the try so the except handler can
+            # check it even if BEGIN IMMEDIATE or any pre-_seq SQL raises.
+            seq_incremented_in_iteration = False
             self._conn.execute("BEGIN IMMEDIATE")
             try:
                 # Fetch prior state for the from→to log entry + bookkeeping decisions.
@@ -602,8 +605,16 @@ class SqliteArtifactRegistry:
                 # Mutation-then-log: emit state_log BEFORE commit. If the callback
                 # raises, ROLLBACK undoes the agent_states change AND we decrement
                 # _seq so gap detection stays consistent.
+                #
+                # COR-02: track _seq mutation in this iteration so the outer
+                # BaseException handler can also roll it back. Without this, a
+                # COMMIT failure leaves in-memory _seq ahead of persisted
+                # registry_meta.sequence_number — subsequent successful emissions
+                # produce a phantom gap. The inner Exception-during-state_log
+                # path already decrements; the outer ROLLBACK path now does too.
                 if self._state_log is not None:
                     self._seq += 1
+                    seq_incremented_in_iteration = True
                     entry = {
                         "tick": tick,
                         "artifact_id": str(artifact_id),
@@ -622,6 +633,7 @@ class SqliteArtifactRegistry:
                         self._state_log(entry)
                     except Exception:
                         self._seq -= 1
+                        seq_incremented_in_iteration = False
                         raise
                     # Persist new _seq value so cross-restart consumers see continuity.
                     self._conn.execute(
@@ -630,12 +642,18 @@ class SqliteArtifactRegistry:
                     )
 
                 self._conn.execute("COMMIT")
+                # COMMIT succeeded — _seq is durably persisted; no rollback needed.
+                seq_incremented_in_iteration = False
             except BaseException:
                 # P2 ce-review fix #14 (kieran-python): BaseException catches
                 # KeyboardInterrupt/SystemExit mid-transaction so ROLLBACK fires
                 # before propagation — otherwise the connection is left with an
                 # uncommitted transaction that the next BEGIN IMMEDIATE sees.
                 self._conn.execute("ROLLBACK")
+                # COR-02: if _seq was bumped in this iteration but COMMIT (or any
+                # later step) failed, decrement to match the rolled-back DB state.
+                if seq_incremented_in_iteration:
+                    self._seq -= 1
                 raise
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two gated_auto correctness fixes from the ce-review run on \`dev\`. Both are P1 findings that survived cross-reviewer dedup, both touch invariants the marketplace cohort will exercise. Separate PR from #33 (safe_auto) so the behavioral diff is reviewable on its own.

### COR-01 — shutdown ordering

\`CoordinatorHTTPServer.shutdown()\` was: \`_server.shutdown() → _server.server_close() (try) → _drain_in_flight + watchdog.shutdown + registry.close (finally)\`. Order is now: \`_server.shutdown() → _drain_in_flight → _server.server_close() → watchdog.shutdown → registry.close\`.

\`_server.shutdown()\` only stops the accept loop; in-flight handler threads own their accepted sockets and finish writing on their own — \`server_close()\` of the listening socket doesn't actively break them, but moving the drain ahead of \`server_close\` keeps the registry open through the drain window and matches the canonical shutdown pattern. The cleanup is now \`try/except\` wrapped around \`server_close\` so a teardown error doesn't skip the watchdog + registry close.

### COR-02 — \`_seq\` rollback on COMMIT failure

In \`set_agent_state\`, the inner \`except Exception\` path during \`state_log\` callback already decrements \`_seq\` when the callback raises. But the outer \`except BaseException\` (which catches COMMIT failures, KeyboardInterrupt mid-transaction, etc.) did NOT. Result: COMMIT failure left in-memory \`_seq\` one ahead of persisted \`registry_meta.sequence_number\` — subsequent successful emissions produced a phantom gap that operator gap-detection tools would flag.

Tracked via \`seq_incremented_in_iteration\` initialised before the try (so the except handler can read it even if BEGIN IMMEDIATE or any pre-_seq SQL raises). True after \`_seq += 1\`; reset to False after the inner-catch decrement and after COMMIT succeeds. Outer \`except BaseException\` decrements iff the flag is still True when ROLLBACK fires.

## Test plan

- [x] \`pytest tests/test_claude_code_coordinator_server.py tests/test_claude_code_lifecycle.py tests/test_sqlite_registry.py -q\` — 154 passed locally
- [ ] CI: Architecture Checks, Tests (3.11 + 3.12), Benchmark Regression, TLA+ Model Check, Benchmark Smoke, Build Package — must all pass before merge into \`dev\` (branch protection)

## Refs

- ce-review run artifact: \`.context/compound-engineering/ce-review/20260521-013506-10711878/\`
- Findings: COR-01 (correctness reviewer, conf 0.92), COR-02 (correctness, conf 0.88)