### PR TITLE
fix(coordinator): ADV-004 — sweep records preemption notice on reclamation

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -108,6 +108,18 @@ the deadline, any still-running handlers are abandoned — they may raise
 ``sqlite3.ProgrammingError`` and return HTTP 500 to their clients. Better
 a 500 than a wedged shutdown (silent hang vs observable failure)."""
 
+# ADV-004: a sentinel preempter UUID the stable-grant sweep uses when
+# recording a preemption notice for an agent whose M/E grant it just
+# reclaimed. The F4 enrichment in ``_handle_post_edit`` compares against
+# this constant to distinguish "your grant was reclaimed by the sweep"
+# from "your grant was preempted by another session" — both surface via
+# the same notice table but communicate distinct failure modes to the
+# model. UUID derived from a stable namespace string so it stays the
+# same across processes, restarts, and instances.
+SWEEP_RECLAMATION_PREEMPTER_ID: UUID = uuid5(
+    NAMESPACE_URL, "ccs-coordinator-sweep:stable-grant-reclamation"
+)
+
 MAX_POLICY_PATHS_PER_REQUEST = 20
 """Cap on the number of paths /policy/track and /policy/untrack accept
 in one request body (security-lens P1)."""
@@ -1325,6 +1337,22 @@ def _handle_post_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer)
             popped = coordinator.registry.pop_preemption_notice(agent_id, artifact_id)
             if popped is not None:
                 preempter_id, preempted_at = popped
+                # ADV-004: distinguish sweep reclamation from peer preemption.
+                # The sweep uses SWEEP_RECLAMATION_PREEMPTER_ID; matching it
+                # means "your heartbeat went stale (or you held the grant past
+                # max-hold) and the coordinator pulled the grant back" — a
+                # different failure mode than "another session committed".
+                if preempter_id == SWEEP_RECLAMATION_PREEMPTER_ID:
+                    reason = (
+                        f"commit_not_allowed: your M/E grant on {path} was "
+                        f"reclaimed by the coordinator sweep (heartbeat "
+                        f"timeout or max-hold ceiling) at "
+                        f"{_iso_utc(preempted_at)}. Your edit landed in your "
+                        f"local worktree but the coordinator's version was "
+                        f"not bumped. Re-fetch the latest via pre-read and "
+                        f"retry. Underlying coordinator error: {exc}"
+                    )
+                    return {"ok": False, "reason": reason, "reclaimed": True}
                 preempter_session = _agent_id_to_session(coordinator, preempter_id) or "<unknown>"
                 reason = (
                     f"commit_not_allowed: your EXCLUSIVE grant on {path} was "
@@ -2194,6 +2222,17 @@ def _build_preemption_text(
     for artifact_id, preempter_id, ts in verbatim:
         artifact = coordinator.registry.get_artifact(artifact_id)
         path = artifact.name if artifact else "<unknown-artifact>"
+        # ADV-004: render sweep-reclaimed notices with a clear cause rather
+        # than the awkward truncated sentinel UUID.
+        if preempter_id == SWEEP_RECLAMATION_PREEMPTER_ID:
+            lines.append(
+                f"  • {path} — reclaimed by the coordinator sweep "
+                f"(heartbeat timeout or max-hold ceiling) at {_iso_utc(ts)}. "
+                f"Any local edit you made to this file will land in your "
+                f"worktree but is NOT reflected in the coordinator's version. "
+                f"Re-fetch via pre-read and retry."
+            )
+            continue
         preempter_session = _agent_id_to_session(coordinator, preempter_id) or "<unknown>"
         lines.append(
             f"  • {path} — preempted/revoked by session {preempter_session[:8]} "

--- a/src/ccs/adapters/claude_code/lifecycle.py
+++ b/src/ccs/adapters/claude_code/lifecycle.py
@@ -617,8 +617,33 @@ def _sweep_loop(entry: _SpawnedEntry, cfg: LifecycleConfig) -> None:
     Order matters per R4: transient sweep first so the stable sweep does
     not race entries that are mid-protocol. F2 notice eviction last —
     it's a pure storage reclaim and doesn't interact with grants.
+
+    ADV-004: stable-grant reclamation records a preemption notice for
+    the reclaimed victim so the victim's eventual post-edit gets an
+    enriched "reclaimed by coordinator sweep" error instead of a
+    generic CoherenceError with no context. The sentinel preempter
+    UUID is ``SWEEP_RECLAMATION_PREEMPTER_ID`` (imported lazily to
+    avoid an import cycle at module load).
     """
+    # Lazy import — coordinator_server imports lifecycle's
+    # CoordinatorHTTPServer; importing back at module load would cycle.
+    from ccs.adapters.claude_code.coordinator_server import (
+        SWEEP_RECLAMATION_PREEMPTER_ID,
+    )
+
     coordinator = entry.coordinator
+
+    def _record_reclamation_notice(artifact_id, agent_id, trigger) -> None:
+        """Per-reclamation callback wired into service.enforce_stable_grant_timeouts.
+        Uses wall-clock time (the notice timestamp is operator-visible
+        via the F4 prose) rather than the monotonic sweep tick."""
+        coordinator.registry.record_preemption_notice(
+            victim_agent_id=agent_id,
+            artifact_id=artifact_id,
+            preempter_agent_id=SWEEP_RECLAMATION_PREEMPTER_ID,
+            preempted_at_unix_ts=time.time(),
+        )
+
     while not coordinator.shutting_down:
         time.sleep(cfg.sweep_interval_sec)
         if coordinator.shutting_down:
@@ -633,6 +658,7 @@ def _sweep_loop(entry: _SpawnedEntry, cfg: LifecycleConfig) -> None:
                 current_tick=now_tick,
                 heartbeat_timeout_ticks=cfg.grant_heartbeat_timeout_sec,
                 max_hold_ticks=cfg.grant_max_hold_sec,
+                on_reclaim=_record_reclamation_notice,
             )
             evicted = coordinator.registry.evict_stale_notices(
                 max_age_sec=cfg.notice_evict_max_age_sec,

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 import warnings
 from dataclasses import dataclass
+from typing import Callable, Optional
 from uuid import UUID
 
 logger = logging.getLogger(__name__)
@@ -377,6 +378,7 @@ class CoordinatorService:
         current_tick: int,
         heartbeat_timeout_ticks: int,
         max_hold_ticks: int,
+        on_reclaim: Optional[Callable[[UUID, UUID, str], None]] = None,
     ) -> int:
         """Reclaim stale stable-state (M∪E) grants whose holders are gone or over-held.
 
@@ -388,6 +390,14 @@ class CoordinatorService:
 
         Pairs with a non-empty transient slot are skipped so the transient sweep
         (which must run first) owns those entries — preserves R4 sweep ordering.
+
+        ADV-004: ``on_reclaim`` is a per-reclamation callback the adapter
+        uses to record a preemption notice for the victim agent — so when
+        the victim's post-edit later arrives and fails CoherenceError, the
+        F4 enrichment path can pop the notice and emit a "reclaimed by
+        sweep" message rather than a generic error with no context.
+        Library code remains preemption-notice-agnostic; the registry
+        method is adapter-only (SqliteArtifactRegistry).
 
         Returns the number of grants reclaimed.
         """
@@ -447,6 +457,16 @@ class CoordinatorService:
             )
             self.registry.record_last_reclamation(agent_id, artifact_id, trigger, current_tick)
             self._validate_single_writer(artifact_id)
+            if on_reclaim is not None:
+                # Best-effort: a notice-recording failure must not stop the sweep
+                # (the reclamation itself already landed in the registry).
+                try:
+                    on_reclaim(artifact_id, agent_id, trigger)
+                except Exception:  # noqa: BLE001 — telemetry surface, best-effort
+                    logger.exception(
+                        "on_reclaim callback raised for agent=%s artifact=%s trigger=%s",
+                        agent_id, artifact_id, trigger,
+                    )
             reclaimed += 1
 
         return reclaimed

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -2224,3 +2224,137 @@ def test_p1_6_status_metrics_exposes_auth_401_counter(client: _Client) -> None:
     assert status == 200
     assert "auth_401_total" in body
     assert isinstance(body["auth_401_total"], int)
+
+
+# ----------------------------------------------------------------------
+# ADV-004 — stable-grant sweep records preemption notice on reclamation
+# ----------------------------------------------------------------------
+
+
+def test_adv004_sweep_reclamation_records_preemption_notice(
+    coordinator, client: _Client,
+) -> None:
+    """ADV-004: the stable-grant sweep must record a preemption notice
+    for the reclaimed victim — otherwise the victim's eventual
+    post-edit fails CoherenceError with no F4 context."""
+    from ccs.adapters.claude_code.coordinator_server import (
+        SWEEP_RECLAMATION_PREEMPTER_ID,
+        session_to_agent_id,
+    )
+
+    sid = _sid("adv004-A")
+    agent_id = session_to_agent_id(sid)
+    # Acquire EXCLUSIVE via pre-edit on a tracked artifact.
+    s, _ = client.post("/hooks/pre-edit", {"session_id": sid, "path": "plan.md"})
+    assert s == 200
+    artifact_id = coordinator.registry.lookup_artifact_id_by_name("plan.md")
+    assert artifact_id is not None
+
+    # Drive the sweep manually so the heartbeat-stale path fires
+    # immediately. heartbeat_timeout_ticks=1 + current_tick well past
+    # the agent's last heartbeat triggers reclaim_heartbeat.
+    reclaimed_n = coordinator.service.enforce_stable_grant_timeouts(
+        current_tick=int(time.time()) + 999_999,
+        heartbeat_timeout_ticks=1,
+        max_hold_ticks=999_999_999,
+        on_reclaim=lambda artifact_id, agent_id, trigger: (
+            coordinator.registry.record_preemption_notice(
+                victim_agent_id=agent_id,
+                artifact_id=artifact_id,
+                preempter_agent_id=SWEEP_RECLAMATION_PREEMPTER_ID,
+                preempted_at_unix_ts=time.time(),
+            )
+        ),
+    )
+    assert reclaimed_n == 1, "sweep should have reclaimed exactly one M/E grant"
+
+    # The preemption notice for the victim must be present and tagged
+    # with the sweep-sentinel preempter.
+    popped = coordinator.registry.pop_preemption_notice(agent_id, artifact_id)
+    assert popped is not None
+    preempter_id, _preempted_at = popped
+    assert preempter_id == SWEEP_RECLAMATION_PREEMPTER_ID
+
+
+def test_adv004_post_edit_after_reclamation_returns_reclaimed_message(
+    coordinator, client: _Client,
+) -> None:
+    """End-to-end: pre-edit → sweep reclaims → post-edit gets the F4
+    'reclaimed by coordinator sweep' message (NOT the generic
+    CoherenceError) and the response carries reclaimed=True instead of
+    preempted=True."""
+    from ccs.adapters.claude_code.coordinator_server import (
+        SWEEP_RECLAMATION_PREEMPTER_ID,
+        session_to_agent_id,
+    )
+
+    sid = _sid("adv004-B")
+    agent_id = session_to_agent_id(sid)
+    client.post("/hooks/pre-edit", {"session_id": sid, "path": "plan.md"})
+    artifact_id = coordinator.registry.lookup_artifact_id_by_name("plan.md")
+
+    # Sweep reclaims agent's grant + records notice via the on_reclaim
+    # callback (same wiring the real adapter sweep uses).
+    coordinator.service.enforce_stable_grant_timeouts(
+        current_tick=int(time.time()) + 999_999,
+        heartbeat_timeout_ticks=1,
+        max_hold_ticks=999_999_999,
+        on_reclaim=lambda aid, sid_, trigger: coordinator.registry.record_preemption_notice(
+            victim_agent_id=sid_,
+            artifact_id=aid,
+            preempter_agent_id=SWEEP_RECLAMATION_PREEMPTER_ID,
+            preempted_at_unix_ts=time.time(),
+        ),
+    )
+
+    # Now post-edit fires — should fail with the reclaimed-message.
+    s, body = client.post("/hooks/post-edit", {
+        "session_id": sid,
+        "path": "plan.md",
+        "content_hash": _hash("adv004-B-late"),
+        "success": True,
+    })
+    assert s == 200, body
+    assert body.get("ok") is False
+    assert body.get("reclaimed") is True, (
+        f"expected reclaimed=True in F4 response; got {body!r}"
+    )
+    assert "reclaimed by the coordinator sweep" in body.get("reason", "")
+    assert "plan.md" in body.get("reason", "")
+    # And NOT the peer-preemption message
+    assert "preempted by session" not in body.get("reason", "")
+
+
+def test_adv004_sweep_on_reclaim_callback_exception_does_not_break_sweep(
+    coordinator,
+) -> None:
+    """Defensive: if the on_reclaim callback raises, the sweep continues
+    and the reclamation itself still lands. The callback is telemetry
+    surface; its failure must not block coherence guarantees."""
+    from ccs.adapters.claude_code.coordinator_server import session_to_agent_id
+
+    sid = _sid("adv004-C")
+    agent_id = session_to_agent_id(sid)
+    # Acquire EXCLUSIVE.
+    coordinator.register_session(sid)
+    artifact_id = coordinator.registry.resolve_or_register("plan.md", content_hash="")
+    coordinator.registry.set_agent_state(
+        artifact_id, agent_id, MESIState.EXCLUSIVE,
+        trigger="test_setup", tick=0, content_hash=None,
+    )
+
+    raises_counter = {"n": 0}
+    def raising_callback(*_a, **_kw) -> None:
+        raises_counter["n"] += 1
+        raise RuntimeError("simulated telemetry failure")
+
+    reclaimed_n = coordinator.service.enforce_stable_grant_timeouts(
+        current_tick=int(time.time()) + 999_999,
+        heartbeat_timeout_ticks=1,
+        max_hold_ticks=999_999_999,
+        on_reclaim=raising_callback,
+    )
+    assert reclaimed_n == 1, "reclamation must still land despite callback failure"
+    assert raises_counter["n"] == 1
+    # The agent's state is invalid (the reclamation itself succeeded).
+    assert coordinator.registry.get_agent_state(artifact_id, agent_id) == MESIState.INVALID


### PR DESCRIPTION
## Summary

ce-review ADV-004 (high): the stable-grant sweep (\`enforce_stable_grant_timeouts\`) reclaims an agent's M/E grant when heartbeat goes stale or max-hold elapses. But the reclamation path did NOT record a preemption notice — so the victim's eventual post-edit got a generic CoherenceError with no F4 context. The model couldn't tell sweep-reclamation from peer-preemption from network-error → silent data loss class.

## Approach

Library code stays preemption-notice-agnostic (\`record_preemption_notice\` is a SqliteArtifactRegistry method; the base \`ArtifactRegistry\` doesn't expose it). Wire a callback instead:

- \`service.enforce_stable_grant_timeouts\` gains an \`on_reclaim: (UUID, UUID, str) → None\` callback invoked per reclaimed grant. Best-effort: callback exceptions are caught + logged, reclamation itself still lands.
- New \`SWEEP_RECLAMATION_PREEMPTER_ID\` sentinel UUID (derived via \`uuid5\` from a stable namespace string) lives in \`coordinator_server.py\`. The adapter's \`_sweep_loop\` wires \`record_preemption_notice\` with the sentinel as \`preempter_id\`.
- F4 enrichment in \`_handle_post_edit\` checks if popped preempter matches the sentinel — emits a distinct "reclaimed by the coordinator sweep (heartbeat timeout or max-hold ceiling)" message with \`reclaimed=True\` in the response.
- \`_build_preemption_text\` (notice surfacing on pre-read/pre-edit) also recognizes the sentinel and renders a distinct line for reclaimed entries.

## Test plan

- [x] 3 new ADV-004 tests:
  - sweep reclamation records the notice with the sentinel
  - end-to-end: pre-edit → sweep reclaims → post-edit returns the reclaimed-message
  - defensive: on_reclaim callback exception does not break the sweep
- [x] 181 passed across crash_recovery + coordinator + lifecycle + e2e suites locally
- [ ] CI: 7 checks must pass before merge

## Refs

- ce-review run: \`.context/compound-engineering/ce-review/20260521-013506-10711878/\`
- Finding: ADV-004 (high)