### PR TITLE
fix(status): P1 #7 — restore coordinator_pid to /status minimal tier

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1774,11 +1774,22 @@ def _handle_status(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) ->
         "tracked_artifacts": tracked,
         "sessions": sessions,
         "policy_summary": coordinator.policy.summary(),
+        # P1 #7: coordinator_pid is in the minimal tier too. Process IDs
+        # are public on POSIX (anyone with `ps` sees them) so this is
+        # not a disclosure beyond the trust boundary the threat model
+        # already accepts. Operators use this field to verify "is the
+        # coordinator I think is running actually mine" — restoring it
+        # closes the regression Unit 6 R12 introduced when it moved pid
+        # behind the operator-header gate. The contract is also
+        # documented in CLAUDE.md and used by status-rendering CLIs.
+        "coordinator_pid": os.getpid(),
         **counters,
     }
     if detail == "full":
+        # Full tier still adds the absolute workspace root — that DOES
+        # leak $HOME / directory layout and stays gated behind the
+        # Coherence-Local-Operator: true header.
         base["coordinator_root"] = str(coordinator.coordinator_root)
-        base["coordinator_pid"] = os.getpid()
     else:
         # Minimal: replace absolute workspace path with sentinel "." so the
         # default tier never leaks $HOME or directory layout.

--- a/tests/test_claude_code_cli.py
+++ b/tests/test_claude_code_cli.py
@@ -285,10 +285,13 @@ def test_status_detail_metrics_renders_counter_block(
     assert "Sessions:" not in captured.out
 
 
-def test_status_detail_minimal_redacts_pid(
+def test_status_detail_minimal_includes_pid_redacts_abs_root(
     live_coordinator, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """--detail minimal must not surface pid in the rendered output."""
+    """--detail minimal shows coordinator_pid (P1 #7: pid is public on
+    POSIX and operators rely on it). The absolute workspace root stays
+    sentinel'd to ``.`` so $HOME / directory layout never leaks at this
+    tier."""
     workspace, port = live_coordinator
     rc = coherence_status.main([
         "--root", str(workspace), "--detail", "minimal",
@@ -296,8 +299,10 @@ def test_status_detail_minimal_redacts_pid(
     captured = capsys.readouterr()
     assert rc == 0
     assert "Coordinator:" in captured.out
-    # pid is not in the minimal tier so the header omits it.
-    assert f"pid={os.getpid()}" not in captured.out
+    # P1 #7: pid IS in the minimal tier header.
+    assert f"pid={os.getpid()}" in captured.out
+    # Absolute root must NOT leak at this tier.
+    assert str(workspace) not in captured.out
 
 
 def test_status_full_default_includes_counters_below_sessions(

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import threading
 import time
 import uuid
@@ -416,9 +417,15 @@ def test_policy_untrack_persists_to_ignored_yaml(coordinator, client: _Client) -
 
 
 def test_status_includes_tracked_artifacts_and_sessions(client: _Client) -> None:
-    """Default (minimal) tier still surfaces tracked artifacts + sessions +
-    counters; operator-level fields (coordinator_pid, absolute root) move
-    to ``?detail=full`` per R12."""
+    """Default (minimal) tier surfaces tracked artifacts + sessions +
+    counters + coordinator_pid; the absolute workspace root stays gated
+    behind ``?detail=full`` per R12.
+
+    P1 #7: coordinator_pid was moved out of minimal in Unit 6 R12 and
+    restored here — pid is public on POSIX (any `ps` invocation lists
+    it) so it does not exceed the threat model's accepted disclosure,
+    and operators rely on it to verify "is the coordinator I think is
+    running actually mine"."""
     a_sid = _sid("A")
     client.post("/hooks/pre-read", {"session_id": a_sid, "path": "plan.md"})
     client.post("/hooks/pre-edit", {"session_id": a_sid, "path": "spec.md"})
@@ -431,10 +438,10 @@ def test_status_includes_tracked_artifacts_and_sessions(client: _Client) -> None
     assert f"claude-session-{a_sid}" in sessions
     assert b["coordinator_uptime_s"] > 0
     assert "policy_summary" in b
-    # R12: minimal tier never leaks coordinator_pid or absolute root.
+    # Minimal tier: absolute root sentinel'd; pid is present (P1 #7 reversion).
     assert b.get("detail") == "minimal"
     assert b.get("coordinator_root") == "."
-    assert "coordinator_pid" not in b
+    assert b.get("coordinator_pid") == os.getpid()
 
 
 # ----------------------------------------------------------------------
@@ -1835,16 +1842,21 @@ def test_r11_ensure_secret_fails_closed_when_empty_file_persists(
 # ----------------------------------------------------------------------
 
 
-def test_r12_status_minimal_default_hides_coordinator_root_and_pid(
+def test_r12_status_minimal_default_hides_coordinator_root(
     client: _Client,
 ) -> None:
     """The default (no query) response is the minimal tier — coordinator_root
-    is the sentinel "." and coordinator_pid is absent."""
+    is the sentinel "." so $HOME / directory layout never leaks.
+
+    P1 #7 (revision to R12): coordinator_pid IS included in minimal —
+    pid is public on POSIX and operators rely on it. Only the absolute
+    workspace root stays behind the operator-header gate at this tier."""
     s, b = client.get("/status")
     assert s == 200
     assert b["detail"] == "minimal"
     assert b["coordinator_root"] == "."
-    assert "coordinator_pid" not in b
+    # P1 #7: pid is in minimal tier (reversion of R12 over-redaction).
+    assert b.get("coordinator_pid") == os.getpid()
 
 
 def test_r12_status_full_requires_operator_header(client: _Client) -> None:
@@ -1896,11 +1908,14 @@ def test_r12_status_metrics_returns_counters_only(client: _Client) -> None:
 
 def test_r12_status_unknown_detail_falls_back_to_minimal(client: _Client) -> None:
     """A typo'd ?detail=value must NOT silently grant more access — it
-    falls back to minimal, never to full."""
+    falls back to minimal, never to full. P1 #7: pid is in minimal
+    so we assert the absolute root is sentinel'd as the actual
+    confidentiality signal instead."""
     s, b = client.get("/status?detail=fully")
     assert s == 200
     assert b["detail"] == "minimal"
-    assert "coordinator_pid" not in b
+    # The fall-back is "minimal" not "full" — absolute root must NOT leak.
+    assert b["coordinator_root"] == "."
 
 
 def test_r11_ensure_secret_concurrent_threads_return_identical(

--- a/tests/test_claude_code_e2e.py
+++ b/tests/test_claude_code_e2e.py
@@ -198,17 +198,22 @@ def test_auth_rejects_request_with_wrong_bearer(live) -> None:
 
 
 def test_auth_accepts_request_with_correct_bearer(live) -> None:
-    """Correct token → 200 + valid JSON status. R12 (Unit 6): default
-    tier no longer includes ``coordinator_pid`` (operator-elevated). The
-    e2e contract here is "Bearer auth gets you a 200 with the minimal
-    shape", not "Bearer auth gets you operator-level fields"."""
+    """Correct token → 200 + valid JSON status. R12 (Unit 6) + P1 #7
+    revision: minimal tier surfaces ``coordinator_pid`` (pid is public
+    on POSIX; operators rely on it) but the absolute workspace root
+    stays sentinel'd ("."). The full tier (gated behind
+    ``Coherence-Local-Operator: true``) is what exposes the absolute
+    root."""
     _, port, secret = live
     status, body = _request(port, "/status", bearer=secret)
     assert status == 200
     payload = json.loads(body)
     assert payload["detail"] == "minimal"
     assert "tracked_artifacts" in payload
-    assert "coordinator_pid" not in payload  # gated by ?detail=full + opt-in header
+    # P1 #7: pid is in the minimal tier.
+    assert payload["coordinator_pid"] == os.getpid()
+    # Absolute root still sentinel'd at this tier.
+    assert payload["coordinator_root"] == "."
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

ce-review P1 #7: Unit 6 R12 moved \`coordinator_pid\` behind the operator-header gate alongside the absolute \`coordinator_root\`. That bundling was a mistake — pid is public on POSIX (any \`ps\` invocation lists it), operators rely on the field to verify "is the coordinator I think is running actually mine", and the move silently broke a contract documented in CLAUDE.md and consumed by status-rendering CLIs.

## Reversion logic

- pid disclosure does NOT exceed the threat model. Adversary 1 (same OS user) already sees every coordinator pid via \`ps\`. Hiding the field behind the operator header gave no real confidentiality and cost real diagnosability.
- The absolute workspace root DOES leak \`$HOME\` / directory layout to anyone pasting \`/status\` output into a public bug report — that field STAYS gated behind \`?detail=full\` + the operator header.

## Test updates

Matching the new contract:

- \`test_status_includes_tracked_artifacts_and_sessions\` — asserts pid present in default tier
- \`test_r12_status_minimal_default_hides_coordinator_root\` (renamed from \`..._and_pid\`) — only asserts root sentinel
- \`test_r12_status_unknown_detail_falls_back_to_minimal\` — asserts root sentinel as the confidentiality signal
- e2e \`test_auth_accepts_request_with_correct_bearer\` — asserts pid presence + root sentinel
- CLI \`test_status_detail_minimal_includes_pid_redacts_abs_root\` (renamed from \`..._redacts_pid\`) — asserts pid in header + no absolute root in output

## Test plan

- [x] 162 passed across coordinator + cli + e2e suites
- [ ] CI: 7 checks must pass before merge

## Refs

- ce-review run: \`.context/compound-engineering/ce-review/20260521-013506-10711878/\`
- Finding: P1 #7
- Updates R12 contract documented in Unit 6