### PR TITLE
fix(cli): normalize absolute paths inside workspace for track/untrack

### DIFF
--- a/src/ccs/cli/_coherence_client.py
+++ b/src/ccs/cli/_coherence_client.py
@@ -66,7 +66,14 @@ def validate_relative_path(p: str) -> str | None:
     P2 ce-review fix #6 (maintainability): consolidates the
     ``_validate_path`` helper that previously existed byte-for-byte in
     both coherence_track.py and coherence_untrack.py — divergence risk
-    eliminated. Both scripts now import this single source of truth."""
+    eliminated. Both scripts now import this single source of truth.
+
+    Note: this is a PURE-STRING validator. Callers that want to accept
+    absolute paths inside the workspace (operator-UX path, exposed via
+    ``/agent-coherence:track`` skill template that passes ``$ARGUMENTS``
+    verbatim) should call :func:`normalize_workspace_path` instead, which
+    handles absolute-vs-relative + workspace-containment before delegating
+    to this function."""
     if not p:
         return "empty"
     if p.startswith("/"):
@@ -74,6 +81,57 @@ def validate_relative_path(p: str) -> str | None:
     if ".." in Path(p).parts:
         return "path must not contain '..' traversal"
     return None
+
+
+def normalize_workspace_path(p: str, root: Path) -> tuple[str, str | None]:
+    """Normalize a CLI path argument to workspace-relative form.
+
+    Returns ``(normalized_path, None)`` if the path is valid; returns
+    ``(original_path, reason_string)`` if invalid. Accepts both relative
+    and absolute paths:
+
+    - **Empty** → ``("", "empty")``
+    - **Relative** (e.g., ``"docs/plan.md"``) → validated as-is via
+      :func:`validate_relative_path`; returned unchanged on success.
+    - **Absolute and inside workspace root** (e.g.,
+      ``"/Users/x/repo/docs/plan.md"`` with ``root=/Users/x/repo``) →
+      stripped to workspace-relative (``"docs/plan.md"``); re-validated
+      for ``..`` traversal defense.
+    - **Absolute and outside workspace root** (e.g., ``"/etc/passwd"``)
+      → rejected with ``"path outside workspace root"``.
+
+    This helper exists because the Claude Code plugin's
+    ``/agent-coherence:track`` skill template substitutes ``$ARGUMENTS``
+    verbatim — operators routinely type absolute paths (autocomplete from
+    their shell or IDE). Pre-2026-05-26 the CLI rejected those outright;
+    this helper normalizes them so the operator UX matches the skill UX.
+
+    The normalized form is what gets written to ``tracked.yaml`` /
+    ``ignored.yaml`` — absolute paths must NEVER leak into those files
+    because they're per-machine / per-worktree and would break cross-host
+    state sharing if the coordinator-backed state.db is ever migrated.
+
+    M-02 trust-boundary note: the server-side validator
+    (:func:`ccs.adapters.claude_code.coordinator_server.validate_path`)
+    still independently rejects absolute paths in the coordinator
+    request body. This client-side normalization happens BEFORE the
+    request is built — by the time the request hits the wire, the path
+    is workspace-relative. The server check remains the authoritative
+    gate against malformed direct-HTTP calls that bypass this CLI.
+    """
+    if not p:
+        return p, "empty"
+    if Path(p).is_absolute():
+        try:
+            normalized = str(Path(p).resolve().relative_to(root.resolve()))
+        except ValueError:
+            return p, "path outside workspace root"
+        # Re-validate the normalized form against the pure-string rules
+        # (catches e.g. a resolved path that still contains '..' — defensive)
+        reason = validate_relative_path(normalized)
+        return (normalized, None) if reason is None else (p, reason)
+    reason = validate_relative_path(p)
+    return (p, None) if reason is None else (p, reason)
 
 
 @dataclass(frozen=True)

--- a/src/ccs/cli/coherence_track.py
+++ b/src/ccs/cli/coherence_track.py
@@ -26,21 +26,27 @@ from ccs.cli._coherence_client import (
     CoordinatorUnavailable,
     err,
     http_status_from_error,
+    normalize_workspace_path,
     post,
     resolve_endpoint,
-    validate_relative_path,
 )
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="agent-coherence-track",
-        description="Add one or more workspace-relative paths to the coordinator's tracked set.",
+        description="Add one or more paths to the coordinator's tracked set.",
     )
     parser.add_argument(
         "paths",
         nargs="+",
-        help="One or more workspace-relative paths to track (no leading '/' or '..').",
+        help=(
+            "One or more paths to track. Accepts workspace-relative paths "
+            "(e.g. 'docs/plan.md') OR absolute paths inside the workspace "
+            "root (auto-normalized to workspace-relative before send). "
+            "Absolute paths outside the workspace are rejected. No '..' "
+            "traversal."
+        ),
     )
     parser.add_argument(
         "--root",
@@ -59,15 +65,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         err("agent-coherence-track: not in a git repository")
         return 1
 
-    # Local pre-validation so we can fail fast without a network round-trip.
+    # Local pre-validation + normalization so we can fail fast without a
+    # network round-trip. normalize_workspace_path accepts both relative
+    # paths (e.g. "docs/plan.md") and absolute paths inside the workspace
+    # root (e.g. "/Users/x/repo/docs/plan.md") — the latter auto-strips to
+    # workspace-relative before send. Absolute paths outside root are
+    # rejected. This matches the operator UX expectation when the path is
+    # passed verbatim from the /agent-coherence:track skill template.
     invalid: list[tuple[str, str]] = []
     valid: list[str] = []
     for p in args.paths:
-        reason = validate_relative_path(p)
+        normalized, reason = normalize_workspace_path(p, Path(root))
         if reason is not None:
-            invalid.append((p, reason))
+            invalid.append((p, reason))  # original input in error for clarity
         else:
-            valid.append(p)
+            valid.append(normalized)  # normalized form to coordinator
 
     if not valid:
         for p, reason in invalid:

--- a/src/ccs/cli/coherence_untrack.py
+++ b/src/ccs/cli/coherence_untrack.py
@@ -26,21 +26,27 @@ from ccs.cli._coherence_client import (
     CoordinatorUnavailable,
     err,
     http_status_from_error,
+    normalize_workspace_path,
     post,
     resolve_endpoint,
-    validate_relative_path,
 )
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="agent-coherence-untrack",
-        description="Append one or more workspace-relative paths to the coordinator's ignored set.",
+        description="Append one or more paths to the coordinator's ignored set.",
     )
     parser.add_argument(
         "paths",
         nargs="+",
-        help="One or more workspace-relative paths to ignore (no leading '/' or '..').",
+        help=(
+            "One or more paths to ignore. Accepts workspace-relative paths "
+            "(e.g. 'docs/draft.md') OR absolute paths inside the workspace "
+            "root (auto-normalized to workspace-relative before send). "
+            "Absolute paths outside the workspace are rejected. No '..' "
+            "traversal."
+        ),
     )
     parser.add_argument(
         "--root",
@@ -59,14 +65,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         err("agent-coherence-untrack: not in a git repository")
         return 1
 
+    # See coherence_track.py for rationale: normalize_workspace_path lets
+    # the operator pass absolute paths inside the workspace and the CLI
+    # auto-strips to workspace-relative before send. Matches the
+    # /agent-coherence:untrack skill template UX (which substitutes
+    # $ARGUMENTS verbatim).
     invalid: list[tuple[str, str]] = []
     valid: list[str] = []
     for p in args.paths:
-        reason = validate_relative_path(p)
+        normalized, reason = normalize_workspace_path(p, Path(root))
         if reason is not None:
             invalid.append((p, reason))
         else:
-            valid.append(p)
+            valid.append(normalized)
 
     if not valid:
         for p, reason in invalid:

--- a/tests/test_claude_code_cli.py
+++ b/tests/test_claude_code_cli.py
@@ -416,7 +416,11 @@ def test_prepare_for_migration_releases_grants_and_shuts_down(
 
 
 @pytest.mark.parametrize("bad_path,reason_substr", [
-    ("/etc/passwd", "must be relative"),
+    # /etc/passwd is absolute AND outside the workspace — error message
+    # changed 2026-05-26 from "must be relative" to "outside workspace root"
+    # because absolute paths INSIDE the workspace are now auto-normalized
+    # (operator-UX fix: skill template passes absolute paths verbatim).
+    ("/etc/passwd", "outside workspace root"),
     ("../../../etc/passwd", "'..'"),
     ("", "empty"),
 ])
@@ -430,6 +434,51 @@ def test_track_rejects_invalid_paths_without_network(
     assert rc == 1
     # ce-review P2 fix #15: rejection messages go to stderr
     assert reason_substr in captured.err
+
+
+def test_track_accepts_absolute_path_inside_workspace(
+    live_coordinator, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Operator-UX fix 2026-05-26: skill template passes absolute paths verbatim
+    (`/agent-coherence:track /abs/path/file.md`); CLI must auto-normalize to
+    workspace-relative form before validation + before send-to-coordinator.
+    Tracked.yaml must contain the WORKSPACE-RELATIVE form, never the absolute
+    path — otherwise tracked.yaml drifts across machines / worktrees."""
+    workspace, port = live_coordinator
+    target = workspace / "docs" / "plan.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("plan v1")
+
+    rc = coherence_track.main(["--root", str(workspace), str(target)])
+    captured = capsys.readouterr()
+    assert rc == 0, f"expected 0, got {rc}; stderr: {captured.err}"
+    # Success message uses the workspace-relative form (operator sees clean output)
+    assert "tracked docs/plan.md" in captured.out
+    # tracked.yaml contains workspace-relative — NO absolute path leak
+    tracked_yaml = workspace / ".coherence" / "tracked.yaml"
+    content = tracked_yaml.read_text()
+    assert "docs/plan.md" in content
+    assert str(target) not in content, (
+        "absolute path leaked into tracked.yaml — file is now machine-specific. "
+        f"content: {content!r}"
+    )
+
+
+def test_untrack_accepts_absolute_path_inside_workspace(
+    live_coordinator, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Same defense-in-depth fix for the sibling untrack CLI."""
+    workspace, port = live_coordinator
+    target = workspace / "docs" / "draft.md"
+
+    rc = coherence_untrack.main(["--root", str(workspace), str(target)])
+    captured = capsys.readouterr()
+    assert rc == 0, f"expected 0, got {rc}; stderr: {captured.err}"
+    assert "untracked docs/draft.md" in captured.out
+    ignored_yaml = workspace / ".coherence" / "ignored.yaml"
+    content = ignored_yaml.read_text()
+    assert "docs/draft.md" in content
+    assert str(target) not in content
 
 
 def test_track_no_coordinator_running_exits_2(
@@ -493,7 +542,10 @@ def test_untrack_against_live_coordinator(
 
 
 @pytest.mark.parametrize("bad_path,reason_substr", [
-    ("/etc/passwd", "must be relative"),
+    # See test_track_rejects_invalid_paths_without_network for rationale on
+    # the 2026-05-26 message change from "must be relative" to "outside
+    # workspace root" — sibling normalization fix applies to untrack too.
+    ("/etc/passwd", "outside workspace root"),
     ("../escape", "'..'"),
     ("", "empty"),
 ])


### PR DESCRIPTION
## Summary

Phase E broad-beta monitoring (closes 2026-06-08) surfaced a skill-UX failure: when an operator invokes `/agent-coherence:track` with an absolute path (autocomplete from shell/IDE), the skill template passes `$ARGUMENTS` verbatim to `agent-coherence-track`, which rejected any leading-`/` path via `validate_relative_path`. From the operator's perspective the skill was broken — `rejected '/abs/path': path must be relative (no leading '/')`.

## What changed

- **New helper** `normalize_workspace_path(p, root)` in `src/ccs/cli/_coherence_client.py` — accepts both relative paths AND absolute paths inside the workspace root (auto-strips to workspace-relative). Absolute paths outside the workspace are rejected with a clearer `"outside workspace root"` message instead of the old `"must be relative"`.
- **`coherence_track.py` + `coherence_untrack.py`** both call the new helper before `validate_relative_path`. The normalized form is what gets written to `tracked.yaml` / `ignored.yaml` — absolute paths never leak (would break per-machine portability).
- **`validate_relative_path` unchanged** — stays as a pure-string validator (still referenced by `coordinator_server`'s server-side check as the lighter trust-boundary layer per the existing M-02 docstring). The new normalization layer composes above it.

## What didn't change

- Server-side `validate_path` in `coordinator_server.py` — the authoritative gate against malformed direct-HTTP calls. Independent rejection of absolute paths on the wire stays in place.
- Other CLIs (`coherence_status`, `coherence_replay`, `coherence_migrate_*`) — don't accept tracked-artifact path arguments; pattern doesn't apply.
- Hook-client `_to_workspace_relative` in `coherence_hook_client.py` — different shape (raises `_SkipHook` for hook-skip semantics); not consolidated to keep one-change-at-a-time discipline.

## Test plan

- [x] 4 new/updated tests in `tests/test_claude_code_cli.py`:
  - `test_track_accepts_absolute_path_inside_workspace` — assert exit 0 + `tracked.yaml` contains workspace-relative form + assert the absolute path does NOT leak into `tracked.yaml`
  - `test_untrack_accepts_absolute_path_inside_workspace` — sibling for untrack
  - `test_track_rejects_invalid_paths_without_network[/etc/passwd-outside workspace root]` — parametrize updated to expect the new error message
  - `test_untrack_rejects_invalid_paths_without_network[/etc/passwd-outside workspace root]` — sibling
- [x] Full broad sweep: `1391 passed, 0 failed` in 167s
- [x] Architecture check: clean (94 modules, 192 edges)

## Related — Phase E follow-ups (NOT in this PR)

Companion Bug A surfaced from the same screenshot: `/agent-coherence:status` requires a Bash permission prompt every invocation. Confirmed via `code.claude.com/docs/en/plugins-reference` that this is **not fixable at code layer** — plugin manifest schema doesn't support `permissions.allow`, and plugin-root `settings.json` only supports `agent` + `subagentStatusLine` keys. Follow-up work queued for the Phase E monitoring window:
1. File upstream Claude Code Issue requesting plugin-shipped permission allowlists for bundled console scripts
2. Add troubleshooting section to plugin README documenting the workaround (`.claude/settings.local.json` allowlist for `agent-coherence-*`)

This PR closes only the absolute-path Bug B. Ships as a v0.2.1 patch candidate.