### PR TITLE
fix: low-tier sweep (SEC-03 + COR-09 + KP-2 audit)

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -2416,28 +2416,31 @@ def _build_preemption_text(
 def _last_writer_for(coordinator: CoordinatorHTTPServer, artifact_id: UUID) -> str | None:
     """Return the session_id (not agent UUID) of the artifact's last writer, if any.
 
-    Best signal: an agent currently in MODIFIED state (they are the current writer).
-
-    Fallback caveat (COR-09): if no agent holds MODIFIED, we fall back to the
-    first entry in the state_map by insertion order. This agent may be in SHARED
-    or EXCLUSIVE state — it is not necessarily the actual last writer. In the
-    common case the querying agent itself may be in state_map (e.g. in SHARED),
-    meaning the stale-read warning could attribute the file to the very session
-    receiving the warning. This is a known limitation of the in-memory fallback;
-    a future improvement should use ``artifacts.last_writer_id`` from the DB
-    (via ``_fetch_artifact_row``) instead of the state_map fallback.
+    COR-09 (fixed): authoritative source is ``artifacts.last_writer_id``
+    in the registry — set by the commit path on successful post-edit and
+    NOT touched by reads or invalidations. Falls back to the state-map
+    only when the registry doesn't have a recorded writer (e.g.,
+    artifact created via first-observation seeding with no subsequent
+    successful commit). The previous state-map fallback could attribute
+    the write to the very session receiving the warning (agent appears
+    in state_map as SHARED, becomes the "first known agent").
     """
-    # The registry's _fetch_artifact_row returns last_writer_id; we expose it
-    # via lookup. For now derive from agent_names cache.
+    # COR-09 primary path: authoritative last_writer_id from the registry.
+    committed_writer = coordinator.registry.last_writer_for(artifact_id)
+    if committed_writer is not None:
+        return _agent_id_to_session(coordinator, committed_writer)
+    # Fallback for artifacts that exist but never had a successful commit
+    # (first-observation seeding with no post-edit yet). Best signal: an
+    # agent currently in MODIFIED state (mid-commit, in case the write
+    # is still in-flight).
     state_map = coordinator.registry.get_state_map(artifact_id)
-    # Best signal: an agent currently in MODIFIED state.
     for agent_id, state in state_map.items():
         if state == MESIState.MODIFIED:
             return _agent_id_to_session(coordinator, agent_id)
-    # Fallback: first known agent by insertion order (see docstring caveat).
-    if state_map:
-        first_agent = next(iter(state_map))
-        return _agent_id_to_session(coordinator, first_agent)
+    # No committed writer + no MODIFIED holder → genuinely unknown.
+    # Return None rather than the misleading "first state-map entry"
+    # which could be the querying agent itself.
+    return None
     return None
 
 

--- a/src/ccs/adapters/claude_code/resolver.py
+++ b/src/ccs/adapters/claude_code/resolver.py
@@ -30,12 +30,11 @@ import logging
 import os
 import subprocess
 from pathlib import Path
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
-def find_coordinator_root(start: str | os.PathLike[str] | None = None) -> Optional[Path]:
+def find_coordinator_root(start: str | os.PathLike[str] | None = None) -> Path | None:
     """Return the parent repo root from any path inside it.
 
     Behavior:
@@ -100,7 +99,7 @@ class _GitInvocationError(RuntimeError):
     """Internal: a non-zero git exit that callers should map to None."""
 
 
-def _git(cwd: Path, *args: str) -> Optional[str]:
+def _git(cwd: Path, *args: str) -> str | None:
     """Run ``git -C <cwd> <args>`` and return stdout stripped, or None on
     a clean non-zero exit (e.g., "not in a git repo"). Raises
     :class:`_GitInvocationError` for unexpected failures (e.g., crash)

--- a/src/ccs/cli/coherence_migrate_rules.py
+++ b/src/ccs/cli/coherence_migrate_rules.py
@@ -477,12 +477,23 @@ def _apply_entries(
                 seen.add(entry)
                 appended += 1
 
+        # SEC-03: write-to-tmpfile + atomic rename. Plain write_text()
+        # truncates the destination first; a crash mid-write leaves the
+        # file partially-truncated and the next claude session sees a
+        # JSONDecodeError on parse + falls back to defaults — silently
+        # losing previously-applied entries. Atomic rename keeps the old
+        # file intact until the new file is fully written.
         try:
-            settings_path.write_text(
-                json.dumps(data, indent=2, ensure_ascii=False) + "\n",
-                encoding="utf-8",
-            )
+            payload = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+            tmp_path = settings_path.with_suffix(settings_path.suffix + ".tmp")
+            tmp_path.write_text(payload, encoding="utf-8")
+            os.replace(str(tmp_path), str(settings_path))
         except OSError as exc:
+            # Best-effort cleanup of the tmp file if rename failed.
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
             print(
                 f"agent-coherence-migrate-rules: could not write {settings_path}: {exc}",
                 file=sys.stderr,

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -1226,6 +1226,25 @@ class SqliteArtifactRegistry:
     # Internals
     # ------------------------------------------------------------------
 
+    def last_writer_for(self, artifact_id: UUID) -> Optional[UUID]:
+        """COR-09: return the agent UUID that most recently committed to
+        ``artifact_id``, or None if the artifact has no committed writer
+        (first-observation-only, no successful post-edit yet).
+
+        Reads ``artifacts.last_writer_id`` directly so the answer reflects
+        actual commit history rather than current in-memory state. Closes
+        the COR-09 gap where the state-map fallback could attribute the
+        write to the very session receiving the stale-read warning.
+        """
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT last_writer_id FROM artifacts WHERE id = ?",
+                (artifact_id.hex,),
+            ).fetchone()
+        if row is None or row[0] is None:
+            return None
+        return UUID(hex=row[0])
+
     def _fetch_artifact_row(self, artifact_id: UUID) -> Optional[_ArtifactRow]:
         with self._lock:
             row = self._conn.execute(


### PR DESCRIPTION
Low-tier ce-review sweep across all 9 reviewers (26 findings).

**Substantive:**
- **SEC-03**: `migrate-rules --apply` now uses tmpfile + `os.replace` for the `settings.local.json` write. Crash-mid-write no longer corrupts the file.
- **COR-09**: `_last_writer_for` now reads `artifacts.last_writer_id` via new public `SqliteArtifactRegistry.last_writer_for()`. State-map fallback only for first-observation; returns None rather than the misleading 'first state-map entry'.
- **KP-2**: removed the last 2 `Optional[X]` in resolver.py.

**Verified already-addressed** (no change): ADV-008, AC-09, AC-10, COR-11, PERF-7, KP-5/6/8/9/10, M-03, M-05, REL-09, REL-10, SEC-02.

**Accepted as-is** (cosmetic / accepted trade-offs): M-07, PERF-3, PERF-8, T-06, T-07, T-08, T-09.

## Test plan
- [x] 218 passed across coordinator + lifecycle + migrate_rules + sqlite_registry + hook_client
- [ ] CI

Refs: ce-review 20260521-013506-10711878 all low-tier findings