### PR TITLE
release: v0.8.1 — cherry-pick Bug 9 CLI absolute-path normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ Alpha — APIs may change before `v1.0`.
 
 ## [Unreleased]
 
+No unreleased work yet — `v0.8.1` patch shipped 2026-05-26; next minor `v0.9.0` is in flight on `dev` (strict-mode telemetry + launch-gate harness + audit log; targeting plugin v0.2.x compatibility).
+
+## [0.8.1] — 2026-05-26
+
+**Patch release — operator-UX fix for `agent-coherence-track` / `agent-coherence-untrack` CLIs.** Surfaced during the Claude Code plugin v0.2.0 broad-beta monitoring window (closes 2026-06-08); cherry-picked from `dev` rather than waiting for the full `v0.9.0` minor.
+
+### Fixed
+
+- **`agent-coherence-track` / `agent-coherence-untrack` accept absolute paths inside the workspace** (cherry-pick of PR #66, commit `10f1e16`). Previously the CLIs rejected any leading-`/` path with `path must be relative (no leading '/')`. The Claude Code plugin's `/agent-coherence:track` skill template substitutes `$ARGUMENTS` verbatim — operators routinely type absolute paths (autocomplete from shell or IDE), so the CLI was breaking on the most common operator input shape. New `normalize_workspace_path(p, root)` helper in `src/ccs/cli/_coherence_client.py` accepts both relative and absolute paths; absolute paths inside the workspace are auto-stripped to workspace-relative before send (the form that goes to `tracked.yaml` / `ignored.yaml` — absolute paths must NEVER leak into those files because they're per-machine). Absolute paths outside the workspace are rejected with a clearer `path outside workspace root` message. The server-side validator in `coordinator_server.py` still independently rejects absolute paths on the wire as a trust-boundary backstop.
+
+### Test coverage
+
+- 4 new/updated tests in `tests/test_claude_code_cli.py` (`test_track_accepts_absolute_path_inside_workspace`, sibling for untrack, plus parametrize updates on the existing `/etc/passwd` rejection cases). 1391 tests pass on the full broad sweep; architecture check clean.
+
+### Compatibility
+
+- Wire contract unchanged. Plugin v0.2.x continues to work against `agent-coherence>=0.8.0`; this patch adds the absolute-path normalization layer that operators benefit from when invoking the CLIs through the plugin's slash commands.
+- No breaking changes; `validate_relative_path` (the pure-string validator) stays unchanged and continues to be referenced by `coordinator_server`'s server-side check per the existing M-02 trust-boundary docstring. The new `normalize_workspace_path` composes above it.
+
+### Related
+
+- Surfaced in Phase E broad-beta monitoring screenshot 2026-05-26 alongside Bugs 8 (plugin permission allowlist — upstream-blocked, [anthropics/claude-code#62616](https://github.com/anthropics/claude-code/issues/62616)) and 10 (plugin `bin/` PATH-resolver shims — shipped in plugin v0.2.1)
+- Full diagnosis in `docs/solutions/best-practices/cli-skill-template-passes-args-verbatim-normalize-at-cli-2026-05-26.md` (Bug 9)
+
 ## [0.8.0] — 2026-05-23
 
 **Stable release of the Claude Code plugin coordinator backend.** Promotes the `0.8.0a1` alpha pre-release to a final `0.8.0` after the v0.1.1 marketplace cohort + full ce-review remediation pass landed. Both the coordinator HTTP surface and the wire contract are now considered stable through the `0.8.x` minor line; breaking changes will bump to `0.9.0` per SemVer.

--- a/src/ccs/__init__.py
+++ b/src/ccs/__init__.py
@@ -3,4 +3,4 @@
 
 """agent-coherence core package."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/src/ccs/cli/_coherence_client.py
+++ b/src/ccs/cli/_coherence_client.py
@@ -66,7 +66,14 @@ def validate_relative_path(p: str) -> str | None:
     P2 ce-review fix #6 (maintainability): consolidates the
     ``_validate_path`` helper that previously existed byte-for-byte in
     both coherence_track.py and coherence_untrack.py — divergence risk
-    eliminated. Both scripts now import this single source of truth."""
+    eliminated. Both scripts now import this single source of truth.
+
+    Note: this is a PURE-STRING validator. Callers that want to accept
+    absolute paths inside the workspace (operator-UX path, exposed via
+    ``/agent-coherence:track`` skill template that passes ``$ARGUMENTS``
+    verbatim) should call :func:`normalize_workspace_path` instead, which
+    handles absolute-vs-relative + workspace-containment before delegating
+    to this function."""
     if not p:
         return "empty"
     if p.startswith("/"):
@@ -74,6 +81,57 @@ def validate_relative_path(p: str) -> str | None:
     if ".." in Path(p).parts:
         return "path must not contain '..' traversal"
     return None
+
+
+def normalize_workspace_path(p: str, root: Path) -> tuple[str, str | None]:
+    """Normalize a CLI path argument to workspace-relative form.
+
+    Returns ``(normalized_path, None)`` if the path is valid; returns
+    ``(original_path, reason_string)`` if invalid. Accepts both relative
+    and absolute paths:
+
+    - **Empty** → ``("", "empty")``
+    - **Relative** (e.g., ``"docs/plan.md"``) → validated as-is via
+      :func:`validate_relative_path`; returned unchanged on success.
+    - **Absolute and inside workspace root** (e.g.,
+      ``"/Users/x/repo/docs/plan.md"`` with ``root=/Users/x/repo``) →
+      stripped to workspace-relative (``"docs/plan.md"``); re-validated
+      for ``..`` traversal defense.
+    - **Absolute and outside workspace root** (e.g., ``"/etc/passwd"``)
+      → rejected with ``"path outside workspace root"``.
+
+    This helper exists because the Claude Code plugin's
+    ``/agent-coherence:track`` skill template substitutes ``$ARGUMENTS``
+    verbatim — operators routinely type absolute paths (autocomplete from
+    their shell or IDE). Pre-2026-05-26 the CLI rejected those outright;
+    this helper normalizes them so the operator UX matches the skill UX.
+
+    The normalized form is what gets written to ``tracked.yaml`` /
+    ``ignored.yaml`` — absolute paths must NEVER leak into those files
+    because they're per-machine / per-worktree and would break cross-host
+    state sharing if the coordinator-backed state.db is ever migrated.
+
+    M-02 trust-boundary note: the server-side validator
+    (:func:`ccs.adapters.claude_code.coordinator_server.validate_path`)
+    still independently rejects absolute paths in the coordinator
+    request body. This client-side normalization happens BEFORE the
+    request is built — by the time the request hits the wire, the path
+    is workspace-relative. The server check remains the authoritative
+    gate against malformed direct-HTTP calls that bypass this CLI.
+    """
+    if not p:
+        return p, "empty"
+    if Path(p).is_absolute():
+        try:
+            normalized = str(Path(p).resolve().relative_to(root.resolve()))
+        except ValueError:
+            return p, "path outside workspace root"
+        # Re-validate the normalized form against the pure-string rules
+        # (catches e.g. a resolved path that still contains '..' — defensive)
+        reason = validate_relative_path(normalized)
+        return (normalized, None) if reason is None else (p, reason)
+    reason = validate_relative_path(p)
+    return (p, None) if reason is None else (p, reason)
 
 
 @dataclass(frozen=True)

--- a/src/ccs/cli/coherence_track.py
+++ b/src/ccs/cli/coherence_track.py
@@ -26,21 +26,27 @@ from ccs.cli._coherence_client import (
     CoordinatorUnavailable,
     err,
     http_status_from_error,
+    normalize_workspace_path,
     post,
     resolve_endpoint,
-    validate_relative_path,
 )
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="agent-coherence-track",
-        description="Add one or more workspace-relative paths to the coordinator's tracked set.",
+        description="Add one or more paths to the coordinator's tracked set.",
     )
     parser.add_argument(
         "paths",
         nargs="+",
-        help="One or more workspace-relative paths to track (no leading '/' or '..').",
+        help=(
+            "One or more paths to track. Accepts workspace-relative paths "
+            "(e.g. 'docs/plan.md') OR absolute paths inside the workspace "
+            "root (auto-normalized to workspace-relative before send). "
+            "Absolute paths outside the workspace are rejected. No '..' "
+            "traversal."
+        ),
     )
     parser.add_argument(
         "--root",
@@ -59,15 +65,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         err("agent-coherence-track: not in a git repository")
         return 1
 
-    # Local pre-validation so we can fail fast without a network round-trip.
+    # Local pre-validation + normalization so we can fail fast without a
+    # network round-trip. normalize_workspace_path accepts both relative
+    # paths (e.g. "docs/plan.md") and absolute paths inside the workspace
+    # root (e.g. "/Users/x/repo/docs/plan.md") — the latter auto-strips to
+    # workspace-relative before send. Absolute paths outside root are
+    # rejected. This matches the operator UX expectation when the path is
+    # passed verbatim from the /agent-coherence:track skill template.
     invalid: list[tuple[str, str]] = []
     valid: list[str] = []
     for p in args.paths:
-        reason = validate_relative_path(p)
+        normalized, reason = normalize_workspace_path(p, Path(root))
         if reason is not None:
-            invalid.append((p, reason))
+            invalid.append((p, reason))  # original input in error for clarity
         else:
-            valid.append(p)
+            valid.append(normalized)  # normalized form to coordinator
 
     if not valid:
         for p, reason in invalid:

--- a/src/ccs/cli/coherence_untrack.py
+++ b/src/ccs/cli/coherence_untrack.py
@@ -26,21 +26,27 @@ from ccs.cli._coherence_client import (
     CoordinatorUnavailable,
     err,
     http_status_from_error,
+    normalize_workspace_path,
     post,
     resolve_endpoint,
-    validate_relative_path,
 )
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="agent-coherence-untrack",
-        description="Append one or more workspace-relative paths to the coordinator's ignored set.",
+        description="Append one or more paths to the coordinator's ignored set.",
     )
     parser.add_argument(
         "paths",
         nargs="+",
-        help="One or more workspace-relative paths to ignore (no leading '/' or '..').",
+        help=(
+            "One or more paths to ignore. Accepts workspace-relative paths "
+            "(e.g. 'docs/draft.md') OR absolute paths inside the workspace "
+            "root (auto-normalized to workspace-relative before send). "
+            "Absolute paths outside the workspace are rejected. No '..' "
+            "traversal."
+        ),
     )
     parser.add_argument(
         "--root",
@@ -59,14 +65,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         err("agent-coherence-untrack: not in a git repository")
         return 1
 
+    # See coherence_track.py for rationale: normalize_workspace_path lets
+    # the operator pass absolute paths inside the workspace and the CLI
+    # auto-strips to workspace-relative before send. Matches the
+    # /agent-coherence:untrack skill template UX (which substitutes
+    # $ARGUMENTS verbatim).
     invalid: list[tuple[str, str]] = []
     valid: list[str] = []
     for p in args.paths:
-        reason = validate_relative_path(p)
+        normalized, reason = normalize_workspace_path(p, Path(root))
         if reason is not None:
             invalid.append((p, reason))
         else:
-            valid.append(p)
+            valid.append(normalized)
 
     if not valid:
         for p, reason in invalid:

--- a/tests/test_claude_code_cli.py
+++ b/tests/test_claude_code_cli.py
@@ -416,7 +416,11 @@ def test_prepare_for_migration_releases_grants_and_shuts_down(
 
 
 @pytest.mark.parametrize("bad_path,reason_substr", [
-    ("/etc/passwd", "must be relative"),
+    # /etc/passwd is absolute AND outside the workspace — error message
+    # changed 2026-05-26 from "must be relative" to "outside workspace root"
+    # because absolute paths INSIDE the workspace are now auto-normalized
+    # (operator-UX fix: skill template passes absolute paths verbatim).
+    ("/etc/passwd", "outside workspace root"),
     ("../../../etc/passwd", "'..'"),
     ("", "empty"),
 ])
@@ -430,6 +434,51 @@ def test_track_rejects_invalid_paths_without_network(
     assert rc == 1
     # ce-review P2 fix #15: rejection messages go to stderr
     assert reason_substr in captured.err
+
+
+def test_track_accepts_absolute_path_inside_workspace(
+    live_coordinator, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Operator-UX fix 2026-05-26: skill template passes absolute paths verbatim
+    (`/agent-coherence:track /abs/path/file.md`); CLI must auto-normalize to
+    workspace-relative form before validation + before send-to-coordinator.
+    Tracked.yaml must contain the WORKSPACE-RELATIVE form, never the absolute
+    path — otherwise tracked.yaml drifts across machines / worktrees."""
+    workspace, port = live_coordinator
+    target = workspace / "docs" / "plan.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("plan v1")
+
+    rc = coherence_track.main(["--root", str(workspace), str(target)])
+    captured = capsys.readouterr()
+    assert rc == 0, f"expected 0, got {rc}; stderr: {captured.err}"
+    # Success message uses the workspace-relative form (operator sees clean output)
+    assert "tracked docs/plan.md" in captured.out
+    # tracked.yaml contains workspace-relative — NO absolute path leak
+    tracked_yaml = workspace / ".coherence" / "tracked.yaml"
+    content = tracked_yaml.read_text()
+    assert "docs/plan.md" in content
+    assert str(target) not in content, (
+        "absolute path leaked into tracked.yaml — file is now machine-specific. "
+        f"content: {content!r}"
+    )
+
+
+def test_untrack_accepts_absolute_path_inside_workspace(
+    live_coordinator, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Same defense-in-depth fix for the sibling untrack CLI."""
+    workspace, port = live_coordinator
+    target = workspace / "docs" / "draft.md"
+
+    rc = coherence_untrack.main(["--root", str(workspace), str(target)])
+    captured = capsys.readouterr()
+    assert rc == 0, f"expected 0, got {rc}; stderr: {captured.err}"
+    assert "untracked docs/draft.md" in captured.out
+    ignored_yaml = workspace / ".coherence" / "ignored.yaml"
+    content = ignored_yaml.read_text()
+    assert "docs/draft.md" in content
+    assert str(target) not in content
 
 
 def test_track_no_coordinator_running_exits_2(
@@ -493,7 +542,10 @@ def test_untrack_against_live_coordinator(
 
 
 @pytest.mark.parametrize("bad_path,reason_substr", [
-    ("/etc/passwd", "must be relative"),
+    # See test_track_rejects_invalid_paths_without_network for rationale on
+    # the 2026-05-26 message change from "must be relative" to "outside
+    # workspace root" — sibling normalization fix applies to untrack too.
+    ("/etc/passwd", "outside workspace root"),
     ("../escape", "'..'"),
     ("", "empty"),
 ])


### PR DESCRIPTION
## Summary

Patch release combining a single cherry-picked Bug 9 fix from `dev` (PR #66 → commit `10f1e16`) with a version bump and CHANGELOG entry. Surfaced during the Claude Code plugin v0.2.0 broad-beta monitoring window (closes 2026-06-08).

## Why cherry-pick instead of waiting for v0.9.0

`dev` has ~9 commits ahead of `main` including the full v0.2 strict-mode-supporting work (KTD-S launch-gate harness, strict-mode telemetry counters, audit log, etc.). That's a minor-version-shaped delta and will ship as **v0.9.0** when ready. Bug 9 alone is a small operator-UX fix that benefits broad-beta operators *now* — cherry-picked rather than blocked on v0.9.0 scoping.

## What's in v0.8.1

| Change | Origin |
|---|---|
| `agent-coherence-track` / `agent-coherence-untrack` accept absolute paths inside the workspace (auto-normalized to workspace-relative before send) | Cherry-pick of `10f1e16` |
| Version bump `0.8.0` → `0.8.1` in `src/ccs/__init__.py` | This PR |
| `CHANGELOG.md` `[0.8.1]` entry with full Phase E context | This PR |

## Phase E broad-beta context (sibling fixes already shipped)

| Bug | Where | Status |
|---|---|---|
| Bug 8 — Plugin permission allowlist (Claude Code platform limit) | Workspace `.claude/settings.local.json` workaround | ✅ Plugin v0.2.1 (shipped); [upstream Issue #62616](https://github.com/anthropics/claude-code/issues/62616) filed |
| **Bug 9 — CLI absolute-path normalization** | Library | **THIS PR** |
| Bug 10 — Plugin `bin/` PATH-resolver shims | Plugin `bin/` shims | ✅ Plugin v0.2.1 (shipped) |

## Preflight (run before push)

- [x] `tools/check_release_readiness.py` — all 3 automated checks pass (`pypi` GitHub environment configured; branch protection on `main` active; tag protection ruleset covers `refs/tags/v*`)
- [x] Architecture check clean
- [x] Cherry-pick clean (4 files; +148 / -15)

## Post-merge actions (operator)

1. Switch to `main`, pull
2. `git tag -a v0.8.1 -m "v0.8.1: cherry-pick Bug 9 CLI absolute-path normalization"`
3. `git push origin v0.8.1` — fires `release.yml` (preflight → build → PyPI publish via Trusted Publishers OIDC → GitHub Release with SBOM)
4. After PyPI publish, optionally bump the plugin's documented library prereq from `>=0.9.0` (aspirational, unreleased) to `>=0.8.1` (released; covers Bug 9)

## Compatibility

No breaking changes. Wire contract unchanged. Plugin v0.2.x continues to work against `agent-coherence>=0.8.0`; this patch adds the absolute-path normalization layer that operators benefit from when invoking the CLIs through the plugin's slash commands.