### PR TITLE
fix(coordinator): P1 #6 — visible 401 (hook.secret deletion / bearer mismatch)

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -290,6 +290,18 @@ class CoordinatorHTTPServer:
         # guarantees atomicity for the single-attribute increment idiom.
         self._watchdog_timeouts_total: int = 0
         self._watchdog_queue_overflows_total: int = 0
+        # P1 #6: silent 401 surface. If hook.secret is deleted out from
+        # under a running coordinator (operator misclick, accidental
+        # rm in .coherence), every subsequent hook request from any
+        # session 401s. The client treats 401 as "no coordinator
+        # available" and degrades silently — agents lose the coherence
+        # layer with zero operator signal. Counter + WARNING log
+        # surface the symptom; 60s dedupe avoids spamming the log when
+        # a real burst hits. ``self._last_401_warn_at`` is the
+        # monotonic timestamp of the last warning emission.
+        self._auth_401_total: int = 0
+        self._last_401_warn_at: float = 0.0
+        self._auth_401_warn_lock = threading.Lock()
         # P1 #5 detection-only: when ``run_with_watchdog`` raises
         # FuturesTimeout, the handler returns degraded — but the
         # underlying ``work()`` future is left running in the pool
@@ -647,6 +659,32 @@ class CoordinatorHTTPServer:
         diagnosable from a bug report."""
         self._watchdog_late_completion_total += 1
 
+    def record_401(self) -> None:
+        """P1 #6: bump ``auth_401_total`` and (deduped to once per 60s)
+        emit a WARNING log explaining the most common cause — operator
+        deleted ``hook.secret`` while the coordinator was running, so
+        every hook request from every session now 401s and the client
+        treats it as a coordinator-unavailable degrade. Without this
+        signal an operator sees no symptom except "coherence stopped
+        working" with no log line to point at. We deliberately do NOT
+        shut down the coordinator on 401 — the secret may be restored,
+        or this may be a single bad request rather than a system
+        misconfig."""
+        self._auth_401_total += 1
+        now = time.monotonic()
+        with self._auth_401_warn_lock:
+            if now - self._last_401_warn_at < 60.0:
+                return
+            self._last_401_warn_at = now
+        logger.warning(
+            "auth: 401 on request — bearer mismatch or hook.secret missing. "
+            "If this is the first 401 after a healthy period, check that "
+            "%s/.coherence/hook.secret exists and matches the client's "
+            "bearer. Subsequent 401s within 60s suppressed; total: %d.",
+            self.coordinator_root,
+            self._auth_401_total,
+        )
+
     def counters_snapshot(self) -> dict[str, Any]:
         """M-03 / finding #31: stable snapshot of ALL coordinator counters
         (per-endpoint + product-signal + infrastructure + watchdog).
@@ -668,6 +706,7 @@ class CoordinatorHTTPServer:
             "intra_task_acquire_release_total": self._intra_task_acquire_release_total,
             "stale_warning_emitted_total": self._stale_warning_emitted_total,
             "stale_warning_reread_total": self._stale_warning_reread_total,
+            "auth_401_total": self._auth_401_total,
         }
 
     def mark_stale_warned(self, agent_id: UUID, artifact_id: UUID) -> None:
@@ -872,6 +911,7 @@ def _make_handler_class(coordinator: CoordinatorHTTPServer) -> type:
                     )
                     return
                 if not verify_bearer(self.headers.get("Authorization"), coordinator.secret):
+                    coordinator.record_401()
                     self._json(401, {"error": "missing or invalid bearer token"})
                     return
 

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -2137,3 +2137,75 @@ def test_p1_5_status_metrics_exposes_late_completion_counter(
     assert status == 200
     assert "watchdog_late_completion_total" in body
     assert isinstance(body["watchdog_late_completion_total"], int)
+
+
+# ----------------------------------------------------------------------
+# P1 #6 — 401 visibility (hook.secret deletion / bearer mismatch)
+# ----------------------------------------------------------------------
+
+
+def test_p1_6_401_increments_auth_counter(coordinator) -> None:
+    """A request with a wrong bearer must bump auth_401_total so
+    operators can spot a hook.secret deletion via /status."""
+    url = f"http://127.0.0.1:{coordinator.port}/hooks/pre-read"
+    req = urlrequest.Request(
+        url, data=b"{}", method="POST",
+        headers={
+            "Authorization": "Bearer wrong-secret",
+            "Host": "127.0.0.1",
+            "Content-Type": "application/json",
+        },
+    )
+    before = coordinator._auth_401_total
+    try:
+        urlrequest.urlopen(req, timeout=5)
+        pytest.fail("expected 401")
+    except urlerror.HTTPError as e:
+        assert e.code == 401
+    assert coordinator._auth_401_total == before + 1
+
+
+def test_p1_6_repeated_401s_dedupe_warning_logs(
+    coordinator, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Counter bumps every 401; WARNING log dedupes to once per 60s so
+    a burst of bad requests doesn't drown the log."""
+    import logging
+    caplog.set_level(logging.WARNING, logger="ccs.adapters.claude_code.coordinator_server")
+    url = f"http://127.0.0.1:{coordinator.port}/hooks/pre-read"
+    def fire_bad() -> None:
+        req = urlrequest.Request(
+            url, data=b"{}", method="POST",
+            headers={
+                "Authorization": "Bearer wrong-secret",
+                "Host": "127.0.0.1",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            urlrequest.urlopen(req, timeout=5)
+        except urlerror.HTTPError:
+            pass
+
+    before_total = coordinator._auth_401_total
+    fire_bad()
+    fire_bad()
+    fire_bad()
+    assert coordinator._auth_401_total == before_total + 3
+    auth_warnings = [
+        r for r in caplog.records
+        if "auth: 401" in r.getMessage()
+    ]
+    # First call emits the warning; next two are deduped.
+    assert len(auth_warnings) == 1, (
+        f"expected exactly one 401 WARNING per dedupe window; got {len(auth_warnings)}: "
+        f"{[r.getMessage() for r in auth_warnings]}"
+    )
+
+
+def test_p1_6_status_metrics_exposes_auth_401_counter(client: _Client) -> None:
+    """auth_401_total visible in /status?detail=metrics."""
+    status, body = client.get("/status?detail=metrics")
+    assert status == 200
+    assert "auth_401_total" in body
+    assert isinstance(body["auth_401_total"], int)


### PR DESCRIPTION
## Summary

ce-review P1 #6: if \`hook.secret\` is deleted out from under a running coordinator (operator misclick, accidental \`rm\` in \`.coherence\`), every subsequent hook request from any session 401s. The client treats 401 as "coordinator-unavailable" and degrades silently — agents lose the coherence layer with zero operator signal until "things stop working" gets noticed.

## Approach: warn + count, don't self-shutdown

Coordinator self-shutdown on bearer mismatch was a tempting symmetric "fail closed" but it's too destructive: the secret may be restored, or this could be a single bad request rather than a system misconfig. The right weight is operator-visible signal:

- New \`auth_401_total\` counter on \`CoordinatorHTTPServer\`
- \`record_401()\` method bumps the counter and (deduped to once per 60s) logs WARNING with remediation pointer
- Counter surfaced in \`/status?detail=metrics\` (and full tier)
- \`_dispatch\` calls \`record_401()\` before emitting the 401

The 60s dedupe keeps the WARNING signal loud enough to spot in a fresh log scan but quiet enough that a burst of bad requests doesn't drown the log.

## Test plan

- [x] 3 new tests:
  - wrong bearer bumps counter
  - 3 wrong-bearer requests → 1 WARNING (dedupe verified)
  - counter visible in \`/status?detail=metrics\`
- [x] 122 coordinator_server tests still pass locally (no regression on existing wrong-bearer 401 tests)
- [ ] CI: 7 checks must pass before merge

## Refs

- ce-review run: \`.context/compound-engineering/ce-review/20260521-013506-10711878/\`
- Finding: P1 #6