### PR TITLE
fix(coordinator): P1 #5 — detect watchdog late completions (phantom grant signal)

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -290,6 +290,22 @@ class CoordinatorHTTPServer:
         # guarantees atomicity for the single-attribute increment idiom.
         self._watchdog_timeouts_total: int = 0
         self._watchdog_queue_overflows_total: int = 0
+        # P1 #5 detection-only: when ``run_with_watchdog`` raises
+        # FuturesTimeout, the handler returns degraded — but the
+        # underlying ``work()`` future is left running in the pool
+        # (cancel_futures=False). If it eventually completes
+        # successfully, any state it mutated (EXCLUSIVE grant from
+        # ``service.write``, for instance) lands in the registry AFTER
+        # the agent received a degraded response — a phantom grant the
+        # agent will never post-edit. We can't cancel the future
+        # without invasive cancel-token plumbing through service.write,
+        # but we CAN detect it: every timed-out future gets a
+        # done_callback that bumps this counter + logs CRITICAL if the
+        # future eventually finished without exception. Operators see
+        # the symptom via ``/status?detail=metrics`` even when the
+        # cause is rare (4s deadline + 1.5s busy_timeout = real-world
+        # only hits with a wedged SQLite or contended drive).
+        self._watchdog_late_completion_total: int = 0
 
         # KTD-I (Unit 5 L2) — in-flight handler counter. Incremented at
         # dispatch entry via :meth:`acquire_handler_slot`, decremented in
@@ -621,6 +637,16 @@ class CoordinatorHTTPServer:
         """M-03 / finding #31: increment the watchdog queue-overflow counter."""
         self._watchdog_queue_overflows_total += 1
 
+    def increment_watchdog_late_completion(self) -> None:
+        """P1 #5: a watchdog-timed-out future eventually completed
+        successfully — any state it mutated (e.g., an EXCLUSIVE grant
+        from ``service.write``) is now in the registry without the
+        agent's knowledge, since the handler had already returned a
+        degraded response. Operator-visible via
+        ``/status?detail=metrics`` so a phantom-grant cluster is
+        diagnosable from a bug report."""
+        self._watchdog_late_completion_total += 1
+
     def counters_snapshot(self) -> dict[str, Any]:
         """M-03 / finding #31: stable snapshot of ALL coordinator counters
         (per-endpoint + product-signal + infrastructure + watchdog).
@@ -631,6 +657,7 @@ class CoordinatorHTTPServer:
         return {
             "watchdog_timeouts_total": self._watchdog_timeouts_total,
             "watchdog_queue_overflows_total": self._watchdog_queue_overflows_total,
+            "watchdog_late_completion_total": self._watchdog_late_completion_total,
             "handler_concurrency_overflows_total": (
                 self._server.handler_concurrency_overflows_total
                 if self._server is not None else 0
@@ -665,9 +692,50 @@ class CoordinatorHTTPServer:
 
     def run_with_watchdog(self, fn: Callable[[], Any]) -> Any:
         """Run a callable under the 4s handler-side timeout. Raises
-        :class:`FuturesTimeout` on timeout (caller decides degradation)."""
+        :class:`FuturesTimeout` on timeout (caller decides degradation).
+
+        P1 #5 (detection-only): when the future times out, ``cancel_futures``
+        is not set so the underlying work continues running in the pool.
+        Attach a done_callback that fires when that runaway work
+        eventually finishes — if it completed successfully, the
+        registry now holds state the agent never saw (phantom EXCLUSIVE
+        grant being the canonical worry). The callback bumps
+        ``watchdog_late_completion_total`` and logs CRITICAL so the
+        operator can correlate a phantom-grant cluster in a bug report
+        with the rate at which late completions are firing.
+        """
         future = self._watchdog.submit(fn)
-        return future.result(timeout=HANDLER_TIMEOUT_SEC)
+        try:
+            return future.result(timeout=HANDLER_TIMEOUT_SEC)
+        except FuturesTimeout:
+            future.add_done_callback(self._on_watchdog_future_done_after_timeout)
+            raise
+
+    def _on_watchdog_future_done_after_timeout(self, future: Any) -> None:
+        """Callback wired by :meth:`run_with_watchdog` when its future
+        timed out. Fires later (microseconds to many seconds) when the
+        underlying work actually completes. We only count + log when
+        the late completion produced state — i.e., the future finished
+        without raising. A future that ultimately raised was a no-op
+        in the registry; nothing phantom there."""
+        if future.cancelled():
+            return
+        try:
+            future.result(timeout=0)
+        except Exception:
+            # Late failure — no phantom state landed in the registry.
+            return
+        self.increment_watchdog_late_completion()
+        logger.critical(
+            "watchdog late completion: a handler future timed out but the "
+            "underlying work completed successfully afterwards. Any state "
+            "it mutated (e.g., an EXCLUSIVE grant) is in the registry "
+            "without the agent's knowledge. Check /status?detail=metrics "
+            "for watchdog_late_completion_total and consider running "
+            "agent-coherence-status --detail=full to inspect orphaned "
+            "M/E grants. Counter total now: %d.",
+            self._watchdog_late_completion_total,
+        )
 
 
 class _ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -2041,3 +2041,99 @@ def test_adv001_repeated_prepare_for_migration_is_idempotent(
         assert body.get("already_in_progress") is True
     finally:
         coordinator._migration_draining = False
+
+
+# ----------------------------------------------------------------------
+# P1 #5 — watchdog late-completion detector
+# ----------------------------------------------------------------------
+
+
+def test_p1_5_watchdog_late_completion_increments_counter(
+    coordinator,
+) -> None:
+    """When run_with_watchdog times out and the underlying future
+    later completes successfully, the late-completion counter must
+    increment and a CRITICAL log line fires."""
+    import threading as _t
+    from concurrent.futures import TimeoutError as _FuturesTimeout
+
+    # Replace HANDLER_TIMEOUT_SEC for the duration of the test so we
+    # don't have to wait 4s. The work function blocks until the test
+    # releases it, then returns a successful payload.
+    release = _t.Event()
+    def slow_work() -> dict:
+        release.wait(timeout=5.0)
+        return {"ok": True, "late": True}
+
+    import ccs.adapters.claude_code.coordinator_server as mod
+    original_timeout = mod.HANDLER_TIMEOUT_SEC
+    try:
+        mod.HANDLER_TIMEOUT_SEC = 0.05  # 50ms — fire timeout fast
+        before = coordinator._watchdog_late_completion_total
+        try:
+            coordinator.run_with_watchdog(slow_work)
+        except _FuturesTimeout:
+            pass
+        else:
+            pytest.fail("expected FuturesTimeout")
+        # Now release the work; the future completes successfully and
+        # the done_callback fires (asynchronously — give the pool a
+        # moment to schedule the callback).
+        release.set()
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if coordinator._watchdog_late_completion_total > before:
+                break
+            time.sleep(0.020)
+        assert coordinator._watchdog_late_completion_total == before + 1, (
+            f"expected late-completion counter to increment by 1; "
+            f"before={before} after={coordinator._watchdog_late_completion_total}"
+        )
+    finally:
+        mod.HANDLER_TIMEOUT_SEC = original_timeout
+        release.set()
+
+
+def test_p1_5_late_failure_does_not_increment_counter(
+    coordinator,
+) -> None:
+    """If a timed-out future later RAISES rather than completing, no
+    phantom state landed in the registry — counter must NOT increment."""
+    import threading as _t
+    from concurrent.futures import TimeoutError as _FuturesTimeout
+
+    release = _t.Event()
+    def slow_failing_work() -> dict:
+        release.wait(timeout=5.0)
+        raise RuntimeError("late failure")
+
+    import ccs.adapters.claude_code.coordinator_server as mod
+    original_timeout = mod.HANDLER_TIMEOUT_SEC
+    try:
+        mod.HANDLER_TIMEOUT_SEC = 0.05
+        before = coordinator._watchdog_late_completion_total
+        try:
+            coordinator.run_with_watchdog(slow_failing_work)
+        except _FuturesTimeout:
+            pass
+        # Release; future fails late; counter should NOT increment.
+        release.set()
+        time.sleep(0.3)
+        assert coordinator._watchdog_late_completion_total == before, (
+            f"late-failure path must not bump phantom-grant counter; "
+            f"before={before} after={coordinator._watchdog_late_completion_total}"
+        )
+    finally:
+        mod.HANDLER_TIMEOUT_SEC = original_timeout
+        release.set()
+
+
+def test_p1_5_status_metrics_exposes_late_completion_counter(
+    client: _Client, coordinator,
+) -> None:
+    """The new counter must show up in /status?detail=metrics so
+    operators can spot a phantom-grant cluster in a bug report."""
+    status, body = client.get("/status?detail=metrics")
+    assert status == 200
+    assert "watchdog_late_completion_total" in body
+    assert isinstance(body["watchdog_late_completion_total"], int)


### PR DESCRIPTION
## Summary

ce-review P1 #5: when \`run_with_watchdog\` raises \`FuturesTimeout\`, the handler returns \`{degraded:true}\` to the agent. But \`cancel_futures=False\` means the underlying \`work()\` keeps running in the pool. If it completes successfully later, any state it mutated (the canonical worry: \`service.write\` granting EXCLUSIVE) lands in the registry AFTER the agent received a degraded response — a phantom grant the agent will never post-edit.

## Approach: detection-only

The cancel-token alternative requires invasive plumbing through \`service.write\` and complicates the transactional boundary. Detection-only:

- New \`watchdog_late_completion_total\` counter on \`CoordinatorHTTPServer\`
- \`run_with_watchdog\` attaches a \`done_callback\` on timeout
- Callback fires when the runaway work eventually finishes; if it finished without exception, bump the counter + log CRITICAL with remediation pointer

Operator sees the symptom in \`/status?detail=metrics\` even when the cause is rare (4s watchdog + 1.5s busy_timeout = real-world only hits with wedged SQLite or contended drive).

## Test plan

- [x] 3 new tests:
  - happy path: timeout → late success → counter increments
  - late failure: timeout → late raise → counter does NOT increment (no phantom state)
  - /status?detail=metrics exposes the counter
- [x] 140 coordinator + lifecycle tests still pass locally
- [ ] CI: 7 checks must pass before merge

## Refs

- ce-review run: \`.context/compound-engineering/ce-review/20260521-013506-10711878/\`
- Finding: P1 #5