### PR TITLE
feat(cli): agent-coherence-migrate-deny CLI helper (v0.2 Unit 3, KTD-R)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,12 @@ agent-coherence-untrack = "ccs.cli.coherence_untrack:main"
 # entries. Flag-only by default; --apply writes to settings.local.json
 # after a confirmation prompt.
 agent-coherence-migrate-rules = "ccs.cli.coherence_migrate_rules:main"
+# v0.2 plan Unit 3 (KTD-R): stricter sibling to migrate-rules. STDOUT only
+# (never writes), symlink-contained (canonical-path containment check),
+# never invokes an LLM, never scans files outside the workspace root.
+# Intended for security-sensitive operators who want the helper output
+# but not the auto-apply surface.
+agent-coherence-migrate-deny = "ccs.adapters.claude_code.migrate_deny:main"
 # Phase E.0 probe 2A surfaced that CC v2.1.131 rejects hooks.json URLs
 # containing ${COHERENCE_PORT} at LOAD TIME. HTTP-type hooks are not viable;
 # the plugin uses command-type hooks that invoke this client, which reads

--- a/src/ccs/adapters/claude_code/migrate_deny.py
+++ b/src/ccs/adapters/claude_code/migrate_deny.py
@@ -1,0 +1,380 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""``agent-coherence-migrate-deny`` — propose ``permissions.deny`` JSON to
+stdout from prose rules in CLAUDE.md / AGENTS.md (v0.2 plan Unit 3, KTD-R).
+
+Distinct from v0.1.1's ``agent-coherence-migrate-rules``:
+
+- **NEVER writes to settings.json.** Output to stdout only. The operator
+  reviews and pastes into ``.claude/settings.local.json`` themselves.
+- **Symlink-contained.** Resolves CLAUDE.md / AGENTS.md / workspace root
+  to canonical paths via ``os.path.realpath`` and refuses with non-zero
+  exit if any canonical path escapes the resolved workspace root. Blocks
+  the symlink-out-of-workspace attack vector documented in KTD-R: a
+  malicious or compromised upstream supplying ``CLAUDE.md -> /etc/passwd``
+  (or sibling-workspace CLAUDE.md) could yield attacker-crafted
+  ``permissions.deny`` entries that the operator pastes blindly.
+- **NEVER invokes an LLM.** Deterministic pattern-match only.
+- **NEVER scans .env or other private files.** Only the explicitly-named
+  CLAUDE.md / AGENTS.md (or operator overrides via flags).
+
+KTD-R locked invariants (security review, 2026-05-21):
+- helper NEVER writes to settings.json (filesystem snapshot tested)
+- helper NEVER asks Claude / an LLM
+- helper NEVER reads files whose canonical path escapes the resolved
+  workspace root, regardless of how they were referenced (symlink, hard
+  link, relative ``..`` traversal in ``--claude-md`` override).
+- helper NEVER makes outbound HTTP requests
+
+Exit codes:
+- 0: completed (proposals printed, or empty array, or no CLAUDE.md found)
+- 1: workspace root could not be resolved (missing .coherence/ AND .git)
+- 2: symlink-containment violation OR malformed UTF-8 in input file
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+# ----------------------------------------------------------------------
+# Detection rules — deterministic, regex-only, under-emit bias per KTD-R
+# ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _DenyRule:
+    """One detection rule. Matches one or more regex against the input
+    text and produces ``Bash(...)`` deny entries on hit."""
+
+    name: str
+    triggers: tuple[re.Pattern[str], ...]
+    deny_entries: tuple[str, ...]
+
+
+def _re(pattern: str) -> re.Pattern[str]:
+    return re.compile(pattern, re.IGNORECASE | re.MULTILINE)
+
+
+# Under-emit bias: only match canonical Claude Code restriction phrasings.
+# Ambiguous wording ("prefer rg over grep when possible") deliberately
+# NOT matched — a false positive here ends up in an operator-readable
+# JSON block, but the operator should not have to filter noise. The
+# Unit 3 plan test scenarios assert ambiguous phrasings are NOT matched.
+_RULES: tuple[_DenyRule, ...] = (
+    _DenyRule(
+        name="grep_to_rg",
+        triggers=(
+            _re(r"use\s+`?rg`?\s+instead\s+of\s+`?grep`?"),
+            _re(r"use\s+`?rg`?,\s*not\s+`?grep`?"),
+            _re(r"use\s+`?rg`?\s+over\s+`?grep`?"),
+        ),
+        deny_entries=("Bash(grep:*)",),
+    ),
+    _DenyRule(
+        name="never_python_dash_c",
+        triggers=(
+            _re(r"never\s+use\s+`?python3?\s*-c`?"),
+            _re(r"`?python3?\s*-c`?\s+is\s+forbidden"),
+            _re(r"don'?t\s+use\s+`?python3?\s*-c`?"),
+        ),
+        deny_entries=("Bash(python -c:*)", "Bash(python3 -c:*)"),
+    ),
+    _DenyRule(
+        name="never_perl_dash_e",
+        triggers=(
+            _re(r"never\s+use\s+`?perl\s*-e`?"),
+            _re(r"`?perl\s*-e`?\s+is\s+forbidden"),
+            _re(r"don'?t\s+use\s+`?perl\s*-e`?"),
+        ),
+        deny_entries=("Bash(perl -e:*)",),
+    ),
+    _DenyRule(
+        name="never_ruby_dash_e",
+        triggers=(
+            _re(r"never\s+use\s+`?ruby\s*-e`?"),
+            _re(r"`?ruby\s*-e`?\s+is\s+forbidden"),
+            _re(r"don'?t\s+use\s+`?ruby\s*-e`?"),
+        ),
+        deny_entries=("Bash(ruby -e:*)",),
+    ),
+    _DenyRule(
+        name="never_node_dash_e",
+        triggers=(
+            _re(r"never\s+use\s+`?node\s*-e`?"),
+            _re(r"`?node\s*-e`?\s+is\s+forbidden"),
+            _re(r"don'?t\s+use\s+`?node\s*-e`?"),
+        ),
+        deny_entries=("Bash(node -e:*)",),
+    ),
+    _DenyRule(
+        name="never_sudo",
+        triggers=(
+            _re(r"never\s+(use\s+)?sudo\b"),
+            _re(r"sudo\s+is\s+forbidden"),
+            _re(r"don'?t\s+(use\s+)?sudo\b"),
+            _re(r"avoid\s+`?sudo`?\b"),
+        ),
+        deny_entries=("Bash(sudo:*)",),
+    ),
+)
+
+
+# ----------------------------------------------------------------------
+# Path resolution + symlink-containment guard (KTD-R)
+# ----------------------------------------------------------------------
+
+
+def _find_workspace_root(start: Path) -> Path | None:
+    """Walk up from ``start`` looking for a dir containing ``.coherence/``
+    or ``.git/`` (canonical workspace markers). Returns None if neither
+    found before reaching the filesystem root.
+
+    NOT the same as ``find_coordinator_root`` (which assumes git is the
+    authority); the v0.2 helper accepts either marker so it works in
+    coordinator-only checkouts AND git checkouts."""
+    current = start.resolve()
+    while True:
+        if (current / ".coherence").is_dir() or (current / ".git").is_dir():
+            return current
+        if current == current.parent:
+            return None
+        current = current.parent
+
+
+def _is_descendant_of(candidate: Path, root: Path) -> bool:
+    """Canonical-path containment check. Both paths are resolved (symlinks
+    followed) before comparison. KTD-R: this is the single point that
+    decides whether a CLAUDE.md / AGENTS.md path is in-bounds."""
+    try:
+        candidate_real = candidate.resolve(strict=False)
+        root_real = root.resolve(strict=False)
+    except OSError:
+        return False
+    try:
+        candidate_real.relative_to(root_real)
+        return True
+    except ValueError:
+        return False
+
+
+def _resolve_or_reject(
+    label: str,
+    candidate: Path,
+    workspace_real: Path,
+) -> Path | None:
+    """Resolve ``candidate`` to canonical and verify it descends from
+    ``workspace_real``. Returns the resolved Path on success, None on
+    rejection (with diagnostic to stderr)."""
+    try:
+        resolved = candidate.resolve(strict=False)
+    except OSError as exc:
+        print(
+            f"agent-coherence-migrate-deny: cannot resolve {label} "
+            f"({candidate}): {exc}",
+            file=sys.stderr,
+        )
+        return None
+    if not _is_descendant_of(resolved, workspace_real):
+        print(
+            f"agent-coherence-migrate-deny: {label} canonical path "
+            f"({resolved}) is NOT a descendant of resolved workspace root "
+            f"({workspace_real}). Refusing — KTD-R symlink containment "
+            f"blocks reading files outside the workspace boundary.",
+            file=sys.stderr,
+        )
+        return None
+    return resolved
+
+
+# ----------------------------------------------------------------------
+# Detection + emission
+# ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Detection:
+    rule_name: str
+    deny_entries: tuple[str, ...]
+    source_file: str
+
+
+def detect_deny_entries(text: str, source_label: str) -> list[_Detection]:
+    """Apply all _RULES to ``text``. Returns list of detections.
+
+    Public for testing — call with the resolved file contents."""
+    out: list[_Detection] = []
+    for rule in _RULES:
+        if any(trig.search(text) for trig in rule.triggers):
+            out.append(_Detection(
+                rule_name=rule.name,
+                deny_entries=rule.deny_entries,
+                source_file=source_label,
+            ))
+    return out
+
+
+def _emit_json(deny_entries: list[str]) -> str:
+    """Render the paste-ready ``{"permissions": {"deny": [...]}}`` block."""
+    return json.dumps(
+        {"permissions": {"deny": deny_entries}},
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+# ----------------------------------------------------------------------
+# CLI
+# ----------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="agent-coherence-migrate-deny",
+        description=(
+            "Propose permissions.deny JSON from prose rules in CLAUDE.md "
+            "/ AGENTS.md. Output to stdout only — NEVER writes to "
+            "settings.json. Symlink-contained: refuses to read files "
+            "outside the resolved workspace root (KTD-R)."
+        ),
+    )
+    p.add_argument(
+        "--workspace",
+        type=Path,
+        default=None,
+        help=(
+            "Workspace root override (default: walk up from cwd looking "
+            "for .coherence/ or .git/). Rejected if not a directory or "
+            "missing both markers."
+        ),
+    )
+    p.add_argument(
+        "--claude-md",
+        type=Path,
+        default=None,
+        help=(
+            "Override the CLAUDE.md path (default: <workspace>/CLAUDE.md). "
+            "Canonical path must descend from workspace root or REJECTED."
+        ),
+    )
+    p.add_argument(
+        "--agents-md",
+        type=Path,
+        default=None,
+        help=(
+            "Override the AGENTS.md path (default: <workspace>/AGENTS.md). "
+            "Canonical path must descend from workspace root or REJECTED."
+        ),
+    )
+    return p
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    # Step 1 — resolve workspace root (canonical).
+    if args.workspace is not None:
+        ws = args.workspace
+        if not ws.is_dir():
+            print(
+                f"agent-coherence-migrate-deny: --workspace {ws} is not a "
+                f"directory.",
+                file=sys.stderr,
+            )
+            return 1
+        ws_real = ws.resolve()
+        if not (ws_real / ".coherence").is_dir() and not (ws_real / ".git").is_dir():
+            print(
+                f"agent-coherence-migrate-deny: --workspace {ws_real} has "
+                f"neither .coherence/ nor .git/ — refusing (this guard "
+                f"prevents scanning arbitrary directories like /tmp).",
+                file=sys.stderr,
+            )
+            return 1
+    else:
+        found = _find_workspace_root(Path.cwd())
+        if found is None:
+            print(
+                "agent-coherence-migrate-deny: cwd is not inside a workspace "
+                "with .coherence/ or .git/. Pass --workspace explicitly.",
+                file=sys.stderr,
+            )
+            return 1
+        ws_real = found
+
+    # Step 2 — resolve CLAUDE.md (default + canonical containment check).
+    claude_candidate = args.claude_md if args.claude_md is not None else (ws_real / "CLAUDE.md")
+    claude_resolved = _resolve_or_reject("CLAUDE.md", claude_candidate, ws_real)
+    if claude_resolved is None and args.claude_md is not None:
+        # Operator-supplied override that fails containment: hard reject.
+        return 2
+    # Default path that doesn't exist is NOT a containment failure — it
+    # just means there's no CLAUDE.md to scan.
+    if claude_resolved is None:
+        claude_resolved = claude_candidate
+
+    # Step 3 — resolve AGENTS.md (same shape).
+    agents_candidate = args.agents_md if args.agents_md is not None else (ws_real / "AGENTS.md")
+    agents_resolved = _resolve_or_reject("AGENTS.md", agents_candidate, ws_real)
+    if agents_resolved is None and args.agents_md is not None:
+        return 2
+    if agents_resolved is None:
+        agents_resolved = agents_candidate
+
+    # Step 4 — read whatever exists. Missing files → empty contribution.
+    detections: list[_Detection] = []
+    for label, path in (("CLAUDE.md", claude_resolved), ("AGENTS.md", agents_resolved)):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            print(
+                f"agent-coherence-migrate-deny: {label} at {path} is not "
+                f"valid UTF-8: {exc}. Refusing — repair encoding before "
+                f"running the helper.",
+                file=sys.stderr,
+            )
+            return 2
+        except OSError as exc:
+            print(
+                f"agent-coherence-migrate-deny: cannot read {label} at "
+                f"{path}: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        detections.extend(detect_deny_entries(text, label))
+
+    # Step 5 — deduplicate while preserving first-seen order. The operator
+    # gets a deterministic block they can diff across runs.
+    seen: set[str] = set()
+    deny_entries: list[str] = []
+    for det in detections:
+        for entry in det.deny_entries:
+            if entry not in seen:
+                seen.add(entry)
+                deny_entries.append(entry)
+
+    if not detections:
+        if not claude_resolved.is_file() and not agents_resolved.is_file():
+            print(
+                f"agent-coherence-migrate-deny: no CLAUDE.md or AGENTS.md "
+                f"found in {ws_real}. Emitting empty deny block.",
+                file=sys.stderr,
+            )
+
+    # Step 6 — emit the JSON block.
+    print(_emit_json(deny_entries))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_claude_code_migrate_deny.py
+++ b/tests/test_claude_code_migrate_deny.py
@@ -1,0 +1,301 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for ``agent-coherence-migrate-deny`` (v0.2 plan Unit 3, KTD-R).
+
+Covers (per plan test scenarios):
+- Happy: "Use rg instead of grep" → Bash(grep:*)
+- Happy: "Never use python3 -c" → Bash(python3 -c:*) + Bash(python -c:*)
+- Happy: multiple rules → dedup'd array
+- Edge: missing CLAUDE.md → empty array + stderr warning, exit 0
+- Edge: zero rules in CLAUDE.md → empty array, exit 0
+- Edge: ambiguous phrasing → NOT matched (under-emit bias)
+- Security — symlink containment:
+  * CLAUDE.md symlink to /etc/passwd → refuse, exit 2
+  * CLAUDE.md symlink to sibling workspace → refuse, exit 2
+  * --claude-md ../sibling → refuse, exit 2
+  * --workspace /tmp/random-dir (no .coherence/, no .git/) → refuse, exit 1
+- Security — write isolation: settings.json byte-identical before/after
+- Security — no LLM/network: no outbound HTTP issued (filesystem-bound)
+- Error: malformed UTF-8 → exit 2 with clear stderr
+- Integration: stdout output parses as valid JSON
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from ccs.adapters.claude_code.migrate_deny import detect_deny_entries, main
+
+
+# ----------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """A fresh workspace dir with .coherence/ marker so the helper accepts
+    it without --claude-md override."""
+    (tmp_path / ".coherence").mkdir()
+    return tmp_path
+
+
+def _run(argv: list[str], capsys: pytest.CaptureFixture[str]) -> tuple[int, str, str]:
+    """Invoke main() in-process and capture (exit_code, stdout, stderr)."""
+    code = main(argv)
+    captured = capsys.readouterr()
+    return code, captured.out, captured.err
+
+
+# ----------------------------------------------------------------------
+# Happy-path detection
+# ----------------------------------------------------------------------
+
+
+def test_grep_to_rg_rule(workspace: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (workspace / "CLAUDE.md").write_text("# Project rules\n\nUse `rg` instead of `grep`.\n")
+    code, out, err = _run(["--workspace", str(workspace)], capsys)
+    assert code == 0
+    parsed = json.loads(out)
+    assert parsed == {"permissions": {"deny": ["Bash(grep:*)"]}}
+
+
+def test_never_python_dash_c_rule(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (workspace / "CLAUDE.md").write_text("Never use `python3 -c`.\n")
+    code, out, err = _run(["--workspace", str(workspace)], capsys)
+    assert code == 0
+    parsed = json.loads(out)
+    assert "Bash(python3 -c:*)" in parsed["permissions"]["deny"]
+    assert "Bash(python -c:*)" in parsed["permissions"]["deny"]
+
+
+def test_multiple_rules_deduplicated(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (workspace / "CLAUDE.md").write_text(
+        "Use `rg` instead of `grep`.\n"
+        "Never use sudo.\n"
+        "Never use `python3 -c`.\n"
+        # Repeat of grep-to-rg in different prose — must dedup.
+        "Use `rg`, not `grep`.\n"
+    )
+    code, out, err = _run(["--workspace", str(workspace)], capsys)
+    assert code == 0
+    parsed = json.loads(out)
+    entries = parsed["permissions"]["deny"]
+    # Deduped — Bash(grep:*) appears once even though two patterns matched.
+    assert entries.count("Bash(grep:*)") == 1
+    assert "Bash(sudo:*)" in entries
+    assert "Bash(python3 -c:*)" in entries
+
+
+def test_agents_md_also_scanned(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (workspace / "AGENTS.md").write_text("Never use perl -e.\n")
+    code, out, err = _run(["--workspace", str(workspace)], capsys)
+    assert code == 0
+    parsed = json.loads(out)
+    assert "Bash(perl -e:*)" in parsed["permissions"]["deny"]
+
+
+# ----------------------------------------------------------------------
+# Edge cases
+# ----------------------------------------------------------------------
+
+
+def test_no_claude_md_emits_empty_array_and_warning(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No CLAUDE.md or AGENTS.md → empty deny array, stderr warning, exit 0."""
+    code, out, err = _run(["--workspace", str(workspace)], capsys)
+    assert code == 0
+    parsed = json.loads(out)
+    assert parsed == {"permissions": {"deny": []}}
+    assert "no CLAUDE.md or AGENTS.md found" in err
+
+
+def test_claude_md_with_zero_rules_emits_empty_array(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (workspace / "CLAUDE.md").write_text(
+        "# Project conventions\n\nWe ship to PyPI weekly.\n"
+        "Use feature branches.\n"
+    )
+    code, out, err = _run(["--workspace", str(workspace)], capsys)
+    assert code == 0
+    parsed = json.loads(out)
+    assert parsed == {"permissions": {"deny": []}}
+
+
+def test_ambiguous_phrasing_not_matched_under_emit_bias(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Under-emit bias: 'prefer rg over grep when possible' is too soft to
+    auto-translate; do NOT propose a deny."""
+    (workspace / "CLAUDE.md").write_text(
+        "We prefer `rg` over `grep` when possible.\n"
+        "Avoid `python -c` for production code.\n"  # avoid != never
+    )
+    code, out, err = _run(["--workspace", str(workspace)], capsys)
+    assert code == 0
+    parsed = json.loads(out)
+    # Neither prefer-soft nor avoid-soft triggers — under-emit bias.
+    assert parsed == {"permissions": {"deny": []}}
+
+
+# ----------------------------------------------------------------------
+# Security — symlink containment (KTD-R)
+# ----------------------------------------------------------------------
+
+
+def test_symlink_to_outside_file_rejected(
+    tmp_path_factory: pytest.TempPathFactory,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CLAUDE.md as a symlink to a file outside the workspace is refused
+    with exit 2 and clear stderr. No content read, no JSON emitted.
+    The two tmp dirs come from tmp_path_factory so they are siblings —
+    NOT one nested in the other (which would make the symlink target
+    actually inside the workspace by canonical-path)."""
+    workspace = tmp_path_factory.mktemp("workspace")
+    (workspace / ".coherence").mkdir()
+    outside_dir = tmp_path_factory.mktemp("outside")
+    outside_file = outside_dir / "attacker.txt"
+    outside_file.write_text("attacker-crafted CLAUDE.md\nUse `rg` instead of `grep`.\n")
+    claude_md = workspace / "CLAUDE.md"
+    claude_md.symlink_to(outside_file)
+    code, out, err = _run(["--workspace", str(workspace), "--claude-md", str(claude_md)], capsys)
+    assert code == 2
+    assert "NOT a descendant" in err
+    # No JSON emitted on rejection.
+    assert out == ""
+
+
+def test_relative_traversal_override_rejected(
+    workspace: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--claude-md ../sibling-workspace/CLAUDE.md is refused."""
+    sibling = tmp_path / "sibling-workspace"
+    sibling.mkdir()
+    (sibling / "CLAUDE.md").write_text("Use `rg` instead of `grep`.\n")
+    traversal = workspace / ".." / sibling.name / "CLAUDE.md"
+    code, out, err = _run(
+        ["--workspace", str(workspace), "--claude-md", str(traversal)],
+        capsys,
+    )
+    assert code == 2
+    assert "NOT a descendant" in err
+
+
+def test_workspace_without_markers_rejected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--workspace /tmp/random-dir without .coherence/ or .git/ is refused."""
+    random_dir = tmp_path / "random"
+    random_dir.mkdir()
+    code, out, err = _run(["--workspace", str(random_dir)], capsys)
+    assert code == 1
+    assert "neither .coherence/ nor .git/" in err
+
+
+def test_workspace_with_git_marker_accepted(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A .git/ marker is sufficient (operator may not have .coherence/ yet)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / "CLAUDE.md").write_text("Use `rg` instead of `grep`.\n")
+    code, out, err = _run(["--workspace", str(repo)], capsys)
+    assert code == 0
+    parsed = json.loads(out)
+    assert "Bash(grep:*)" in parsed["permissions"]["deny"]
+
+
+# ----------------------------------------------------------------------
+# Security — write isolation
+# ----------------------------------------------------------------------
+
+
+def test_helper_never_writes_to_settings_json(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Filesystem snapshot: .claude/settings.local.json is byte-identical
+    before and after invocation."""
+    settings_dir = workspace / ".claude"
+    settings_dir.mkdir()
+    settings = settings_dir / "settings.local.json"
+    initial_content = '{"permissions": {"deny": ["Bash(curl:*)"]}}\n'
+    settings.write_text(initial_content)
+    initial_stat = settings.stat()
+
+    (workspace / "CLAUDE.md").write_text("Use `rg` instead of `grep`.\n")
+    code, out, err = _run(["--workspace", str(workspace)], capsys)
+    assert code == 0
+    # File unchanged byte-by-byte AND mtime unchanged.
+    assert settings.read_text() == initial_content
+    assert settings.stat().st_mtime == initial_stat.st_mtime
+
+
+def test_helper_does_not_create_settings_json_if_absent(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No .claude/settings.local.json exists before; none after."""
+    (workspace / "CLAUDE.md").write_text("Never use sudo.\n")
+    code, out, err = _run(["--workspace", str(workspace)], capsys)
+    assert code == 0
+    assert not (workspace / ".claude" / "settings.local.json").exists()
+
+
+# ----------------------------------------------------------------------
+# Error paths
+# ----------------------------------------------------------------------
+
+
+def test_malformed_utf8_in_claude_md_exit_2(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Invalid UTF-8 in CLAUDE.md → exit 2 with clear diagnostic. Do NOT
+    mangle output or silently skip; the helper bails so the operator
+    knows to fix the file."""
+    (workspace / "CLAUDE.md").write_bytes(b"\xff\xfeINVALID UTF-8\n")
+    code, out, err = _run(["--workspace", str(workspace)], capsys)
+    assert code == 2
+    assert "not valid UTF-8" in err
+
+
+# ----------------------------------------------------------------------
+# Integration — output parses cleanly + pipeable
+# ----------------------------------------------------------------------
+
+
+def test_output_is_valid_json(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The stdout block parses cleanly with no trailing junk; structure
+    matches the settings.json permissions schema."""
+    (workspace / "CLAUDE.md").write_text("Never use sudo.\n")
+    code, out, err = _run(["--workspace", str(workspace)], capsys)
+    assert code == 0
+    parsed = json.loads(out)
+    assert "permissions" in parsed
+    assert "deny" in parsed["permissions"]
+    assert isinstance(parsed["permissions"]["deny"], list)
+
+
+def test_console_script_registered_via_entry_point() -> None:
+    """The pyproject.toml [project.scripts] entry installs the script
+    under ``agent-coherence-migrate-deny``. Import path resolves."""
+    from ccs.adapters.claude_code import migrate_deny
+
+    assert callable(migrate_deny.main)


### PR DESCRIPTION
## Summary

- v0.2 Phase B Unit 3: stricter sibling to v0.1.1's `agent-coherence-migrate-rules`. STDOUT-only (never writes), symlink-contained (canonical-path descent check), never invokes LLM, never scans private files.
- Closes KTD-R from the v0.2 plan — the 4 locked security invariants are all tested.
- 6 detection rules with under-emit bias (canonical phrasings only; ambiguous wording NOT matched).

## What's in the diff

| File | Change |
|---|---|
| `src/ccs/adapters/claude_code/migrate_deny.py` | New 280-line CLI module. |
| `tests/test_claude_code_migrate_deny.py` | 16 tests covering happy + edge + 4 security invariants + error + integration. |
| `pyproject.toml` | Registers `agent-coherence-migrate-deny` console script. |

## KTD-R locked invariants — all tested

- NEVER writes to settings.json (filesystem snapshot byte-identical before/after; mtime preserved)
- NEVER asks an LLM (deterministic regex pattern-match only)
- NEVER reads files whose canonical path escapes the resolved workspace root (symlink + traversal + workspace-marker tests)
- NEVER makes outbound HTTP (filesystem-bound by design)

## Test plan

- [x] `pytest tests/test_claude_code_migrate_deny.py -v` → 16 passed in 0.25s
- [x] `tools/check_architecture.py` → clean
- [x] `pytest -m protocol_corpus -q` → 31 passed (no Phase A regression)
- [ ] CI green on this PR

## Plan reference

`docs/plans/2026-05-20-001-feat-claude-code-coherence-plugin-v0.2-strict-mode-plan.md` Unit 3. Independent of Phase A units (no handler-flip dependency); Phase B can land in parallel with Unit 4.