### PR TITLE
fix(hook-client): precompute content_hash on pre-read (Bug 3 — strict mode)

### DIFF
--- a/src/ccs/cli/coherence_hook_client.py
+++ b/src/ccs/cli/coherence_hook_client.py
@@ -250,7 +250,23 @@ def _build_pre_read(cc: dict[str, Any], root: Path) -> dict[str, Any]:
     session_id = _require_session_id(cc)
     file_path = _require_file_path(cc)
     rel = _to_workspace_relative(file_path, root)
-    return {"session_id": session_id, "path": rel}
+    body: dict[str, Any] = {"session_id": session_id, "path": rel}
+    # v0.2 KTD-O: compute content_hash from disk so the coordinator's
+    # strict-mode gate can disambiguate "session sees stale bytes"
+    # (first-observer reading a peer-updated file → strict-deny) from
+    # "session sees current bytes" (first-observer with content matching
+    # what the registry recorded → warn-mode allow). Without this,
+    # PreToolUse:Read carries no hash (Claude Code's Read tool reads
+    # AFTER the hook fires, so tool_response.content_hash is undefined
+    # at hook time), and the strict-deny gate's hash_differs branch is
+    # unreachable. Best-effort: _hash_file returns None on OSError
+    # (file missing, permission denied) — coordinator then falls back
+    # to the INVALID-only branch of the strict-deny gate, preserving
+    # v0.1.1 warn-mode behavior for non-strict workspaces.
+    content_hash = _hash_file(Path(file_path))
+    if content_hash is not None:
+        body["content_hash"] = content_hash
+    return body
 
 
 def _build_pre_edit(cc: dict[str, Any], root: Path) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Operator's pilot run (3/3 models DEGENERATE) after the previous fix surfaced Bug 3. The preserved diagnostic transcript showed the hook fired correctly but returned warn-mode allow with \`hash_differs: false\`.

## Root cause

The narrow strict-deny gate in the previous fix requires \`content_hash\` in the pre-read payload to disambiguate first-observer cases. Claude Code's Read tool fires PreToolUse BEFORE reading the file → \`tool_response.content_hash\` is undefined at hook time → \`_build_pre_read\` in \`coherence_hook_client.py\` was passing no content_hash → coordinator's \`hash_differs\` branch was unreachable.

\`_build_post_edit\` had the same hash-from-disk computation for years (post-edit had the same "hash not in tool_response" gap). Same pattern, just hadn't been needed for pre-read until v0.2 strict mode.

## Fix

```python
def _build_pre_read(cc, root):
    ...
    body = {"session_id": session_id, "path": rel}
    content_hash = _hash_file(Path(file_path))  # NEW: compute from disk
    if content_hash is not None:
        body["content_hash"] = content_hash
    return body
```

Best-effort: \`_hash_file\` returns None on OSError → coordinator falls back to INVALID-only strict-deny branch → preserves v0.1.1 warn-mode behavior for non-strict workspaces.

## Why this works on the launch gate

| Scenario | Disk content | Registry hash | Computed pre-read hash | hash_differs | Gate fires? |
|---|---|---|---|---|---|
| Launch-gate synthetic | "REVISED v4" bytes | "f" × 64 (sentinel) | real SHA-256 of disk bytes | **True** | ✅ strict-deny |
| Unit-test multi-session | A's v1 content | hash(v1 content) | hash(v1 content) (B reads same disk) | False | warn-mode allow |
| Real-world first-observer matching | current content | hash(current content) | hash(current content) | False | warn-mode allow |
| Real preemption | new bytes | hash(new bytes) | hash(new bytes) | False | INVALID-branch fires (state==INVALID) |

## Test plan

- [x] 184 cross-cutting tests pass (hook-client + strict-mode integration + telemetry + coordinator-server)
- [x] 31 protocol corpus tests pass (wire shape unchanged for warn-mode + strict-mode fixtures)
- [ ] CI green on this PR
- [ ] **Operator re-runs pilot** — \`pytest -m launch_gate_pilot_matrix -s\` — expect non-DEGENERATE verdicts on all 3 models

## Performance note

Hash-from-disk on every pre-read adds disk I/O. Bounded by:
1. tracked_paths globs (operators don't track binary blobs)
2. SHA-256 throughput (~300 MB/s on modern CPUs — even 10 MB markdown takes ~30ms)
3. Same shape as \`_build_post_edit\` which has used this pattern since v0.1.0

If perf becomes an issue, a v0.2.x optimization could cache hashes by (path, mtime).

## Plan reference

\`docs/plans/2026-05-20-001-feat-claude-code-coherence-plugin-v0.2-strict-mode-plan.md\` — closes the third root cause in the launch-gate bring-up sequence.