### PR TITLE
perf(coordinator): PERF-1 — /status batched snapshot + PERF-2/4/5/6 status notes

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1938,31 +1938,23 @@ def _handle_status(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) ->
         req._json(200, {"detail": "metrics", **counters})
         return
 
-    # Artifacts + sessions — needed for minimal AND full tiers. Keep the
-    # P2 ce-review fix #18 batched-query pattern.
-    artifact_ids_snapshot = list(coordinator.registry.artifact_ids())
+    # PERF-1: single batched snapshot — replaces 2N SELECTs (one
+    # get_artifact + one get_state_map per artifact) with 2 SELECTs total
+    # held under one registry lock so the view is consistent.
+    artifact_by_id, state_by_artifact = coordinator.registry.status_snapshot()
     agent_names_snapshot = coordinator.agent_names_snapshot()
-    artifact_by_id = {}
-    for artifact_id in artifact_ids_snapshot:
-        art = coordinator.registry.get_artifact(artifact_id)
-        if art is not None:
-            artifact_by_id[artifact_id] = art
 
     tracked: list[dict] = [
-        {"path": art.name, "version": art.version, "id": str(artifact_id)}
-        for artifact_id, art in artifact_by_id.items()
+        {"path": meta["name"], "version": meta["version"], "id": str(artifact_id)}
+        for artifact_id, meta in artifact_by_id.items()
     ]
-    state_by_artifact = {
-        artifact_id: coordinator.registry.get_state_map(artifact_id)
-        for artifact_id in artifact_by_id
-    }
     sessions: list[dict] = []
     for agent_id, name in agent_names_snapshot:
         per_artifact: dict[str, str] = {}
-        for artifact_id, art in artifact_by_id.items():
+        for artifact_id, meta in artifact_by_id.items():
             state = state_by_artifact[artifact_id].get(agent_id)
             if state is not None and state != MESIState.INVALID:
-                per_artifact[art.name] = state.name
+                per_artifact[meta["name"]] = state.name
         sessions.append({
             "agent_name": name,
             "agent_id": str(agent_id),

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -503,6 +503,47 @@ class SqliteArtifactRegistry:
             ).fetchall()
         return {UUID(hex=r[0]): MESIState[r[1]] for r in rows}
 
+    def status_snapshot(
+        self,
+    ) -> tuple[
+        dict[UUID, dict[str, Any]],
+        dict[UUID, dict[UUID, MESIState]],
+    ]:
+        """PERF-1 single-query batch for /status. Returns:
+
+        - ``artifact_by_id``: ``{artifact_id: {"name", "version"}}`` — every
+          known artifact, one entry per row.
+        - ``state_by_artifact``: ``{artifact_id: {agent_id: MESIState}}`` —
+          the per-artifact state map for every artifact (empty inner dict
+          for artifacts no agent has ever held).
+
+        Two queries (artifacts + agent_states joined by artifact_id), held
+        under one lock so the snapshot is consistent. Replaces the old
+        per-artifact loop that issued ``2 * N`` separate SELECTs
+        (``get_artifact`` + ``get_state_map`` for each id) — eliminates
+        the N+1 hot path in ``_handle_status``.
+        """
+        artifact_by_id: dict[UUID, dict[str, Any]] = {}
+        state_by_artifact: dict[UUID, dict[UUID, MESIState]] = {}
+        with self._lock:
+            for row in self._conn.execute(
+                "SELECT id, name, version FROM artifacts"
+            ).fetchall():
+                aid = UUID(hex=row[0])
+                artifact_by_id[aid] = {"name": row[1], "version": row[2]}
+                state_by_artifact[aid] = {}
+            for row in self._conn.execute(
+                "SELECT artifact_id, agent_id, state FROM agent_states"
+            ).fetchall():
+                aid = UUID(hex=row[0])
+                gid = UUID(hex=row[1])
+                # Only artifacts present in artifact_by_id get state rows.
+                # Defensive: skip orphans from race with concurrent delete.
+                if aid not in state_by_artifact:
+                    continue
+                state_by_artifact[aid][gid] = MESIState[row[2]]
+        return artifact_by_id, state_by_artifact
+
     def get_agent_state(self, artifact_id: UUID, agent_id: UUID) -> MESIState | None:
         """Return MESI state for one agent/artifact pair if present."""
         with self._lock:


### PR DESCRIPTION
Performance medium tier:

- **PERF-1**: `/status` per-artifact loop issued 2N SELECTs (`get_artifact` + `get_state_map`). New `SqliteArtifactRegistry.status_snapshot()` returns the snapshot in 2 SQL queries held under one registry lock. O(1) network round-trips for any N.
- **PERF-2** (regex compile per call): already done — pre-compiled `_compiled_patterns` cache on `TrackedArtifactPolicy`.
- **PERF-4**: reviewer verdict 'no action required' (5s self-probe budget + -1 fallback). Existing doc covers it.
- **PERF-5**: reviewer verdict 'no action required' (RLock serializes intra-process; busy_timeout is the external-process safety net). Existing KTD-K doc covers it.
- **PERF-6**: reviewer verdict 'current design correct for v0.1.1; configurable in v0.2'. Documented at `HANDLER_CONCURRENCY_LIMIT`.

## Test plan
- [x] 159 passed across coordinator + sqlite_registry (existing /status suite covers refactored handler)
- [ ] CI

Refs: ce-review 20260521-013506-10711878 PERF-1, PERF-2, PERF-4, PERF-5, PERF-6