### PR TITLE
fix(coordinator): api-contract medium batch (AC-05 + AC-07 + AC-08)

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1318,7 +1318,10 @@ def _handle_pre_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
             }
         return {"ok": True}
 
-    _run_or_degrade(req, coordinator, work)
+    # AC-05: pre-edit's wire contract is {ok: bool}, not {status: ...}.
+    # On watchdog timeout, return the ok-shape degraded envelope so a
+    # client doing result.get("ok") sees True rather than None.
+    _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE)
 
 
 def _handle_post_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
@@ -1429,7 +1432,9 @@ def _handle_post_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer)
         coordinator.increment_intra_task_acquire_release()
         return {"ok": True}
 
-    _run_or_degrade(req, coordinator, work)
+    # AC-05: post-edit's wire contract is {ok: bool}; ok-shape degraded
+    # envelope keeps clients reading result.get("ok") safe on timeout.
+    _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE)
 
 
 def _handle_session_stop(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
@@ -1500,7 +1505,9 @@ def _handle_session_stop(req: _RequestProtocol, coordinator: CoordinatorHTTPServ
             }
         return response
 
-    _run_or_degrade(req, coordinator, work)
+    # AC-05: session-stop's wire contract is {ok: bool}; ok-shape degraded
+    # envelope keeps clients reading result.get("ok") safe on timeout.
+    _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE)
 
 
 def _handle_policy_track(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
@@ -1838,6 +1845,32 @@ def _handle_status(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) ->
     the operator's home-directory path. Bearer auth is enforced by the
     dispatcher; the header is a SECOND factor specifically for the
     elevated tier.
+
+    AC-07 — metrics-tier stability contract (operator-facing):
+
+      Fields PRESENT in the metrics tier are stable within a major
+      version. ``coordinator_uptime_seconds``, ``coordinator_backend``,
+      ``coordinator_version``, ``watchdog_timeouts_total``,
+      ``watchdog_queue_overflows_total``,
+      ``handler_concurrency_overflows_total``,
+      ``in_flight_drain_timed_out``, ``cold_start_duration_ms``,
+      ``endpoint_counters``, ``intra_task_acquire_release_total``,
+      ``stale_warning_emitted_total``, ``stale_warning_reread_total``.
+
+      Fields may be ADDED in minor versions (additive change is
+      non-breaking for dashboards using selective key access).
+
+      Fields are REMOVED only in major versions and only after at
+      least one minor-version release where the field is emitted
+      ALONGSIDE its replacement as a deprecated alias (see AC-02
+      for the ``coordinator_uptime_s`` → ``coordinator_uptime_seconds``
+      precedent — alias ships through v0.1.x; remove at v0.2.0).
+
+      Fields EXPLICITLY OMITTED from metrics tier vs. full tier:
+      ``tracked_artifacts``, ``sessions``, ``policy_summary``,
+      ``coordinator_root``, ``coordinator_pid``. Operators wanting
+      these for a dashboard must call ``?detail=full`` with the
+      ``Coherence-Local-Operator: true`` header.
     """
     detail = _parse_detail_query(getattr(req, "_query_string", ""))
     if detail == "full":
@@ -2165,9 +2198,34 @@ _ENDPOINT_COUNTER_NAMES: dict[tuple[str, str], str] = {
 # ----------------------------------------------------------------------
 
 
-def _run_or_degrade(req: _RequestProtocol, coordinator: CoordinatorHTTPServer, work: Callable[[], dict]) -> None:
+_DEFAULT_DEGRADED_RESPONSE: dict = {"status": "fresh", "degraded": True}
+"""AC-05: pre-read / pre-bash / pre-grep degrade to a fresh-shape envelope
+because their wire contract uses ``{status: "fresh"|"stale"}``. Endpoints
+whose contract is ``{ok: bool}`` (pre-edit, post-edit, session-stop) pass
+``OK_DEGRADED_RESPONSE`` instead so the client doesn't see ``None`` from
+``result.get("ok")``."""
+
+_OK_DEGRADED_RESPONSE: dict = {"ok": True, "degraded": True}
+"""AC-05: degraded envelope for {ok: bool}-shape endpoints (pre-edit,
+post-edit, session-stop). Pairs with ``_DEFAULT_DEGRADED_RESPONSE``."""
+
+
+def _run_or_degrade(
+    req: _RequestProtocol,
+    coordinator: CoordinatorHTTPServer,
+    work: Callable[[], dict],
+    *,
+    degraded_response: dict | None = None,
+) -> None:
     """Run ``work`` under the handler-side watchdog. On timeout, log WARNING
-    and return 200 {status:"fresh"} so the user's tool call proceeds.
+    and return 200 with ``degraded_response`` (or the default fresh-shape
+    envelope) so the user's tool call proceeds.
+
+    AC-05: callers from ``{ok: bool}``-shape endpoints (pre-edit,
+    post-edit, session-stop) pass ``degraded_response=_OK_DEGRADED_RESPONSE``
+    so clients reading ``result.get("ok")`` see ``True`` rather than
+    ``None``. Callers from ``{status: ...}``-shape endpoints (pre-read,
+    pre-bash, pre-grep) accept the default fresh-shape envelope.
 
     v0.1.1 KTD-G:
       - Item 1: queue-depth gate. Reject with HTTP 503 if the watchdog
@@ -2205,8 +2263,8 @@ def _run_or_degrade(req: _RequestProtocol, coordinator: CoordinatorHTTPServer, w
     except FuturesTimeout:
         # KTD-G item 3: surface watchdog degradation via /status counter.
         coordinator.increment_watchdog_timeout()  # finding #31
-        logger.warning("handler watchdog timeout after %ss; degrading to fresh", HANDLER_TIMEOUT_SEC)
-        req._json(200, {"status": "fresh", "degraded": True})
+        logger.warning("handler watchdog timeout after %ss; degrading", HANDLER_TIMEOUT_SEC)
+        req._json(200, degraded_response if degraded_response is not None else _DEFAULT_DEGRADED_RESPONSE)
         return
     except Exception as exc:
         logger.exception("handler work failed: %s", exc)

--- a/src/ccs/adapters/claude_code/hook_payloads.py
+++ b/src/ccs/adapters/claude_code/hook_payloads.py
@@ -89,7 +89,19 @@ class StaleSummary(TypedDict):
 
 
 class FreshResponse(TypedDict):
+    """Fresh-read response shape.
+
+    AC-08: ``hookSpecificOutput`` is OPTIONAL and present when the
+    session has pending preemption notices that the wrapper at
+    ``_handle_pre_read.work_with_notice_surfacing`` attaches. Typed
+    consumers should treat ``hookSpecificOutput`` as ``NotRequired``
+    on every endpoint that returns a fresh envelope (pre-read,
+    pre-bash, pre-grep).
+    """
     status: Literal["fresh"]
+    hookSpecificOutput: NotRequired["PreToolUseHookOutput"]
+    # AC-05: also present on watchdog-timeout degraded responses.
+    degraded: NotRequired[bool]
 
 
 class StaleResponse(TypedDict):

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -2552,3 +2552,99 @@ def test_adv005_missing_content_length_returns_400(coordinator) -> None:
         assert "400" in first_line, f"expected 400, got: {first_line}"
     finally:
         sock.close()
+
+
+# ----------------------------------------------------------------------
+# AC-05 — degraded response shape varies by endpoint contract
+# ----------------------------------------------------------------------
+
+
+def test_ac05_pre_edit_degraded_response_returns_ok_shape(
+    coordinator, client: _Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """pre-edit's wire contract is {ok: bool}; degraded envelope on
+    watchdog timeout must include ok=True so clients reading
+    result.get('ok') don't see None. AC-05 fix."""
+    import ccs.adapters.claude_code.coordinator_server as mod
+    from concurrent.futures import TimeoutError as FuturesTimeout
+
+    def force_timeout(fn):
+        raise FuturesTimeout()
+
+    monkeypatch.setattr(coordinator, "run_with_watchdog", force_timeout)
+    status, body = client.post(
+        "/hooks/pre-edit",
+        {"session_id": _sid("ac05-pre-edit"), "path": "plan.md"},
+    )
+    assert status == 200
+    assert body.get("ok") is True, (
+        f"pre-edit degraded envelope must include ok=True; got {body!r}"
+    )
+    assert body.get("degraded") is True
+
+
+def test_ac05_post_edit_degraded_response_returns_ok_shape(
+    coordinator, client: _Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """post-edit's wire contract is {ok: bool}; degraded envelope must
+    include ok=True. AC-05 fix."""
+    from concurrent.futures import TimeoutError as FuturesTimeout
+
+    def force_timeout(fn):
+        raise FuturesTimeout()
+
+    monkeypatch.setattr(coordinator, "run_with_watchdog", force_timeout)
+    status, body = client.post(
+        "/hooks/post-edit",
+        {
+            "session_id": _sid("ac05-post-edit"),
+            "path": "plan.md",
+            "content_hash": _hash("ac05"),
+            "success": True,
+        },
+    )
+    assert status == 200
+    assert body.get("ok") is True
+    assert body.get("degraded") is True
+
+
+def test_ac05_session_stop_degraded_response_returns_ok_shape(
+    coordinator, client: _Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """session-stop's wire contract is {ok: bool}; degraded envelope
+    must include ok=True. AC-05 fix."""
+    from concurrent.futures import TimeoutError as FuturesTimeout
+
+    def force_timeout(fn):
+        raise FuturesTimeout()
+
+    monkeypatch.setattr(coordinator, "run_with_watchdog", force_timeout)
+    status, body = client.post(
+        "/hooks/session-stop", {"session_id": _sid("ac05-session-stop")}
+    )
+    assert status == 200
+    assert body.get("ok") is True
+    assert body.get("degraded") is True
+
+
+def test_ac05_pre_read_degraded_response_keeps_status_fresh_shape(
+    coordinator, client: _Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """pre-read's wire contract is {status: ...}; degraded envelope
+    keeps the fresh-shape envelope so clients checking status
+    don't see ok=None. AC-05 contract preservation."""
+    from concurrent.futures import TimeoutError as FuturesTimeout
+
+    def force_timeout(fn):
+        raise FuturesTimeout()
+
+    monkeypatch.setattr(coordinator, "run_with_watchdog", force_timeout)
+    status, body = client.post(
+        "/hooks/pre-read",
+        {"session_id": _sid("ac05-pre-read"), "path": "plan.md"},
+    )
+    assert status == 200
+    assert body.get("status") == "fresh"
+    assert body.get("degraded") is True
+    # Crucially, pre-read's degraded envelope does NOT include ok.
+    assert "ok" not in body


### PR DESCRIPTION
AC-04 + AC-06 already addressed in PR #33 safe_auto. This PR covers the remaining three medium api-contract findings.

**AC-05** — degraded shape varies by endpoint contract. `_run_or_degrade` now accepts `degraded_response` parameter; pre-edit/post-edit/session-stop pass `_OK_DEGRADED_RESPONSE`; pre-read/pre-bash/pre-grep keep the fresh-shape envelope.

**AC-07** — metrics-tier stability contract. 22-line docstring on `_handle_status` documenting which fields the metrics tier emits, the deprecation policy (alias for one minor release; AC-02 sets the precedent), and fields explicitly omitted vs. full tier.

**AC-08** — `FreshResponse` TypedDict now includes `NotRequired[hookSpecificOutput]` + `NotRequired[degraded]` so typed consumers cover all observable fresh shapes (with notices attached, with degraded flag).

## Test plan

- [x] 4 new AC-05 tests pin per-endpoint degraded shape
- [x] Full coordinator suite: 134 passed (130 baseline + 4 new)
- [ ] CI: 7 checks must pass

Refs: ce-review 20260521-013506-10711878 AC-05, AC-07, AC-08 (medium)