### PR TITLE
docs: library changelog + README cross-link for v0.2 strict mode (Unit 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,66 @@ Alpha — APIs may change before `v1.0`.
 
 ## [Unreleased]
 
+Unreleased work targets `v0.9.0`. Breaks the `coordinator_uptime_s`
+deprecation contract (alias removed per the `0.8.0` AC-02 plan) AND
+introduces new wire fields for v0.2 strict mode, so a minor bump is
+required.
+
+### Added — v0.2 strict mode (Python coordinator)
+
+- **Per-artifact strict-mode opt-in** via `.coherence/strict_mode.yaml`
+  (KTD-O). An artifact is strict iff its path matches both the
+  `tracked_paths` set AND the new `strict_mode_paths` globs. Empty
+  strict_mode_paths preserves v0.1.1 warn-mode for every artifact.
+- **Handler decision-flip in all 4 PreToolUse handlers** (Read,
+  Edit/Write, Bash, Grep) — `permissionDecision: "deny"` with the
+  static reason template `STRICT_MODE_DENY_REASON_TEMPLATE` (KTD-P)
+  fires when (strict + tracked + invalidated). First-time observers
+  (state None on existing artifact) fall through to warn-mode allow
+  per the semantic refinement during implementation.
+- **`TERMINAL_DENIAL_CLASSES` security invariant** (KTD-U) — module-
+  level `frozenset` enumerating denial classes that must never be
+  converted to `permissionDecision: "allow"`. All 6 allow-emission
+  call sites route through `emit_allow()` which asserts the invariant;
+  AST-based meta-test grep-counts call sites in `coordinator_server.py`
+  + `hook_payloads.py` so a future contributor adding a new allow
+  path is forced to extend the parameter list.
+- **`agent-coherence-migrate-deny` CLI** (KTD-R) — stricter sibling
+  to `agent-coherence-migrate-rules`. STDOUT-only (never writes to
+  settings.json), symlink-contained (canonical-path containment check),
+  never invokes an LLM, never reads files outside resolved workspace
+  root. Under-emit bias: only canonical phrasings trigger.
+- **Strict-mode telemetry** (KTD-V minimal + KTD-J extension) —
+  `strict_mode_denials_total`, `strict_mode_routed_around_via_bash_total`
+  (Phase 0 H4 routing pattern detector with 30s window),
+  `audit_log_mode_drift_total` counters surfaced via
+  `/status?detail=metrics`. Minimal deny-only audit log appended as
+  JSONL to `.coherence/audit.log` (mode 0o600, no schema_version, no
+  command bodies, no user content).
+- **Cross-implementation protocol corpus** (Unit 7) —
+  `tests/protocol_corpus/` harness + 12 warn-mode + 8 strict-mode
+  fixtures + opt-in `protocol_corpus` pytest marker + new
+  `protocol-corpus` CI job. Catches Python ↔ Node coordinator
+  wire-shape drift before it ships. Strict-mode fixtures are
+  python-only (Node coordinator doesn't ship strict mode in v0.2).
+
+### Changed
+
+- **Hook payload builders** (`build_stale_response`,
+  `build_collision_response`) now route through `emit_allow()` per
+  the KTD-U structural invariant.
+- **Static deny-reason text** for strict-mode replaces v0.1.1's
+  per-invocation-varying warn-mode prose. Phase 0 H1 falsification
+  inverted the original "varied text bounds retries" hypothesis on
+  opus; static text byte-identical across retries is the right shape.
+
+### Plugin compatibility
+
+- v0.2 of the [agent-coherence-plugin](https://github.com/hipvlady/agent-coherence-plugin)
+  consumes this library via its broad-beta launch package (plan Units
+  8-11). The Node coordinator does NOT ship strict mode in v0.2 —
+  strict-mode workspaces must use `coherence.coordinator_backend = "python"`.
+
 ## [0.8.0] — 2026-05-23
 
 **Stable release of the Claude Code plugin coordinator backend.** Promotes the `0.8.0a1` alpha pre-release to a final `0.8.0` after the v0.1.1 marketplace cohort + full ce-review remediation pass landed. Both the coordinator HTTP surface and the wire contract are now considered stable through the `0.8.x` minor line; breaking changes will bump to `0.9.0` per SemVer.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Protocol safety properties (single-writer, monotonic versioning, crash-recovery 
 
 `v0.8.0` released — full Claude Code plugin coordinator (Python backend) plus the ce-review remediation pass. Adds six console scripts (`agent-coherence-coordinator`, `-status`, `-track`, `-untrack`, `-hook-client`, `-migrate-rules`); ships KTD-J telemetry, `/status` three-tier disclosure, `--self-test`, and `--prepare-for-migration` for safe Python↔Node coordinator backend switching. The companion [agent-coherence-plugin](https://github.com/hipvlady/agent-coherence-plugin) ships `v0.1.1` of the marketplace plugin against this library. See [CHANGELOG.md](CHANGELOG.md) for the full version history and [releases](https://github.com/hipvlady/agent-coherence/releases) for tagged artifacts. Alpha — APIs may change before `v1.0`.
 
+**v0.9.0 unreleased — v0.2 strict mode.** Phase A+B of the v0.2 plan have landed on `dev`: per-artifact `strict_mode_paths` opt-in via `.coherence/strict_mode.yaml`, all 4 PreToolUse handlers flip to `permissionDecision: "deny"` when (strict + tracked + invalidated), `TERMINAL_DENIAL_CLASSES` structural invariant guarding allow-emission paths, new `agent-coherence-migrate-deny` console script (STDOUT-only sibling to `-migrate-rules` with symlink containment), strict-mode telemetry counters + deny-only `.coherence/audit.log` JSONL surface. Strict mode is Python-coordinator-only in v0.2; the Node coordinator backend stays warn-mode. Plugin-side broad-beta launch package (Units 8-11) lands separately. See [CHANGELOG.md](CHANGELOG.md) `[Unreleased]` for the full scope.
+
 ## Paper
 
 **Token Coherence: Adapting MESI Cache Protocols to Minimize Synchronization Overhead in Multi-Agent LLM Systems**


### PR DESCRIPTION
## Summary

- Library-side documentation for the v0.2 strict-mode work that landed in Phase A + Phase B (Units 1, 2, 3, 4, 7a, 7b — all merged).
- CHANGELOG.md `[Unreleased]` block now documents the v0.9.0-target additions; README status section adds a cross-link paragraph.
- Plugin-side docs land in Phase D Unit 8 (plugin repo README depth-parity overhaul).

## What's in the diff

| File | Change |
|---|---|
| `CHANGELOG.md` | +60 lines: `[Unreleased]` section documenting v0.2 strict-mode additions per KTD ID, with Added/Changed/Plugin-compatibility subsections. |
| `README.md` | +2 lines: new v0.9.0-unreleased paragraph in Status section pointing at the strict-mode surface. |

## Test plan

Pure docs change — no code touched. CI runs default test suite as smoke; should remain green.

- [ ] CI green on this PR

## Plan reference

`docs/plans/2026-05-20-001-feat-claude-code-coherence-plugin-v0.2-strict-mode-plan.md` Unit 6 (library-side scope).