### PR TITLE
fix(coordinator,tests): launch-gate harness + strict-deny semantics (2 root causes)

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1299,33 +1299,60 @@ def _handle_pre_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
             "hash_differs": hash_differs,
         }
 
-        # v0.2 KTD-O / KTD-P: strict-mode deny branch. If the artifact is
-        # opted into strict mode via .coherence/strict_mode.yaml AND the
-        # session was previously invalidated (preempted by a peer commit),
-        # return permissionDecision:"deny" with the static reason template.
-        # Otherwise fall through to v0.1.1 warn-mode allow path unchanged.
+        # v0.2 KTD-O / KTD-P: strict-mode deny branch.
         #
-        # Semantic guard: strict-deny fires only on agent_state == INVALID
-        # (true preemption). A first-time observer (agent_state is None on
-        # an existing artifact) gets warn-mode allow + additionalContext
-        # because they have not "acted on stale" — they have never seen
-        # the artifact before. The operator's intent for strict mode is
-        # "must re-read after invalidation," not "must read before any
-        # cross-session activity exists."
+        # Gate (refined 2026-05-24 per launch-gate finding): strict-deny
+        # fires when the artifact is in strict mode AND the session
+        # demonstrably lacks a fresh view of the current content. Two
+        # branches:
         #
-        # KTD-Q: this is the Read surface; the same gate fires on
-        # pre-edit / pre-bash / pre-grep for Edit|Write / Bash / Grep.
+        # 1. ``agent_state == INVALID`` — true preemption. Session
+        #    previously held SHARED on an older version; a peer commit
+        #    invalidated it. The session's context still carries the
+        #    stale beliefs. Strict-deny forces explicit re-read.
+        #
+        # 2. ``agent_state is None AND hash_differs`` — session has no
+        #    prior grant on the artifact AND the content the session
+        #    just hashed at the disk does not match what the registry
+        #    last recorded as the canonical content. This catches the
+        #    "agent has stale beliefs from somewhere else (CLAUDE.md
+        #    at session start, an earlier subagent's prose summary, a
+        #    file on disk that's been peer-updated)" pattern. If hashes
+        #    MATCH, the session is observing the same bytes the
+        #    registry recorded — no stale content to act on — falls
+        #    through to warn-mode allow.
+        #
+        # The hash_differs branch was added because the original "any
+        # None on existing artifact = deny" rule broke the unit-test
+        # setup pattern (warn-mode-style multi-session setup where
+        # both sessions read the same registered artifact). The hash
+        # check disambiguates "session sees identical bytes" (safe)
+        # from "session sees different bytes" (must re-acknowledge).
+        # Multi-model launch-gate scenarios always trigger via the
+        # hash-differs branch because the synthetic SQLite injection
+        # uses a sentinel hash ("f" * 64) that no real SHA-256
+        # matches.
+        #
+        # KTD-Q: this is the Read surface only. Pre-edit reverts to
+        # INVALID-only because pre-edit has no caller content_hash to
+        # apply the hash_differs disambiguation. Pre-bash + pre-grep
+        # capture None|INVALID via the loop's `state is not None and
+        # != INVALID: continue` filter — same effective gate as the
+        # original Unit 2 design, applied per-detected-path.
         #
         # KTD-T: do NOT re-grant SHARED on deny. The MESI state stays
-        # INVALID across the model's retry loop so every retry produces
-        # the same byte-stable deny reason text. Per Phase 0 finding the
-        # model exits the retry loop after 2-5 attempts and routes to
-        # alternative behavior; the deny IS the signal. Re-granting
-        # would let the second retry get fresh and silently downgrade
-        # the operator's hard guardrail.
+        # INVALID (or None) across the model's retry loop so every
+        # retry produces the same byte-stable deny reason text. Per
+        # Phase 0 finding the model exits the retry loop after 2-5
+        # attempts and routes to alternative behavior; the deny IS the
+        # signal. Re-granting would let the second retry get fresh and
+        # silently downgrade the operator's hard guardrail.
         if (
-            agent_state == MESIState.INVALID
-            and coordinator.policy.is_strict_mode(path)
+            coordinator.policy.is_strict_mode(path)
+            and (
+                agent_state == MESIState.INVALID
+                or (agent_state is None and hash_differs)
+            )
         ):
             coordinator.increment_stale_warning_emitted()
             coordinator.mark_stale_warned(agent_id, artifact_id)
@@ -1442,6 +1469,15 @@ def _handle_pre_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
         if coordinator.policy.is_strict_mode(path):
             artifact = coordinator.registry.get_artifact(artifact_id)
             editor_state = coordinator.registry.get_agent_state(artifact_id, agent_id)
+            # Reverted to INVALID-only 2026-05-24 per the launch-gate
+            # finding. Pre-edit has no caller content_hash so it cannot
+            # apply the hash_differs disambiguation that pre-read uses
+            # (see pre-read gate above). Treating None as stale here
+            # would deny first-time editors on any tracked-strict
+            # artifact even when their working content is current.
+            # The original Unit 2 design — INVALID-only — is the right
+            # gate for the Edit/Write surface: pre-edit strict-deny
+            # fires after a session has been explicitly preempted.
             editor_stale = editor_state == MESIState.INVALID
             if artifact is not None and artifact.version > 0 and editor_stale:
                 last_writer_id = _last_writer_for(coordinator, artifact_id)

--- a/tests/integration/test_strict_mode_launch_gate.py
+++ b/tests/integration/test_strict_mode_launch_gate.py
@@ -176,10 +176,19 @@ def _run_strict_scenario(
                 notes="coordinator failed to spawn",
             )
         try:
-            # Seed in the order: registered-in-policy (warn-mode helper)
-            # then promoted-to-strict-mode (our extension).
-            _seed_coordinator_state(workspace, scenario, port)
+            # Seeding order (FIXED 2026-05-24 per launch-gate finding):
+            # _seed_strict_mode writes strict_mode.yaml to disk BEFORE
+            # _seed_coordinator_state triggers a policy reload via the
+            # /policy/track HTTP call. The reload reads tracked.yaml +
+            # ignored.yaml + strict_mode.yaml in one shot — so strict
+            # mode is active by the time the test agent runs. Earlier
+            # implementation reversed this order; strict_mode.yaml was
+            # written AFTER the only policy-reload trigger, so
+            # is_strict_mode() returned False forever and every
+            # scenario degraded to warn-mode (which the strict-only
+            # classifier reads as "no denies → DEGENERATE").
             _seed_strict_mode(workspace, scenario)
+            _seed_coordinator_state(workspace, scenario, port)
 
             transcript_dir = Path(tempfile.mkdtemp(prefix="strict-transcript-"))
             try:
@@ -214,12 +223,26 @@ def _run_strict_scenario(
                 verdict, deny_seen, deny_count = _classify_strict(
                     proc.stdout, scenario["seed"]["artifact_path"]
                 )
+                # Diagnostic preservation: on DEGENERATE, persist the full
+                # claude transcript + stderr to /tmp so the operator can
+                # inspect what actually happened (was the plugin loaded?
+                # did the hook fire? did is_strict_mode return False?).
+                # Default temp transcript_dir is rm'd in the finally
+                # block, so we explicitly copy out before that.
+                notes_extra = ""
+                if verdict == StrictVerdict.DEGENERATE:
+                    debug_dir = Path("/tmp") / f"strict-mode-degenerate-{scenario['id']}-{model}-{int(time.time())}"
+                    debug_dir.mkdir(parents=True, exist_ok=True)
+                    (debug_dir / "stream.jsonl").write_text(proc.stdout or "")
+                    (debug_dir / "stderr.log").write_text(proc.stderr or "")
+                    (debug_dir / "scenario.json").write_text(json.dumps(scenario, indent=2))
+                    notes_extra = f"; transcript preserved at {debug_dir}"
                 return StrictScenarioResult(
                     **common_kw,
                     verdict=verdict,
                     deny_seen=deny_seen,
                     deny_count=deny_count,
-                    notes="" if proc.returncode == 0 else f"claude exit={proc.returncode}",
+                    notes=(("" if proc.returncode == 0 else f"claude exit={proc.returncode}") + notes_extra),
                 )
             finally:
                 shutil.rmtree(transcript_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary

Operator's first \`pytest -m launch_gate_strict\` run hit 30/30 DEGENERATE across haiku/sonnet/opus (~\$15-25 + 11min wall). Diagnosed two root causes from the run output without re-running.

## Bug 1 — harness seeding order

Strict_mode.yaml was written AFTER the only policy-reload trigger (\`/policy/track\` via \`_seed_coordinator_state\`). Coordinator's in-memory policy had empty \`strict_mode_paths\` for the entire test → \`is_strict_mode()\` returned False → strict-deny never fired → every scenario degraded to warn-mode → strict-only classifier read "no denies" → DEGENERATE.

**Fix:** swap the order. \`_seed_strict_mode\` now runs BEFORE \`_seed_coordinator_state\`.

## Bug 2 — strict-deny gate too narrow

My Unit 2 implementation gated strict-deny on \`agent_state == INVALID\` alone. The launch-gate synthesizes a pre-existing artifact via direct SQLite injection (sentinel content_hash \`"f" * 64\`) then runs a fresh claude session whose state is None. Strict-deny never fires on first-observer state=None.

Wholesale loosening to \`(state is None or state == INVALID)\` was the first fix attempt — it broke 12 unit tests because warn-mode-style setup patterns rely on first-read NOT strict-denying.

**Final fix:** narrow gate disambiguated by content_hash:

\`\`\`python
if is_strict_mode(path) AND (
    agent_state == INVALID
    OR (agent_state is None AND hash_differs)
):
    strict_deny
\`\`\`

| Branch | Catches |
|---|---|
| INVALID | True preemption — session held SHARED on older version, peer committed new version, invalidated us |
| None + hash_differs | Session has no prior grant AND the bytes it just hashed don't match what registry recorded — "agent has stale beliefs from elsewhere" |
| None + hashes match | Falls through to warn-mode allow — observing identical bytes, nothing stale to act on |

Hash-differs branch catches every launch-gate scenario (sentinel hash never matches real SHA-256). Unit-test setup pattern preserved (matching hashes → warn-mode). Real-world first-observer with current content gets warn-mode (correct: nothing stale to act on).

Pre-edit reverts to INVALID-only (no caller hash → can't disambiguate). Pre-bash + pre-grep keep their loop-captures-None|INVALID pattern (no caller hash; launch-gate Bash/Grep scenarios are intentionally first-observer + state=None).

## Diagnostic addition

\`_run_strict_scenario\` now preserves the claude stream-json + stderr + scenario.json to \`/tmp/strict-mode-degenerate-*\` on every DEGENERATE result. Operator can inspect what actually happened without re-running the gate.

## Test plan

- [x] 37 strict-mode unit + integration tests pass (was 12 failed/25 passed under wholesale loosening; now all green under narrow gate)
- [x] 198 coordinator-server + policy regression tests pass
- [x] 31 protocol corpus tests pass (warn-mode + strict-mode fixtures)
- [x] Architecture checks clean
- [x] Launch-gate harness self-tests (YAML schema + 5 classifier unit tests) pass
- [ ] CI green on this PR
- [ ] **Operator re-runs \`pytest -m launch_gate_strict\` against live claude** (recommendation: start with the cheap pilot \`pytest -m launch_gate_pilot_matrix\` ~\$0.50 to verify the fix works before committing to the full ~\$15-25 × 2 gate)

## Pilot then full gate

\`\`\`bash
# Pilot first (~5 min, ~\$0.50) — 1 scenario × 3 models
pytest -m launch_gate_pilot_matrix -v 2>&1 | tee /tmp/launch_gate_pilot.log

# If pilot shows non-DEGENERATE results, run the full gate
pytest -m launch_gate_strict -v 2>&1 | tee /tmp/launch_gate_run1.log
pytest -m launch_gate_strict -v 2>&1 | tee /tmp/launch_gate_run2.log
\`\`\`

## Plan reference

\`docs/plans/2026-05-20-001-feat-claude-code-coherence-plugin-v0.2-strict-mode-plan.md\` — fixes Unit 2 + Unit 5 surfaces; updates the gate semantics documented in KTD-O / KTD-P inline.