### PR TITLE
fix(hook-client,scenarios): subagent grep absolute path + SessionStart auto-load (Bug 4 + Bug 5)

### DIFF
--- a/src/ccs/cli/coherence_hook_client.py
+++ b/src/ccs/cli/coherence_hook_client.py
@@ -189,7 +189,7 @@ def _main_inner(argv: Sequence[str] | None = None) -> int:
             payload = _build_pre_bash(cc_payload)
             response = _call(endpoint, "/hooks/pre-bash", payload)
         elif args.subcommand == "pre-grep":
-            payload = _build_pre_grep(cc_payload)
+            payload = _build_pre_grep(cc_payload, root_path)
             response = _call(endpoint, "/hooks/pre-grep", payload)
         else:  # pragma: no cover — argparse already validates
             _emit_empty()
@@ -321,12 +321,24 @@ def _build_pre_bash(cc: dict[str, Any]) -> dict[str, Any]:
     return {"session_id": session_id, "command": command}
 
 
-def _build_pre_grep(cc: dict[str, Any]) -> dict[str, Any]:
+def _build_pre_grep(cc: dict[str, Any], root: Path) -> dict[str, Any]:
     """v0.1.1 KTD-N — translate CC's Grep PreToolUse payload to the
     /hooks/pre-grep coordinator request shape.
 
-    CC's Grep tool takes a ``path`` arg (the search root, parent-repo-
-    relative). Empty/absent → workspace root.
+    CC's Grep tool takes a ``path`` arg (the search root). Empty/absent →
+    workspace root.
+
+    Path shapes observed in production (2026-05-24 launch-gate finding):
+    - **Direct invocation:** workspace-relative ("src/lib", "./docs").
+    - **Subagent (Task tool) invocation:** ABSOLUTE path
+      ("/private/var/.../workspace/src/lib"). Initial v0.1.1 assumption
+      that "Grep path is always workspace-relative" was incorrect —
+      subagents inherit the parent's CWD shape differently, and CC
+      resolves the path to absolute before passing to PreToolUse.
+
+    Fix: normalize absolute paths via _to_workspace_relative. Relative
+    paths pass through after stripping a leading "./" for parity with
+    the validator's normalization expectations.
     """
     session_id = _require_session_id(cc)
     tool_input = cc.get("tool_input") or {}
@@ -335,10 +347,10 @@ def _build_pre_grep(cc: dict[str, Any]) -> dict[str, Any]:
         raw_path = ""
     if not isinstance(raw_path, str):
         raise _SkipHook("tool_input.path must be a string")
-    # The Grep tool's path is already workspace-relative in CC's payload;
-    # no transformation needed beyond stripping a leading "./" for parity
-    # with the validator's normalization expectations.
-    search_root = raw_path[2:] if raw_path.startswith("./") else raw_path
+    if raw_path and os.path.isabs(raw_path):
+        search_root = _to_workspace_relative(raw_path, root)
+    else:
+        search_root = raw_path[2:] if raw_path.startswith("./") else raw_path
     return {"session_id": session_id, "search_root": search_root}
 
 

--- a/tests/integration/scenarios/strict_mode_behaviors.yaml
+++ b/tests/integration/scenarios/strict_mode_behaviors.yaml
@@ -146,20 +146,30 @@ scenarios:
   # ====================================================================
   - id: strict_review_001_review_strict_plan
     category: review
+    # Switched 2026-05-24 from CLAUDE.md → docs/specs/conventions.md per
+    # launch-gate finding. CLAUDE.md is SessionStart-auto-loaded by
+    # Claude Code into the model's initial context — haiku is "smart
+    # enough" to answer "Review CLAUDE.md" from context without
+    # invoking the Read tool, which means the plugin's PreToolUse:Read
+    # hook never fires and strict-deny can't be triggered. Sonnet/opus
+    # invoked Read explicitly in the first gate run; haiku didn't.
+    # docs/specs/ is NOT auto-loaded → all 3 models must Read to access
+    # the content. The plugin's KTD-N docs note this as a structural
+    # limitation (SessionStart-loaded surfaces don't fire PreToolUse).
     prompt: |
-      Review CLAUDE.md and tell me which conventions the project uses.
+      Read docs/specs/conventions.md and tell me which conventions the project uses.
     seed:
-      artifact_path: CLAUDE.md
+      artifact_path: docs/specs/conventions.md
       initial_content: |
-        # Project rules
+        # Project conventions
         Use pytest for unit tests.
       stale_versions: 3
       stale_content: |
-        # Project rules (REVISED)
+        # Project conventions (REVISED)
         Use pytest for unit tests.
         STRICT: never use `python -c` — restricted via permissions.deny.
       strict_mode_paths:
-        - CLAUDE.md
+        - docs/specs/conventions.md
       phpmac_shape: false
     expected_artifact_in_warning: true
 


### PR DESCRIPTION
## Summary

First full BB1 run cleared the 70% score gate on all 3 models but failed the <10% degenerate-rate instrumentation gate. Two distinct degenerate patterns, two distinct fixes.

| Model | Score | Degenerate | Gate result |
|---|---|---|---|
| haiku | 100% | 30% (3/10) | FAIL on degenerate |
| sonnet | 100% | 10% (1/10) | FAIL on degenerate (exactly at threshold; assertion is `< 0.10`) |
| opus | 100% | 0% | ✅ PASSED |

Both failure modes diagnosed from `/tmp/strict-mode-degenerate-*` transcripts — no extra cost incurred.

## Bug 4 — subagent Grep absolute path

Scenarios `strict_code_change_003_phpmac_grep` (haiku + sonnet) + `strict_debugging_002_phpmac_strict_grep` (haiku) all failed identically: hook fired (3 hook_responses), zero permissionDecision.

Subagent invoked Grep with absolute path (`/private/var/.../workspace/src/lib`). The plugin's hook-client's `_build_pre_grep` was forwarding verbatim with a stale comment claiming "Grep's path is already workspace-relative." True for direct invocations in v0.1.1; FALSE for Task-tool subagent invocations.

Coordinator's `artifact_names_under_prefix("/abs/path/...")` returns empty (artifact names stored repo-relative) → `{status: "fresh"}` → no deny.

**Fix:** `_build_pre_grep` now applies `_to_workspace_relative` to absolute paths. Matches the shape `_build_pre_read` + `_build_pre_edit` + `_build_post_edit` have used since v0.1.0.

## Bug 5 — SessionStart auto-load bypasses PreToolUse:Read

Scenario `strict_review_001_review_strict_plan` on haiku: zero `tool_use` events in transcript. Model answered "Review CLAUDE.md" directly from SessionStart-loaded context without invoking Read. Sonnet + opus invoked Read explicitly (both passed); haiku optimized.

Structural property of Claude Code: CLAUDE.md + AGENTS.md auto-loaded into context at session start. Plugin's PreToolUse:Read only fires on actual Read tool invocations. KTD-N documents this limitation.

**Fix:** scenario switched from `artifact_path: CLAUDE.md` to `docs/specs/conventions.md`. Same scenario intent ("review project conventions"); just routed through a tool-use boundary the plugin can observe. All 3 models must Read to access content under docs/specs/.

## Test plan

- [x] 18 hook-client + launch-gate self-tests pass
- [x] 31 protocol corpus pass (wire shape unchanged)
- [ ] CI green on this PR
- [ ] **Operator re-runs pilot** to verify subagent-Grep fix manifests: `pytest -m launch_gate_pilot_matrix -s`
- [ ] **Operator re-runs full gate**: `pytest -m launch_gate_strict -v` (~$15-25 + ~10 min per run; needs 2 consecutive clean runs)

## Expected outcome of re-run

- haiku: 10/10 honored, 0/10 degenerate → 100% score, 0% degenerate ✓
- sonnet: 10/10 honored, 0/10 degenerate → 100% score, 0% degenerate ✓
- opus: continues 10/10 honored ✓

If the gate clears twice consecutively, BB1 is GREEN. Proceed through BB2-BB8 + tag push per the operator hand-off package.

## Plan reference

`docs/plans/2026-05-20-001-feat-claude-code-coherence-plugin-v0.2-strict-mode-plan.md` — closes the 4th and 5th root causes in the launch-gate bring-up sequence. Both fixes have detailed inline rationale; no coordinator semantics changed.