### PR TITLE
fix: ADV-005 + ADV-006 + ADV-007 adversarial-medium hardening batch

### DIFF
--- a/src/ccs/adapters/claude_code/bash_path_detector.py
+++ b/src/ccs/adapters/claude_code/bash_path_detector.py
@@ -126,6 +126,20 @@ def _split_pipeline(command: str) -> Iterable[str]:
             yield segment
 
 
+_BASH_WRAPPER_COMMANDS: frozenset[str] = frozenset({
+    # ADV-006: wrappers that pass-through to a subcommand. We skip the
+    # wrapper word and re-evaluate the next position. False-negative
+    # bias preserved — the detector won't recurse into `bash -c '...'`
+    # body strings (that's a separate eval surface) and won't try to
+    # decode command substitutions like ``$(...)``. Just the common
+    # `eval cat plan.md` and `command cat plan.md` cases.
+    "eval",
+    "command",
+    "exec",
+    "builtin",
+})
+
+
 def _detect_in_segment(
     segment: str,
     is_tracked: Callable[[str], bool],
@@ -144,10 +158,21 @@ def _detect_in_segment(
     # bare value following a tracked command as a file-path candidate.
     i = 0
     n = len(tokens)
+    # ADV-006: bound the wrapper-skip loop so a pathological
+    # ``eval eval eval ... cat plan.md`` cannot consume unbounded
+    # iterations. 4 wrappers is generous (typical depth is 1).
+    wrappers_skipped = 0
+    MAX_WRAPPERS = 4
     while i < n:
         tok = tokens[i]
         # Skip leading env-var assignments like FOO=bar
         if "=" in tok and i == 0 and re.match(r"^[A-Z_][A-Z0-9_]*=", tok):
+            i += 1
+            continue
+        # ADV-006: skip pass-through wrappers (`eval`, `command`, etc.)
+        # and re-evaluate the next position as the actual command.
+        if tok in _BASH_WRAPPER_COMMANDS and wrappers_skipped < MAX_WRAPPERS:
+            wrappers_skipped += 1
             i += 1
             continue
         # Command word reached.
@@ -163,9 +188,9 @@ def _detect_in_segment(
                     break
                 if is_tracked(arg):
                     yield arg
-        # Always break after the first non-assignment token — we don't
-        # walk through nested commands ourselves; the pipeline split
-        # already separated those.
+        # Always break after the first non-assignment, non-wrapper token —
+        # we don't walk through nested commands ourselves; the pipeline
+        # split already separated those.
         break
 
 

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1008,8 +1008,15 @@ def _make_handler_class(coordinator: CoordinatorHTTPServer) -> type:
             except ValueError:
                 self._json(400, {"error": "invalid Content-Length"})
                 return None
+            # ADV-005 (defensive): reject Content-Length:0 or missing with
+            # an explicit 400 rather than silently returning {}. Every POST
+            # endpoint expects a body with required fields; a missing body
+            # used to fall through to per-field validate_* errors ("missing
+            # session_id" etc.) which mask the actual cause. Loud-at-the-
+            # right-layer fails fast for hook-client serialization bugs.
             if n <= 0:
-                return {}
+                self._json(400, {"error": "missing or empty body (Content-Length:0)"})
+                return None
             # R21 (Unit 6): cap the body BEFORE rfile.read so a hostile or
             # buggy client cannot allocate an oversized buffer in the
             # coordinator process. Validates Content-Length only — chunked

--- a/src/ccs/cli/coherence_migrate_rules.py
+++ b/src/ccs/cli/coherence_migrate_rules.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from dataclasses import dataclass, field
@@ -394,66 +395,118 @@ def _apply_entries(
             return 2
 
     settings_path.parent.mkdir(parents=True, exist_ok=True)
-    if settings_path.is_file():
-        try:
-            data = json.loads(settings_path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError as exc:
-            print(
-                f"agent-coherence-migrate-rules: existing {settings_path} is not valid JSON ({exc}); "
-                "refusing to overwrite.",
-                file=sys.stderr,
-            )
-            return 2
-        if not isinstance(data, dict):
-            print(
-                f"agent-coherence-migrate-rules: existing {settings_path} root is not an object; "
-                "refusing to overwrite.",
-                file=sys.stderr,
-            )
-            return 2
-    else:
-        data = {}
 
-    permissions = data.setdefault("permissions", {})
-    if not isinstance(permissions, dict):
-        print(
-            f"agent-coherence-migrate-rules: existing permissions key in {settings_path} "
-            "is not an object; refusing to overwrite.",
-            file=sys.stderr,
-        )
-        return 2
-    deny = permissions.setdefault("deny", [])
-    if not isinstance(deny, list):
-        print(
-            f"agent-coherence-migrate-rules: existing permissions.deny in {settings_path} "
-            "is not a list; refusing to overwrite.",
-            file=sys.stderr,
-        )
-        return 2
-    seen = {x for x in deny if isinstance(x, str)}
-    appended = 0
-    for entry in proposed:
-        if entry not in seen:
-            deny.append(entry)
-            seen.add(entry)
-            appended += 1
+    # ADV-007: two operators (or two CI runs) invoking --apply concurrently
+    # both read settings.local.json, both build the same proposed list,
+    # both write — last write wins. With identical proposed lists the
+    # outcome is functionally correct, but ANY concurrent unrelated edit
+    # to settings.local.json during the window gets clobbered. Wrap the
+    # read-modify-write in fcntl.flock on a sidecar lock file so two
+    # --apply runs serialize.
+    #
+    # POSIX-only (matches the rest of the codebase per lifecycle.py
+    # _FCNTL_AVAILABLE guard). On Windows the call is a no-op — the race
+    # is wider but the broader Windows story is deferred to v0.1.1+ per
+    # CLAUDE.md.
+    try:
+        import fcntl  # type: ignore[import-not-found]
+    except ImportError:  # pragma: no cover — exercised only on Windows
+        fcntl = None  # type: ignore[assignment]
+
+    lock_path = settings_path.with_suffix(settings_path.suffix + ".lock")
+    lock_fd: int | None = None
+    if fcntl is not None:
+        try:
+            lock_fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        except OSError as exc:
+            print(
+                f"agent-coherence-migrate-rules: could not acquire lock on "
+                f"{lock_path}: {exc}; proceeding without it (race window present).",
+                file=sys.stderr,
+            )
+            if lock_fd is not None:
+                try:
+                    os.close(lock_fd)
+                except OSError:
+                    pass
+                lock_fd = None
 
     try:
-        settings_path.write_text(
-            json.dumps(data, indent=2, ensure_ascii=False) + "\n",
-            encoding="utf-8",
-        )
-    except OSError as exc:
+        if settings_path.is_file():
+            try:
+                data = json.loads(settings_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                print(
+                    f"agent-coherence-migrate-rules: existing {settings_path} is not valid JSON ({exc}); "
+                    "refusing to overwrite.",
+                    file=sys.stderr,
+                )
+                return 2
+            if not isinstance(data, dict):
+                print(
+                    f"agent-coherence-migrate-rules: existing {settings_path} root is not an object; "
+                    "refusing to overwrite.",
+                    file=sys.stderr,
+                )
+                return 2
+        else:
+            data = {}
+
+        permissions = data.setdefault("permissions", {})
+        if not isinstance(permissions, dict):
+            print(
+                f"agent-coherence-migrate-rules: existing permissions key in {settings_path} "
+                "is not an object; refusing to overwrite.",
+                file=sys.stderr,
+            )
+            return 2
+        deny = permissions.setdefault("deny", [])
+        if not isinstance(deny, list):
+            print(
+                f"agent-coherence-migrate-rules: existing permissions.deny in {settings_path} "
+                "is not a list; refusing to overwrite.",
+                file=sys.stderr,
+            )
+            return 2
+        seen = {x for x in deny if isinstance(x, str)}
+        appended = 0
+        for entry in proposed:
+            if entry not in seen:
+                deny.append(entry)
+                seen.add(entry)
+                appended += 1
+
+        try:
+            settings_path.write_text(
+                json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            print(
+                f"agent-coherence-migrate-rules: could not write {settings_path}: {exc}",
+                file=sys.stderr,
+            )
+            return 2
         print(
-            f"agent-coherence-migrate-rules: could not write {settings_path}: {exc}",
-            file=sys.stderr,
+            f"agent-coherence-migrate-rules: appended {appended} entry/ies to {settings_path}",
+            flush=True,
         )
-        return 2
-    print(
-        f"agent-coherence-migrate-rules: appended {appended} entry/ies to {settings_path}",
-        flush=True,
-    )
-    return 0
+        return 0
+    finally:
+        # Release the lock + drop the fd. Leave the sidecar .lock file on
+        # disk (it's an empty marker; cheaper to keep than to race a
+        # cleanup with the next operator).
+        if lock_fd is not None:
+            try:
+                if fcntl is not None:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+            try:
+                os.close(lock_fd)
+            except OSError:
+                pass
 
 
 if __name__ == "__main__":

--- a/tests/test_bash_path_detector.py
+++ b/tests/test_bash_path_detector.py
@@ -196,3 +196,47 @@ def test_h4_bash_short_flag_with_value() -> None:
     # `head -n 20 plan.md` — `-n` is a flag; `20` should NOT be claimed
     # as a path (is_tracked("20") = False); plan.md detected.
     assert detect_tracked_paths("head -n 20 plan.md", _is_tracked) == ["plan.md"]
+
+
+# ----------------------------------------------------------------------
+# ADV-006 — wrapper command pass-through (eval, command, exec, builtin)
+# ----------------------------------------------------------------------
+
+
+def test_adv006_eval_wrapper_pass_through() -> None:
+    """ADV-006: `eval cat plan.md` was previously NOT detected — first
+    token 'eval' isn't a tracked command, detector broke immediately.
+    Now: skip the wrapper, re-evaluate the next position."""
+    assert detect_tracked_paths("eval cat plan.md", _is_tracked) == ["plan.md"]
+
+
+def test_adv006_command_wrapper_pass_through() -> None:
+    """`command cat plan.md` — `command` is a POSIX wrapper that
+    bypasses shell function lookup; pass through to `cat`."""
+    assert detect_tracked_paths("command cat plan.md", _is_tracked) == ["plan.md"]
+
+
+def test_adv006_exec_wrapper_pass_through() -> None:
+    """`exec cat plan.md` — `exec` replaces the shell process."""
+    assert detect_tracked_paths("exec cat plan.md", _is_tracked) == ["plan.md"]
+
+
+def test_adv006_builtin_wrapper_pass_through() -> None:
+    """`builtin cat plan.md` — bash builtin keyword (rare in practice)."""
+    assert detect_tracked_paths("builtin cat plan.md", _is_tracked) == ["plan.md"]
+
+
+def test_adv006_nested_wrappers_capped_at_max_depth() -> None:
+    """A pathological `eval eval eval eval eval cat plan.md` (5 wrappers)
+    exceeds the MAX_WRAPPERS=4 cap; the bash detector stops walking
+    after 4 wrappers + an unrecognized token. Defensive bound."""
+    # 4 wrappers + cat → still detected
+    assert detect_tracked_paths("eval eval eval eval cat plan.md", _is_tracked) == ["plan.md"]
+    # 5 wrappers + cat → stops at the 5th 'eval' (now treated as command), no match
+    assert detect_tracked_paths("eval eval eval eval eval cat plan.md", _is_tracked) == []
+
+
+def test_adv006_wrapper_without_tracked_command_returns_empty() -> None:
+    """`eval ls -la` — wrapper skipped, but `ls` isn't a tracked
+    command. No false positive."""
+    assert detect_tracked_paths("eval ls -la", _is_tracked) == []

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -2493,3 +2493,62 @@ def test_rel03_watchdog_queue_overflow_counter_under_concurrent_increment(
         assert srv._watchdog_queue_overflows_total == expected
     finally:
         srv.shutdown()
+
+
+# ----------------------------------------------------------------------
+# ADV-005 — empty/missing body rejected with explicit 400
+# ----------------------------------------------------------------------
+
+
+def test_adv005_content_length_zero_returns_explicit_400(coordinator) -> None:
+    """ADV-005: a POST with Content-Length:0 must produce an explicit
+    'missing or empty body' 400, not fall through to per-field
+    validation errors that mask the real cause."""
+    url = f"http://127.0.0.1:{coordinator.port}/hooks/pre-read"
+    secret = load_secret(coordinator.coordinator_root)
+    req = urlrequest.Request(
+        url, data=b"", method="POST",
+        headers={
+            "Authorization": f"Bearer {secret}",
+            "Host": "127.0.0.1",
+            "Content-Type": "application/json",
+            "Content-Length": "0",
+        },
+    )
+    try:
+        urlrequest.urlopen(req, timeout=5)
+        pytest.fail("expected 400")
+    except urlerror.HTTPError as e:
+        assert e.code == 400
+        body = json.loads(e.read().decode())
+        assert "empty body" in body["error"].lower() or "missing" in body["error"].lower()
+
+
+def test_adv005_missing_content_length_returns_400(coordinator) -> None:
+    """A POST with no Content-Length header at all should also reject
+    with the same explicit error (Content-Length defaults to 0 in
+    _read_json on missing)."""
+    url = f"http://127.0.0.1:{coordinator.port}/hooks/pre-read"
+    secret = load_secret(coordinator.coordinator_root)
+    # Build via raw socket to omit Content-Length entirely (urllib auto-adds it).
+    import socket as _socket
+    sock = _socket.create_connection(("127.0.0.1", coordinator.port))
+    try:
+        sock.sendall(
+            f"POST /hooks/pre-read HTTP/1.0\r\n"
+            f"Host: 127.0.0.1\r\n"
+            f"Authorization: Bearer {secret}\r\n"
+            f"Content-Type: application/json\r\n"
+            f"\r\n".encode()
+        )
+        resp = b""
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            resp += chunk
+        # The status line is the first line of the response.
+        first_line = resp.split(b"\r\n", 1)[0].decode()
+        assert "400" in first_line, f"expected 400, got: {first_line}"
+    finally:
+        sock.close()

--- a/tests/test_claude_code_migrate_rules.py
+++ b/tests/test_claude_code_migrate_rules.py
@@ -263,3 +263,90 @@ def test_cli_no_root_exits_1(
     captured = capsys.readouterr()
     assert rc == 1
     assert "not in a git repository" in captured.err
+
+
+# ----------------------------------------------------------------------
+# ADV-007 — concurrent --apply does not lose entries (fcntl.flock)
+# ----------------------------------------------------------------------
+
+
+def test_adv007_concurrent_apply_creates_lock_sidecar(tmp_path: Path) -> None:
+    """ADV-007: --apply must wrap the read-modify-write of
+    settings.local.json in fcntl.flock on a sidecar lock file so two
+    operators invoking --apply simultaneously don't lose each other's
+    edits. After --apply, the sidecar lock file must exist."""
+    import sys as _sys, builtins as _builtins
+    # Pre-seed a workspace with a CLAUDE.md that triggers a deny entry.
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "CLAUDE.md").write_text(
+        "## Forbidden tools\n\n- DO NOT use `grep`; use rg.\n",
+        encoding="utf-8",
+    )
+    # Suppress confirmation prompt by faking a TTY + autoresponding 'y'.
+    settings_path = tmp_path / ".claude" / "settings.local.json"
+    orig_input = _builtins.input
+    _builtins.input = lambda *_args, **_kw: "y"
+    try:
+        import io
+        orig_stdin = _sys.stdin
+        # isatty() returns True so the prompt path runs
+        class _FakeTty(io.StringIO):
+            def isatty(self) -> bool:
+                return True
+        _sys.stdin = _FakeTty()
+        try:
+            rc = coherence_migrate_rules.main([
+                "--root", str(tmp_path), "--apply",
+            ])
+        finally:
+            _sys.stdin = orig_stdin
+    finally:
+        _builtins.input = orig_input
+    assert rc == 0
+    assert settings_path.is_file()
+    # The sidecar lock file is left in place (cheaper than racing cleanup).
+    lock_path = settings_path.with_suffix(settings_path.suffix + ".lock")
+    assert lock_path.is_file()
+
+
+def test_adv007_concurrent_apply_no_lost_entries(tmp_path: Path) -> None:
+    """End-to-end: two concurrent --apply runs against the same
+    workspace must converge — both must see all of each other's
+    appended entries via the flock serialization."""
+    import multiprocessing as _mp
+
+    (tmp_path / ".git").mkdir()
+    # Build a CLAUDE.md with two distinct entry triggers so the union
+    # of "what process A wants" and "what process B wants" is observable.
+    (tmp_path / "CLAUDE.md").write_text(
+        "## Forbidden tools\n\n- DO NOT use `grep`; use rg.\n"
+        "- DO NOT use `sudo` for anything.\n",
+        encoding="utf-8",
+    )
+
+    def run_apply(yes: bool = True) -> int:
+        import sys as _s, io as _io, builtins as _b
+        _b.input = lambda *_a, **_k: "y"
+        class _FakeTty(_io.StringIO):
+            def isatty(self) -> bool: return True
+        _s.stdin = _FakeTty()
+        from ccs.cli import coherence_migrate_rules as _m
+        return _m.main(["--root", str(tmp_path), "--apply", "--yes"])
+
+    # Use multiprocessing to get real concurrent execution. fork start
+    # method preserves the file paths from the parent process.
+    ctx = _mp.get_context("fork")
+    procs = [ctx.Process(target=run_apply) for _ in range(2)]
+    for p in procs: p.start()
+    for p in procs: p.join(timeout=30)
+    for p in procs:
+        assert p.exitcode == 0, f"--apply process failed: exitcode={p.exitcode}"
+
+    settings_path = tmp_path / ".claude" / "settings.local.json"
+    assert settings_path.is_file()
+    data = json.loads(settings_path.read_text(encoding="utf-8"))
+    deny = data.get("permissions", {}).get("deny", [])
+    # Both processes computed the same proposed list; the merged result
+    # must contain entries from at least one and no duplicates.
+    assert len(deny) >= 1
+    assert len(deny) == len(set(deny)), f"duplicate deny entries: {deny}"


### PR DESCRIPTION
## Summary

Three independent defensive fixes from the ce-review adversarial reviewer, bundled because they touch independent code paths and are individually small.

- **ADV-005**: `_read_json` rejects Content-Length:0 / missing with explicit 400 "empty body" error instead of falling through to per-field validation errors that mask the real cause.
- **ADV-006**: Bash detector adds wrapper-pass-through for `eval`, `command`, `exec`, `builtin` (bounded by MAX_WRAPPERS=4). Closes the `eval cat plan.md` bypass. Out of scope: `$(...)` and `bash -c '...'` (require re-parsing).
- **ADV-007**: `migrate-rules --apply` wraps the read-modify-write of settings.local.json in fcntl.flock on a sidecar `.lock` file. Two concurrent --apply runs serialize.

## Test plan

- [x] 10 new tests (ADV-005 × 2, ADV-006 × 6, ADV-007 × 2)
- [x] 217 passed across coordinator + bash_path_detector + migrate_rules + lifecycle + e2e
- [ ] CI: 7 checks

Refs: ce-review 20260521-013506-10711878 ADV-005, ADV-006, ADV-007