### PR TITLE
fix(coordinator): correctness medium batch (COR-04..COR-08)

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -472,6 +472,18 @@ class CoordinatorHTTPServer:
         raise ``sqlite3.ProgrammingError`` (becoming HTTP 500 to clients),
         which is observable. The alternative — wedging shutdown waiting
         for a stuck handler — is silent and worse.
+
+        COR-07: actual wall-clock shutdown time can EXCEED
+        ``IN_FLIGHT_DRAIN_TIMEOUT_SEC`` when watchdog timeouts have
+        fired. The in-flight counter decrements when the handler
+        thread returns (after FuturesTimeout), but the corresponding
+        watchdog-pool future may still be running. The subsequent
+        ``self._watchdog.shutdown(wait=True, cancel_futures=False)``
+        waits for those orphaned futures to complete. Worst-case
+        addition: one extra ``HANDLER_TIMEOUT_SEC`` (4s) per orphaned
+        future. ``cancel_futures=True`` would shorten shutdown but
+        risk aborting a SQLite write mid-transaction; documented
+        trade-off, not a bug.
         """
         # REL-05 / finding #42: protect the check-then-set with a lock so
         # concurrent callers (idle thread + stop_coordinator) cannot both
@@ -1213,6 +1225,14 @@ def _handle_pre_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
 
     # Wrap _run_or_degrade so we can also pop notices for the FRESH-response
     # path (work() returned {status: "fresh"} without going through stale logic).
+    #
+    # COR-08: graceful-degradation note — if work() raises before this
+    # wrapper can drain notices, pop_pending_notices never runs and the
+    # notice stays in the DB. That's intentional: the notice will surface
+    # on the next successful pre-read for the same (agent, artifact) OR
+    # on session-stop OR via the F2 sweep eviction at
+    # notice_evict_max_age_sec. A transient SQLite error delays — but
+    # does not lose — the notice surface.
     def work_with_notice_surfacing() -> dict:
         result = work()
         if result.get("status") == "fresh" and "hookSpecificOutput" not in result:
@@ -1546,7 +1566,17 @@ def _handle_policy_track(req: _RequestProtocol, coordinator: CoordinatorHTTPServ
         req._json(400, {"error": str(exc)})
         return
     # Reload the live policy so subsequent hook calls see the additions.
-    coordinator.policy = TrackedArtifactPolicy.load(coordinator.coordinator_root)
+    #
+    # COR-05: this is an atomic-swap-via-local-variable pattern. The RHS
+    # evaluates fully (TrackedArtifactPolicy.load returns a new object)
+    # before the attribute assignment fires. Single PyObject* write is
+    # atomic on CPython, and even on free-threading builds the per-object
+    # lock makes the swap visible to other threads as a single edge.
+    # Handlers reading coordinator.policy bind it to a local at entry
+    # (see pre-read / pre-edit / pre-bash / pre-grep) so a mid-handler
+    # swap can't change which policy object the handler reasons about.
+    new_policy = TrackedArtifactPolicy.load(coordinator.coordinator_root)
+    coordinator.policy = new_policy
     req._json(200, {
         "ok": True, "added": added, "rejected": rejected + pre_rejected,
     })
@@ -2384,10 +2414,23 @@ def _append_policy_yaml(yaml_path: Path, new_paths: list[str]) -> tuple[list[str
     pre-state, both compute "previous + my_paths", second write loses the
     first writer's additions). fcntl is POSIX-only; on the deferred
     Windows path this is a no-op (lifecycle already disables the
-    coordinator on Windows per _FCNTL_AVAILABLE)."""
+    coordinator on Windows per _FCNTL_AVAILABLE).
+
+    COR-06: callers pre-validate via ``validate_path`` (or equivalent)
+    and pass only safe paths. The local re-check below is a defensive
+    second pass that catches accidentally-bypassed validation BUT in
+    the normal flow the ``rejected`` list it returns from this branch
+    is always empty (everything passes the caller's check already).
+    Kept as defense-in-depth — removing it would couple this helper to
+    the caller's validation discipline, which is a tighter contract
+    than the function's current "self-contained validate-and-write"
+    behaviour. Tests should assert callers reject before reaching here.
+    """
     yaml_path.parent.mkdir(parents=True, exist_ok=True)
     # Validate each path the same way TrackedArtifactPolicy does. This
     # validation is pure (no I/O) so it lives outside the lock window.
+    # Defense-in-depth per COR-06: callers pre-validate, but this loop
+    # ensures the YAML write is never reached with traversal patterns.
     added: list[str] = []
     rejected: list[dict] = []
     for p in new_paths:

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -891,15 +891,29 @@ class SqliteArtifactRegistry:
                 )
                 self._conn.execute("COMMIT")
                 return new_id
-            except sqlite3.IntegrityError:
+            except sqlite3.IntegrityError as exc:
                 # Lost the UNIQUE-on-name race; another caller inserted between
                 # our SELECT and INSERT. ROLLBACK and re-fetch.
+                #
+                # COR-04: a concurrent remove_artifact between ROLLBACK and
+                # re-fetch can leave the row absent. Old behaviour: re-raise
+                # the original IntegrityError with no context — operator sees
+                # a confusing "UNIQUE constraint failed" trace for what's
+                # really a delete race. New behaviour: raise an explicit
+                # informative RuntimeError so the operator knows exactly
+                # what happened.
                 self._conn.execute("ROLLBACK")
                 row = self._conn.execute(
                     "SELECT id FROM artifacts WHERE name = ?", (parent_rel_path,)
                 ).fetchone()
                 if row is None:
-                    raise  # genuine integrity error, not the race
+                    raise RuntimeError(
+                        f"resolve_or_register: lost INSERT race on {parent_rel_path!r} "
+                        "but the winning row was deleted before re-fetch. This "
+                        "indicates a concurrent remove_artifact running against the "
+                        "same name — caller should retry or treat the artifact as "
+                        f"absent. Original IntegrityError: {exc}"
+                    ) from exc
                 return UUID(hex=row[0])
             except BaseException:
                 # P2 ce-review fix #14 (kieran-python): BaseException catches

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -405,3 +405,64 @@ def test_concurrent_state_changes_no_deadlock(db_path: Path) -> None:
         state_map = reg.get_state_map(art.id)
         assert len(state_map) == 10
         assert all(s == MESIState.SHARED for s in state_map.values())
+
+
+# ----------------------------------------------------------------------
+# COR-04 — resolve_or_register re-fetch race produces informative error
+# ----------------------------------------------------------------------
+
+
+def test_cor04_resolve_or_register_post_rollback_delete_raises_runtime_error(
+    tmp_path
+):
+    """COR-04: when a concurrent remove_artifact deletes the winning
+    racer's row between our ROLLBACK and re-fetch, the function must
+    raise an informative RuntimeError explaining the race rather than
+    re-raising the original sqlite3.IntegrityError with no context.
+
+    Wraps reg._conn in a proxy that forces INSERT to raise IntegrityError
+    and the post-ROLLBACK SELECT to return None.
+    """
+    import sqlite3
+    from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+
+    reg = SqliteArtifactRegistry(tmp_path / "state.db")
+    try:
+        real_conn = reg._conn
+        call_state = {"insert_seen": False, "post_rollback_select_seen": False}
+
+        class _ConnProxy:
+            def execute(self, sql, *args):
+                sql_lower = sql.strip().lower()
+                if sql_lower.startswith("insert into artifacts"):
+                    call_state["insert_seen"] = True
+                    raise sqlite3.IntegrityError("simulated UNIQUE collision")
+                if (
+                    call_state["insert_seen"]
+                    and not call_state["post_rollback_select_seen"]
+                    and sql_lower.startswith("select id from artifacts where name")
+                ):
+                    call_state["post_rollback_select_seen"] = True
+
+                    class _Empty:
+                        def fetchone(self_inner):
+                            return None
+
+                    return _Empty()
+                return real_conn.execute(sql, *args)
+
+            def __getattr__(self, name):
+                return getattr(real_conn, name)
+
+        reg._conn = _ConnProxy()
+        try:
+            import pytest as _pytest
+            with _pytest.raises(RuntimeError) as excinfo:
+                reg.resolve_or_register("plan.md", content_hash="abc")
+            assert "lost INSERT race" in str(excinfo.value)
+            assert "plan.md" in str(excinfo.value)
+            assert isinstance(excinfo.value.__cause__, sqlite3.IntegrityError)
+        finally:
+            reg._conn = real_conn
+    finally:
+        reg.close()


### PR DESCRIPTION
Five correctness-medium findings, 3 small code changes + 2 docstring updates.

- **COR-04**: `resolve_or_register` re-fetch race on concurrent DELETE now raises informative `RuntimeError` chained from the original IntegrityError instead of an opaque UNIQUE-constraint trace.
- **COR-05**: Policy reload documented as atomic-swap-via-local. Already correct on CPython + free-threading per-object-locks; added explicit local-bind + comment.
- **COR-06**: `_append_policy_yaml` internal traversal check reframed as documented defense-in-depth (was flagged as duplicate; kept for self-contained contract).
- **COR-07**: Documented that shutdown wall-clock can exceed `IN_FLIGHT_DRAIN_TIMEOUT_SEC` when watchdog timeouts fire (orphaned futures + `cancel_futures=False`).
- **COR-08**: Documented graceful degradation when `work()` raises before notice drain — notice surfaces on next pre-read / session-stop / F2 eviction.

Tests: 1 new COR-04 regression. 155 passed locally.

Refs: ce-review 20260521-013506-10711878 COR-04..COR-08 (medium)