### PR TITLE
feat(tests): strict-mode protocol corpus fixtures (v0.2 Unit 7b)

### DIFF
--- a/tests/protocol_corpus/fixtures/strict_mode/01-pre-read-strict-tracked-stale-denies.json
+++ b/tests/protocol_corpus/fixtures/strict_mode/01-pre-read-strict-tracked-stale-denies.json
@@ -1,0 +1,51 @@
+{
+  "name": "pre-read-strict-tracked-stale-denies",
+  "description": "Canonical strict-mode deny flow on /hooks/pre-read. Sessions A and B both pre-read v1, B pre-edits + post-edits v2 (invalidates A). A's next pre-read on the strict-tracked artifact returns permissionDecision:'deny' with the static reason template per KTD-P. This is the regression net for Unit 2's KTD-O/P/T decisions.",
+  "setup": {
+    "tracked": ["CLAUDE.md"],
+    "strict_mode": ["CLAUDE.md"],
+    "files": {"CLAUDE.md": "# Project rules\nv1 content\n"},
+    "preflight_requests": [
+      {"method": "POST", "path": "/hooks/pre-read",
+       "body": {"session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+                "path": "CLAUDE.md",
+                "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"}},
+      {"method": "POST", "path": "/hooks/pre-read",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "CLAUDE.md",
+                "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"}},
+      {"method": "POST", "path": "/hooks/pre-edit",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "CLAUDE.md"}},
+      {"method": "POST", "path": "/hooks/post-edit",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "CLAUDE.md",
+                "content_hash": "ad0f2f1b1e8d8c5a8c2e6f4b0d3a7b5e9c8f1e2d3a4b5c6d7e8f9a0b1c2d3e4f",
+                "success": true}}
+    ]
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-read",
+    "body": {
+      "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+      "path": "CLAUDE.md",
+      "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"
+    }
+  },
+  "ignore_keys": ["permissionDecisionReason", "summary"],
+  "expected": {
+    "status": 200,
+    "body": {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": "<IGNORED>"
+      },
+      "status": "stale",
+      "summary": "<IGNORED>"
+    }
+  },
+  "_comment": "permissionDecisionReason text is asserted at the unit-test level (test_strict_deny_reason_byte_stable_across_retries + test_strict_mode_deny_reason_template_is_static in tests/integration/test_strict_mode.py); corpus level only asserts the WIRE SHAPE (permissionDecision='deny', presence of permissionDecisionReason). summary is normalized because its timestamps/versions vary per setup invocation.",
+  "backends": ["python"]
+}

--- a/tests/protocol_corpus/fixtures/strict_mode/02-pre-read-strict-tracked-fresh-allows.json
+++ b/tests/protocol_corpus/fixtures/strict_mode/02-pre-read-strict-tracked-fresh-allows.json
@@ -1,0 +1,23 @@
+{
+  "name": "pre-read-strict-tracked-fresh-allows",
+  "description": "Strict-mode artifact + first observation by a session = fresh allow (no deny). This is the negative-test counterpart to fixture 01 — strict mode only denies on TRUE preemption (state == INVALID), not on first observation. Documents the v0.2 semantic refinement: strict mode means 'must re-read after invalidation,' not 'must read before any cross-session activity.'",
+  "setup": {
+    "tracked": ["CLAUDE.md"],
+    "strict_mode": ["CLAUDE.md"],
+    "files": {"CLAUDE.md": "# Project rules\n"}
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-read",
+    "body": {
+      "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+      "path": "CLAUDE.md",
+      "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"
+    }
+  },
+  "expected": {
+    "status": 200,
+    "body": {"status": "fresh"}
+  },
+  "backends": ["python"]
+}

--- a/tests/protocol_corpus/fixtures/strict_mode/03-pre-read-strict-mode-set-but-untracked-path.json
+++ b/tests/protocol_corpus/fixtures/strict_mode/03-pre-read-strict-mode-set-but-untracked-path.json
@@ -1,0 +1,21 @@
+{
+  "name": "pre-read-strict-mode-set-but-untracked-path",
+  "description": "Workspace has strict_mode.yaml configured, but the requested path is not in the tracked set. The is_tracked policy fast-path fires BEFORE any strict-mode check (per KTD-O intersection semantics), returning fresh. This guards against the failure mode where strict_mode_paths leaks into untracked paths.",
+  "setup": {
+    "tracked": ["CLAUDE.md"],
+    "strict_mode": ["CLAUDE.md"]
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-read",
+    "body": {
+      "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+      "path": "untracked-file.txt"
+    }
+  },
+  "expected": {
+    "status": 200,
+    "body": {"status": "fresh"}
+  },
+  "backends": ["python"]
+}

--- a/tests/protocol_corpus/fixtures/strict_mode/04-pre-read-tracked-but-not-strict-falls-through-to-warn.json
+++ b/tests/protocol_corpus/fixtures/strict_mode/04-pre-read-tracked-but-not-strict-falls-through-to-warn.json
@@ -1,0 +1,51 @@
+{
+  "name": "pre-read-tracked-but-not-strict-falls-through-to-warn",
+  "description": "Artifact is in tracked.yaml but NOT in strict_mode.yaml. After preemption, A's re-read gets v0.1.1 warn-mode allow + additionalContext — strict_mode_paths only affects artifacts explicitly opted in. Regression guard for the byte-identical-warn-mode invariant under § Unit 2 Verification.",
+  "setup": {
+    "tracked": ["CLAUDE.md", "docs/plans/x.md"],
+    "strict_mode": ["CLAUDE.md"],
+    "files": {"docs/plans/x.md": "# X\nv1\n"},
+    "preflight_requests": [
+      {"method": "POST", "path": "/hooks/pre-read",
+       "body": {"session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+                "path": "docs/plans/x.md",
+                "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"}},
+      {"method": "POST", "path": "/hooks/pre-read",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "docs/plans/x.md",
+                "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"}},
+      {"method": "POST", "path": "/hooks/pre-edit",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "docs/plans/x.md"}},
+      {"method": "POST", "path": "/hooks/post-edit",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "docs/plans/x.md",
+                "content_hash": "ad0f2f1b1e8d8c5a8c2e6f4b0d3a7b5e9c8f1e2d3a4b5c6d7e8f9a0b1c2d3e4f",
+                "success": true}}
+    ]
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-read",
+    "body": {
+      "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+      "path": "docs/plans/x.md",
+      "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"
+    }
+  },
+  "ignore_keys": ["additionalContext", "summary"],
+  "expected": {
+    "status": 200,
+    "body": {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow",
+        "additionalContext": "<IGNORED>"
+      },
+      "status": "stale",
+      "summary": "<IGNORED>"
+    }
+  },
+  "_comment": "additionalContext text is per-invocation-varying (warn-mode template carries timestamps); corpus asserts only the wire shape (permissionDecision='allow', additionalContext present, status='stale').",
+  "backends": ["python"]
+}

--- a/tests/protocol_corpus/fixtures/strict_mode/05-pre-edit-strict-tracked-stale-denies.json
+++ b/tests/protocol_corpus/fixtures/strict_mode/05-pre-edit-strict-tracked-stale-denies.json
@@ -1,0 +1,50 @@
+{
+  "name": "pre-edit-strict-tracked-stale-denies",
+  "description": "Pre-edit on a strict + tracked + preempted artifact denies before acquiring EXCLUSIVE. The editor must re-read first per KTD-Q's Edit/Write surface (hooks.json matcher Edit|Write routes both to /hooks/pre-edit). Wire shape: {ok: false, hookSpecificOutput: deny, status: stale, summary}.",
+  "setup": {
+    "tracked": ["plan.md"],
+    "strict_mode": ["plan.md"],
+    "files": {"plan.md": "# Plan\nv1\n"},
+    "preflight_requests": [
+      {"method": "POST", "path": "/hooks/pre-read",
+       "body": {"session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+                "path": "plan.md",
+                "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"}},
+      {"method": "POST", "path": "/hooks/pre-read",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "plan.md",
+                "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"}},
+      {"method": "POST", "path": "/hooks/pre-edit",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "plan.md"}},
+      {"method": "POST", "path": "/hooks/post-edit",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "plan.md",
+                "content_hash": "ad0f2f1b1e8d8c5a8c2e6f4b0d3a7b5e9c8f1e2d3a4b5c6d7e8f9a0b1c2d3e4f",
+                "success": true}}
+    ]
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-edit",
+    "body": {
+      "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+      "path": "plan.md"
+    }
+  },
+  "ignore_keys": ["permissionDecisionReason", "summary"],
+  "expected": {
+    "status": 200,
+    "body": {
+      "ok": false,
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": "<IGNORED>"
+      },
+      "status": "stale",
+      "summary": "<IGNORED>"
+    }
+  },
+  "backends": ["python"]
+}

--- a/tests/protocol_corpus/fixtures/strict_mode/06-pre-bash-strict-tracked-stale-denies.json
+++ b/tests/protocol_corpus/fixtures/strict_mode/06-pre-bash-strict-tracked-stale-denies.json
@@ -1,0 +1,49 @@
+{
+  "name": "pre-bash-strict-tracked-stale-denies",
+  "description": "Bash command that reads a strict + tracked + preempted artifact denies the whole command. KTD-Q multi-tool coverage: this is the Bash surface for the H4 routing pattern (model routes around denied Read via `bash cat plan.md`). Wire shape: {hookSpecificOutput: deny, status: stale, stale_paths: [path]}.",
+  "setup": {
+    "tracked": ["plan.md"],
+    "strict_mode": ["plan.md"],
+    "files": {"plan.md": "# Plan\nv1\n"},
+    "preflight_requests": [
+      {"method": "POST", "path": "/hooks/pre-read",
+       "body": {"session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+                "path": "plan.md",
+                "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"}},
+      {"method": "POST", "path": "/hooks/pre-read",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "plan.md",
+                "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"}},
+      {"method": "POST", "path": "/hooks/pre-edit",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "plan.md"}},
+      {"method": "POST", "path": "/hooks/post-edit",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "plan.md",
+                "content_hash": "ad0f2f1b1e8d8c5a8c2e6f4b0d3a7b5e9c8f1e2d3a4b5c6d7e8f9a0b1c2d3e4f",
+                "success": true}}
+    ]
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-bash",
+    "body": {
+      "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+      "command": "cat plan.md"
+    }
+  },
+  "ignore_keys": ["permissionDecisionReason"],
+  "expected": {
+    "status": 200,
+    "body": {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": "<IGNORED>"
+      },
+      "status": "stale",
+      "stale_paths": ["plan.md"]
+    }
+  },
+  "backends": ["python"]
+}

--- a/tests/protocol_corpus/fixtures/strict_mode/07-pre-bash-multi-path-one-strict-one-warn-denies.json
+++ b/tests/protocol_corpus/fixtures/strict_mode/07-pre-bash-multi-path-one-strict-one-warn-denies.json
@@ -1,0 +1,56 @@
+{
+  "name": "pre-bash-multi-path-one-strict-one-warn-denies",
+  "description": "Bash command `cat plan.md docs/plans/x.md` where plan.md is strict + preempted and docs/plans/x.md is tracked-but-warn-only + preempted. ANY strict-stale match triggers deny for the WHOLE command per the plan's KTD-Q edge case. The stale_paths array still reflects all preempted paths in the command (both plan.md and docs/plans/x.md surface as stale).",
+  "setup": {
+    "tracked": ["plan.md", "docs/plans/x.md"],
+    "strict_mode": ["plan.md"],
+    "files": {"plan.md": "# Plan\nv1\n", "docs/plans/x.md": "# X\nv1\n"},
+    "preflight_requests": [
+      {"method": "POST", "path": "/hooks/pre-read",
+       "body": {"session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+                "path": "plan.md", "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"}},
+      {"method": "POST", "path": "/hooks/pre-read",
+       "body": {"session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+                "path": "docs/plans/x.md", "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"}},
+      {"method": "POST", "path": "/hooks/pre-read",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "plan.md", "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"}},
+      {"method": "POST", "path": "/hooks/pre-read",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "docs/plans/x.md", "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"}},
+      {"method": "POST", "path": "/hooks/pre-edit",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002", "path": "plan.md"}},
+      {"method": "POST", "path": "/hooks/post-edit",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002", "path": "plan.md",
+                "content_hash": "ad0f2f1b1e8d8c5a8c2e6f4b0d3a7b5e9c8f1e2d3a4b5c6d7e8f9a0b1c2d3e4f", "success": true}},
+      {"method": "POST", "path": "/hooks/pre-edit",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002", "path": "docs/plans/x.md"}},
+      {"method": "POST", "path": "/hooks/post-edit",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002", "path": "docs/plans/x.md",
+                "content_hash": "be1f3a2c2e9e9d6b9d3e7f5c1e4b8c6f0d9e3f4a5b6c7d8e9f0a1b2c3d4e5f6a", "success": true}}
+    ]
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-bash",
+    "body": {
+      "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+      "command": "cat plan.md docs/plans/x.md"
+    }
+  },
+  "ignore_keys": ["permissionDecisionReason", "stale_paths"],
+  "expected": {
+    "status": 200,
+    "body": {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": "<IGNORED>"
+      },
+      "status": "stale",
+      "stale_paths": "<IGNORED>"
+    }
+  },
+  "_comment": "stale_paths ordering is non-deterministic (depends on bash_path_detector iteration order); ignored at corpus level. Existence and shape ('stale') are asserted.",
+  "backends": ["python"]
+}

--- a/tests/protocol_corpus/fixtures/strict_mode/08-pre-grep-strict-tracked-stale-denies.json
+++ b/tests/protocol_corpus/fixtures/strict_mode/08-pre-grep-strict-tracked-stale-denies.json
@@ -1,0 +1,44 @@
+{
+  "name": "pre-grep-strict-tracked-stale-denies",
+  "description": "Grep over the workspace root denies when the search range covers a strict + tracked + preempted artifact. KTD-Q Grep surface — closes the bypass route where the model routes around a denied Read via Grep. Wire shape mirrors pre-bash strict-deny.",
+  "setup": {
+    "tracked": ["plan.md"],
+    "strict_mode": ["plan.md"],
+    "files": {"plan.md": "# Plan\nv1\n"},
+    "preflight_requests": [
+      {"method": "POST", "path": "/hooks/pre-read",
+       "body": {"session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+                "path": "plan.md", "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"}},
+      {"method": "POST", "path": "/hooks/pre-read",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+                "path": "plan.md", "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"}},
+      {"method": "POST", "path": "/hooks/pre-edit",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002", "path": "plan.md"}},
+      {"method": "POST", "path": "/hooks/post-edit",
+       "body": {"session_id": "bbbbbbbb-0000-4000-8000-000000000002", "path": "plan.md",
+                "content_hash": "ad0f2f1b1e8d8c5a8c2e6f4b0d3a7b5e9c8f1e2d3a4b5c6d7e8f9a0b1c2d3e4f", "success": true}}
+    ]
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-grep",
+    "body": {
+      "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+      "search_root": ""
+    }
+  },
+  "ignore_keys": ["permissionDecisionReason", "stale_paths"],
+  "expected": {
+    "status": 200,
+    "body": {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": "<IGNORED>"
+      },
+      "status": "stale",
+      "stale_paths": "<IGNORED>"
+    }
+  },
+  "backends": ["python"]
+}

--- a/tests/protocol_corpus/harness.py
+++ b/tests/protocol_corpus/harness.py
@@ -273,8 +273,15 @@ def apply_setup(workspace: Path, setup: dict[str, Any]) -> None:
 
     - ``files``: writes named files relative to the workspace root.
     - ``tracked``: writes ``.coherence/tracked.yaml`` with one path per line.
-    - ``policy``: NOT IMPLEMENTED yet — strict-mode-fixture-only; lands in
-      Unit 7b alongside Unit 2's strict-mode wire shape additions."""
+    - ``ignored``: writes ``.coherence/ignored.yaml`` with one path per line.
+    - ``strict_mode``: writes ``.coherence/strict_mode.yaml`` with one path
+      per line (Unit 7b — strict-mode-fixture support; the Node coordinator
+      doesn't ship strict_mode.yaml loading in v0.2 so strict fixtures are
+      python-only).
+    - ``preflight_requests``: list of request dicts fired BEFORE the main
+      test request; responses ignored. Used to drive multi-step setup like
+      "session A reads → session B preempts → A re-reads (the test request)".
+      Schema mirrors the top-level ``request``: ``{method, path, body, headers}``."""
     coherence_dir = workspace / ".coherence"
     coherence_dir.mkdir(exist_ok=True, mode=0o700)
 
@@ -284,16 +291,37 @@ def apply_setup(workspace: Path, setup: dict[str, Any]) -> None:
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(contents)
 
-    tracked = setup.get("tracked") or []
-    if tracked:
-        # Match TrackedArtifactPolicy.load expectations — YAML list form. We
-        # write the minimal valid shape that the policy loader accepts; if
-        # the policy loader's API changes, this stays the only place to
-        # adapt.
-        lines = ["tracked:"]
-        for pat in tracked:
-            lines.append(f"  - {pat}")
-        (coherence_dir / "tracked.yaml").write_text("\n".join(lines) + "\n")
+    # YAML loaders for tracked/ignored/strict_mode all accept a top-level
+    # list of patterns. Write the simplest valid shape that
+    # TrackedArtifactPolicy.load accepts.
+    for setup_key, yaml_file in (
+        ("tracked", "tracked.yaml"),
+        ("ignored", "ignored.yaml"),
+        ("strict_mode", "strict_mode.yaml"),
+    ):
+        patterns = setup.get(setup_key) or []
+        if patterns:
+            (coherence_dir / yaml_file).write_text(
+                "\n".join(f"- {p}" for p in patterns) + "\n"
+            )
+
+
+def apply_preflight_requests(
+    backend: CoordinatorBackend,
+    preflight: list[dict[str, Any]],
+) -> None:
+    """Fire each preflight request against ``backend``, ignoring responses.
+    Status-code mismatches in preflight are reported as RuntimeError so a
+    broken setup surfaces early instead of corrupting the main assertion."""
+    for i, req in enumerate(preflight):
+        status, body = execute_request(backend, req)
+        # Allow 200, 400 (preflight that expects validation errors), 404.
+        # Anything in the 500s indicates a coordinator bug — fail loud.
+        if status >= 500:
+            raise RuntimeError(
+                f"Preflight request #{i} ({req.get('method', 'POST')} "
+                f"{req.get('path')!r}) returned 5xx: status={status}, body={body!r}"
+            )
 
 
 # ----------------------------------------------------------------------
@@ -574,10 +602,18 @@ def run_scenario(
     workspace: Path,
     node_dist_path: Optional[Path] = None,
 ) -> tuple[int, dict[str, Any]]:
-    """End-to-end: setup workspace → spawn backend → POST → normalize → return.
+    """End-to-end: setup workspace → spawn backend → preflight requests →
+    main request → normalize → return.
 
-    Returns the normalized (status, body) for assertion by the caller."""
+    Returns the normalized (status, body) for assertion by the caller. The
+    preflight_requests list in fixture.setup is fired against the same live
+    coordinator BEFORE the main request — used by strict-mode fixtures to
+    drive the multi-step "A reads → B preempts → A re-reads (test)" setup
+    without requiring a separate fixture per step."""
     apply_setup(workspace, fixture.setup)
     with coordinator_running(backend_id, workspace, node_dist_path) as backend:
+        preflight = fixture.setup.get("preflight_requests") or []
+        if preflight:
+            apply_preflight_requests(backend, preflight)
         status, body = execute_request(backend, fixture.request)
     return status, normalize_response(body, ignore_keys=fixture.ignore_keys)

--- a/tests/protocol_corpus/test_strict_mode_corpus.py
+++ b/tests/protocol_corpus/test_strict_mode_corpus.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Cross-implementation strict-mode wire-shape corpus tests (plan Unit 7b).
+
+Parametrized over (fixture, backend) like the warn-mode corpus, but the
+fixtures only declare ``"backends": ["python"]`` — the Node coordinator does
+NOT ship strict-mode in v0.2 (strict mode lives on the Python coordinator
+only per § System-Wide Impact). Node parity is deferred to v0.3.
+
+Marked ``protocol_corpus`` — opt-in via ``pytest -m protocol_corpus``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.protocol_corpus.harness import (
+    BACKEND_NODE,
+    Fixture,
+    load_fixtures,
+    normalize_response,
+    resolve_node_dist_path,
+    run_scenario,
+)
+
+
+pytestmark = pytest.mark.protocol_corpus
+
+
+def _all_strict_mode_fixtures() -> list[Fixture]:
+    return load_fixtures("strict_mode")
+
+
+def _parametrize_rows() -> list[tuple[Fixture, str]]:
+    rows: list[tuple[Fixture, str]] = []
+    for fixture in _all_strict_mode_fixtures():
+        for backend in fixture.backends:
+            rows.append((fixture, backend))
+    return rows
+
+
+def _row_id(row: tuple[Fixture, str]) -> str:
+    fixture, backend = row
+    return f"{fixture.name}[{backend}]"
+
+
+_ROWS = _parametrize_rows()
+_NODE_DIST_PATH = resolve_node_dist_path()
+
+
+@pytest.mark.parametrize("row", _ROWS, ids=[_row_id(r) for r in _ROWS] if _ROWS else None)
+def test_strict_mode_fixture_response_matches_expected(
+    row: tuple[Fixture, str],
+    tmp_path: Path,
+) -> None:
+    fixture, backend = row
+    if backend == BACKEND_NODE and _NODE_DIST_PATH is None:
+        pytest.xfail(
+            "Node coordinator dist not resolvable; Node strict-mode is NOT "
+            "shipped in v0.2 anyway. v0.3 deferred."
+        )
+
+    actual_status, actual_body = run_scenario(
+        fixture=fixture,
+        backend_id=backend,
+        workspace=tmp_path,
+        node_dist_path=_NODE_DIST_PATH,
+    )
+
+    expected_status = fixture.expected["status"]
+    expected_body = normalize_response(
+        fixture.expected["body"], ignore_keys=fixture.ignore_keys
+    )
+
+    assert actual_status == expected_status, (
+        f"{fixture.name}[{backend}]: status mismatch — "
+        f"expected {expected_status}, got {actual_status}\n"
+        f"body={actual_body!r}"
+    )
+    assert actual_body == expected_body, (
+        f"{fixture.name}[{backend}]: body mismatch\n"
+        f"expected={expected_body!r}\nactual=  {actual_body!r}"
+    )
+
+
+def test_collection_loaded_strict_mode_fixtures() -> None:
+    """Self-test: at least 5 strict-mode fixtures are present so parametrize
+    doesn't silently no-op. Catches the failure mode where the fixtures
+    directory is empty."""
+    fixtures = _all_strict_mode_fixtures()
+    assert len(fixtures) >= 5, (
+        f"Expected ≥5 strict-mode fixtures, found {len(fixtures)}. "
+        f"Add coverage in tests/protocol_corpus/fixtures/strict_mode/."
+    )


### PR DESCRIPTION
## Summary

- Closes v0.2 Phase A: extends the cross-impl protocol corpus with 8 strict-mode fixtures + a python-only test driver. The corpus now catches BOTH warn-mode wire-shape drift (Python ↔ Node, 12 fixtures from Unit 7a) AND strict-mode wire-shape drift (Python-only, 8 fixtures from this PR).
- Per § System-Wide Impact, Node coordinator does NOT ship strict mode in v0.2 — strict fixtures declare `"backends": ["python"]`. v0.3 deferred when multi-target converter lands.
- Harness extended (backward compatible): `apply_setup` now also loads `ignored.yaml` + `strict_mode.yaml`; new `apply_preflight_requests()` fires multi-step setup against the live coordinator BEFORE the main test request.

## Coverage

| # | Fixture | What it asserts |
|---|---|---|
| 01 | pre-read strict + tracked + **stale** | deny + hookSpecificOutput wire shape + status:stale |
| 02 | pre-read strict + tracked + **fresh** (first observation) | fresh allow — KTD-O semantic refinement (strict-deny fires only on INVALID, not None) |
| 03 | strict_mode.yaml set but path **untracked** | fresh — intersection fast-path; KTD-O regression guard |
| 04 | tracked but **not strict** | warn-mode allow — v0.1.1 byte-identical preservation regression guard |
| 05 | pre-edit strict + tracked + stale | deny + {ok: false, status: stale} (Edit/Write surface) |
| 06 | pre-bash strict + tracked + stale | deny + stale_paths (Bash surface, KTD-Q H4 mitigation) |
| 07 | pre-bash multi-path, one strict + one warn, both stale | deny — any-strict-match triggers (KTD-Q edge case) |
| 08 | pre-grep strict + tracked + stale | deny + stale_paths (Grep surface) |

Each strict fixture ignores `permissionDecisionReason` and `summary` at the corpus level — text and timestamps vary per setup invocation. Byte-stability + template format-lock are asserted at the unit-test level in `tests/integration/test_strict_mode.py` (Unit 2). Corpus asserts only the **wire shape**: deny emission, `permissionDecisionReason` presence, `status: "stale"`, `stale_paths` list shape.

## Test plan

- [x] `pytest -m protocol_corpus -v` → 31 passed (8 strict + 19 warn-mode fixture×backend + 4 self-tests) in 14.56s
- [x] Default `pytest -q` unaffected
- [ ] CI `protocol-corpus` job green on this PR

## What's in the diff

| File | Change |
|---|---|
| `tests/protocol_corpus/harness.py` | +51 lines: `apply_setup` extended for `ignored` + `strict_mode` keys; new `apply_preflight_requests()`; `run_scenario` fires preflight before main request. |
| `tests/protocol_corpus/test_strict_mode_corpus.py` | New driver (mirrors warn-mode shape; python-only parametrize). |
| `tests/protocol_corpus/fixtures/strict_mode/*.json` | 8 new fixtures covering the strict-mode wire surface. |

## Plan reference

`docs/plans/2026-05-20-001-feat-claude-code-coherence-plugin-v0.2-strict-mode-plan.md` Unit 7b.

Phase A dependency chain: Unit 1 (merged #55) → Unit 2 (merged #56) → **Unit 7b (this PR)** = Phase A closer. Phase B opens after merge (Units 3 + 4 — migration helper + minimal audit log).