### PR TITLE
docs(coordinator,cli): M-02 path-validator layer doc + M-01/M-06 deferral

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -208,11 +208,22 @@ def validate_session_id(
 
 
 def validate_path(path: Any) -> str | None:
-    """Return reason if invalid, None if valid. The coordinator stores paths
-    as parent-repo-relative — KTD-7 normalization happens client-side (the
-    hook script must compute repo-relative from CC's absolute tool_input.
-    file_path). The boundary validation here is defense-in-depth against
-    bad hook clients AND prose-injection abuse (Adv #4 + Adv #11)."""
+    """Server-side authoritative path check. Return reason if invalid,
+    None if valid. The coordinator stores paths as parent-repo-relative
+    — KTD-7 normalization happens client-side (the hook script must
+    compute repo-relative from CC's absolute tool_input.file_path).
+    The boundary validation here is defense-in-depth against bad hook
+    clients AND prose-injection abuse (Adv #4 + Adv #11).
+
+    M-02 layer-distinction note: this is the STRICTER server-side check
+    (rejects non-string types, leading backslash, control characters,
+    paths longer than MAX_PATH_LEN). The CLI-side counterpart is
+    :func:`ccs.cli._coherence_client.validate_relative_path` — lighter
+    (string-typed-input assumed, just empty/leading-slash/`..` checks),
+    runs before the HTTP request is built for fast operator feedback.
+    This function is the authoritative gate; do NOT remove either —
+    they live at different layers of the trust boundary.
+    """
     if not isinstance(path, str):
         return "path must be a string"
     if not path:

--- a/src/ccs/cli/_coherence_client.py
+++ b/src/ccs/cli/_coherence_client.py
@@ -48,8 +48,20 @@ def err(message: str) -> None:
 
 
 def validate_relative_path(p: str) -> str | None:
-    """Reject absolute paths, ``..`` traversal, and empty input. Returns
+    """Client-side path pre-check before sending to the coordinator.
+
+    Reject absolute paths, ``..`` traversal, and empty input. Returns
     None on valid, a reason string on invalid.
+
+    M-02 layer-distinction note: this is the CLI-side check (light;
+    designed for friendly operator error messages before the request
+    is built). The server-side check is
+    :func:`ccs.adapters.claude_code.coordinator_server.validate_path`
+    — STRICTER (also rejects backslash-leading paths, control characters,
+    paths longer than MAX_PATH_LEN, non-string types). The server-side
+    check is the authoritative gate; this CLI check is for fast feedback
+    without a coordinator round-trip. Do NOT remove either — they live
+    at different layers of the trust boundary.
 
     P2 ce-review fix #6 (maintainability): consolidates the
     ``_validate_path`` helper that previously existed byte-for-byte in


### PR DESCRIPTION
Maintainability medium tier:

- **M-01** (2006-line file): **DEFERRED**, same rationale as KP-3/KP-11.
- **M-02**: documented the deliberate layer split between strict server-side `validate_path` and lighter CLI-side `validate_relative_path`. Both stay; cross-refs added so future maintainers don't accidentally consolidate them.
- **M-04** (duplicate HTTP transport): already done in earlier batch.
- **M-06** (pre-bash/pre-grep shared logic): **DEFERRED** with M-01 rationale.

Doc-only; 162 passed.

Refs: ce-review 20260521-013506-10711878 M-01, M-02, M-04, M-06