### PR TITLE
feat(coordinator): strict-mode handler decision-flip + KTD-U invariant (v0.2 Unit 2)

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1213,6 +1213,44 @@ def _handle_pre_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
             "hash_differs": hash_differs,
         }
 
+        # v0.2 KTD-O / KTD-P: strict-mode deny branch. If the artifact is
+        # opted into strict mode via .coherence/strict_mode.yaml AND the
+        # session was previously invalidated (preempted by a peer commit),
+        # return permissionDecision:"deny" with the static reason template.
+        # Otherwise fall through to v0.1.1 warn-mode allow path unchanged.
+        #
+        # Semantic guard: strict-deny fires only on agent_state == INVALID
+        # (true preemption). A first-time observer (agent_state is None on
+        # an existing artifact) gets warn-mode allow + additionalContext
+        # because they have not "acted on stale" — they have never seen
+        # the artifact before. The operator's intent for strict mode is
+        # "must re-read after invalidation," not "must read before any
+        # cross-session activity exists."
+        #
+        # KTD-Q: this is the Read surface; the same gate fires on
+        # pre-edit / pre-bash / pre-grep for Edit|Write / Bash / Grep.
+        #
+        # KTD-T: do NOT re-grant SHARED on deny. The MESI state stays
+        # INVALID across the model's retry loop so every retry produces
+        # the same byte-stable deny reason text. Per Phase 0 finding the
+        # model exits the retry loop after 2-5 attempts and routes to
+        # alternative behavior; the deny IS the signal. Re-granting
+        # would let the second retry get fresh and silently downgrade
+        # the operator's hard guardrail.
+        if (
+            agent_state == MESIState.INVALID
+            and coordinator.policy.is_strict_mode(path)
+        ):
+            coordinator.increment_stale_warning_emitted()
+            coordinator.mark_stale_warned(agent_id, artifact_id)
+            return {
+                "hookSpecificOutput": _payloads.emit_strict_deny(
+                    source="pre_read_strict_deny", summary=summary,
+                ),
+                "status": "stale",
+                "summary": summary,
+            }
+
         # Re-grant SHARED so this read doesn't re-fire stale on every call.
         coordinator.registry.set_agent_state(
             artifact_id, agent_id, MESIState.SHARED,
@@ -1252,11 +1290,10 @@ def _handle_pre_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
                 notice_text = _build_preemption_text(coordinator, notices)
                 return {
                     "status": "fresh",
-                    "hookSpecificOutput": {
-                        "hookEventName": "PreToolUse",
-                        "permissionDecision": "allow",
-                        "additionalContext": notice_text,
-                    },
+                    "hookSpecificOutput": _payloads.emit_allow(
+                        source="pre_read_fresh_with_notice",
+                        additional_context=notice_text,
+                    ),
                 }
         return result
 
@@ -1291,6 +1328,51 @@ def _handle_pre_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
         artifact_id = coordinator.registry.lookup_artifact_id_by_name(path)
         if artifact_id is None:
             artifact_id = coordinator.registry.resolve_or_register(path, content_hash="")
+
+        # v0.2 KTD-O / KTD-P: strict-mode stale-edit deny branch. If the
+        # artifact is opted into strict mode AND the editor's prior state
+        # is INVALID (preempted by a peer commit), deny before acquiring
+        # EXCLUSIVE. The editor must re-read first to take a fresh
+        # SHARED grant.
+        #
+        # Semantic guard (matches pre-read): strict-deny fires only on
+        # editor_state == INVALID. A first-time editor (state is None on
+        # an existing artifact) falls through to the normal acquire flow
+        # — they have not acted on stale state, they're establishing a
+        # new write claim. The strict-mode intent is "must re-read after
+        # preemption," not "must read before any write."
+        #
+        # This is the Edit/Write surface of KTD-Q (the hooks.json matcher
+        # routes both tools through /hooks/pre-edit).
+        if coordinator.policy.is_strict_mode(path):
+            artifact = coordinator.registry.get_artifact(artifact_id)
+            editor_state = coordinator.registry.get_agent_state(artifact_id, agent_id)
+            editor_stale = editor_state == MESIState.INVALID
+            if artifact is not None and artifact.version > 0 and editor_stale:
+                last_writer_id = _last_writer_for(coordinator, artifact_id)
+                last_writer_ts = (
+                    _last_writer_unix_ts(coordinator, artifact_id) or _payloads.now_unix()
+                )
+                summary: _payloads.StaleSummary = {
+                    "path": path,
+                    "current_version": artifact.version,
+                    "prior_version_seen_by_session": (
+                        artifact.version - 1 if editor_state == MESIState.INVALID else None
+                    ),
+                    "last_writer_session_id": last_writer_id or "<unknown>",
+                    "last_writer_at_unix_ts": last_writer_ts,
+                    "warning_generated_at_unix_ts": _payloads.now_unix(),
+                    "hash_differs": False,  # pre-edit doesn't carry content_hash
+                }
+                coordinator.increment_stale_warning_emitted()
+                return {
+                    "ok": False,
+                    "hookSpecificOutput": _payloads.emit_strict_deny(
+                        source="pre_edit_strict_deny", summary=summary,
+                    ),
+                    "status": "stale",
+                    "summary": summary,
+                }
 
         # A1: snapshot peers in M∪E BEFORE write so we can record preemption
         # notices for victims after the side-effecting invalidation.
@@ -1341,11 +1423,10 @@ def _handle_pre_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
             # promote {ok: true} into a hookSpecificOutput.
             return {
                 "ok": True,
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "allow",
-                    "additionalContext": notice_text,
-                },
+                "hookSpecificOutput": _payloads.emit_allow(
+                    source="pre_edit_notice_only",
+                    additional_context=notice_text,
+                ),
             }
         return {"ok": True}
 
@@ -1696,6 +1777,11 @@ def _handle_pre_bash(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
     def work() -> dict:
         coordinator.service.record_heartbeat(agent_id=agent_id, now_tick=now)
         stale_summaries: list[dict] = []
+        # v0.2 KTD-Q: track the first strict + stale path encountered so we
+        # can emit a strict-mode deny on the whole bash command. ANY strict-
+        # stale match in the path set triggers deny per the plan's edge-case
+        # contract (cat a.md b.md where a.md is strict → deny).
+        strict_stale_first: dict | None = None
         for path in tracked_paths:
             artifact_id = coordinator.registry.lookup_artifact_id_by_name(path)
             if artifact_id is None:
@@ -1718,10 +1804,46 @@ def _handle_pre_bash(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
                 "path": path,
                 "current_version": artifact.version,
             })
+            if (
+                strict_stale_first is None
+                and coordinator.policy.is_strict_mode(path)
+            ):
+                last_writer_id = _last_writer_for(coordinator, artifact_id)
+                last_writer_ts = (
+                    _last_writer_unix_ts(coordinator, artifact_id) or _payloads.now_unix()
+                )
+                strict_stale_first = {
+                    "path": path,
+                    "current_version": artifact.version,
+                    "prior_version_seen_by_session": (
+                        artifact.version - 1 if agent_state == MESIState.INVALID else None
+                    ),
+                    "last_writer_session_id": last_writer_id or "<unknown>",
+                    "last_writer_at_unix_ts": last_writer_ts,
+                    "warning_generated_at_unix_ts": _payloads.now_unix(),
+                    "hash_differs": False,
+                }
             coordinator.registry.set_agent_state(
                 artifact_id, agent_id, MESIState.SHARED,
                 trigger="post_stale_bash", tick=now,
             )
+
+        # v0.2 KTD-Q strict-mode deny short-circuit. If any detected path in
+        # the bash command is strict + stale, deny the whole command. The
+        # reason references the first strict-stale path; multi-path bash
+        # commands with multiple strict-stale paths re-deny on retry with
+        # the next path's reason as the model resolves them one by one
+        # (bounded by the model's own retry-loop per Phase 0 finding).
+        if strict_stale_first is not None:
+            coordinator.increment_stale_warning_emitted()
+            summary_typed: _payloads.StaleSummary = strict_stale_first  # type: ignore[assignment]
+            return {
+                "hookSpecificOutput": _payloads.emit_strict_deny(
+                    source="pre_bash_strict_deny", summary=summary_typed,
+                ),
+                "status": "stale",
+                "stale_paths": [s["path"] for s in stale_summaries],
+            }
 
         notices = coordinator.registry.pop_pending_notices(agent_id)
 
@@ -1747,11 +1869,10 @@ def _handle_pre_bash(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
             )
 
         resp: dict[str, Any] = {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "allow",  # v0.1.1 warn-only per KTD-E
-                "additionalContext": "\n\n".join(parts),
-            },
+            "hookSpecificOutput": _payloads.emit_allow(
+                source="pre_bash_stale_warn",
+                additional_context="\n\n".join(parts),
+            ),
         }
         if stale_summaries:
             resp["status"] = "stale"
@@ -1809,6 +1930,9 @@ def _handle_pre_grep(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
     def work() -> dict:
         coordinator.service.record_heartbeat(agent_id=agent_id, now_tick=now)
         stale_summaries: list[dict] = []
+        # v0.2 KTD-Q: track the first strict + stale path encountered so we
+        # can emit strict-mode deny on the whole grep command. Mirrors pre-bash.
+        strict_stale_first: dict | None = None
         for path in tracked_paths:
             artifact_id = coordinator.registry.lookup_artifact_id_by_name(path)
             if artifact_id is None:
@@ -1821,10 +1945,41 @@ def _handle_pre_grep(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
                 "path": path,
                 "current_version": artifact.version,
             })
+            if (
+                strict_stale_first is None
+                and coordinator.policy.is_strict_mode(path)
+            ):
+                last_writer_id = _last_writer_for(coordinator, artifact_id)
+                last_writer_ts = (
+                    _last_writer_unix_ts(coordinator, artifact_id) or _payloads.now_unix()
+                )
+                strict_stale_first = {
+                    "path": path,
+                    "current_version": artifact.version,
+                    "prior_version_seen_by_session": (
+                        artifact.version - 1 if agent_state == MESIState.INVALID else None
+                    ),
+                    "last_writer_session_id": last_writer_id or "<unknown>",
+                    "last_writer_at_unix_ts": last_writer_ts,
+                    "warning_generated_at_unix_ts": _payloads.now_unix(),
+                    "hash_differs": False,
+                }
             coordinator.registry.set_agent_state(
                 artifact_id, agent_id, MESIState.SHARED,
                 trigger="post_stale_grep", tick=now,
             )
+
+        # v0.2 KTD-Q strict-mode deny short-circuit. Same shape as pre-bash.
+        if strict_stale_first is not None:
+            coordinator.increment_stale_warning_emitted()
+            summary_typed: _payloads.StaleSummary = strict_stale_first  # type: ignore[assignment]
+            return {
+                "hookSpecificOutput": _payloads.emit_strict_deny(
+                    source="pre_grep_strict_deny", summary=summary_typed,
+                ),
+                "status": "stale",
+                "stale_paths": [s["path"] for s in stale_summaries],
+            }
 
         notices = coordinator.registry.pop_pending_notices(agent_id)
 
@@ -1847,11 +2002,10 @@ def _handle_pre_grep(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
             )
 
         resp: dict[str, Any] = {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "allow",
-                "additionalContext": "\n\n".join(parts),
-            },
+            "hookSpecificOutput": _payloads.emit_allow(
+                source="pre_grep_stale_warn",
+                additional_context="\n\n".join(parts),
+            ),
         }
         if stale_summaries:
             resp["status"] = "stale"

--- a/src/ccs/adapters/claude_code/hook_payloads.py
+++ b/src/ccs/adapters/claude_code/hook_payloads.py
@@ -8,24 +8,150 @@ coordinator accepts/emits. The cc_hook_stdin contract test in Unit 8
 round-trips realistic Claude Code hook stdin payloads through this
 contract; CI catches drift on every Claude Code minor version bump.
 
-Per-invocation variation in warning templates (per Unit 4 pre-flight):
-- Every additionalContext payload includes a timestamp + last-writer
-  session id, so the exact prose differs on every invocation. When
-  v0.2 strict mode swaps ``permissionDecision: "allow"`` → ``"deny"``,
-  the model receives a varying reason each time it retries — sidesteps
-  the empirical retry-loop hazard from brainstorm §13.5 where identical
-  deny reasons caused the model to retry with a fresh ``tool_use_id``.
+Per-invocation variation in WARN-mode templates (v0.1.1 design):
+- Every additionalContext payload on the WARN-mode allow path includes a
+  timestamp + last-writer session id, so the exact prose differs on every
+  invocation. The original §13.5 rationale was that varied text sidesteps
+  the model retry loop on identical denials. NOTE: the v0.2 Phase 0
+  falsifiability experiment (see ``docs/probes/2026-05-19-ktd-e-falsifiability/REPORT.md``)
+  inverted this finding for the DENY path — varied text actually WORSENS
+  opus (5 retries vs 2 with static text; opus reads varied deny text as
+  prompt-injection patterns and retries to disambiguate). v0.2 strict-mode
+  deny therefore uses a STATIC reason template
+  (``STRICT_MODE_DENY_REASON_TEMPLATE``) byte-stable across retries.
 
 Constraint per origin §7.4 + KTD-12: the structured ``summary`` metadata
 NEVER includes raw file content, content hashes themselves, diff text, or
 content-derived data. Only path / version / session-id / timestamp.
+
+v0.2 KTD-U structural invariant (security):
+- ``TERMINAL_DENIAL_CLASSES`` enumerates denial classes that MUST NEVER be
+  converted to ``permissionDecision: "allow"``. Every allow-emission path
+  routes through ``emit_allow()`` which asserts membership; tests in
+  ``tests/integration/test_strict_mode.py`` parametrize over the
+  call-site list and a meta-test grep-counts call sites in this file +
+  ``coordinator_server.py`` to force list extension on every new allow
+  path. See plan Unit 2 (KTD-P, KTD-Q, KTD-U).
 """
 
 from __future__ import annotations
 
 import time
 from datetime import datetime, timezone
-from typing import Literal, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
+
+
+# ----------------------------------------------------------------------
+# v0.2 strict-mode helpers — KTD-P (static deny text), KTD-U (terminal
+# denial invariant)
+# ----------------------------------------------------------------------
+
+
+TERMINAL_DENIAL_CLASSES: frozenset[str] = frozenset({
+    "permissions_deny_strict_mode",
+})
+"""KTD-U security invariant: denial classes that MUST NEVER be converted to
+``permissionDecision: "allow"``. Any code path emitting allow checks
+membership via :func:`emit_allow`; passing a terminal class raises
+AssertionError. Tests at ``tests/integration/test_strict_mode.py``
+parametrize the call-site list and meta-test the count so a future
+contributor adding a new allow path is forced to extend the parameter list
+(and therefore consider the invariant) rather than satisfying the test
+trivially. Adding a new terminal class extends the boundary; never remove
+an entry without a security review."""
+
+
+STRICT_MODE_DENY_REASON_TEMPLATE: str = (
+    "Stale read denied: {path} was updated by session {last_writer_short} "
+    "at {last_writer_ts_iso}. Re-read {path} via the Read tool before "
+    "proceeding. This denial is structural (v0.2 strict mode); retrying "
+    "the same operation will produce the same denial."
+)
+"""KTD-P static deny text. Byte-stable across retries of the same
+(session, artifact) staleness event because every substitution is
+deterministic per-artifact (path), per-preempter (last_writer_short), or
+per-commit-tick (last_writer_ts_iso). The Phase 0 H1 falsification proved
+varied deny text WORSENS opus behavior (5 retries vs 2 with static text);
+this template guards against accidental re-introduction of per-invocation
+fields. The format-string placeholder set is locked by
+``test_strict_mode_deny_reason_template_is_static``."""
+
+
+def emit_allow(
+    *,
+    source: str,
+    additional_context: str | None = None,
+    denial_class: str | None = None,
+) -> dict[str, Any]:
+    """Build the ``hookSpecificOutput`` envelope for a ``permissionDecision:
+    "allow"`` response. ALL allow emissions route through this helper.
+
+    KTD-U enforcement: if ``denial_class`` is in :data:`TERMINAL_DENIAL_CLASSES`,
+    raises ``AssertionError`` with a diagnostic naming the source call site.
+    A code path that knows it's converting a terminal-class denial back to
+    allow cannot satisfy this check; that's the structural invariant.
+
+    Args:
+        source: short identifier of the call site (e.g. ``"pre_read_fresh_with_notice"``).
+            Used by the KTD-U meta-test for parameter-list coverage and the
+            AssertionError diagnostic.
+        additional_context: optional ``additionalContext`` prose. Omitted when
+            None — the model gets a quiet allow.
+        denial_class: optional denial classification the caller is converting
+            to allow. Almost always ``None`` for legitimate allow paths; the
+            argument exists so tests can synthesize "this caller refuses to
+            convert TERMINAL_DENIAL_CLASSES inputs to allow."
+    """
+    assert denial_class not in TERMINAL_DENIAL_CLASSES, (
+        f"emit_allow(source={source!r}, denial_class={denial_class!r}): "
+        f"refused to convert TERMINAL_DENIAL_CLASSES member to allow. "
+        f"This is the KTD-U security invariant — strict-mode denials are "
+        f"structurally terminal."
+    )
+    out: dict[str, Any] = {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow",
+    }
+    if additional_context is not None:
+        out["additionalContext"] = additional_context
+    return out
+
+
+def emit_strict_deny(
+    *,
+    source: str,
+    summary: "StaleSummary",
+) -> dict[str, Any]:
+    """Build the ``hookSpecificOutput`` envelope for a v0.2 strict-mode
+    deny response.
+
+    The ``permissionDecisionReason`` is rendered via
+    :data:`STRICT_MODE_DENY_REASON_TEMPLATE` — static, byte-stable across
+    retries per KTD-P. The ``source`` argument is preserved for telemetry
+    (Unit 4 audit-log append) and parameter-list parity with :func:`emit_allow`.
+    """
+    last_writer_full = summary.get("last_writer_session_id") or "<unknown>"
+    # Preserve placeholder values like "<unknown>" verbatim — slicing to 8
+    # would lose the closing angle bracket and produce malformed prose
+    # ("<unknown" instead of "<unknown>"). Real UUIDv4 session ids are 36
+    # chars, so the 8-char short form is unambiguous when present.
+    if last_writer_full.startswith("<") and last_writer_full.endswith(">"):
+        last_writer_short = last_writer_full
+    else:
+        last_writer_short = last_writer_full[:8]
+    last_writer_ts_iso = datetime.fromtimestamp(
+        summary["last_writer_at_unix_ts"], tz=timezone.utc
+    ).isoformat()
+    reason = STRICT_MODE_DENY_REASON_TEMPLATE.format(
+        path=summary["path"],
+        last_writer_short=last_writer_short,
+        last_writer_ts_iso=last_writer_ts_iso,
+    )
+    return {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    }
 
 
 # ----------------------------------------------------------------------
@@ -247,15 +373,19 @@ def edit_collision_warning(
 
 
 def build_stale_response(summary: StaleSummary) -> dict:
-    """Top-level hookSpecificOutput for a stale-read PreToolUse response.
-    Returns a plain dict (not StaleResponse TypedDict) so JSON serializer
-    accepts it without runtime TypedDict gymnastics."""
+    """Top-level hookSpecificOutput for a v0.1.1 warn-mode stale-read
+    PreToolUse response. Routes through :func:`emit_allow` to satisfy the
+    KTD-U structural invariant.
+
+    Strict-mode callers must call :func:`emit_strict_deny` directly +
+    wrap the result; this builder is reserved for the warn-mode (allow)
+    path that v0.1.1 ships and v0.2 preserves for non-strict-mode
+    artifacts."""
     return {
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "allow",  # v0.1 warn-only; v0.2 may flip
-            "additionalContext": stale_read_warning(summary),
-        },
+        "hookSpecificOutput": emit_allow(
+            source="stale_response_builder",
+            additional_context=stale_read_warning(summary),
+        ),
         "status": "stale",
         "summary": summary,
     }
@@ -266,15 +396,19 @@ def build_collision_response(
     holder_acquired_at_unix_ts: float,
     path: str,
 ) -> dict:
-    """Top-level hookSpecificOutput for an edit-collision PreToolUse response."""
+    """Top-level hookSpecificOutput for an edit-collision PreToolUse response.
+
+    Edit collisions are distinct from stale-reads — the editor wants
+    EXCLUSIVE but another session holds it. v0.1.1 surfaces the collision
+    via warn-mode allow + additionalContext; v0.2 preserves this shape
+    (strict-mode flip applies to stale-reads, not contention)."""
     return {
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "allow",  # v0.1 warn-only
-            "additionalContext": edit_collision_warning(
+        "hookSpecificOutput": emit_allow(
+            source="collision_response_builder",
+            additional_context=edit_collision_warning(
                 holder_session_id, holder_acquired_at_unix_ts, path
             ),
-        },
+        ),
         "ok": True,
         "collision": True,
     }

--- a/tests/integration/test_strict_mode.py
+++ b/tests/integration/test_strict_mode.py
@@ -1,0 +1,442 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Integration tests for v0.2 strict-mode handler decision-flip (plan Unit 2).
+
+Covers (per plan Unit 2 Test scenarios):
+
+- Happy path: strict + tracked + stale on each of the 4 PreToolUse handlers
+  (Read, Edit/Write via pre-edit, Bash, Grep) returns ``permissionDecision:
+  "deny"`` with the static reason text.
+- Negative: strict + tracked + FRESH → allow (no stale-read).
+- Negative: tracked + NOT strict + stale → warn (v0.1.1 behavior unchanged).
+- Negative: NOT tracked + stale → allow passthrough (fast-path).
+- Edge: Bash multi-path where ONLY one path is strict → deny (any strict
+  match triggers).
+- Edge: static deny reason byte-stable across N retries (KTD-T; H1
+  falsification regression guard).
+- KTD-U structural invariant: parameterized over allow-emitting call sites;
+  each call site refuses to convert a TERMINAL_DENIAL_CLASSES-member input
+  to allow.
+- KTD-U coverage meta-test: the parameter list covers every call site of
+  ``emit_allow`` in ``coordinator_server.py`` + ``hook_payloads.py``
+  (static grep + count check).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+import pytest
+
+from ccs.adapters.claude_code.auth import load_secret
+from ccs.adapters.claude_code.coordinator_server import CoordinatorHTTPServer
+from ccs.adapters.claude_code.hook_payloads import (
+    STRICT_MODE_DENY_REASON_TEMPLATE,
+    TERMINAL_DENIAL_CLASSES,
+    emit_allow,
+)
+
+
+# ----------------------------------------------------------------------
+# Test plumbing — mirrors tests/test_claude_code_coordinator_server.py
+# ----------------------------------------------------------------------
+
+
+_TEST_SESSION_NS = uuid.UUID("11111111-1111-4111-8111-111111111111")
+
+
+def _sid(label: str) -> str:
+    return str(uuid.uuid5(_TEST_SESSION_NS, f"strict-mode-test:{label}"))
+
+
+def _hash(label: str) -> str:
+    return hashlib.sha256(label.encode()).hexdigest()
+
+
+class _Client:
+    """Tiny urllib client mirroring test_claude_code_coordinator_server._Client."""
+
+    def __init__(self, host: str, port: int, secret: str) -> None:
+        self.base = f"http://{host}:{port}"
+        self.headers = {
+            "Authorization": f"Bearer {secret}",
+            "Host": "127.0.0.1",
+            "Content-Type": "application/json",
+        }
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: Optional[dict] = None,
+    ) -> tuple[int, dict]:
+        url = self.base + path
+        data = json.dumps(body).encode("utf-8") if body is not None else b""
+        req = urlrequest.Request(
+            url,
+            data=data if method == "POST" else None,
+            method=method,
+            headers=self.headers,
+        )
+        try:
+            with urlrequest.urlopen(req, timeout=10) as resp:
+                return resp.status, json.loads(resp.read().decode("utf-8") or "{}")
+        except urlerror.HTTPError as e:
+            return e.code, json.loads(e.read().decode("utf-8") or "{}")
+
+    def post(self, path: str, body: dict) -> tuple[int, dict]:
+        return self.request("POST", path, body)
+
+    def get(self, path: str) -> tuple[int, dict]:
+        return self.request("GET", path)
+
+
+def _write_policy(workspace: Path, *, tracked: list[str], strict: list[str]) -> None:
+    """Materialize tracked.yaml + strict_mode.yaml under .coherence/."""
+    coherence_dir = workspace / ".coherence"
+    coherence_dir.mkdir(exist_ok=True, mode=0o700)
+    if tracked:
+        (coherence_dir / "tracked.yaml").write_text(
+            "\n".join(f"- {p}" for p in tracked) + "\n"
+        )
+    if strict:
+        (coherence_dir / "strict_mode.yaml").write_text(
+            "\n".join(f"- {p}" for p in strict) + "\n"
+        )
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """A fresh workspace per test."""
+    return tmp_path
+
+
+@pytest.fixture
+def strict_coordinator(workspace: Path):
+    """Coordinator with CLAUDE.md tracked + strict, plan.md tracked + strict,
+    docs/plans/x.md tracked + warn-mode (NOT strict). Matches the most common
+    test scenario shape across this file."""
+    _write_policy(
+        workspace,
+        tracked=["CLAUDE.md", "plan.md", "docs/plans/x.md"],
+        strict=["CLAUDE.md", "plan.md"],
+    )
+    server = CoordinatorHTTPServer(workspace, port=0, instance_id="strict-mode-test")
+    server.serve_in_thread()
+    time.sleep(0.05)
+    try:
+        yield server
+    finally:
+        server.shutdown()
+
+
+@pytest.fixture
+def strict_client(strict_coordinator) -> _Client:
+    secret = load_secret(strict_coordinator.coordinator_root)
+    assert secret is not None
+    return _Client("127.0.0.1", strict_coordinator.port, secret)
+
+
+# ----------------------------------------------------------------------
+# Happy path — strict deny on each handler (4 surfaces)
+# ----------------------------------------------------------------------
+
+
+def _setup_stale(client: _Client, path: str) -> None:
+    """Set up the canonical stale scenario: sessions A and B both read path
+    (each takes SHARED), B edits + commits (acquires EXCLUSIVE then MODIFIED,
+    invalidates A), leaving A in INVALID state on path. The caller's NEXT
+    operation on path from session A is the stale event under test.
+
+    Both sessions must pre-read first because v0.2 strict-mode pre-edit
+    requires the editor to have a fresh grant — an editor without prior
+    read on a strict-mode artifact gets strict-deny (correct behavior;
+    matches the operator's intent "agent MUST re-read before edit")."""
+    client.post("/hooks/pre-read",
+                {"session_id": _sid("A"), "path": path, "content_hash": _hash("v1")})
+    client.post("/hooks/pre-read",
+                {"session_id": _sid("B"), "path": path, "content_hash": _hash("v1")})
+    client.post("/hooks/pre-edit",
+                {"session_id": _sid("B"), "path": path})
+    client.post("/hooks/post-edit",
+                {"session_id": _sid("B"), "path": path,
+                 "content_hash": _hash("v2"), "success": True})
+
+
+def test_pre_read_strict_tracked_stale_denies(strict_client: _Client) -> None:
+    """Read on a strict + tracked + stale artifact returns deny + static reason."""
+    _setup_stale(strict_client, "CLAUDE.md")
+    status, body = strict_client.post(
+        "/hooks/pre-read",
+        {"session_id": _sid("A"), "path": "CLAUDE.md", "content_hash": _hash("v1")},
+    )
+    assert status == 200
+    out = body["hookSpecificOutput"]
+    assert out["permissionDecision"] == "deny"
+    assert out["hookEventName"] == "PreToolUse"
+    assert "permissionDecisionReason" in out
+    reason = out["permissionDecisionReason"]
+    assert "CLAUDE.md" in reason
+    assert "Re-read" in reason
+
+
+def test_pre_edit_strict_tracked_stale_denies(strict_client: _Client) -> None:
+    """Edit on a strict + tracked + stale artifact returns deny (the Edit/Write
+    surface — pre-edit handles both per the hooks.json matcher Edit|Write)."""
+    _setup_stale(strict_client, "plan.md")
+    # Session A tries to edit plan.md without re-reading.
+    status, body = strict_client.post(
+        "/hooks/pre-edit",
+        {"session_id": _sid("A"), "path": "plan.md"},
+    )
+    assert status == 200
+    out = body["hookSpecificOutput"]
+    assert out["permissionDecision"] == "deny"
+    assert out["hookEventName"] == "PreToolUse"
+    assert "plan.md" in out["permissionDecisionReason"]
+
+
+def test_pre_bash_strict_tracked_stale_denies(strict_client: _Client) -> None:
+    """Bash command that reads a strict + tracked + stale artifact denies."""
+    _setup_stale(strict_client, "plan.md")
+    status, body = strict_client.post(
+        "/hooks/pre-bash",
+        {"session_id": _sid("A"), "command": "cat plan.md"},
+    )
+    assert status == 200
+    out = body["hookSpecificOutput"]
+    assert out["permissionDecision"] == "deny"
+    assert "plan.md" in out["permissionDecisionReason"]
+
+
+def test_pre_grep_strict_tracked_stale_denies(strict_client: _Client) -> None:
+    """Grep over a directory containing a strict + tracked + stale artifact
+    denies the whole grep command."""
+    _setup_stale(strict_client, "plan.md")
+    status, body = strict_client.post(
+        "/hooks/pre-grep",
+        {"session_id": _sid("A"), "search_root": ""},
+    )
+    assert status == 200
+    out = body["hookSpecificOutput"]
+    assert out["permissionDecision"] == "deny"
+    assert "plan.md" in out["permissionDecisionReason"]
+
+
+# ----------------------------------------------------------------------
+# Negative paths — preserve v0.1.1 warn-mode behavior for non-strict
+# ----------------------------------------------------------------------
+
+
+def test_pre_read_strict_tracked_fresh_allows(strict_client: _Client) -> None:
+    """Strict + tracked + FRESH (no stale event) returns the fresh allow shape
+    — no deny when the artifact is up to date for this session."""
+    status, body = strict_client.post(
+        "/hooks/pre-read",
+        {"session_id": _sid("A"), "path": "CLAUDE.md", "content_hash": _hash("v1")},
+    )
+    assert status == 200
+    # First observation seeds SHARED → fresh response, no hookSpecificOutput.
+    assert body == {"status": "fresh"}
+
+
+def test_pre_read_tracked_not_strict_stale_returns_warn(strict_client: _Client) -> None:
+    """Tracked + NOT strict + stale returns warn-mode allow (v0.1.1 behavior
+    preserved for warn-mode artifacts even when strict_mode is configured for
+    other artifacts in the same workspace)."""
+    # docs/plans/x.md is tracked but NOT in strict_mode_paths.
+    _setup_stale(strict_client, "docs/plans/x.md")
+    status, body = strict_client.post(
+        "/hooks/pre-read",
+        {"session_id": _sid("A"), "path": "docs/plans/x.md", "content_hash": _hash("v1")},
+    )
+    assert status == 200
+    out = body["hookSpecificOutput"]
+    assert out["permissionDecision"] == "allow"
+    assert "Stale read" in out["additionalContext"]
+
+
+def test_pre_read_untracked_path_strict_irrelevant(strict_client: _Client) -> None:
+    """Untracked path takes the policy fast-path; strict mode never applies."""
+    status, body = strict_client.post(
+        "/hooks/pre-read",
+        {"session_id": _sid("A"), "path": "untracked.txt"},
+    )
+    assert status == 200
+    assert body == {"status": "fresh"}
+
+
+# ----------------------------------------------------------------------
+# Edge cases
+# ----------------------------------------------------------------------
+
+
+def test_pre_bash_multi_path_one_strict_one_warn_denies(strict_client: _Client) -> None:
+    """`cat plan.md docs/plans/x.md` — plan.md is strict, docs/plans/x.md is
+    warn-only. ANY strict-stale match triggers deny for the whole command."""
+    _setup_stale(strict_client, "plan.md")           # strict
+    _setup_stale(strict_client, "docs/plans/x.md")  # warn-only
+    status, body = strict_client.post(
+        "/hooks/pre-bash",
+        {"session_id": _sid("A"), "command": "cat plan.md docs/plans/x.md"},
+    )
+    assert status == 200
+    out = body["hookSpecificOutput"]
+    assert out["permissionDecision"] == "deny"
+    assert "plan.md" in out["permissionDecisionReason"]
+
+
+def test_pre_bash_only_warn_paths_still_allows(strict_client: _Client) -> None:
+    """If a Bash command touches only warn-mode tracked artifacts (none in
+    strict), the v0.1.1 warn-mode allow shape is preserved."""
+    _setup_stale(strict_client, "docs/plans/x.md")
+    status, body = strict_client.post(
+        "/hooks/pre-bash",
+        {"session_id": _sid("A"), "command": "cat docs/plans/x.md"},
+    )
+    assert status == 200
+    assert body["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+def test_strict_deny_reason_byte_stable_across_retries(strict_client: _Client) -> None:
+    """KTD-T (H1 falsification regression guard): the deny reason MUST be
+    byte-identical across N retries of the same (session, path) staleness
+    event. Per-invocation timestamp variation would re-introduce the opus
+    prompt-injection retry hazard the Phase 0 falsifiability experiment
+    surfaced."""
+    _setup_stale(strict_client, "CLAUDE.md")
+    reasons: list[str] = []
+    for _ in range(5):
+        _, body = strict_client.post(
+            "/hooks/pre-read",
+            {"session_id": _sid("A"), "path": "CLAUDE.md", "content_hash": _hash("v1")},
+        )
+        reasons.append(body["hookSpecificOutput"]["permissionDecisionReason"])
+    assert len(set(reasons)) == 1, (
+        f"Deny reason rotated across retries — KTD-P invariant violated. "
+        f"Unique reasons: {set(reasons)}"
+    )
+
+
+# ----------------------------------------------------------------------
+# KTD-U structural invariant: emit_allow refuses terminal-denial conversion
+# ----------------------------------------------------------------------
+
+
+# Parameter list: ALL call sites of emit_allow in coordinator_server.py +
+# hook_payloads.py. The meta-test below grep-counts emit_allow calls in those
+# files and asserts this list has the same length. Adding a new emit_allow
+# call site MUST extend this parameter list — that's the structural guarantee
+# Unit 2's KTD-U design provides.
+ALLOW_EMISSION_SOURCES: list[str] = [
+    "stale_response_builder",        # hook_payloads.build_stale_response
+    "collision_response_builder",    # hook_payloads.build_collision_response
+    "pre_read_fresh_with_notice",    # coordinator_server._handle_pre_read
+    "pre_edit_notice_only",          # coordinator_server._handle_pre_edit
+    "pre_bash_stale_warn",           # coordinator_server._handle_pre_bash
+    "pre_grep_stale_warn",           # coordinator_server._handle_pre_grep
+]
+
+
+@pytest.mark.parametrize("source", ALLOW_EMISSION_SOURCES)
+def test_emit_allow_refuses_terminal_denial_class(source: str) -> None:
+    """KTD-U invariant (structural, not behavioral): for every allow-emitting
+    call site, ``emit_allow`` with a TERMINAL_DENIAL_CLASSES-member denial_class
+    raises AssertionError. A future contributor cannot satisfy the test
+    trivially by adding a new allow path — they must extend the parameter
+    list and therefore think about the invariant."""
+    terminal_class = next(iter(TERMINAL_DENIAL_CLASSES))
+    with pytest.raises(AssertionError, match="TERMINAL_DENIAL_CLASSES"):
+        emit_allow(source=source, denial_class=terminal_class)
+
+
+def test_emit_allow_passes_for_non_terminal_class() -> None:
+    """Sanity: emit_allow returns the allow envelope when denial_class is
+    None or not in the terminal set."""
+    out = emit_allow(source="sanity_test", additional_context="hello")
+    assert out["permissionDecision"] == "allow"
+    assert out["hookEventName"] == "PreToolUse"
+    assert out["additionalContext"] == "hello"
+
+
+def test_terminal_denial_classes_includes_strict_mode_deny() -> None:
+    """The strict-mode deny class is in TERMINAL_DENIAL_CLASSES. This is the
+    security marker the deny path uses."""
+    assert "permissions_deny_strict_mode" in TERMINAL_DENIAL_CLASSES
+
+
+# ----------------------------------------------------------------------
+# KTD-U coverage meta-test: parameter list covers every emit_allow call
+# ----------------------------------------------------------------------
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCANNED_FILES = (
+    _REPO_ROOT / "src" / "ccs" / "adapters" / "claude_code" / "coordinator_server.py",
+    _REPO_ROOT / "src" / "ccs" / "adapters" / "claude_code" / "hook_payloads.py",
+)
+
+
+def _count_emit_allow_call_sites(path: Path) -> int:
+    """AST-based call-site counter. Matches only real ``emit_allow(...)``
+    Call nodes — not docstring mentions, error-message strings, or the
+    function definition itself."""
+    import ast
+
+    tree = ast.parse(path.read_text())
+    count = 0
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "emit_allow":
+                count += 1
+            elif isinstance(func, ast.Attribute) and func.attr == "emit_allow":
+                count += 1
+    return count
+
+
+def test_ktd_u_emit_allow_call_sites_covered_by_parameter_list() -> None:
+    """AST scan: total real ``emit_allow(...)`` call sites across
+    coordinator_server.py + hook_payloads.py must equal
+    ``len(ALLOW_EMISSION_SOURCES)``. Adding a new emit_allow call site
+    requires extending the parameter list — that's the structural guarantee
+    that future code reviews catch the invariant discussion before the new
+    site can land."""
+    call_count = sum(_count_emit_allow_call_sites(p) for p in _SCANNED_FILES)
+    assert call_count == len(ALLOW_EMISSION_SOURCES), (
+        f"emit_allow() call sites in scanned files: {call_count}; "
+        f"ALLOW_EMISSION_SOURCES parameter list: {len(ALLOW_EMISSION_SOURCES)}. "
+        f"Extend ALLOW_EMISSION_SOURCES or audit the new call site for KTD-U "
+        f"invariant compliance."
+    )
+
+
+# ----------------------------------------------------------------------
+# Static reason template format string sanity
+# ----------------------------------------------------------------------
+
+
+def test_strict_mode_deny_reason_template_is_static() -> None:
+    """KTD-P (static deny text, NO template rotation). The template is a
+    module-level constant; this test guards against accidental
+    timestamp-of-rendering interpolation that would violate byte-stability."""
+    expected_placeholders = {"path", "last_writer_short", "last_writer_ts_iso"}
+    # Extract format-string placeholders.
+    actual = set(
+        m.group(1) for m in re.finditer(r"\{([a-z_]+)\}", STRICT_MODE_DENY_REASON_TEMPLATE)
+    )
+    assert actual == expected_placeholders, (
+        f"STRICT_MODE_DENY_REASON_TEMPLATE placeholders changed: "
+        f"expected {expected_placeholders}, got {actual}. Adding a "
+        f"per-invocation field (e.g., warning_generated_at) violates "
+        f"KTD-P byte-stability."
+    )


### PR DESCRIPTION
## Summary

- v0.2 Phase A meat: all 4 PreToolUse handlers (Read, Edit/Write, Bash, Grep) flip permissionDecision from `"allow"` to `"deny"` when the artifact is in strict_mode_paths AND the session was previously invalidated.
- v0.1.1 warn-mode behavior preserved byte-identical for every artifact NOT in `strict_mode_paths` — no regression on the 214 existing coordinator/policy/contract tests.
- KTD-U structural security invariant codified: TERMINAL_DENIAL_CLASSES + emit_allow guard + AST-based meta-test that forces parameter-list extension on every new allow-emission call site.

## Key design decisions

| KTD | Decision |
|---|---|
| **O** | strict mode is intersection of tracked + strict_mode_paths (foundation in Unit 1). |
| **P** | Static deny text via `STRICT_MODE_DENY_REASON_TEMPLATE` — all substitutions deterministic per (artifact, version, preempter); no `warning_generated_at` or other call-time fields. Phase 0 H1 falsification proved varied deny text WORSENS opus. |
| **Q** | 4 handlers, 5 tool surfaces (Edit + Write share pre-edit per hooks.json `Edit\|Write` matcher). Bash/Grep deny on first strict-stale path in the detected set ("any match triggers"). |
| **T** | Strict-deny does NOT re-grant SHARED — state stays INVALID across retry loop so every retry produces byte-identical deny reason; model exits the loop after 2-5 attempts per Phase 0. |
| **U** | `TERMINAL_DENIAL_CLASSES` + `emit_allow` helper + 6 refactored allow-emission sites + parameterized integration test + AST-based meta-test that grep-counts `emit_allow(...)` calls. |

## Semantic refinement during implementation

Strict-deny fires only on `agent_state == MESIState.INVALID` (true preemption). A first-time observer with `state == None` on an existing artifact falls through to v0.1.1 warn-mode allow + additionalContext. The operator's intent is "must re-read AFTER invalidation," not "must read before any cross-session activity exists." Documented in the new branch comments.

## Test plan

- [x] `pytest tests/integration/test_strict_mode.py -v` → 20 passed
- [x] `pytest tests/test_claude_code_coordinator_server.py tests/test_claude_code_policy*.py tests/test_claude_code_contract.py -q` → 214 passed (v0.1.1 warn-mode regression clean)
- [x] `pytest -m protocol_corpus -q` → 22 passed (no wire-shape drift on the Unit 7a baseline)
- [x] `pytest -q` (full default suite) → 1286 passed, 2 skipped, 24 deselected
- [x] `tools/check_architecture.py` → clean
- [ ] CI green on this PR

## What's in the diff

| File | Change |
|---|---|
| `src/ccs/adapters/claude_code/hook_payloads.py` | +178 lines: `TERMINAL_DENIAL_CLASSES`, `STRICT_MODE_DENY_REASON_TEMPLATE`, `emit_allow()`, `emit_strict_deny()`, refactor `build_stale_response` + `build_collision_response` to route through `emit_allow`, file-top docstring updated for Phase 0 H1 finding. |
| `src/ccs/adapters/claude_code/coordinator_server.py` | +194 lines: strict-deny branches in all 4 PreToolUse handlers; inline allow literals refactored to call `emit_allow`; multi-path strict-deny short-circuit in pre-bash + pre-grep. |
| `tests/integration/test_strict_mode.py` | New file — 20 tests: 4 handler happy-path denies, 4 negative paths (fresh, warn-only, untracked, bash-only-warn), Bash multi-path edge, KTD-T byte-stability, 6-site KTD-U parameterized + meta-test, template format-lock. |

## Plan reference

`docs/plans/2026-05-20-001-feat-claude-code-coherence-plugin-v0.2-strict-mode-plan.md` Unit 2.

Phase A dependency chain: Unit 1 (merged #55) → **Unit 2 (this PR)** → Unit 7b (strict-mode corpus fixtures, blocked on this merge).