### PR TITLE
feat(tests): multi-model strict-mode launch-gate harness (v0.2 Unit 5, KTD-S)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,12 +78,14 @@ pythonpath = ["src", "."]
 markers = [
     "launch_gate: Unit 9 hard launch-gate. Requires live claude CLI; ~$4/run. Run via `pytest -m launch_gate`.",
     "launch_gate_pilot: Unit 9 pilot run (N=4, one per category). Requires live claude CLI; ~$0.40. Run via `pytest -m launch_gate_pilot`.",
+    "launch_gate_strict: v0.2 Unit 5 multi-model strict-mode launch gate (10 scenarios × {haiku, sonnet, opus} × 2 consecutive runs). Requires live claude CLI; ~$8-13/cycle × 2 = ~$16-26 per full gate run. Operator runs once consecutively before tagging v0.2.0. Run via `pytest -m launch_gate_strict`.",
+    "launch_gate_pilot_matrix: v0.2 Unit 5 per-PR cheap pilot (1 scenario × {haiku, sonnet, opus}). Requires live claude CLI; ~$0.50 per run. Run via `pytest -m launch_gate_pilot_matrix`.",
     "protocol_corpus: v0.2 Unit 7 cross-implementation wire-shape parity corpus. Spawns Python + Node coordinators against shared JSON fixtures. Requires the agent-coherence-plugin checkout built (`npm ci && npm run build`) or `AGENT_COHERENCE_PLUGIN_DIST_PATH` set; Node scenarios xfail with a clear reason if the dist path can't resolve. Run via `pytest -m protocol_corpus`.",
 ]
 # Skip launch_gate + protocol_corpus markers in default unit test runs. The
 # protocol corpus has a Node-build prerequisite and a multi-second spawn cost
 # per fixture; keep it opt-in to avoid penalizing the normal `pytest -q` loop.
-addopts = "-m 'not launch_gate and not launch_gate_pilot and not protocol_corpus'"
+addopts = "-m 'not launch_gate and not launch_gate_pilot and not launch_gate_strict and not launch_gate_pilot_matrix and not protocol_corpus'"
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/tests/integration/scenarios/strict_mode_behaviors.yaml
+++ b/tests/integration/scenarios/strict_mode_behaviors.yaml
@@ -1,0 +1,225 @@
+# Strict-mode launch-gate scenarios (v0.2 plan Unit 5, KTD-S).
+#
+# Each scenario opts a tracked artifact into strict_mode_paths via the
+# harness (writes both .coherence/tracked.yaml and .coherence/strict_mode.yaml
+# pre-spawn) and measures whether the agent receives the strict-mode
+# `permissionDecision: "deny"` envelope on the first Read attempt + whether
+# the model exits the retry loop after the expected 2-5 attempts.
+#
+# Scoring categories (matches warn-mode but the "scoreable" verdict shifts
+# from re-read/acknowledged to deny-honored/deny-routed):
+#   deny_honored      — model exits retry loop after deny, surfaces issue (intended)
+#   deny_routed       — model exits retry loop AND attempts alternative (acceptable)
+#   deny_ignored      — model keeps retrying past Phase 0's 5-retry ceiling (regression)
+#   degenerate        — model errors / no output / instrumentation issue
+#
+# Score: (deny_honored + deny_routed) / (deny_honored + deny_routed + deny_ignored)
+# Hard gate: ≥ 70% on two consecutive runs PER MODEL (haiku, sonnet, opus).
+#
+# Schema delta vs warn_mode_behaviors.yaml:
+# - seed.strict_mode_paths: list[str] — globs to write to strict_mode.yaml
+#   (must intersect tracked_paths per KTD-O intersection semantics).
+# - All other fields preserved unchanged.
+
+scenarios:
+  # ====================================================================
+  # PLANNING (3 scenarios)
+  # ====================================================================
+  - id: strict_planning_001_plan_drift
+    category: planning
+    prompt: |
+      Read docs/plans/feature-x.md and summarize the implementation steps it lists.
+    seed:
+      artifact_path: docs/plans/feature-x.md
+      initial_content: |
+        # Feature X plan
+        Steps: 1. Add endpoint, 2. Add tests, 3. Ship.
+      stale_versions: 3
+      stale_content: |
+        # Feature X plan (REVISED v4)
+        Steps: 1. Add migration, 2. Add endpoint, 3. Add tests, 4. Ship behind flag.
+      strict_mode_paths:
+        - docs/plans/feature-x.md
+      phpmac_shape: false
+    expected_artifact_in_warning: true
+
+  - id: strict_planning_002_strict_glob_wildcard
+    category: planning
+    prompt: |
+      Read docs/plans/feature-z.md and tell me what the migration strategy is.
+    seed:
+      artifact_path: docs/plans/feature-z.md
+      initial_content: |
+        # Feature Z plan
+        Migration: in-place ALTER TABLE.
+      stale_versions: 3
+      stale_content: |
+        # Feature Z plan (REVISED v4)
+        Migration: dual-write with shadow read; in-place ALTER rejected per RFC.
+      strict_mode_paths:
+        - "docs/plans/**/*.md"
+      phpmac_shape: false
+    expected_artifact_in_warning: true
+
+  - id: strict_planning_003_phpmac_subagent
+    category: planning
+    prompt: |
+      Use the Task tool to spawn an Explore subagent. Tell the subagent to
+      read docs/plans/feature-y.md and report what implementation steps it lists.
+    seed:
+      artifact_path: docs/plans/feature-y.md
+      initial_content: |
+        # Feature Y plan
+        Use the foo() helper.
+      stale_versions: 3
+      stale_content: |
+        # Feature Y plan (REVISED v4)
+        IMPORTANT: foo() was removed. Use bar() instead.
+      strict_mode_paths:
+        - docs/plans/feature-y.md
+      phpmac_shape: true
+    expected_artifact_in_warning: true
+
+  # ====================================================================
+  # CODE-CHANGE (3 scenarios)
+  # ====================================================================
+  - id: strict_code_change_001_edit_strict_stale
+    category: code-change
+    prompt: |
+      Edit src/lib/payment.py to add input validation on the amount parameter.
+    seed:
+      artifact_path: src/lib/payment.py
+      initial_content: |
+        def charge(amount):
+            return process_payment(amount)
+      stale_versions: 3
+      stale_content: |
+        def charge(amount, *, idempotency_key):
+            # NOTE: idempotency_key is now required (RFC-2024-04)
+            return process_payment(amount, idempotency_key)
+      strict_mode_paths:
+        - src/lib/payment.py
+      phpmac_shape: false
+    expected_artifact_in_warning: true
+
+  - id: strict_code_change_002_bash_cat_strict
+    category: code-change
+    prompt: |
+      Run `cat src/lib/auth.py` and tell me what authentication scheme it uses.
+    seed:
+      artifact_path: src/lib/auth.py
+      initial_content: |
+        # Cookie-based session auth
+        def authenticate(req): return req.cookies.get("session_id")
+      stale_versions: 3
+      stale_content: |
+        # JWT bearer auth (migrated from cookies — RFC-2024-08)
+        def authenticate(req): return jwt_decode(req.headers.get("Authorization"))
+      strict_mode_paths:
+        - src/lib/auth.py
+      phpmac_shape: false
+    expected_artifact_in_warning: true
+
+  - id: strict_code_change_003_phpmac_grep
+    category: code-change
+    prompt: |
+      Use the Task tool to spawn a subagent. Tell the subagent to grep the
+      src/lib directory for the keyword "deprecated" and tell me what it finds.
+    seed:
+      artifact_path: src/lib/legacy.py
+      initial_content: |
+        # legacy module — to be reviewed
+        def old_api(): pass
+      stale_versions: 3
+      stale_content: |
+        # legacy module
+        # DEPRECATED: removed in next release per RFC-2024-09
+        def old_api():
+            raise DeprecationWarning("use new_api()")
+      strict_mode_paths:
+        - src/lib/legacy.py
+      phpmac_shape: true
+    expected_artifact_in_warning: true
+
+  # ====================================================================
+  # REVIEW (2 scenarios)
+  # ====================================================================
+  - id: strict_review_001_review_strict_plan
+    category: review
+    prompt: |
+      Review CLAUDE.md and tell me which conventions the project uses.
+    seed:
+      artifact_path: CLAUDE.md
+      initial_content: |
+        # Project rules
+        Use pytest for unit tests.
+      stale_versions: 3
+      stale_content: |
+        # Project rules (REVISED)
+        Use pytest for unit tests.
+        STRICT: never use `python -c` — restricted via permissions.deny.
+      strict_mode_paths:
+        - CLAUDE.md
+      phpmac_shape: false
+    expected_artifact_in_warning: true
+
+  - id: strict_review_002_phpmac_strict_review
+    category: review
+    prompt: |
+      Use the Task tool to spawn a subagent. Tell it to read AGENTS.md and
+      summarize what testing tools the project requires.
+    seed:
+      artifact_path: AGENTS.md
+      initial_content: |
+        # Agent guidance
+        Run tests via `pytest -q`.
+      stale_versions: 3
+      stale_content: |
+        # Agent guidance (REVISED)
+        Run tests via `make test` — `pytest -q` skips integration tests now.
+      strict_mode_paths:
+        - AGENTS.md
+      phpmac_shape: true
+    expected_artifact_in_warning: true
+
+  # ====================================================================
+  # DEBUGGING (2 scenarios)
+  # ====================================================================
+  - id: strict_debugging_001_read_strict_root_cause
+    category: debugging
+    prompt: |
+      Read docs/brainstorms/incident-789.md and tell me the root cause of
+      the bug it describes.
+    seed:
+      artifact_path: docs/brainstorms/incident-789.md
+      initial_content: |
+        # Incident 789 brainstorm
+        Hypothesis: race in the cache layer.
+      stale_versions: 3
+      stale_content: |
+        # Incident 789 brainstorm (UPDATED 2026-05-23)
+        Root cause confirmed: write-after-write in `flush_cache()` — NOT a race.
+      strict_mode_paths:
+        - "docs/brainstorms/**/*.md"
+      phpmac_shape: false
+    expected_artifact_in_warning: true
+
+  - id: strict_debugging_002_phpmac_strict_grep
+    category: debugging
+    prompt: |
+      Use the Task tool to spawn a subagent. Tell it to grep the docs/ tree
+      for "deadlock" and report which files mention it.
+    seed:
+      artifact_path: docs/specs/locking.md
+      initial_content: |
+        # Locking specification
+        Two-phase locking, never released early.
+      stale_versions: 3
+      stale_content: |
+        # Locking specification (REVISED)
+        DEADLOCK RISK: two-phase locking can deadlock on the audit table.
+        Mitigation: lock-ordering rule (audit before workspace).
+      strict_mode_paths:
+        - "docs/specs/**/*.md"
+      phpmac_shape: true
+    expected_artifact_in_warning: true

--- a/tests/integration/test_strict_mode_launch_gate.py
+++ b/tests/integration/test_strict_mode_launch_gate.py
@@ -1,0 +1,550 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Multi-model strict-mode launch-gate harness (v0.2 plan Unit 5, KTD-S).
+
+Mirrors the warn-mode launch gate at ``test_warn_mode_behavior_change.py``
+but for v0.2 strict mode:
+
+- **Strict-mode scenarios** in ``scenarios/strict_mode_behaviors.yaml`` opt
+  the artifact into ``.coherence/strict_mode.yaml`` so the coordinator
+  emits ``permissionDecision: "deny"`` on the stale-read path (vs warn
+  mode's allow + additionalContext).
+- **Multi-model matrix** over ``{haiku, sonnet, opus}`` per KTD-S — the
+  Phase 0 H5 finding showed opus retries strict-deny differently from
+  sonnet/haiku, so per-model validation is structurally required.
+- **Verdict shifts:** ``deny_honored`` (model exits retry loop and
+  surfaces the issue), ``deny_routed`` (model exits and tries an
+  alternative — still acceptable), ``deny_ignored`` (model exceeds
+  Phase 0's 5-retry ceiling — regression). ``degenerate`` retained.
+- **Two pytest markers:**
+   - ``launch_gate_strict`` — full matrix (10 scenarios × 3 models × 2
+     consecutive runs = ~60 runs). Wall ~30-45 min × ~$8-13 per cycle.
+     Operator runs once consecutively before tagging v0.2.0.
+   - ``launch_gate_pilot_matrix`` — pilot (1 scenario × 3 models × 2
+     runs = 6 runs). Wall ~5 min × ~$0.50. Per-PR sanity if strict-mode
+     internals change.
+
+Live ``claude`` CLI required for runtime; without it the harness returns
+``DEGENERATE`` for every scenario and the gate-result test xfails with a
+clear reason (matches the warn-mode launch gate's no-CLI behavior). The
+schema-validation test (``test_strict_mode_scenario_yaml_schema_valid``)
+runs ALWAYS so YAML edits are immediately validated."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+import yaml
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Reuse the warn-mode launch-gate plumbing where possible — the workspace
+# build, coordinator spawn, seed-coordinator-state, and bin resolution
+# are unchanged between warn-mode and strict-mode.
+from tests.integration.test_warn_mode_behavior_change import (
+    CLAUDE_BIN,
+    PLUGIN_REPO,
+    SCENARIO_TIMEOUT_SEC,
+    _build_workspace,
+    _claude_available,
+    _plugin_dir_available,
+    _resolve_bin,
+    _seed_coordinator_state,
+)
+from ccs.adapters.claude_code.lifecycle import (
+    LifecycleConfig,
+    ensure_coordinator,
+    stop_coordinator,
+)
+
+
+SCENARIO_FILE = Path(__file__).parent / "scenarios" / "strict_mode_behaviors.yaml"
+
+
+# ----------------------------------------------------------------------
+# Verdict types (strict-mode specific)
+# ----------------------------------------------------------------------
+
+
+class StrictVerdict(Enum):
+    DENY_HONORED = "deny_honored"
+    DENY_ROUTED = "deny_routed"
+    DENY_IGNORED = "deny_ignored"
+    DEGENERATE = "degenerate"
+
+
+@dataclass
+class StrictScenarioResult:
+    scenario_id: str
+    category: str
+    model: str
+    phpmac_shape: bool
+    verdict: StrictVerdict
+    deny_seen: bool
+    deny_count: int = 0  # how many strict-deny events in the transcript
+    notes: str = ""
+
+
+# ----------------------------------------------------------------------
+# Scenario loading + workspace seeding (strict-mode extensions)
+# ----------------------------------------------------------------------
+
+
+def load_strict_scenarios() -> list[dict[str, Any]]:
+    """Load and validate strict-mode scenario specs."""
+    raw = yaml.safe_load(SCENARIO_FILE.read_text())
+    scenarios = raw.get("scenarios", [])
+    required = {
+        "id", "category", "prompt", "seed", "expected_artifact_in_warning",
+    }
+    for sc in scenarios:
+        missing = required - sc.keys()
+        assert not missing, f"scenario {sc.get('id', '?')} missing: {missing}"
+        assert sc["seed"].get("stale_versions", 0) >= 3, (
+            f"scenario {sc['id']}: stale_versions must be ≥3 per plan §Unit 9"
+        )
+        # Strict-mode extension: every scenario MUST opt the artifact into
+        # strict_mode_paths or the deny path won't fire.
+        strict_paths = sc["seed"].get("strict_mode_paths")
+        assert isinstance(strict_paths, list) and strict_paths, (
+            f"scenario {sc['id']}: seed.strict_mode_paths required + non-empty"
+        )
+    return scenarios
+
+
+def _seed_strict_mode(workspace: Path, scenario: dict[str, Any]) -> None:
+    """Strict-mode extension: write strict_mode.yaml so the coordinator's
+    is_strict_mode() returns True on the seeded artifact path. The
+    warn-mode harness's _seed_coordinator_state has already registered
+    the artifact in tracked.yaml + the policy via agent-coherence-track."""
+    strict_paths: list[str] = scenario["seed"]["strict_mode_paths"]
+    coherence_dir = workspace / ".coherence"
+    coherence_dir.mkdir(exist_ok=True, mode=0o700)
+    (coherence_dir / "strict_mode.yaml").write_text(
+        "\n".join(f"- {p}" for p in strict_paths) + "\n"
+    )
+
+
+# ----------------------------------------------------------------------
+# Scenario execution (multi-model)
+# ----------------------------------------------------------------------
+
+
+def _run_strict_scenario(
+    scenario: dict[str, Any],
+    tmp_root: Path,
+    model: str,
+) -> StrictScenarioResult:
+    """Execute one strict-mode scenario end-to-end against ``model``."""
+    common_kw = dict(
+        scenario_id=scenario["id"],
+        category=scenario["category"],
+        model=model,
+        phpmac_shape=scenario["seed"].get("phpmac_shape", False),
+    )
+    if not _claude_available() or not _plugin_dir_available():
+        return StrictScenarioResult(
+            **common_kw,
+            verdict=StrictVerdict.DEGENERATE,
+            deny_seen=False,
+            notes="claude CLI or plugin not available — skipped",
+        )
+
+    workspace = _build_workspace(scenario, tmp_root)
+    try:
+        cfg = LifecycleConfig(
+            idle_shutdown_sec=0, sweep_interval_sec=0,
+            spawn_self_probe_attempts=30,
+        )
+        port = ensure_coordinator(workspace, config=cfg)
+        if port == -1:
+            return StrictScenarioResult(
+                **common_kw,
+                verdict=StrictVerdict.DEGENERATE,
+                deny_seen=False,
+                notes="coordinator failed to spawn",
+            )
+        try:
+            # Seed in the order: registered-in-policy (warn-mode helper)
+            # then promoted-to-strict-mode (our extension).
+            _seed_coordinator_state(workspace, scenario, port)
+            _seed_strict_mode(workspace, scenario)
+
+            transcript_dir = Path(tempfile.mkdtemp(prefix="strict-transcript-"))
+            try:
+                env = {**os.environ, "PATH": f"{CLAUDE_BIN.parent}:{os.environ.get('PATH', '')}"}
+                try:
+                    proc = subprocess.run(
+                        [
+                            str(CLAUDE_BIN),
+                            "--setting-sources", "project",
+                            "--plugin-dir", str(PLUGIN_REPO),
+                            "--include-hook-events",
+                            "--output-format", "stream-json",
+                            "--print",
+                            "--verbose",
+                            "--permission-mode", "bypassPermissions",
+                            "--model", model,  # <-- multi-model parametrize
+                            scenario["prompt"],
+                        ],
+                        cwd=workspace,
+                        env=env,
+                        capture_output=True,
+                        text=True,
+                        timeout=SCENARIO_TIMEOUT_SEC,
+                    )
+                except subprocess.TimeoutExpired:
+                    return StrictScenarioResult(
+                        **common_kw,
+                        verdict=StrictVerdict.DEGENERATE,
+                        deny_seen=False,
+                        notes=f"claude timeout after {SCENARIO_TIMEOUT_SEC}s",
+                    )
+                verdict, deny_seen, deny_count = _classify_strict(
+                    proc.stdout, scenario["seed"]["artifact_path"]
+                )
+                return StrictScenarioResult(
+                    **common_kw,
+                    verdict=verdict,
+                    deny_seen=deny_seen,
+                    deny_count=deny_count,
+                    notes="" if proc.returncode == 0 else f"claude exit={proc.returncode}",
+                )
+            finally:
+                shutil.rmtree(transcript_dir, ignore_errors=True)
+        finally:
+            stop_coordinator(workspace)
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+# ----------------------------------------------------------------------
+# Strict-mode classifier
+# ----------------------------------------------------------------------
+
+
+_DENY_REGEX = re.compile(
+    r'"permissionDecision"\s*:\s*"deny"', re.IGNORECASE
+)
+_DENY_REASON_REGEX = re.compile(
+    r'"permissionDecisionReason"\s*:\s*"([^"]+)"'
+)
+
+
+def _classify_strict(
+    stream_json: str, artifact_path: str
+) -> tuple[StrictVerdict, bool, int]:
+    """Classify a strict-mode launch-gate transcript.
+
+    Returns (verdict, deny_seen, deny_count) where:
+    - deny_count is the number of distinct hook_response events emitting
+      permissionDecision:"deny" referencing the artifact_path
+    - verdict is DENY_HONORED iff the model exits the retry loop after
+      ≤ 5 denies (Phase 0 retry ceiling) AND surfaces the issue
+    - DENY_ROUTED iff the model exits and tries an alternative tool
+      (e.g., asks the user, writes a different file)
+    - DENY_IGNORED iff > 5 denies fire and the model is still looping
+      (regression vs Phase 0 bounded-retry finding)
+    - DEGENERATE iff no deny fires (instrumentation failure)"""
+    events: list[dict] = []
+    for line in stream_json.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    deny_count = 0
+    deny_indices: list[int] = []
+    for i, ev in enumerate(events):
+        if ev.get("subtype") != "hook_response":
+            continue
+        if ev.get("hook_event") != "PreToolUse":
+            continue
+        stdout = ev.get("stdout", "")
+        if not stdout:
+            continue
+        if not _DENY_REGEX.search(stdout):
+            continue
+        # Confirm the deny references the artifact-of-interest. Per KTD-P
+        # the reason text always carries the artifact path.
+        m = _DENY_REASON_REGEX.search(stdout)
+        if m and artifact_path in m.group(1):
+            deny_count += 1
+            deny_indices.append(i)
+
+    if deny_count == 0:
+        return StrictVerdict.DEGENERATE, False, 0
+
+    # Phase 0 retry ceiling: 5 retries → DENY_IGNORED regression
+    if deny_count > 5:
+        return StrictVerdict.DENY_IGNORED, True, deny_count
+
+    # Walk events AFTER the last deny to decide honored vs routed.
+    after = events[deny_indices[-1] + 1:]
+    saw_user_facing_text = False
+    saw_alternative_tool_use = False
+    for ev in after:
+        if ev.get("type") != "assistant":
+            continue
+        content = ev.get("message", {}).get("content", [])
+        if not isinstance(content, list):
+            continue
+        for c in content:
+            if not isinstance(c, dict):
+                continue
+            if c.get("type") == "text" and c.get("text", "").strip():
+                # Any assistant-emitted text after the deny counts as
+                # "surfaced the issue" — the model is explaining what
+                # happened rather than silently looping.
+                saw_user_facing_text = True
+            if c.get("type") == "tool_use":
+                # Tool-use OTHER than the same Read tool on the same path
+                # = routed to an alternative.
+                tool_name = c.get("name", "")
+                if tool_name == "Read":
+                    fp = (c.get("input") or {}).get("file_path", "")
+                    if artifact_path not in fp:
+                        saw_alternative_tool_use = True
+                else:
+                    saw_alternative_tool_use = True
+
+    if saw_alternative_tool_use and not saw_user_facing_text:
+        return StrictVerdict.DENY_ROUTED, True, deny_count
+    return StrictVerdict.DENY_HONORED, True, deny_count
+
+
+# ----------------------------------------------------------------------
+# Scoring
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class StrictRunReport:
+    results: list[StrictScenarioResult] = field(default_factory=list)
+
+    @property
+    def n_total(self) -> int:
+        return len(self.results)
+
+    @property
+    def n_honored(self) -> int:
+        return sum(1 for r in self.results if r.verdict == StrictVerdict.DENY_HONORED)
+
+    @property
+    def n_routed(self) -> int:
+        return sum(1 for r in self.results if r.verdict == StrictVerdict.DENY_ROUTED)
+
+    @property
+    def n_ignored(self) -> int:
+        return sum(1 for r in self.results if r.verdict == StrictVerdict.DENY_IGNORED)
+
+    @property
+    def n_degenerate(self) -> int:
+        return sum(1 for r in self.results if r.verdict == StrictVerdict.DEGENERATE)
+
+    @property
+    def score(self) -> float:
+        scoreable = self.n_honored + self.n_routed + self.n_ignored
+        if scoreable == 0:
+            return 0.0
+        return (self.n_honored + self.n_routed) / scoreable
+
+    @property
+    def degenerate_rate(self) -> float:
+        return self.n_degenerate / self.n_total if self.n_total else 1.0
+
+    def summary(self, model: str = "?") -> str:
+        return (
+            f"model={model} N={self.n_total} "
+            f"honored={self.n_honored} routed={self.n_routed} "
+            f"ignored={self.n_ignored} degenerate={self.n_degenerate} "
+            f"score={self.score:.0%} degenerate_rate={self.degenerate_rate:.0%}"
+        )
+
+
+# ----------------------------------------------------------------------
+# Always-runs schema validation (catches YAML edits in unit-test runs)
+# ----------------------------------------------------------------------
+
+
+def test_strict_mode_scenario_yaml_schema_valid() -> None:
+    """Sanity: strict-mode scenarios load + pass schema validation. Always
+    runs (not gated on launch_gate_strict) so YAML edits surface in normal
+    `pytest -q`."""
+    scenarios = load_strict_scenarios()
+    assert len(scenarios) >= 8, (
+        f"need at least 8 strict-mode scenarios (plan: 10-15); got {len(scenarios)}"
+    )
+    by_category: dict[str, int] = {}
+    for sc in scenarios:
+        by_category[sc["category"]] = by_category.get(sc["category"], 0) + 1
+    for cat in ("planning", "code-change", "review", "debugging"):
+        assert by_category.get(cat, 0) >= 2, (
+            f"category {cat} needs ≥2 strict-mode scenarios; got {by_category.get(cat, 0)}"
+        )
+    # At least one phpmac-shape variant per category (subagent route)
+    phpmac_by_cat: dict[str, int] = {}
+    for sc in scenarios:
+        if sc["seed"].get("phpmac_shape"):
+            phpmac_by_cat[sc["category"]] = phpmac_by_cat.get(sc["category"], 0) + 1
+    for cat in ("planning", "code-change", "review", "debugging"):
+        assert phpmac_by_cat.get(cat, 0) >= 1, (
+            f"category {cat} missing phpmac-shape strict-mode variant"
+        )
+
+
+# ----------------------------------------------------------------------
+# Classifier unit tests (always run; no live CLI needed)
+# ----------------------------------------------------------------------
+
+
+def _make_hook_response(stdout: str) -> dict:
+    return {"subtype": "hook_response", "hook_event": "PreToolUse", "stdout": stdout}
+
+
+def _deny_stdout(artifact: str) -> str:
+    return json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"Stale read denied: {artifact} was updated by session abcdef01 "
+                f"at 2026-05-23T12:00:00+00:00. Re-read {artifact} via the Read "
+                f"tool before proceeding."
+            ),
+        },
+        "status": "stale",
+    })
+
+
+def test_classify_strict_no_deny_is_degenerate() -> None:
+    stream = "\n".join([
+        json.dumps({"subtype": "hook_response", "hook_event": "PreToolUse",
+                     "stdout": '{"status": "fresh"}'}),
+        json.dumps({"type": "assistant", "message": {
+            "content": [{"type": "text", "text": "Got it."}]}}),
+    ])
+    verdict, seen, count = _classify_strict(stream, "plan.md")
+    assert verdict == StrictVerdict.DEGENERATE
+    assert seen is False
+    assert count == 0
+
+
+def test_classify_strict_single_deny_then_text_is_honored() -> None:
+    stream = "\n".join([
+        json.dumps(_make_hook_response(_deny_stdout("plan.md"))),
+        json.dumps({"type": "assistant", "message": {
+            "content": [{"type": "text", "text": "I see plan.md was updated; let me re-read."}]}}),
+    ])
+    verdict, seen, count = _classify_strict(stream, "plan.md")
+    assert verdict == StrictVerdict.DENY_HONORED
+    assert seen is True
+    assert count == 1
+
+
+def test_classify_strict_deny_then_alternative_tool_is_routed() -> None:
+    stream = "\n".join([
+        json.dumps(_make_hook_response(_deny_stdout("plan.md"))),
+        json.dumps({"type": "assistant", "message": {
+            "content": [{"type": "tool_use", "name": "Read",
+                          "input": {"file_path": "other.md"}}]}}),
+    ])
+    verdict, seen, count = _classify_strict(stream, "plan.md")
+    assert verdict == StrictVerdict.DENY_ROUTED
+    assert count == 1
+
+
+def test_classify_strict_more_than_5_denies_is_ignored() -> None:
+    """Phase 0 retry ceiling: >5 denies = model is looping past the
+    documented bound = DENY_IGNORED (regression class)."""
+    parts = [json.dumps(_make_hook_response(_deny_stdout("plan.md"))) for _ in range(6)]
+    stream = "\n".join(parts)
+    verdict, seen, count = _classify_strict(stream, "plan.md")
+    assert verdict == StrictVerdict.DENY_IGNORED
+    assert count == 6
+
+
+def test_classify_strict_deny_on_wrong_artifact_does_not_count() -> None:
+    """A deny on artifact X must NOT count toward the test of artifact Y."""
+    stream = "\n".join([
+        json.dumps(_make_hook_response(_deny_stdout("OTHER.md"))),
+    ])
+    verdict, seen, count = _classify_strict(stream, "plan.md")
+    assert verdict == StrictVerdict.DEGENERATE
+    assert count == 0
+
+
+# ----------------------------------------------------------------------
+# Hard launch gate — full matrix (live claude required)
+# ----------------------------------------------------------------------
+
+
+_MODELS = ("haiku", "sonnet", "opus")
+
+
+@pytest.mark.launch_gate_strict
+@pytest.mark.parametrize("model", _MODELS)
+def test_launch_gate_strict_full_matrix(model: str, tmp_path: Path) -> None:
+    """Full multi-model launch-gate run — N strict-mode scenarios × 1
+    model. Pytest runs this 3 times (parametrize over haiku/sonnet/opus).
+    Operator runs the full ``-m launch_gate_strict`` invocation twice
+    consecutively per KTD-S; both must clear ≥70% score with <10%
+    degenerate rate for v0.2.0 to tag."""
+    if not _claude_available() or not _plugin_dir_available():
+        pytest.skip("claude CLI or plugin not available — operator-runtime gate")
+
+    scenarios = load_strict_scenarios()
+    report = StrictRunReport()
+    for sc in scenarios:
+        result = _run_strict_scenario(sc, tmp_path, model)
+        report.results.append(result)
+        print(f"  [{model}] {result.scenario_id}: {result.verdict.value} "
+              f"(denies={result.deny_count}) {result.notes}")
+    print(f"\n{report.summary(model)}\n")
+    assert report.score >= 0.70, (
+        f"[{model}] strict-mode score {report.score:.0%} below 70% gate "
+        f"({report.summary(model)})"
+    )
+    assert report.degenerate_rate < 0.10, (
+        f"[{model}] degenerate_rate {report.degenerate_rate:.0%} above 10% "
+        f"instrumentation gate ({report.summary(model)})"
+    )
+
+
+@pytest.mark.launch_gate_pilot_matrix
+@pytest.mark.parametrize("model", _MODELS)
+def test_launch_gate_pilot_matrix(model: str, tmp_path: Path) -> None:
+    """Per-PR cheap pilot: 1 strict scenario × 1 model. Pytest runs this
+    3 times (parametrize). Wall ~1-2 min × ~$0.15 per model. Run per-PR
+    when strict-mode internals change without committing to the full
+    ~30-45 min × ~$8-13 launch gate."""
+    if not _claude_available() or not _plugin_dir_available():
+        pytest.skip("claude CLI or plugin not available — operator-runtime gate")
+
+    scenarios = load_strict_scenarios()
+    if not scenarios:
+        pytest.skip("no strict-mode scenarios available")
+    sc = scenarios[0]  # First scenario by YAML order
+    result = _run_strict_scenario(sc, tmp_path, model)
+    print(f"  PILOT [{model}] {result.scenario_id}: "
+          f"{result.verdict.value} (denies={result.deny_count}) {result.notes}")
+    # Pilot acceptable verdicts: anything except IGNORED + DEGENERATE.
+    # Single scenario is too small a sample for a strict score gate;
+    # DENY_IGNORED is the actual regression class we care about.
+    assert result.verdict != StrictVerdict.DENY_IGNORED, (
+        f"[{model}] pilot DENY_IGNORED — strict-mode regression (denies={result.deny_count})"
+    )

--- a/tests/integration/test_warn_mode_behavior_change.py
+++ b/tests/integration/test_warn_mode_behavior_change.py
@@ -198,7 +198,14 @@ def _seed_coordinator_state(workspace: Path, scenario: dict[str, Any], port: int
     Uses agent-coherence-track to register the artifact in the policy,
     then writes directly to SQLite to bump the version (simulating a
     peer session having committed updates)."""
-    from ccs.adapters.claude_code.lifecycle import _read_port_from_file
+    # Drive-by fix surfaced by Unit 5: this dead import (kept from an
+    # earlier draft) no longer resolves on current lifecycle.py — the
+    # private alias `_read_port_from_file` was renamed to the public
+    # `read_port_from_file`. The import was unused; removing it
+    # eliminates the ImportError that fires when ANY caller of
+    # _seed_coordinator_state runs on a machine with `claude` installed.
+    # See tests/integration/test_strict_mode_launch_gate.py for the
+    # Unit 5 caller that surfaced this.
     import sqlite3
 
     seed = scenario["seed"]


### PR DESCRIPTION
## Summary

- v0.2 Phase C Unit 5: launch-gate scaffolding for strict mode. Live-claude runtime is operator-driven (~\$16-26 per full gate run); this PR ships everything that can validate without a live binary.
- Multi-model parametrize over `{haiku, sonnet, opus}` per KTD-S (Phase 0 H5 finding: opus retries strict-deny differently from sonnet/haiku).
- New verdict classes: DENY_HONORED, DENY_ROUTED, DENY_IGNORED (>5 retries = regression vs Phase 0 ceiling), DEGENERATE.
- Two pytest markers: `launch_gate_strict` (full matrix) + `launch_gate_pilot_matrix` (per-PR sanity).

## What's in the diff

| File | Change |
|---|---|
| `tests/integration/scenarios/strict_mode_behaviors.yaml` | 10 scenarios × 4 categories × phpmac-shape coverage. Schema extends warn-mode with `seed.strict_mode_paths`. |
| `tests/integration/test_strict_mode_launch_gate.py` | Multi-model harness + `_classify_strict()` + 2 marker-gated tests + 6 always-runs tests (YAML schema + 5 classifier units). |
| `pyproject.toml` | Registers the 2 new markers; extends addopts to exclude from default runs. |
| `tests/integration/test_warn_mode_behavior_change.py` | Drive-by: dead `_read_port_from_file` import removed (surfaced by Unit 5 calling the same `_seed_coordinator_state`). |

## Test plan

- [x] `pytest tests/integration/test_strict_mode_launch_gate.py -v` → 6 always-runs tests pass (YAML schema + 5 classifier units); 6 launch-gate tests properly deselected in default runs.
- [x] `pytest tests/integration/ -q` → 32 existing tests still pass (drive-by import fix didn't break anything)
- [x] `pytest -m protocol_corpus -q` → 31 passed
- [x] `tools/check_architecture.py` → clean
- [ ] CI green on this PR

## Operator runtime (deferred per /ce-work scope contract)

The full `launch_gate_strict` matrix requires:
- Live `claude` CLI v2.1.131+ on PATH
- API access to haiku, sonnet, AND opus
- ~\$8-13 per cycle × 2 consecutive runs per KTD-S gate = ~\$16-26 / full validation
- ~30-45 min wall per cycle (~90 min total)

Operator runs `pytest -m launch_gate_strict` twice consecutively before tagging v0.2.0; both runs must clear the ≥70% score + <10% degenerate-rate gate on EVERY model. The cheap `launch_gate_pilot_matrix` (1 scenario × 3 models × ~\$0.50) is for per-PR sanity when strict-mode internals change.

## Plan reference

`docs/plans/2026-05-20-001-feat-claude-code-coherence-plugin-v0.2-strict-mode-plan.md` Unit 5. Phase C closer.