### PR TITLE
fix(status): AC-02 — rename coordinator_uptime_s → coordinator_uptime_seconds

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1796,8 +1796,17 @@ def _handle_status(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) ->
     # alongside the existing watchdog/concurrency counters.
     # M-03 / finding #31: use counters_snapshot() instead of reaching into
     # private attrs directly — single source of truth for the counter set.
+    # AC-02 cross-backend parity: KTD-J naming convention locks the
+    # full-word ``_seconds`` suffix for duration fields. Node emits
+    # ``coordinator_uptime_seconds``; Python now matches. The old
+    # ``coordinator_uptime_s`` field is emitted ALONGSIDE the new one
+    # for one release as a backward-compat alias (consumers can detect
+    # which field to read by checking which is present, or just read
+    # the canonical name). Deprecation note in docs/metrics.md (TODO).
+    _uptime = coordinator.uptime_s
     counters = {
-        "coordinator_uptime_s": coordinator.uptime_s,
+        "coordinator_uptime_seconds": _uptime,
+        "coordinator_uptime_s": _uptime,  # AC-02: deprecated alias, removed in v0.2
         "coordinator_backend": "python",
         "coordinator_version": _COORDINATOR_VERSION,
         **coordinator.counters_snapshot(),

--- a/src/ccs/adapters/claude_code/hook_payloads.py
+++ b/src/ccs/adapters/claude_code/hook_payloads.py
@@ -141,6 +141,11 @@ class PolicyUntrackResponse(TypedDict):
 class StatusResponse(TypedDict):
     tracked_artifacts: list[dict]  # [{"path": "...", "version": int, "last_writer": "..."}, ...]
     sessions: list[dict]  # [{"session_id": "...", "states": {path: state_name}}, ...]
+    # AC-02: canonical name follows KTD-J convention (full-word _seconds
+    # suffix). ``coordinator_uptime_s`` is emitted alongside as a
+    # deprecated alias for one release; consumers should migrate to the
+    # canonical name. Removed in v0.2.
+    coordinator_uptime_seconds: float
     coordinator_uptime_s: float
     coordinator_pid: int
 

--- a/src/ccs/cli/coherence_status.py
+++ b/src/ccs/cli/coherence_status.py
@@ -267,7 +267,12 @@ def _render_table(payload: dict[str, Any]) -> None:
     tracked = payload.get("tracked_artifacts", [])
     sessions = payload.get("sessions", [])
     policy = payload.get("policy_summary", {})
-    uptime = payload.get("coordinator_uptime_s", 0.0)
+    # AC-02 cross-backend parity: prefer canonical ``coordinator_uptime_seconds``
+    # (KTD-J _seconds convention), fall back to deprecated ``coordinator_uptime_s``
+    # so we keep working against pre-rename coordinators during the
+    # deprecation window.
+    uptime = payload.get("coordinator_uptime_seconds",
+                         payload.get("coordinator_uptime_s", 0.0))
     pid = payload.get("coordinator_pid", 0)
     backend = payload.get("coordinator_backend", "python")
     version = payload.get("coordinator_version", "")

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -436,7 +436,9 @@ def test_status_includes_tracked_artifacts_and_sessions(client: _Client) -> None
     assert "spec.md" in tracked_paths
     sessions = {sess["agent_name"] for sess in b["sessions"]}
     assert f"claude-session-{a_sid}" in sessions
-    assert b["coordinator_uptime_s"] > 0
+    # AC-02: canonical field; old _s alias also present for one release.
+    assert b["coordinator_uptime_seconds"] > 0
+    assert b["coordinator_uptime_s"] == b["coordinator_uptime_seconds"]
     assert "policy_summary" in b
     # Minimal tier: absolute root sentinel'd; pid is present (P1 #7 reversion).
     assert b.get("detail") == "minimal"
@@ -1897,7 +1899,8 @@ def test_r12_status_metrics_returns_counters_only(client: _Client) -> None:
     assert "policy_summary" not in b
     # Counters must be present.
     for k in (
-        "coordinator_uptime_s",
+        "coordinator_uptime_seconds",  # AC-02 canonical field
+        "coordinator_uptime_s",  # AC-02 deprecated alias (one release)
         "watchdog_timeouts_total",
         "handler_concurrency_overflows_total",
         "in_flight_drain_timed_out",


### PR DESCRIPTION
## Summary

ce-review AC-02 (high): cross-backend field divergence. Python emits \`coordinator_uptime_s\`, Node emits \`coordinator_uptime_seconds\`. Operators switching \`coordinator_backend\` read a different field name depending on which backend is active.

The KTD-J counter-naming convention (locked at v0.1.1 plan) specifies the full-word \`_seconds\` suffix. Python was the deviant — rename to match Node.

## Backward compat

\`coordinator_uptime_s\` stays alongside \`coordinator_uptime_seconds\` as a deprecated alias for one release. Existing dashboards/scrapers keep working through the migration window. The alias removes in v0.2.

## Test plan

- [x] minimal-tier shape test asserts both fields present + equal
- [x] metrics-tier shape test asserts both fields present
- [x] CLI reads canonical with fallback to alias
- [x] 168 passed across coordinator + cli + e2e suites
- [ ] CI: 7 checks must pass before merge

## Refs

- ce-review run: \`.context/compound-engineering/ce-review/20260521-013506-10711878/\`
- Finding: AC-02 (high)
- KTD-J naming convention: v0.1.1 plan