### PR TITLE
fix(lifecycle,cli): KP-7 — wait_for_shutdown public API + KP-3/KP-11 deferral

### DIFF
--- a/src/ccs/adapters/claude_code/lifecycle.py
+++ b/src/ccs/adapters/claude_code/lifecycle.py
@@ -368,6 +368,41 @@ def stop_coordinator(coordinator_root: Path) -> bool:
     return ran
 
 
+def wait_for_shutdown(
+    coordinator_root: Path,
+    *,
+    poll_interval_sec: float = 1.0,
+    timeout_sec: float | None = None,
+) -> bool:
+    """KP-7 public API. Block until the coordinator at ``coordinator_root``
+    has reached shutdown_done (idle-shutdown completed, stop_coordinator
+    called, or shutdown raised). Returns True if shutdown completed, False
+    if ``timeout_sec`` elapsed first or no in-process coordinator entry
+    exists for this root.
+
+    Designed for the ``agent-coherence-coordinator --_daemonized`` worker
+    that needs to keep the main thread alive until daemon threads have
+    cleanly torn down. Replaces direct reach-into ``_SPAWNED_REGISTRY``
+    + ``entry.shutdown_done.is_set()`` polling.
+
+    KeyboardInterrupt during the wait raises through to the caller so a
+    SIGINT can trigger the caller's own ``stop_coordinator`` shutdown
+    path (the wait itself never initiates shutdown — it only observes).
+    """
+    key = str(Path(coordinator_root).resolve())
+    entry = _SPAWNED_REGISTRY.get(key)
+    if entry is None:
+        return False
+    deadline: float | None = None
+    if timeout_sec is not None:
+        deadline = time.monotonic() + timeout_sec
+    while not entry.shutdown_done.is_set():
+        if deadline is not None and time.monotonic() >= deadline:
+            return False
+        time.sleep(poll_interval_sec)
+    return True
+
+
 # ----------------------------------------------------------------------
 # Internals — pid file, port file, sockets
 # ----------------------------------------------------------------------

--- a/src/ccs/cli/coherence_coordinator.py
+++ b/src/ccs/cli/coherence_coordinator.py
@@ -244,20 +244,18 @@ def _run_daemonized(root: Path) -> int:
         return 2
 
     # Block the main thread so the daemon HTTP/sweep/idle threads stay
-    # alive. Exit when the coordinator transitions to shutting_down (e.g.
-    # via the idle-shutdown loop).
-    from ccs.adapters.claude_code import lifecycle as _lc
-    entry = _lc._SPAWNED_REGISTRY.get(str(root.resolve()))
-    if entry is None:
-        # Should not happen — ensure_coordinator just populated this.
-        return 2
-    while not entry.shutdown_done.is_set():
-        try:
-            time.sleep(1.0)
-        except KeyboardInterrupt:
-            from ccs.adapters.claude_code.lifecycle import stop_coordinator
-            stop_coordinator(root)
-            break
+    # alive. KP-7: use the public wait_for_shutdown API rather than
+    # reaching into lifecycle._SPAWNED_REGISTRY + entry.shutdown_done.
+    # The wait blocks until idle-shutdown completes, stop_coordinator
+    # fires, or the shutdown sequence aborts.
+    from ccs.adapters.claude_code.lifecycle import (
+        stop_coordinator,
+        wait_for_shutdown,
+    )
+    try:
+        wait_for_shutdown(root)
+    except KeyboardInterrupt:
+        stop_coordinator(root)
     return 0
 
 

--- a/tests/test_claude_code_lifecycle.py
+++ b/tests/test_claude_code_lifecycle.py
@@ -809,3 +809,57 @@ def test_l3_cold_start_duration_populated_on_winner_path(
         )
     finally:
         stop_coordinator(workspace)
+
+
+# ----------------------------------------------------------------------
+# KP-7 — wait_for_shutdown public API
+# ----------------------------------------------------------------------
+
+
+def test_kp7_wait_for_shutdown_returns_false_when_no_entry(tmp_path):
+    """wait_for_shutdown returns False when no in-process coordinator
+    entry exists for the given root (idempotent observer; no spawn)."""
+    from ccs.adapters.claude_code.lifecycle import wait_for_shutdown
+    assert wait_for_shutdown(tmp_path, timeout_sec=0.1) is False
+
+
+def test_kp7_wait_for_shutdown_returns_true_after_stop(tmp_path, fast_cfg):
+    """End-to-end: spawn → stop in background → wait_for_shutdown
+    returns True once shutdown_done flips."""
+    import threading as _t
+    from ccs.adapters.claude_code.lifecycle import (
+        ensure_coordinator,
+        stop_coordinator,
+        wait_for_shutdown,
+    )
+
+    port = ensure_coordinator(tmp_path, config=fast_cfg)
+    assert port > 0
+
+    # Stop in a background thread; main waits.
+    def trigger_stop():
+        time.sleep(0.1)
+        stop_coordinator(tmp_path)
+
+    _t.Thread(target=trigger_stop, daemon=True).start()
+    assert wait_for_shutdown(tmp_path, poll_interval_sec=0.05, timeout_sec=3.0) is True
+
+
+def test_kp7_wait_for_shutdown_times_out_when_coordinator_stays_up(
+    tmp_path, fast_cfg
+):
+    """timeout_sec elapsed without shutdown → returns False, leaves the
+    coordinator running so the caller can react."""
+    from ccs.adapters.claude_code.lifecycle import (
+        ensure_coordinator,
+        stop_coordinator,
+        wait_for_shutdown,
+    )
+
+    port = ensure_coordinator(tmp_path, config=fast_cfg)
+    assert port > 0
+    try:
+        # Coordinator is up; wait_for_shutdown must time out.
+        assert wait_for_shutdown(tmp_path, poll_interval_sec=0.05, timeout_sec=0.3) is False
+    finally:
+        stop_coordinator(tmp_path)


### PR DESCRIPTION
Kieran-python medium tier:

- **KP-1** (typed req): already done — `_RequestProtocol` covers all 10 handlers.
- **KP-3** (long handlers / nested closures): **DEFERRED**. Closure pattern is HTTP-end-to-end-test-covered. Full extraction is a 1000+ line refactor across 4 handlers with no correctness win — style win that risks dispatch regression on a stable v0.1.1 coordinator. Revisit if a v0.2 refactor organically extracts these helpers.
- **KP-4** (private counter mutation): already done — `increment_*` methods + `counters_snapshot()`.
- **KP-7** (CLI reach-into `_SPAWNED_REGISTRY`): this PR. New `lifecycle.wait_for_shutdown(coordinator_root, *, poll_interval_sec, timeout_sec)` public API. CLI's `--_daemonized` worker uses it instead of touching internals. KeyboardInterrupt propagates so `stop_coordinator` still fires.
- **KP-11** (long `_handle_status` / `_handle_prepare_for_migration`): **DEFERRED** with same KP-3 rationale.

## Test plan

- [x] 3 new KP-7 tests (no entry / end-to-end / timeout)
- [x] 49 lifecycle + CLI tests pass locally
- [ ] CI

Refs: ce-review 20260521-013506-10711878 KP-1, KP-3, KP-4, KP-7, KP-11