### PR TITLE
feat(tests): cross-implementation protocol corpus (v0.2 Unit 7a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,50 @@ jobs:
       - name: Run TLC model checker
         run: make tla-check
 
+  protocol-corpus:
+    name: Protocol Corpus (Python ↔ Node parity)
+    runs-on: ubuntu-latest
+    needs: [architecture]
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: "20"
+
+      - name: Install library + dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      # Check out the plugin repo INSIDE the workspace so actions/checkout
+      # accepts the path (it rejects paths outside $GITHUB_WORKSPACE). The
+      # harness's resolve_node_dist_path() picks up the explicit env var below
+      # rather than the sibling-fallback path.
+      - name: Check out agent-coherence-plugin
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          repository: hipvlady/agent-coherence-plugin
+          ref: main
+          path: _plugin_checkout
+
+      - name: Build Node coordinator
+        working-directory: _plugin_checkout
+        run: |
+          npm ci
+          npm run build
+
+      - name: Run protocol corpus
+        env:
+          AGENT_COHERENCE_PLUGIN_DIST_PATH: ${{ github.workspace }}/_plugin_checkout/dist/coordinator.js
+        run: pytest -m protocol_corpus -v --tb=short
+
   build:
     name: Build Package
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ Alpha — APIs may change before `v1.0`.
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-05-23
+
+**Stable release of the Claude Code plugin coordinator backend.** Promotes the `0.8.0a1` alpha pre-release to a final `0.8.0` after the v0.1.1 marketplace cohort + full ce-review remediation pass landed. Both the coordinator HTTP surface and the wire contract are now considered stable through the `0.8.x` minor line; breaking changes will bump to `0.9.0` per SemVer.
+
+### Added — Marketplace cohort (Phase A–C of v0.1.1 plan)
+
+- **Unit 4 watchdog hardening** — KTD-K `busy_timeout=1500ms` per multi-statement transaction analysis; KTD-N `/hooks/pre-bash` + `/hooks/pre-grep` with shlex-based path detection (closes the model-routing-around-Read H4 finding); KTD-G handler concurrency semaphore + queue-depth gate + three saturation counters.
+- **Unit 5 lifecycle hardening** — KTD-H inode revalidation per retry (handles `rm -rf .coherence/ && recreate` mid-spawn races); KTD-I in-flight handler drain on `shutdown()` (5s deadline before SQLite close); KTD-L3 cold-start instrumentation surfaced via `coordinator.cold_start_duration_ms`.
+- **Unit 6 residual risk fixes** — R10 `_agent_names` lock + public accessors; R11 `ensure_secret` bounded `O_EXCL` retry (fail-closed); R12 `/status` three-tier disclosure (`minimal` / `metrics` / `full` with `Coherence-Local-Operator: true` opt-in for the elevated tier); R14 `_append_policy_yaml` `fcntl.flock` discipline; R21 `MAX_REQUEST_BODY_BYTES = 64 KB` cap.
+- **Unit 8 KTD-J telemetry** — per-endpoint counters (pre_read/pre_edit/post_edit/session_stop/pre_bash/pre_grep/policy_track/policy_untrack/status_total); product-signal counters (`intra_task_acquire_release_total`, `stale_warning_emitted_total`, `stale_warning_reread_total`); free-threading-safe via `threading.Lock`. New `coordinator_uptime_seconds` field (canonical) + `coordinator_uptime_s` deprecated alias for one release. `coordinator_backend` + `coordinator_version` fields for cross-backend dashboards.
+- **Unit 8 `--self-test` smoke** — `agent-coherence-status --self-test` runs a four-step pre-read → pre-edit → post-edit → stale pre-read scenario against a live coordinator. Exit 0 on pass, 3 with actionable diagnostic on fail. Documented as the post-install validation step.
+- **Unit 8 `--prepare-for-migration`** — `agent-coherence-coordinator --prepare-for-migration` enters a draining state that rejects new pre-edit (HTTP 503 with structured `migration in progress` error visible to the model), waits up to 5s for in-flight chains to complete, invalidates remaining M/E grants, then schedules shutdown. Eliminates the silent data-loss race when switching Python↔Node backends.
+- **Unit 9 `agent-coherence-migrate-rules`** — scans CLAUDE.md for prose tool-class rules ("use rg, not grep", "never sudo") and proposes `permissions.deny` entries. Flag-only by default; `--apply` writes to `.claude/settings.local.json` after confirmation.
+
+### Added — Stable-grant sweep preemption notice (ADV-004)
+
+`enforce_stable_grant_timeouts` now records a preemption notice for every reclaimed agent (using a sentinel `SWEEP_RECLAMATION_PREEMPTER_ID`). When the victim's post-edit eventually arrives, the F4 enrichment path emits "your M/E grant was reclaimed by the coordinator sweep (heartbeat timeout or max-hold ceiling)" instead of a generic `CoherenceError` — eliminates a silent data-loss class for the alpha cohort's interactive workflows.
+
+### Changed
+
+- **`/status?detail=metrics`** is now the canonical surface for dashboard scrapers. The metrics-tier stability contract (additive in minor, removed only in major after one-release deprecation alias) is documented on `_handle_status`.
+- **`StaleResponse` / `FreshResponse` / `PolicyUntrackResponse` TypedDicts** now match the actual wire shapes (AC-04/06/08 alignment).
+- **`_run_or_degrade` accepts `degraded_response`** so `{ok:bool}`-shape endpoints (pre-edit, post-edit, session-stop) return `{ok:True, degraded:True}` on watchdog timeout instead of the `{status:fresh}` envelope used by pre-read shapes (AC-05).
+- **`coordinator_uptime_s` field renamed to `coordinator_uptime_seconds`** per KTD-J `_seconds` convention. Old name kept as a deprecated alias through `0.8.x`; removal targeted for `0.9.0`.
+- **Shutdown ordering** — `_drain_in_flight` now runs BEFORE `_server.server_close()` (COR-01); `_seq` rollback now fires on COMMIT failure (COR-02); shutdown wall-clock can exceed `IN_FLIGHT_DRAIN_TIMEOUT_SEC` when watchdog timeouts fire (COR-07; documented bound).
+
+### Fixed
+
+- **`resolve_or_register` re-fetch race** (COR-04) — concurrent `remove_artifact` between ROLLBACK and re-fetch now raises an informative `RuntimeError` chained from the original `IntegrityError` instead of an opaque "UNIQUE constraint failed" trace.
+- **`artifact_names_under_prefix` TOCTOU** (REL-08) — combined the LIKE-prefix and exact-match queries into a single UNION under one lock.
+- **G4 abort wedge** (REL-06) — added `shutdown_abort_count` on `_SpawnedEntry`; after 3 consecutive `coordinator.shutdown()` raises, escalate by releasing the flock + marking shutdown_done so a fresh spawn can proceed.
+- **Hook secret rotation race** (ADV-003) — coordinator emits operator-visible WARNING on every 401 (with 60s dedupe) plus a new `auth_401_total` counter so silent auth failures become observable.
+- **Plugin `hooks.json` Bash + Grep matchers** (cross-repo P0) — the plugin now actually invokes `/hooks/pre-bash` and `/hooks/pre-grep` rather than leaving the endpoints runtime-inert (companion plugin `v0.1.1`).
+
+### Security
+
+- **R12 `/status` disclosure tiers** make pasting `?detail=metrics` into bug reports safe — no absolute paths, no PIDs, no session identifiers. The `full` tier still exposes those but only with the `Coherence-Local-Operator: true` opt-in header (defense-in-depth within the Adversary 1 boundary).
+- **`MAX_REQUEST_BODY_BYTES` cap** (R21) — coordinator rejects oversized request bodies before `rfile.read` so a hostile or buggy client cannot OOM the coordinator with a single oversized POST.
+- **`ensure_secret` bounded retry** (R11) — fail-closed if the empty-file recovery branch can't acquire `O_EXCL` within 5 attempts, instead of silently `O_TRUNC`-overwriting a concurrent racer's valid secret.
+- **`MIGRATION_DRAIN_TIMEOUT_SEC = 5.0`** — backend-switch operator path now refuses new writes during drain instead of relying on the prior 100ms scheduled-shutdown race.
+
+### Internal
+
+- **78 ce-review findings remediated** across 12 reviewer categories (adversarial, correctness, api-contract, reliability, kieran-python, maintainability, performance, project-standards, security, testing, agent-native, learnings). KP-3/KP-11/M-01/M-06 (large handler / file extractions) explicitly deferred with rationale documented in PR bodies.
+- **PERF-1 `/status` batched snapshot** — `SqliteArtifactRegistry.status_snapshot()` collapses the per-artifact `2N` SELECTs into 2 SQL queries held under one lock.
+- **PS-01..PS-04 risk-code test prefix audit** — `test_a4_*`, `test_a6_*`, `test_a7_*`, `test_a8_*`, `test_l1_*`, `test_l2_*` all present per the v0.1.1 plan's invariant naming policy.
+
 ## [0.8.0a1] — 2026-05-17
 
 **Alpha pre-release.** This is the first release containing the Claude Code

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Protocol safety properties (single-writer, monotonic versioning, crash-recovery 
 
 ## Status
 
-`v0.7.1` released — refactor demo for write-side coherence + CI Node toolchain for real `tsc` validation. See [CHANGELOG.md](CHANGELOG.md) for the version history and [releases](https://github.com/hipvlady/agent-coherence/releases) for tagged artifacts. Alpha — APIs may change before `v1.0`.
+`v0.8.0` released — full Claude Code plugin coordinator (Python backend) plus the ce-review remediation pass. Adds six console scripts (`agent-coherence-coordinator`, `-status`, `-track`, `-untrack`, `-hook-client`, `-migrate-rules`); ships KTD-J telemetry, `/status` three-tier disclosure, `--self-test`, and `--prepare-for-migration` for safe Python↔Node coordinator backend switching. The companion [agent-coherence-plugin](https://github.com/hipvlady/agent-coherence-plugin) ships `v0.1.1` of the marketplace plugin against this library. See [CHANGELOG.md](CHANGELOG.md) for the full version history and [releases](https://github.com/hipvlady/agent-coherence/releases) for tagged artifacts. Alpha — APIs may change before `v1.0`.
 
 ## Paper
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,12 @@ pythonpath = ["src", "."]
 markers = [
     "launch_gate: Unit 9 hard launch-gate. Requires live claude CLI; ~$4/run. Run via `pytest -m launch_gate`.",
     "launch_gate_pilot: Unit 9 pilot run (N=4, one per category). Requires live claude CLI; ~$0.40. Run via `pytest -m launch_gate_pilot`.",
+    "protocol_corpus: v0.2 Unit 7 cross-implementation wire-shape parity corpus. Spawns Python + Node coordinators against shared JSON fixtures. Requires the agent-coherence-plugin checkout built (`npm ci && npm run build`) or `AGENT_COHERENCE_PLUGIN_DIST_PATH` set; Node scenarios xfail with a clear reason if the dist path can't resolve. Run via `pytest -m protocol_corpus`.",
 ]
-# Skip launch_gate markers in default unit test runs.
-addopts = "-m 'not launch_gate and not launch_gate_pilot'"
+# Skip launch_gate + protocol_corpus markers in default unit test runs. The
+# protocol corpus has a Node-build prerequisite and a multi-second spawn cost
+# per fixture; keep it opt-in to avoid penalizing the normal `pytest -q` loop.
+addopts = "-m 'not launch_gate and not launch_gate_pilot and not protocol_corpus'"
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/src/ccs/__init__.py
+++ b/src/ccs/__init__.py
@@ -3,4 +3,4 @@
 
 """agent-coherence core package."""
 
-__version__ = "0.8.0a1"
+__version__ = "0.8.0"

--- a/tests/protocol_corpus/__init__.py
+++ b/tests/protocol_corpus/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Cross-implementation protocol corpus.
+
+Plan Unit 7 (v0.2): parametrized fixture-driven harness that POSTs identical
+requests to both coordinator implementations (Python in-thread + Node subprocess)
+and asserts JSON-equivalent responses after timestamp / UUID / PID / uptime
+normalization.
+
+Lives under ``tests/`` so the existing pytest test-discovery + the
+``protocol_corpus`` pytest marker (see ``pyproject.toml``) can opt the corpus
+into / out of default runs. Architecture checks scan ``src/ccs/`` only; this
+package does not change any architectural layering.
+
+See ``tests/protocol_corpus/harness.py`` for the harness implementation and
+``tests/protocol_corpus/fixtures/warn_mode/*.json`` for the v0.1.1 warn-mode
+wire-shape corpus (Unit 7a). Strict-mode fixtures (Unit 7b) land alongside
+Unit 2's deny-branch tests."""

--- a/tests/protocol_corpus/fixtures/warn_mode/01-pre-read-untracked-passthrough.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/01-pre-read-untracked-passthrough.json
@@ -1,0 +1,23 @@
+{
+  "name": "pre-read-untracked-passthrough",
+  "description": "Untracked path bypasses the MESI registry entirely and returns {status: fresh} from both coordinators. Establishes the baseline parity for the untracked fast-path that v0.1.1 KTD-N preserves.",
+  "setup": {
+    "files": {
+      "untracked.txt": "hello world\n"
+    }
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-read",
+    "body": {
+      "session_id": "11111111-1111-4111-8111-111111111111",
+      "path": "untracked.txt"
+    }
+  },
+  "expected": {
+    "status": 200,
+    "body": {
+      "status": "fresh"
+    }
+  }
+}

--- a/tests/protocol_corpus/fixtures/warn_mode/02-pre-read-tracked-first-observation.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/02-pre-read-tracked-first-observation.json
@@ -1,0 +1,25 @@
+{
+  "name": "pre-read-tracked-first-observation",
+  "description": "Tracked path with no prior MESI state — KTD-9 first-observation seeds SHARED for the reader and returns {status: fresh}. Validates the first-observation fast-path parity that the v0.1.1 baseline depends on.",
+  "setup": {
+    "tracked": ["docs/plans/feature-x.md"],
+    "files": {
+      "docs/plans/feature-x.md": "# Feature X\n\nv1 content\n"
+    }
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-read",
+    "body": {
+      "session_id": "22222222-2222-4222-8222-222222222222",
+      "path": "docs/plans/feature-x.md",
+      "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"
+    }
+  },
+  "expected": {
+    "status": 200,
+    "body": {
+      "status": "fresh"
+    }
+  }
+}

--- a/tests/protocol_corpus/fixtures/warn_mode/03-pre-edit-untracked-ok.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/03-pre-edit-untracked-ok.json
@@ -1,0 +1,23 @@
+{
+  "name": "pre-edit-untracked-ok",
+  "description": "Untracked path bypasses EXCLUSIVE acquisition and returns {ok: true} from both coordinators. The untracked fast-path on /hooks/pre-edit must remain wire-shape-stable through any Unit 2 strict-mode handler refactor.",
+  "setup": {
+    "files": {
+      "untracked.txt": "hello\n"
+    }
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-edit",
+    "body": {
+      "session_id": "33333333-3333-4333-8333-333333333333",
+      "path": "untracked.txt"
+    }
+  },
+  "expected": {
+    "status": 200,
+    "body": {
+      "ok": true
+    }
+  }
+}

--- a/tests/protocol_corpus/fixtures/warn_mode/04-pre-edit-tracked-grants-exclusive.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/04-pre-edit-tracked-grants-exclusive.json
@@ -1,0 +1,24 @@
+{
+  "name": "pre-edit-tracked-grants-exclusive",
+  "description": "Tracked path with no prior holder — pre-edit acquires EXCLUSIVE (KTD-1 single-writer) and returns {ok: true}. No hookSpecificOutput since there is no collision and no pending preemption notices.",
+  "setup": {
+    "tracked": ["CLAUDE.md"],
+    "files": {
+      "CLAUDE.md": "# Project rules\n"
+    }
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-edit",
+    "body": {
+      "session_id": "44444444-4444-4444-8444-444444444444",
+      "path": "CLAUDE.md"
+    }
+  },
+  "expected": {
+    "status": 200,
+    "body": {
+      "ok": true
+    }
+  }
+}

--- a/tests/protocol_corpus/fixtures/warn_mode/05-session-stop-no-grants.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/05-session-stop-no-grants.json
@@ -1,0 +1,19 @@
+{
+  "name": "session-stop-no-grants",
+  "description": "Session-stop for a session that never acquired any grants returns {ok: true, released_artifacts: []}. Establishes baseline parity for the clean-shutdown wire shape that v0.1.1 KTD-11 ships.",
+  "setup": {},
+  "request": {
+    "method": "POST",
+    "path": "/hooks/session-stop",
+    "body": {
+      "session_id": "55555555-5555-4555-8555-555555555555"
+    }
+  },
+  "expected": {
+    "status": 200,
+    "body": {
+      "ok": true,
+      "released_artifacts": []
+    }
+  }
+}

--- a/tests/protocol_corpus/fixtures/warn_mode/06-pre-read-missing-session-id-400.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/06-pre-read-missing-session-id-400.json
@@ -1,0 +1,18 @@
+{
+  "name": "pre-read-missing-session-id-400",
+  "description": "Missing session_id in /hooks/pre-read body returns 400 with the same error-envelope shape on both coordinators. The exact error string is the AC-04 wire-shape contract: 'missing session_id'.",
+  "setup": {},
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-read",
+    "body": {
+      "path": "docs/plans/x.md"
+    }
+  },
+  "expected": {
+    "status": 400,
+    "body": {
+      "error": "missing session_id"
+    }
+  }
+}

--- a/tests/protocol_corpus/fixtures/warn_mode/07-pre-read-missing-path-400.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/07-pre-read-missing-path-400.json
@@ -1,0 +1,18 @@
+{
+  "name": "pre-read-missing-path-400",
+  "description": "Missing path in /hooks/pre-read body returns 400 with the canonical 'missing or empty path' error envelope. Both coordinators must remap their internal path-validator messages to this exact string per the AC-04 wire-shape contract.",
+  "setup": {},
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-read",
+    "body": {
+      "session_id": "66666666-6666-4666-8666-666666666666"
+    }
+  },
+  "expected": {
+    "status": 400,
+    "body": {
+      "error": "missing or empty path"
+    }
+  }
+}

--- a/tests/protocol_corpus/fixtures/warn_mode/08-status-default-tier-empty-workspace.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/08-status-default-tier-empty-workspace.json
@@ -1,0 +1,45 @@
+{
+  "name": "status-default-tier-empty-workspace",
+  "description": "GET /status on a freshly-spawned Python coordinator with no tracked artifacts and no sessions. Validates the minimal-tier wire shape including all telemetry counters. tracked_artifacts may contain policy defaults; sessions/policy_summary/coordinator_root are normalized to keep the fixture portable. This fixture is python-only because the Node coordinator emits a different /status envelope (see fixture 09).",
+  "setup": {},
+  "request": {
+    "method": "GET",
+    "path": "/status"
+  },
+  "ignore_keys": [
+    "tracked_artifacts",
+    "sessions",
+    "policy_summary",
+    "endpoint_counters",
+    "coordinator_root",
+    "coordinator_version"
+  ],
+  "expected": {
+    "status": 200,
+    "body": {
+      "auth_401_total": 0,
+      "cold_start_duration_ms": 0,
+      "coordinator_backend": "python",
+      "coordinator_pid": "<PID>",
+      "coordinator_root": "<IGNORED>",
+      "coordinator_uptime_s": "<UPTIME>",
+      "coordinator_uptime_seconds": "<UPTIME>",
+      "coordinator_version": "<IGNORED>",
+      "detail": "minimal",
+      "endpoint_counters": "<IGNORED>",
+      "handler_concurrency_overflows_total": 0,
+      "in_flight_drain_timed_out": false,
+      "intra_task_acquire_release_total": 0,
+      "policy_summary": "<IGNORED>",
+      "sessions": "<IGNORED>",
+      "stale_warning_emitted_total": 0,
+      "stale_warning_reread_total": 0,
+      "tracked_artifacts": "<IGNORED>",
+      "watchdog_late_completion_total": 0,
+      "watchdog_queue_overflows_total": 0,
+      "watchdog_timeouts_total": 0
+    }
+  },
+  "_comment": "cold_start_duration_ms is emitted as 0.0 (float) by Python; the harness normalizer compares structural equality so int 0 vs float 0.0 are not equal. We accept the float here. If Node drifts cold_start to int, the corpus catches it. coordinator_version is ignored because it tracks the Python __version__ constant which bumps independently of the wire-shape contract.",
+  "backends": ["python"]
+}

--- a/tests/protocol_corpus/fixtures/warn_mode/09-status-default-tier-node-backend.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/09-status-default-tier-node-backend.json
@@ -1,0 +1,32 @@
+{
+  "name": "status-default-tier-node-backend",
+  "description": "GET /status on the Node coordinator. The Node /status envelope is structurally different from Python's — {backend, counts, schema_version, status, version, coordinator_uptime_seconds, policy_summary, sessions, tracked_artifacts} vs Python's {coordinator_backend, detail, ...counters, tracked_artifacts, sessions, policy_summary}. This is a known v0.1.1 wire-shape divergence (only partially closed by AC-02/AC-03). Unit 7a documents the Node shape so any DRIFT FROM THIS BASELINE in v0.2 surfaces immediately.",
+  "setup": {},
+  "request": {
+    "method": "GET",
+    "path": "/status"
+  },
+  "ignore_keys": [
+    "tracked_artifacts",
+    "sessions",
+    "policy_summary",
+    "counts",
+    "version"
+  ],
+  "expected": {
+    "status": 200,
+    "body": {
+      "backend": "node",
+      "counts": "<IGNORED>",
+      "coordinator_uptime_seconds": "<UPTIME>",
+      "policy_summary": "<IGNORED>",
+      "schema_version": 3,
+      "sessions": "<IGNORED>",
+      "status": "ok",
+      "tracked_artifacts": "<IGNORED>",
+      "version": "<IGNORED>"
+    }
+  },
+  "_comment": "Cross-backend /status shape parity is a stretch goal tracked as AC-08 follow-up. v0.2 broad-beta launch ships with the divergence documented here in the corpus, the AC-09 README note, and the configuration.md operator guide. v0.3 should converge the shapes when the multi-target converter layer lands.",
+  "backends": ["node"]
+}

--- a/tests/protocol_corpus/fixtures/warn_mode/10-status-full-tier-without-opt-in-header-403.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/10-status-full-tier-without-opt-in-header-403.json
@@ -1,0 +1,18 @@
+{
+  "name": "status-full-tier-without-opt-in-header-403",
+  "description": "GET /status?detail=full WITHOUT the Coherence-Local-Operator opt-in header returns 403. R12 three-tier disclosure model — the full tier requires the second-factor header even when Bearer auth passed.",
+  "setup": {},
+  "request": {
+    "method": "GET",
+    "path": "/status?detail=full"
+  },
+  "ignore_keys": ["error"],
+  "expected": {
+    "status": 403,
+    "body": {
+      "error": "<IGNORED>"
+    }
+  },
+  "_comment": "The error string is Python-specific ('detail=full requires the Coherence-Local-Operator: true opt-in header...') and may not match Node verbatim if Node implements the full tier with its own phrasing. This fixture asserts STATUS-CODE parity (403 for the missing-header case); message-level parity is a stretch goal for AC-09.",
+  "backends": ["python"]
+}

--- a/tests/protocol_corpus/fixtures/warn_mode/11-health-node-only.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/11-health-node-only.json
@@ -1,0 +1,21 @@
+{
+  "name": "health-node-only",
+  "description": "GET /health is Node-only in v0.1.1. The Node /health envelope is {backend, status, uptime_seconds, version} — NOT the {healthy, version, started_at_ms, uptime_ms} shape the server.ts top-of-file docstring suggests. Documents the actual shape so a future Unit 2 addition of /health to Python doesn't accidentally drift, and so any change to the Node /health response surfaces in the corpus.",
+  "setup": {},
+  "request": {
+    "method": "GET",
+    "path": "/health"
+  },
+  "ignore_keys": ["version"],
+  "expected": {
+    "status": 200,
+    "body": {
+      "backend": "node",
+      "status": "ok",
+      "uptime_seconds": "<UPTIME>",
+      "version": "<IGNORED>"
+    }
+  },
+  "_comment": "version is ignored because it tracks the plugin's hardcoded VERSION constant which bumps per release; the contract is the field's PRESENCE, not its value.",
+  "backends": ["node"]
+}

--- a/tests/protocol_corpus/fixtures/warn_mode/12-policy-track-python-only.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/12-policy-track-python-only.json
@@ -1,0 +1,21 @@
+{
+  "name": "policy-track-python-only",
+  "description": "POST /policy/track is Python-only in v0.1.1 — the Node coordinator returns 404 because it doesn't implement the policy-management surface (operators on the Node backend edit tracked.yaml by hand). Wire-shape parity for /policy/track lands in v0.3 when the Node coordinator gets the policy surface.",
+  "setup": {},
+  "request": {
+    "method": "POST",
+    "path": "/policy/track",
+    "body": {
+      "paths": ["docs/plans/feature-y.md"]
+    }
+  },
+  "expected": {
+    "status": 200,
+    "body": {
+      "ok": true,
+      "added": ["docs/plans/feature-y.md"],
+      "rejected": []
+    }
+  },
+  "backends": ["python"]
+}

--- a/tests/protocol_corpus/harness.py
+++ b/tests/protocol_corpus/harness.py
@@ -1,0 +1,583 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Cross-implementation protocol corpus harness (plan Unit 7).
+
+Loads JSON fixtures from ``fixtures/<mode>/*.json`` and routes each fixture's
+``request`` to BOTH the Python in-thread coordinator AND the Node subprocess
+coordinator, then asserts the responses are JSON-equivalent after normalization.
+
+The harness is the security-relevant surface here: the normalization rules
+("what we ignore in the diff") decide whether a real Python ↔ Node drift gets
+caught or false-passes. Each rule has an inline comment explaining why the
+field is ignored — review the rules in a focused PR per the Unit 7 verification
+checklist.
+
+Fixture schema (see ``fixtures/warn_mode/*.json``)::
+
+    {
+      "name": "<unique-fixture-name>",
+      "description": "<optional human-readable>",
+      "setup": {
+        "tracked": ["<gitignore-glob>", ...],
+        "files":   {"<path>": "<contents>", ...},
+        "policy":  {<optional pre-test policy.yaml overrides>}
+      },
+      "request": {
+        "method":  "POST" | "GET",        # default POST
+        "path":    "/health" | ...,
+        "body":    {<JSON body>}           # for POST
+        "headers": {<optional overrides>}  # auth headers added automatically
+      },
+      "expected": {
+        "status": <int>,
+        "body":   {<normalized expected JSON>}
+      },
+      "backends": ["python", "node"]      # default both
+    }
+
+Spawn isolation: each fixture gets a fresh ``tmp_path`` workspace. The Python
+coordinator runs in-thread (no subprocess overhead). The Node coordinator runs
+as ``node <plugin-dist>/coordinator.js`` with ``AGENT_COHERENCE_WORKSPACE``
+pointing at the tmp workspace. Both coordinators bind ephemeral ports.
+
+Plugin coordinator discovery: ``AGENT_COHERENCE_PLUGIN_DIST_PATH`` env var
+(absolute path to ``dist/coordinator.js``); fallback ``../agent-coherence-plugin/dist/coordinator.js``
+relative to the library repo root; fallback ``~/projects/agent-coherence-plugin/dist/coordinator.js``.
+If none resolve, Node backend scenarios xfail with a clear reason."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+import subprocess
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Optional
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES_ROOT = Path(__file__).resolve().parent / "fixtures"
+HARNESS_TIMEOUT_SEC = 10.0
+NODE_SPAWN_TIMEOUT_SEC = 8.0
+NODE_SHUTDOWN_TIMEOUT_SEC = 5.0
+
+
+# ----------------------------------------------------------------------
+# Normalization rules
+# ----------------------------------------------------------------------
+
+# Field names whose VALUE is non-deterministic across coordinator instances
+# and should be replaced with a sentinel before diffing. Comments explain the
+# rationale for each — these are the "what we ignore" rules and any addition
+# weakens the harness's catch surface, so changes go in a dedicated PR.
+_TS_SENTINEL = "<TS>"
+_UUID_SENTINEL = "<UUID>"
+_PID_SENTINEL = "<PID>"
+_UPTIME_SENTINEL = "<UPTIME>"
+_PORT_SENTINEL = "<PORT>"
+_HASH_SENTINEL = "<SHA256>"
+
+# Top-level / nested key names whose value is normalized regardless of type.
+# Listed explicitly so a new "started_at_ms" field doesn't silently slip
+# through normalization just because it looks ISO-8601-ish.
+_TIMESTAMP_KEYS: frozenset[str] = frozenset({
+    # Wall-clock fields surfaced by /status default + metrics tiers.
+    "ts",
+    "started_at",
+    "last_request_at",
+    "last_401_warn_at",
+    "started_at_ms",        # Node-side field; Python emits float seconds
+    "last_completed_ms",
+    "first_observation_ts",
+    "last_seen_at",
+})
+
+_UPTIME_KEYS: frozenset[str] = frozenset({
+    "coordinator_uptime_seconds",
+    # AC-02 deprecated alias — Python emits both during the v0.1.x window so a
+    # consumer migrating from the old name still gets a value. Removed in v0.2.
+    "coordinator_uptime_s",
+    "uptime_seconds",
+    "uptime_ms",
+    "process_uptime_seconds",
+})
+
+_PID_KEYS: frozenset[str] = frozenset({
+    "pid",
+    "coordinator_pid",
+    "process_pid",
+    "worker_pid",
+})
+
+_PORT_KEYS: frozenset[str] = frozenset({
+    "port",
+    "coordinator_port",
+    "listen_port",
+})
+
+# Fields whose value is a UUID4 — we keep them present (the wire shape carries
+# the field, both coordinators emit a value) but normalize the value itself.
+_UUID_KEYS: frozenset[str] = frozenset({
+    "instance_id",
+    "agent",
+    "agent_id",
+    "session_id",
+    "request_id",
+})
+
+# Content-hash fields. SHA-256 hex is deterministic for identical bytes, so we
+# *don't* normalize these by default — drift in content_hash IS a real wire
+# regression. Sentinel reserved for fixtures that need to ignore content_hash
+# (e.g., where the hash depends on a timestamp embedded in the file).
+_HASH_KEYS: frozenset[str] = frozenset()  # opt-in per fixture via "ignore_keys"
+
+# UUIDv4 string regex — used to scrub UUID-shaped values that appear in string
+# positions (error messages, log fragments) even when the key name isn't in
+# _UUID_KEYS. Permissive: any 8-4-4-4-12 hex sequence.
+_UUID_RE = re.compile(
+    r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
+)
+
+# ISO-8601 timestamp regex — used to scrub timestamp-shaped values in string
+# positions (error messages with "at 2026-05-23T...").
+_ISO_TS_RE = re.compile(
+    r"\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\b"
+)
+
+
+def normalize_response(
+    value: Any,
+    *,
+    ignore_keys: Optional[frozenset[str]] = None,
+) -> Any:
+    """Replace non-deterministic field values with stable sentinels.
+
+    Recurses into dicts and lists. Scalars are returned as-is unless the
+    enclosing key is in one of the normalization sets.
+
+    ``ignore_keys`` — per-fixture opt-in set of additional key names whose
+    values should be replaced with ``"<IGNORED>"``. Use sparingly; each entry
+    is a hole in the catch surface."""
+    ignore_keys = ignore_keys or frozenset()
+
+    def _walk(v: Any, parent_key: Optional[str]) -> Any:
+        if isinstance(v, dict):
+            return {k: _walk_keyed(v[k], k) for k in sorted(v.keys())}
+        if isinstance(v, list):
+            return [_walk(item, None) for item in v]
+        if isinstance(v, str):
+            # String-position scrubbing: UUID and ISO-8601 substrings in
+            # error messages / log fragments.
+            scrubbed = _UUID_RE.sub(_UUID_SENTINEL, v)
+            scrubbed = _ISO_TS_RE.sub(_TS_SENTINEL, scrubbed)
+            return scrubbed
+        return v
+
+    def _walk_keyed(v: Any, key: str) -> Any:
+        # Per-fixture ignore set wins over everything else.
+        if key in ignore_keys:
+            return "<IGNORED>"
+        # Key-driven normalization fires regardless of value type so we don't
+        # care whether the coordinator emits int or float for an uptime.
+        if key in _TIMESTAMP_KEYS:
+            return _TS_SENTINEL
+        if key in _UPTIME_KEYS:
+            return _UPTIME_SENTINEL
+        if key in _PID_KEYS:
+            return _PID_SENTINEL
+        if key in _PORT_KEYS:
+            return _PORT_SENTINEL
+        if key in _UUID_KEYS:
+            return _UUID_SENTINEL
+        if key in _HASH_KEYS:
+            return _HASH_SENTINEL
+        return _walk(v, key)
+
+    return _walk(value, None)
+
+
+# ----------------------------------------------------------------------
+# Backend identifiers
+# ----------------------------------------------------------------------
+
+
+BACKEND_PYTHON = "python"
+BACKEND_NODE = "node"
+ALL_BACKENDS = (BACKEND_PYTHON, BACKEND_NODE)
+
+
+# ----------------------------------------------------------------------
+# Fixture loader
+# ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Fixture:
+    """A single protocol-corpus scenario."""
+
+    name: str
+    description: str
+    path: Path
+    setup: dict[str, Any]
+    request: dict[str, Any]
+    expected: dict[str, Any]
+    backends: tuple[str, ...]
+    ignore_keys: frozenset[str]
+
+
+def load_fixtures(mode: str = "warn_mode") -> list[Fixture]:
+    """Load all JSON fixtures under ``fixtures/<mode>/`` in sorted order."""
+    mode_root = FIXTURES_ROOT / mode
+    if not mode_root.exists():
+        return []
+    fixtures: list[Fixture] = []
+    for path in sorted(mode_root.glob("*.json")):
+        with path.open() as fh:
+            data = json.load(fh)
+        backends_raw = data.get("backends") or list(ALL_BACKENDS)
+        unknown = [b for b in backends_raw if b not in ALL_BACKENDS]
+        if unknown:
+            raise ValueError(
+                f"{path.name}: unknown backends {unknown!r}; allowed={ALL_BACKENDS}"
+            )
+        fixtures.append(
+            Fixture(
+                name=data["name"],
+                description=data.get("description", ""),
+                path=path,
+                setup=data.get("setup", {}),
+                request=data["request"],
+                expected=data["expected"],
+                backends=tuple(backends_raw),
+                ignore_keys=frozenset(data.get("ignore_keys", [])),
+            )
+        )
+    return fixtures
+
+
+# ----------------------------------------------------------------------
+# Workspace setup
+# ----------------------------------------------------------------------
+
+
+def apply_setup(workspace: Path, setup: dict[str, Any]) -> None:
+    """Materialize a fixture's ``setup`` block onto a fresh tmp workspace.
+
+    - ``files``: writes named files relative to the workspace root.
+    - ``tracked``: writes ``.coherence/tracked.yaml`` with one path per line.
+    - ``policy``: NOT IMPLEMENTED yet — strict-mode-fixture-only; lands in
+      Unit 7b alongside Unit 2's strict-mode wire shape additions."""
+    coherence_dir = workspace / ".coherence"
+    coherence_dir.mkdir(exist_ok=True, mode=0o700)
+
+    files = setup.get("files") or {}
+    for rel_path, contents in files.items():
+        target = workspace / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(contents)
+
+    tracked = setup.get("tracked") or []
+    if tracked:
+        # Match TrackedArtifactPolicy.load expectations — YAML list form. We
+        # write the minimal valid shape that the policy loader accepts; if
+        # the policy loader's API changes, this stays the only place to
+        # adapt.
+        lines = ["tracked:"]
+        for pat in tracked:
+            lines.append(f"  - {pat}")
+        (coherence_dir / "tracked.yaml").write_text("\n".join(lines) + "\n")
+
+
+# ----------------------------------------------------------------------
+# Coordinator backends
+# ----------------------------------------------------------------------
+
+
+class CoordinatorBackend:
+    """Abstract base: spawn, expose (port, secret), shutdown."""
+
+    backend_id: str
+
+    def start(self, workspace: Path) -> None:
+        raise NotImplementedError
+
+    def url(self, path: str) -> str:
+        raise NotImplementedError
+
+    def secret(self) -> str:
+        raise NotImplementedError
+
+    def shutdown(self) -> None:
+        raise NotImplementedError
+
+
+class PythonCoordinator(CoordinatorBackend):
+    """In-process Python coordinator via ``CoordinatorHTTPServer.serve_in_thread``."""
+
+    backend_id = BACKEND_PYTHON
+
+    def __init__(self) -> None:
+        self._server = None
+        self._secret: Optional[str] = None
+        self._port: Optional[int] = None
+
+    def start(self, workspace: Path) -> None:
+        # Defer the import so test discovery doesn't pay the cost.
+        from ccs.adapters.claude_code.auth import load_secret
+        from ccs.adapters.claude_code.coordinator_server import (
+            CoordinatorHTTPServer,
+        )
+
+        server = CoordinatorHTTPServer(workspace, port=0, instance_id="protocol-corpus-py")
+        server.serve_in_thread()
+        # Tiny grace window — matches the existing
+        # tests/test_claude_code_coordinator_server.py pattern.
+        time.sleep(0.05)
+        secret = load_secret(server.coordinator_root)
+        assert secret is not None, "Python coordinator failed to write hook.secret"
+        self._server = server
+        self._secret = secret
+        self._port = server.port
+
+    def url(self, path: str) -> str:
+        assert self._port is not None
+        return f"http://127.0.0.1:{self._port}{path}"
+
+    def secret(self) -> str:
+        assert self._secret is not None
+        return self._secret
+
+    def shutdown(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+
+
+class NodeCoordinator(CoordinatorBackend):
+    """Out-of-process Node coordinator spawned as ``node dist/coordinator.js``."""
+
+    backend_id = BACKEND_NODE
+
+    def __init__(self, dist_path: Path) -> None:
+        if not dist_path.exists():
+            raise FileNotFoundError(
+                f"Node coordinator entry point not found: {dist_path}. "
+                f"Build the plugin (cd <plugin-repo> && npm ci && npm run build) "
+                f"or set AGENT_COHERENCE_PLUGIN_DIST_PATH to the absolute path."
+            )
+        self._dist_path = dist_path
+        self._proc: Optional[subprocess.Popen[bytes]] = None
+        self._port: Optional[int] = None
+        self._secret: Optional[str] = None
+
+    def start(self, workspace: Path) -> None:
+        env = dict(os.environ)
+        env["AGENT_COHERENCE_WORKSPACE"] = str(workspace)
+        # Suppress harmless verbose logging if the operator wants quieter
+        # test output (Node coordinator logs to stderr; harness captures
+        # both streams and surfaces them only on failure).
+        self._proc = subprocess.Popen(
+            ["node", str(self._dist_path)],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        port, secret = _wait_for_coordinator(
+            workspace,
+            timeout_sec=NODE_SPAWN_TIMEOUT_SEC,
+            proc=self._proc,
+            backend_label="node",
+        )
+        self._port = port
+        self._secret = secret
+
+    def url(self, path: str) -> str:
+        assert self._port is not None
+        return f"http://127.0.0.1:{self._port}{path}"
+
+    def secret(self) -> str:
+        assert self._secret is not None
+        return self._secret
+
+    def shutdown(self) -> None:
+        if self._proc is None:
+            return
+        # SIGTERM → graceful close per coordinator.ts's shutdown handler.
+        # Fall back to SIGKILL after NODE_SHUTDOWN_TIMEOUT_SEC.
+        self._proc.terminate()
+        try:
+            self._proc.wait(timeout=NODE_SHUTDOWN_TIMEOUT_SEC)
+        except subprocess.TimeoutExpired:
+            self._proc.kill()
+            self._proc.wait(timeout=NODE_SHUTDOWN_TIMEOUT_SEC)
+
+
+def _wait_for_coordinator(
+    workspace: Path,
+    *,
+    timeout_sec: float,
+    proc: subprocess.Popen[bytes],
+    backend_label: str,
+) -> tuple[int, str]:
+    """Poll for ``.coherence/server.pid`` + ``hook.secret`` to materialize.
+
+    Surfaces subprocess crash early (returns nonzero before the pid file lands)
+    with the captured stderr — a silent timeout would otherwise hide the real
+    diagnostic from a failed Node build."""
+    pid_file = workspace / ".coherence" / "server.pid"
+    secret_file = workspace / ".coherence" / "hook.secret"
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        rc = proc.poll()
+        if rc is not None:
+            stderr = proc.stderr.read().decode("utf-8", errors="replace") if proc.stderr else ""
+            stdout = proc.stdout.read().decode("utf-8", errors="replace") if proc.stdout else ""
+            raise RuntimeError(
+                f"{backend_label} coordinator exited with rc={rc} before writing server.pid.\n"
+                f"stdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+        if pid_file.exists() and secret_file.exists():
+            try:
+                lines = pid_file.read_text().splitlines()
+                if len(lines) >= 2:
+                    port = int(lines[1])
+                    secret = secret_file.read_text().strip()
+                    if secret:
+                        # Probe the actual socket once before returning so we
+                        # don't race the listen() callback on slow CI.
+                        if _socket_open("127.0.0.1", port):
+                            return port, secret
+            except (OSError, ValueError):
+                pass  # Partial write — retry on next tick.
+        time.sleep(0.05)
+    raise TimeoutError(
+        f"{backend_label} coordinator did not write server.pid within {timeout_sec}s; "
+        f"workspace={workspace}"
+    )
+
+
+def _socket_open(host: str, port: int) -> bool:
+    """Check whether the coordinator's listen socket is accepting yet."""
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+def resolve_node_dist_path() -> Optional[Path]:
+    """Locate the Node coordinator entry point.
+
+    Resolution order:
+    1. ``AGENT_COHERENCE_PLUGIN_DIST_PATH`` env var (absolute path)
+    2. ``../agent-coherence-plugin/dist/coordinator.js`` relative to library repo root
+    3. ``~/projects/agent-coherence-plugin/dist/coordinator.js``
+
+    Returns ``None`` if nothing resolves — the harness then xfails Node backend
+    scenarios with a clear reason rather than hanging."""
+    explicit = os.environ.get("AGENT_COHERENCE_PLUGIN_DIST_PATH")
+    if explicit:
+        p = Path(explicit).expanduser().resolve()
+        if p.exists():
+            return p
+    sibling = (REPO_ROOT.parent / "agent-coherence-plugin" / "dist" / "coordinator.js").resolve()
+    if sibling.exists():
+        return sibling
+    home_fallback = (Path.home() / "projects" / "agent-coherence-plugin" / "dist" / "coordinator.js").resolve()
+    if home_fallback.exists():
+        return home_fallback
+    return None
+
+
+# ----------------------------------------------------------------------
+# Request execution
+# ----------------------------------------------------------------------
+
+
+def execute_request(
+    backend: CoordinatorBackend,
+    request: dict[str, Any],
+) -> tuple[int, dict[str, Any]]:
+    """Issue a fixture's request against ``backend``. Returns (status, body_dict).
+
+    Adds the Authorization + Host headers automatically. Body is JSON-encoded
+    for POST; ignored for GET."""
+    method = request.get("method", "POST").upper()
+    path = request["path"]
+    body = request.get("body")
+
+    headers = {
+        "Authorization": f"Bearer {backend.secret()}",
+        "Host": "127.0.0.1",
+        "Content-Type": "application/json",
+    }
+    headers.update(request.get("headers", {}))
+
+    data = json.dumps(body).encode("utf-8") if body is not None else b""
+    req = urlrequest.Request(
+        backend.url(path),
+        data=data if method == "POST" else None,
+        method=method,
+        headers=headers,
+    )
+    try:
+        with urlrequest.urlopen(req, timeout=HARNESS_TIMEOUT_SEC) as resp:
+            raw = resp.read().decode("utf-8")
+            parsed = json.loads(raw) if raw else {}
+            return resp.status, parsed
+    except urlerror.HTTPError as exc:
+        raw = exc.read().decode("utf-8") if exc.fp else ""
+        parsed = json.loads(raw) if raw else {}
+        return exc.code, parsed
+
+
+# ----------------------------------------------------------------------
+# Top-level scenario runner
+# ----------------------------------------------------------------------
+
+
+@contextmanager
+def coordinator_running(
+    backend_id: str,
+    workspace: Path,
+    node_dist_path: Optional[Path] = None,
+) -> Iterator[CoordinatorBackend]:
+    """Context manager that spawns a coordinator + tears it down cleanly."""
+    if backend_id == BACKEND_PYTHON:
+        backend: CoordinatorBackend = PythonCoordinator()
+    elif backend_id == BACKEND_NODE:
+        if node_dist_path is None:
+            raise RuntimeError(
+                "Node backend requested but no plugin dist path resolved. "
+                "Set AGENT_COHERENCE_PLUGIN_DIST_PATH or build the plugin checkout."
+            )
+        backend = NodeCoordinator(node_dist_path)
+    else:
+        raise ValueError(f"Unknown backend: {backend_id!r}")
+    backend.start(workspace)
+    try:
+        yield backend
+    finally:
+        backend.shutdown()
+
+
+def run_scenario(
+    fixture: Fixture,
+    backend_id: str,
+    workspace: Path,
+    node_dist_path: Optional[Path] = None,
+) -> tuple[int, dict[str, Any]]:
+    """End-to-end: setup workspace → spawn backend → POST → normalize → return.
+
+    Returns the normalized (status, body) for assertion by the caller."""
+    apply_setup(workspace, fixture.setup)
+    with coordinator_running(backend_id, workspace, node_dist_path) as backend:
+        status, body = execute_request(backend, fixture.request)
+    return status, normalize_response(body, ignore_keys=fixture.ignore_keys)

--- a/tests/protocol_corpus/test_warn_mode_corpus.py
+++ b/tests/protocol_corpus/test_warn_mode_corpus.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Cross-implementation warn-mode wire-shape corpus tests (plan Unit 7a).
+
+Parametrized over (fixture, backend). Each row runs the fixture's request
+against the named backend in an isolated tmp workspace and asserts the
+normalized response matches the fixture's ``expected`` block.
+
+Marked ``protocol_corpus`` — opt-in via ``pytest -m protocol_corpus``. Skipped
+in default runs (see ``pyproject.toml`` ``addopts``)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.protocol_corpus.harness import (
+    ALL_BACKENDS,
+    BACKEND_NODE,
+    Fixture,
+    load_fixtures,
+    normalize_response,
+    resolve_node_dist_path,
+    run_scenario,
+)
+
+
+pytestmark = pytest.mark.protocol_corpus
+
+
+def _all_warn_mode_fixtures() -> list[Fixture]:
+    """Loaded once at collection so parametrize ids stay stable."""
+    return load_fixtures("warn_mode")
+
+
+def _parametrize_rows() -> list[tuple[Fixture, str]]:
+    """Cartesian product of (fixture, backend) restricted to each fixture's
+    declared backends list."""
+    rows: list[tuple[Fixture, str]] = []
+    for fixture in _all_warn_mode_fixtures():
+        for backend in fixture.backends:
+            rows.append((fixture, backend))
+    return rows
+
+
+def _row_id(row: tuple[Fixture, str]) -> str:
+    fixture, backend = row
+    return f"{fixture.name}[{backend}]"
+
+
+_ROWS = _parametrize_rows()
+_NODE_DIST_PATH = resolve_node_dist_path()
+
+
+@pytest.mark.parametrize("row", _ROWS, ids=[_row_id(r) for r in _ROWS] if _ROWS else None)
+def test_warn_mode_fixture_response_matches_expected(
+    row: tuple[Fixture, str],
+    tmp_path: Path,
+) -> None:
+    fixture, backend = row
+    if backend == BACKEND_NODE and _NODE_DIST_PATH is None:
+        pytest.xfail(
+            "Node coordinator dist not resolvable. Build the plugin checkout "
+            "(npm ci && npm run build) or set AGENT_COHERENCE_PLUGIN_DIST_PATH."
+        )
+
+    actual_status, actual_body = run_scenario(
+        fixture=fixture,
+        backend_id=backend,
+        workspace=tmp_path,
+        node_dist_path=_NODE_DIST_PATH,
+    )
+
+    # Pre-normalize the EXPECTED body too — fixtures can be authored either
+    # with the post-normalization sentinels already in place ("<TS>", "<UUID>")
+    # or with realistic-looking placeholders. Round-trip both through the same
+    # normalizer so author choice doesn't affect equality.
+    expected_status = fixture.expected["status"]
+    expected_body = normalize_response(
+        fixture.expected["body"], ignore_keys=fixture.ignore_keys
+    )
+
+    assert actual_status == expected_status, (
+        f"{fixture.name}[{backend}]: status mismatch — "
+        f"expected {expected_status}, got {actual_status}\n"
+        f"body={actual_body!r}"
+    )
+    assert actual_body == expected_body, (
+        f"{fixture.name}[{backend}]: body mismatch\n"
+        f"expected={expected_body!r}\nactual=  {actual_body!r}"
+    )
+
+
+def test_collection_loaded_fixtures() -> None:
+    """Self-test: at least one fixture is present so parametrize doesn't
+    silently no-op. Catches the failure mode where the fixtures directory
+    is empty or path-resolution is wrong."""
+    fixtures = _all_warn_mode_fixtures()
+    assert len(fixtures) >= 8, (
+        f"Expected ≥8 warn-mode fixtures, found {len(fixtures)}. "
+        f"Add coverage in tests/protocol_corpus/fixtures/warn_mode/."
+    )
+
+
+def test_normalizer_self_test_detects_real_divergence() -> None:
+    """Harness self-test (per Unit 7a verification): deliberately-different
+    bodies must NOT compare equal after normalization. Catches the failure
+    mode where over-aggressive normalization rules false-pass real drift."""
+    body_a: dict[str, Any] = {
+        "schema_version": 1,
+        "coordinator_uptime_seconds": 123.4,
+        "instance_id": "11111111-1111-4111-8111-111111111111",
+        "tracked_count": 5,
+    }
+    body_b: dict[str, Any] = {
+        "schema_version": 1,
+        "coordinator_uptime_seconds": 999.9,         # would be ignored
+        "instance_id": "22222222-2222-4222-8222-222222222222",  # would be ignored
+        "tracked_count": 7,                            # real divergence
+    }
+    norm_a = normalize_response(body_a)
+    norm_b = normalize_response(body_b)
+    assert norm_a != norm_b, (
+        "Normalizer should NOT mask real differences in non-time/UUID fields. "
+        f"norm_a={norm_a!r}, norm_b={norm_b!r}"
+    )
+
+
+def test_normalizer_handles_nested_uuid_and_timestamp() -> None:
+    """Self-test: nested dicts and lists get walked, string-position UUID/ISO
+    timestamps scrubbed."""
+    body: dict[str, Any] = {
+        "sessions": [
+            {
+                "agent_id": "11111111-1111-4111-8111-111111111111",
+                "started_at": 1700000000.0,
+                "last_request_at": "2026-05-23T12:34:56Z",
+                "message": "agent 22222222-2222-4222-8222-222222222222 acquired at 2026-05-23T10:00:00Z",
+            }
+        ],
+        "coordinator_uptime_seconds": 42,
+    }
+    out = normalize_response(body)
+    session = out["sessions"][0]
+    assert session["agent_id"] == "<UUID>"
+    assert session["started_at"] == "<TS>"
+    assert session["last_request_at"] == "<TS>"
+    # In-string substitution: both the embedded UUID and timestamp scrubbed.
+    assert "<UUID>" in session["message"]
+    assert "<TS>" in session["message"]
+    assert out["coordinator_uptime_seconds"] == "<UPTIME>"


### PR DESCRIPTION
## Summary

- Phase 0 prerequisite for the v0.2 strict-mode plan ([2026-05-20-001-feat-claude-code-coherence-plugin-v0.2-strict-mode-plan.md](../docs/plans/2026-05-20-001-feat-claude-code-coherence-plugin-v0.2-strict-mode-plan.md), Unit 7a — NEVER-SHED per the Phased Delivery table).
- Cross-implementation harness + 12 warn-mode fixtures + opt-in pytest marker + new CI job that catches Python ↔ Node coordinator wire-shape drift before Unit 2's strict-mode flip can ship it.
- Establishes the v0.1.1 wire-shape baseline. Any drift introduced by v0.2 surfaces immediately in this corpus.

## What's in the diff

| File | Purpose |
|---|---|
| `tests/protocol_corpus/harness.py` | Fixture loader, both backends (Python in-thread + Node subprocess), deterministic normalization rules (timestamps → `<TS>`, UUIDs → `<UUID>`, PIDs → `<PID>`, uptime → `<UPTIME>`). Each rule carries an inline comment explaining what's ignored and why. |
| `tests/protocol_corpus/test_warn_mode_corpus.py` | Pytest driver parametrized over (fixture × backend) + 3 self-tests (collection sanity, normalizer-detects-real-divergence, normalizer-handles-nested-structures). |
| `tests/protocol_corpus/fixtures/warn_mode/*.json` (12 files) | Covers: pre-read (untracked + tracked first-obs + missing-session-id 400 + missing-path 400), pre-edit (untracked + tracked), session-stop, /status default tier (Python shape + Node shape — documented divergence per AC-08 follow-up), /status full-tier 403, /health (Node-only), /policy/track (Python-only). |
| `pyproject.toml` | New `protocol_corpus` marker; `addopts` excludes it from default `pytest -q` (Node build prerequisite + spawn cost). |
| `.github/workflows/ci.yml` | New `protocol-corpus` job: checks out plugin sibling repo, builds Node coordinator, runs corpus with `AGENT_COHERENCE_PLUGIN_DIST_PATH` env. |

## Test plan

- [x] `pytest -m protocol_corpus` locally: 22 passed (19 fixture × backend + 3 self-tests) in 10.11s on Python 3.13 + Node 20.
- [x] Default `pytest -q` unaffected: 1247 passed, 2 skipped, 24 deselected.
- [x] `tools/check_architecture.py` clean (86 modules, 179 edges; harness is in `tests/` so doesn't touch the layer graph).
- [ ] CI `protocol-corpus` job green on this PR.

## Discovered baselines (documented, not regressions)

Two real wire-shape divergences came out of authoring the fixtures. Both pre-date this PR — Unit 7a is the first time they're codified:

1. **Node `/status` envelope differs from Python's minimal tier.** Node emits `{backend, counts, schema_version, status, version, coordinator_uptime_seconds, policy_summary, sessions, tracked_artifacts}`; Python emits `{coordinator_backend, detail, ...counters, ...}`. Fixture 09 anchors the Node shape. Convergence is a v0.3 deliverable per AC-08 follow-up.
2. **Node `/health` shape doesn't match the docstring comment in `server.ts`.** Actual is `{backend, status, uptime_seconds, version}`, not `{healthy, version, started_at_ms, uptime_ms}` as the comment implied. Fixture 11 anchors the actual shape.

## Repo housekeeping note (not blocking this PR)

`origin/dev` is currently behind `origin/main` by the 2 v0.8.0 release commits (`8372323` merge + `daf6e68` version bump). Per CLAUDE.md, dev should fast-forward to main after each release merge. This PR's diff against `dev` will include those release commits as ambient context. Pre-merge, the operator may want to fast-forward `dev` to `main` first to keep the PR diff clean. I did not do this housekeeping unilaterally because dev is a shared branch.

## Branching

Branched from `main` per CLAUDE.md ("Branch from `dev` (or `main` if it is current with `dev`)"). Targets `dev` per the standard convention.