### PR TITLE
fix(cli,replay): ce-review P1/P2 fixes — --show-policy, quiet JSON, fd leak, tier disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ store = CCSStore(strategy="lazy")
 
 `store.get()`, `store.put()`, `store.search()` keep working unchanged. Savings show up immediately on any workload where multiple agents read the same artifact more often than they write it.
 
+`agent-coherence-replay` — invariant-replay for any CoherenceAdapterCore-mediated agent system. LangGraph capture verified in v1 via `CCSStore.record_to(path)`; CrewAI / AutoGen wired through the same seam but unverified — file an issue if it breaks.
+
 | Workload | Agents | Reads:Writes | Hit rate | Savings |
 |---|---|---|---|---|
 | Planning (read-heavy) | 4 | 12:1 | 75% | **69%** |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -648,6 +648,112 @@ See [docs/ccs-diagnose.md](ccs-diagnose.md) for the full reference: usage, flags
 
 ---
 
+## Replay (v0.10.0+)
+
+`agent-coherence-replay` is an invariant-replay tool that walks a captured
+coordinator session and reports breaches of the four core MESI invariants —
+single-writer, monotonic-version, stale-read, lost-write — without re-executing
+any agents. Capture rides on the existing `state_log` and `content_audit_log`
+callback seams via `CCSStore.record_to(path)`.
+
+### Capture and replay (LangGraph quickstart)
+
+```python
+from langgraph.config import get_store as lg_get_store
+from langgraph.graph import END, START, StateGraph
+from typing import TypedDict
+
+from ccs.adapters.ccsstore import CCSStore
+
+
+class GraphState(TypedDict):
+    log: list[str]
+
+
+def planner_node(state: GraphState) -> dict:
+    store: CCSStore = lg_get_store()  # type: ignore[assignment]
+    store.put(("planner", "shared"), "plan", {"step": 1})
+    return {"log": [*state["log"], "planner: wrote plan"]}
+
+
+def reviewer_node(state: GraphState) -> dict:
+    store: CCSStore = lg_get_store()  # type: ignore[assignment]
+    item = store.get(("reviewer", "shared"), "plan")
+    assert item is not None
+    return {"log": [*state["log"], "reviewer: read plan"]}
+
+
+def build_graph(store: CCSStore):
+    builder = StateGraph(GraphState)
+    builder.add_node("planner", planner_node)
+    builder.add_node("reviewer", reviewer_node)
+    builder.add_edge(START, "planner")
+    builder.add_edge("planner", "reviewer")
+    builder.add_edge("reviewer", END)
+    return builder.compile(store=store)
+
+
+# Wrap the store with record_to(...) for the duration of the run.
+with CCSStore.record_to("/tmp/coherence-session", strategy="lazy") as store:
+    graph = build_graph(store)
+    graph.invoke({"log": []})
+```
+
+The session directory now contains a `manifest.json` plus one JSONL file per
+captured stream (`state_log.jsonl`, `content_audit_log.jsonl`). Inspect it with:
+
+```bash
+# Human-readable findings + summary
+agent-coherence-replay /tmp/coherence-session
+
+# Machine-readable, one JSON object per line (per-finding + final summary)
+agent-coherence-replay /tmp/coherence-session --json | jq .
+```
+
+### Exit codes
+
+| Exit code | Meaning |
+|---|---|
+| `0` | Clean trace (or all SKIPPED entries are explicit compliance opt-outs) |
+| `1` | At least one CONFIRMED invariant breach |
+| `2` | Capture-side bug: a manifest-declared stream is missing from the directory |
+| `3` | Trace error (multi-instance, duplicate sequence number, missing manifest) |
+
+### Useful flags
+
+- `--invariant <name>` (repeatable) — restrict to a subset of `single-writer`, `monotonic-version`, `stale-read`, `lost-write`.
+- `--include-ambiguous` — show same-tick read/commit collisions as per-finding entries (suppressed from default output; always counted in summary).
+- `--quiet` — suppress non-breach output; cron-friendly.
+- `--json` — newline-delimited JSON conforming to the trace-format schema.
+
+### Capturing PII-constrained traces
+
+Pass `streams={"state_log"}` to opt out of the content-audit stream while
+keeping the other three invariants live:
+
+```python
+with CCSStore.record_to(
+    "/tmp/coherence-session",
+    streams={"state_log"},
+    strategy="lazy",
+) as store:
+    ...
+```
+
+Replay then reports stale-read as SKIPPED with `opted_out=True` and the run
+still exits 0.
+
+### Non-LangGraph adapters (CrewAI / AutoGen)
+
+CrewAI and AutoGen capture is wired through the same `CoherenceAdapterCore`
+seam via `ccs.replay.record_callbacks(...)`, but v1 only verifies the
+LangGraph path end-to-end. Direct callers must pass `accept_unverified=True`
+to acknowledge the v1 scope boundary — file an issue if the unverified path
+breaks for your stack. Ergonomic per-adapter wrappers (`record_to` mirrors)
+ship in the next release.
+
+---
+
 ## Command-line tools
 
 All bundled CLIs are installed as console scripts when you
@@ -660,6 +766,7 @@ All bundled CLIs are installed as console scripts when you
 | `ccs-simulate` | — | Run a protocol-only simulation scenario from a YAML file |
 | `ccs-compare` | — | Compare two or more strategies on the same scenario |
 | `ccs-check-architecture` | — | Verify the four-layer architecture boundary (also runs in CI) |
+| `agent-coherence-replay` | `[langgraph]` | Replay a captured coordinator session and report invariant breaches |
 
 Run any command with `--help` for the full option list.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,11 @@ agent-coherence-migrate-deny = "ccs.adapters.claude_code.migrate_deny:main"
 # the plugin uses command-type hooks that invoke this client, which reads
 # .coherence/server.pid directly. See docs/probes/2026-05-17-*.md.
 agent-coherence-hook-client = "ccs.cli.coherence_hook_client:main"
+# D v1 Unit 5: invariant replay CLI. Walks a captured session directory
+# through the predicate engine (single-writer / monotonic-version /
+# stale-read / lost-write) and emits human or JSON findings. Exit-code
+# mapping per docs/proposals/replay_trace_format.md §7.3.
+agent-coherence-replay = "ccs.cli.coherence_replay:main"
 # Note: ccs-check-release is intentionally NOT exposed as a public console
 # script. It's a maintainer-only pre-tag-push verifier that queries this
 # repo's GitHub admin settings (hardcoded defaults to hipvlady/agent-coherence).

--- a/src/ccs/adapters/ccsstore.py
+++ b/src/ccs/adapters/ccsstore.py
@@ -11,8 +11,10 @@ import logging
 import threading
 import uuid
 import warnings
+from contextlib import contextmanager
 from datetime import datetime, timezone
-from typing import Any, Callable, Iterable
+from pathlib import Path
+from typing import Any, Callable, Iterable, Iterator
 
 from langgraph.store.base import (
     BaseStore,
@@ -110,6 +112,78 @@ class CCSStore(BaseStore):
         self._bm_actual: int | None = 0 if benchmark else None
         self._bm_ops: int | None = 0 if benchmark else None
         self._bm_hits: int | None = 0 if benchmark else None
+
+    # ------------------------------------------------------------------
+    # Replay capture — thin wrapper over ccs.replay.record_callbacks
+    # ------------------------------------------------------------------
+
+    @classmethod
+    @contextmanager
+    def record_to(
+        cls,
+        path: str | Path,
+        *,
+        streams: set[str] | frozenset[str] | None = None,
+        **ccsstore_kwargs: Any,
+    ) -> Iterator["CCSStore"]:
+        """LangGraph-shaped capture context manager.
+
+        ``with CCSStore.record_to(path) as store: ...`` produces an
+        invariant-replay trace on disk per
+        ``docs/proposals/replay_trace_format.md``.
+
+        Composes any caller-supplied ``state_log`` / ``content_audit_log``
+        callbacks with the file-writing callbacks; never overrides them.
+
+        ``content_audit_log`` is ALWAYS passed to ``CCSStore.__init__``
+        (even when ``streams={'state_log'}``) because
+        ``retain_versions=content_audit_log is not None`` (init line 88)
+        is required by the other three invariants. The opt-out only
+        suppresses the on-disk JSONL writer.
+
+        CCSStore is the verified adapter in v1, so this wrapper sets
+        ``accept_unverified=True`` automatically — no
+        ``UnverifiedAdapterCaptureError`` and no stderr warning. The
+        opt-in gate is on ``record_callbacks`` for direct (CrewAI /
+        AutoGen) callers.
+        """
+        # Import inside the method body — keeps the optional replay
+        # surface out of the CCSStore import path for installs that
+        # don't use it. (Same-layer import; no architecture violation.)
+        from ccs.replay.recorder import record_callbacks
+
+        caller_state_log = ccsstore_kwargs.pop("state_log", None)
+        caller_audit_log = ccsstore_kwargs.pop("content_audit_log", None)
+        # accept_unverified is enforced by CCSStore (verified adapter).
+        # If a caller passes it here, drop it — the wrapper owns the flag.
+        ccsstore_kwargs.pop("accept_unverified", None)
+
+        # Mutable cell so the drain closure can see the store that
+        # only exists after record_callbacks has opened the session.
+        store_cell: list["CCSStore"] = []
+
+        def _drain() -> tuple[dict[str, str], dict[str, str]]:
+            if not store_cell:
+                return {}, {}
+            return _drain_store_registries(store_cell[0])
+
+        with record_callbacks(
+            path,
+            streams=streams,
+            accept_unverified=True,
+            state_log=caller_state_log,
+            content_audit_log=caller_audit_log,
+            adapter_type="langgraph-ccsstore",
+            drain_registries=_drain,
+            _verified_caller=True,
+        ) as (state_cb, audit_cb):
+            store = cls(
+                state_log=state_cb,
+                content_audit_log=audit_cb,
+                **ccsstore_kwargs,
+            )
+            store_cell.append(store)
+            yield store
 
     # ------------------------------------------------------------------
     # BaseStore interface — batch is the single implementation point
@@ -549,6 +623,26 @@ class CCSStore(BaseStore):
         if "__ccs_size_tokens__" in value:
             return int(value["__ccs_size_tokens__"])
         return max(1, len(json.dumps(value, sort_keys=True, separators=(",", ":"))) // 4)
+
+
+def _drain_store_registries(store: CCSStore) -> tuple[dict[str, str], dict[str, str]]:
+    """Snapshot agents + artifacts from a CCSStore for manifest finalization.
+
+    Called by ``CCSStore.record_to``'s drain closure on session
+    ``__exit__``. Returns ``(agents_by_uuid, artifacts_by_uuid)`` —
+    UUID strings to display names. Empty dicts when no MESI activity
+    has fired.
+    """
+    core = store.core
+    # agent_id (UUID) → name; sourced from the same dict that ArtifactRegistry
+    # uses for state_log entry naming.
+    agents = {str(uid): name for uid, name in core._agent_names.items()}
+    artifacts: dict[str, str] = {}
+    for artifact_id in core.registry.artifact_ids():
+        meta = core.registry.get_artifact(artifact_id)
+        if meta is not None:
+            artifacts[str(artifact_id)] = meta.name
+    return agents, artifacts
 
 
 def _ns_starts_with(ns: tuple[str, ...], prefix: tuple[str, ...]) -> bool:

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -2291,11 +2291,17 @@ def _handle_status(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) ->
             "states": per_artifact,
         })
 
+    policy_summary = coordinator.policy.summary()
+    if detail != "full":
+        # user_added_patterns is a list of workspace-relative paths.
+        # Leaking it at minimal/metrics tiers would expose the operator's
+        # directory layout to non-operator callers — keep it full-tier only.
+        policy_summary = {k: v for k, v in policy_summary.items() if k != "user_added_patterns"}
     base = {
         "detail": detail,
         "tracked_artifacts": tracked,
         "sessions": sessions,
-        "policy_summary": coordinator.policy.summary(),
+        "policy_summary": policy_summary,
         # P1 #7: coordinator_pid is in the minimal tier too. Process IDs
         # are public on POSIX (anyone with `ps` sees them) so this is
         # not a disclosure beyond the trust boundary the threat model
@@ -2785,6 +2791,26 @@ def _agent_id_to_session(coordinator: CoordinatorHTTPServer, agent_id: UUID) -> 
     return None
 
 
+def _parse_yaml_pattern_lines(text: str) -> set[str]:
+    """Extract pattern strings already present in a YAML list file.
+
+    Used to detect already-present entries before appending, keeping
+    /policy/track idempotent. Uses yaml.safe_load so quoted values
+    (``- "plan.md"``) and inline comments are handled correctly.
+    Returns empty set on empty input or malformed YAML — the caller
+    re-appends, which is safe (MAX_POLICY_YAML_BYTES caps growth)."""
+    if not text.strip():
+        return set()
+    import yaml as _yaml
+    try:
+        parsed = _yaml.safe_load(text)
+    except _yaml.YAMLError:
+        return set()
+    if not isinstance(parsed, list):
+        return set()
+    return {item for item in parsed if isinstance(item, str)}
+
+
 def _append_policy_yaml(yaml_path: Path, new_paths: list[str]) -> tuple[list[str], list[dict]]:
     """Append valid patterns to a YAML file. Returns (added, rejected).
     Honors MAX_POLICY_YAML_BYTES — raises ValueError if the resulting file
@@ -2837,8 +2863,15 @@ def _append_policy_yaml(yaml_path: Path, new_paths: list[str]) -> tuple[list[str
         lock_fd: int | None = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
         try:
             _fcntl.flock(lock_fd, _fcntl.LOCK_EX)
-            existing = yaml_path.read_text() if yaml_path.is_file() else ""
-            new_lines = "\n".join(f"- {p}" for p in added)
+            try:
+                existing = yaml_path.read_text()
+            except FileNotFoundError:
+                existing = ""
+            already_present = _parse_yaml_pattern_lines(existing)
+            truly_new = [p for p in added if p not in already_present]
+            if not truly_new:
+                return [], rejected
+            new_lines = "\n".join(f"- {p}" for p in truly_new)
             new_content = (
                 (existing.rstrip("\n") + "\n" + new_lines + "\n") if existing
                 else (new_lines + "\n")
@@ -2848,7 +2881,7 @@ def _append_policy_yaml(yaml_path: Path, new_paths: list[str]) -> tuple[list[str
                     f"policy YAML cap of {MAX_POLICY_YAML_BYTES} bytes would be exceeded"
                 )
             yaml_path.write_text(new_content)
-            return added, rejected
+            return truly_new, rejected
         finally:
             try:
                 _fcntl.flock(lock_fd, _fcntl.LOCK_UN)
@@ -2861,8 +2894,15 @@ def _append_policy_yaml(yaml_path: Path, new_paths: list[str]) -> tuple[list[str
     except ImportError:
         # Windows fallback: no fcntl. Lifecycle already disables the
         # coordinator on Windows, but degrade defensively if reached.
-        existing = yaml_path.read_text() if yaml_path.is_file() else ""
-        new_lines = "\n".join(f"- {p}" for p in added)
+        try:
+            existing = yaml_path.read_text()
+        except FileNotFoundError:
+            existing = ""
+        already_present = _parse_yaml_pattern_lines(existing)
+        truly_new = [p for p in added if p not in already_present]
+        if not truly_new:
+            return [], rejected
+        new_lines = "\n".join(f"- {p}" for p in truly_new)
         new_content = (
             (existing.rstrip("\n") + "\n" + new_lines + "\n") if existing
             else (new_lines + "\n")
@@ -2872,4 +2912,4 @@ def _append_policy_yaml(yaml_path: Path, new_paths: list[str]) -> tuple[list[str
                 f"policy YAML cap of {MAX_POLICY_YAML_BYTES} bytes would be exceeded"
             )
         yaml_path.write_text(new_content)
-        return added, rejected
+        return truly_new, rejected

--- a/src/ccs/adapters/claude_code/policy.py
+++ b/src/ccs/adapters/claude_code/policy.py
@@ -257,6 +257,7 @@ class TrackedArtifactPolicy:
             "coordinator_root": str(self.coordinator_root),
             "default_pattern_count": len(self.tracked_patterns),
             "user_added_pattern_count": len(self.user_added_patterns),
+            "user_added_patterns": list(self.user_added_patterns),
             "ignored_pattern_count": len(self.ignored_patterns),
             "strict_mode_pattern_count": len(self.strict_mode_paths),
             "rejected_pattern_count": len(self.rejected_patterns),

--- a/src/ccs/cli/coherence_replay.py
+++ b/src/ccs/cli/coherence_replay.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""``agent-coherence-replay`` — invariant replay CLI (Unit 5 of D v1).
+
+Walks a captured session directory (manifest.json + per-stream JSONL)
+through the predicate engine and emits human-readable or JSON findings.
+
+Exit-code mapping resolved in plan Open Question P1-A (mirrors
+``docs/proposals/replay_trace_format.md`` §7.3):
+
+- ``0`` — clean OR all SKIPPED entries are compliance opt-outs
+  (``opted_out=True``) declared in ``manifest.streams``.
+- ``1`` — ≥1 CONFIRMED breach.
+- ``2`` — ≥1 SKIPPED with ``opted_out=False`` (manifest declared the
+  stream but the file is missing — capture-side bug; surfaces as a
+  distinct exit code so CI catches it instead of treating it as clean).
+- ``3`` — trace error (``MultiInstanceTraceError``,
+  ``TraceCorruptionError``, ``ManifestMissingOrUnreadableError``). The
+  exception's message is printed to stderr verbatim; tracebacks are
+  caught so partners get the actionable next-step pointer instead of
+  Python internals.
+
+AMBIGUOUS suppression resolved in plan Open Question P1-B: per-finding
+output suppresses AMBIGUOUS by default; ``--include-ambiguous`` opts
+in. Summary ALWAYS counts AMBIGUOUS, and the callout fires when count
+exceeds ``--ambiguous-threshold`` (default 10), naming both remedies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from ccs.replay import (
+    ManifestMissingOrUnreadableError,
+    MultiInstanceTraceError,
+    TraceCorruptionError,
+    load,
+    run_predicates,
+)
+from ccs.replay.formatters import emit_human, emit_json
+from ccs.replay.predicates import Finding, SummaryFinding
+
+_VALID_INVARIANTS: tuple[str, ...] = (
+    "single-writer",
+    "monotonic-version",
+    "stale-read",
+    "lost-write",
+)
+
+# Trace-format spec maps these three loader/iterator errors to exit
+# code 3. Tuple lives at module scope so main() and _safe_load() share
+# one definition (drift between them would silently route a trace
+# error to a Python traceback).
+_TRACE_ERRORS = (
+    ManifestMissingOrUnreadableError,
+    MultiInstanceTraceError,
+    TraceCorruptionError,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="agent-coherence-replay",
+        description=(
+            "Replay a captured coordinator session and report invariant "
+            "breaches. Consumes the trace format documented in "
+            "docs/proposals/replay_trace_format.md."
+        ),
+    )
+    parser.add_argument(
+        "session_dir",
+        type=Path,
+        help=(
+            "Path to a captured session directory containing manifest.json "
+            "plus per-stream .jsonl files."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Emit newline-delimited JSON (per-finding lines + one summary "
+            "object) matching the spec's §7 schema."
+        ),
+    )
+    parser.add_argument(
+        "--invariant",
+        action="append",
+        choices=list(_VALID_INVARIANTS),
+        default=None,
+        help=(
+            "Restrict the run to the named predicate(s). Repeatable. "
+            "Omitting the flag runs all four."
+        ),
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help=(
+            "Suppress non-breach output. Cron-friendly: a clean trace "
+            "(no CONFIRMED + no opted_out=False SKIPPED) emits nothing."
+        ),
+    )
+    parser.add_argument(
+        "--include-ambiguous",
+        action="store_true",
+        help=(
+            "Include per-finding details for AMBIGUOUS classifications "
+            "(suppressed from default output; same-tick intra-collisions)."
+        ),
+    )
+    parser.add_argument(
+        "--ambiguous-threshold",
+        type=int,
+        default=10,
+        help=(
+            "Threshold for the AMBIGUOUS summary callout (default: 10). "
+            "When the count exceeds the threshold, the summary block "
+            "names both remedies (--include-ambiguous + D+1 global-seq)."
+        ),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point — returns the exit code; never calls ``sys.exit``.
+
+    The full trace-error guard wraps load + walk + emit because the
+    loader's iterator is lazy: MultiInstance / TraceCorruption raise
+    mid-walk, not at ``load()`` time. Catching only ``load()`` would
+    leak a traceback when the corruption hides past the manifest.
+    """
+    args = build_parser().parse_args(argv)
+    try:
+        return _run(args)
+    except _TRACE_ERRORS as exc:
+        print(f"agent-coherence-replay: {exc}", file=sys.stderr)
+        return 3
+
+
+def _run(args: argparse.Namespace) -> int:
+    """Load, run predicates, emit, and return the exit code.
+
+    Split from ``main()`` so the trace-error guard stays a single
+    try/except over the full pipeline without bloating ``main()`` past
+    the style-guide line ceiling.
+    """
+    loaded = load(args.session_dir)
+    findings, summary = run_predicates(loaded, invariants=args.invariant)
+    if args.json:
+        emit_json(
+            findings,
+            summary,
+            include_ambiguous=args.include_ambiguous,
+            ambiguous_threshold=args.ambiguous_threshold,
+            manifest=loaded.manifest,
+            streams_present=loaded.streams_present,
+        )
+    else:
+        emit_human(
+            findings,
+            summary,
+            include_ambiguous=args.include_ambiguous,
+            ambiguous_threshold=args.ambiguous_threshold,
+            quiet=args.quiet,
+        )
+    return _exit_code(findings, summary)
+
+
+def _exit_code(
+    findings: list[Finding],
+    summary: list[SummaryFinding],
+) -> int:
+    """Apply the resolved exit-code mapping from plan P1-A."""
+    has_confirmed = any(f.severity == "CONFIRMED" for f in findings)
+    if has_confirmed:
+        return 1
+    has_unannounced_skip = any(s.opted_out is False for s in summary)
+    if has_unannounced_skip:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ccs/cli/coherence_replay.py
+++ b/src/ccs/cli/coherence_replay.py
@@ -52,10 +52,14 @@ _VALID_INVARIANTS: tuple[str, ...] = (
 )
 
 # Trace-format spec maps these three loader/iterator errors to exit
-# code 3. Tuple lives at module scope so main() and _safe_load() share
-# one definition (drift between them would silently route a trace
-# error to a Python traceback).
-_TRACE_ERRORS = (
+# code 3. Tuple lives at module scope so the except clause in main()
+# and any future helper share one definition (drift would silently
+# route a trace error to a Python traceback).
+_TRACE_ERRORS: tuple[
+    type[ManifestMissingOrUnreadableError],
+    type[MultiInstanceTraceError],
+    type[TraceCorruptionError],
+] = (
     ManifestMissingOrUnreadableError,
     MultiInstanceTraceError,
     TraceCorruptionError,
@@ -137,7 +141,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         return _run(args)
-    except _TRACE_ERRORS as exc:
+    except (*_TRACE_ERRORS, OSError) as exc:
         print(f"agent-coherence-replay: {exc}", file=sys.stderr)
         return 3
 
@@ -149,6 +153,13 @@ def _run(args: argparse.Namespace) -> int:
     try/except over the full pipeline without bloating ``main()`` past
     the style-guide line ceiling.
     """
+    if not args.session_dir.exists():
+        print(
+            f"agent-coherence-replay: session directory not found: "
+            f"{args.session_dir}",
+            file=sys.stderr,
+        )
+        return 3
     loaded = load(args.session_dir)
     findings, summary = run_predicates(loaded, invariants=args.invariant)
     if args.json:
@@ -157,6 +168,7 @@ def _run(args: argparse.Namespace) -> int:
             summary,
             include_ambiguous=args.include_ambiguous,
             ambiguous_threshold=args.ambiguous_threshold,
+            quiet=args.quiet,
             manifest=loaded.manifest,
             streams_present=loaded.streams_present,
         )

--- a/src/ccs/cli/coherence_status.py
+++ b/src/ccs/cli/coherence_status.py
@@ -83,6 +83,15 @@ def build_parser() -> argparse.ArgumentParser:
             "failure with an actionable diagnostic on stderr."
         ),
     )
+    parser.add_argument(
+        "--show-policy",
+        action="store_true",
+        help=(
+            "Show user-added tracked paths that have not yet been observed "
+            "(i.e., no pre-read hook has fired for them yet). These paths "
+            "are in the policy but absent from the artifact registry."
+        ),
+    )
     return parser
 
 
@@ -120,13 +129,19 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.json:
         import json as _json
+        if args.show_policy:
+            observed = {a.get("path", "") for a in payload.get("tracked_artifacts", [])}
+            payload["policy_pending_first_read"] = [
+                p for p in payload.get("policy_summary", {}).get("user_added_patterns", [])
+                if p not in observed
+            ]
         print(_json.dumps(payload, indent=2), flush=True)
         return 0
 
     if args.detail == "metrics":
         _render_metrics(payload)
     else:
-        _render_table(payload)
+        _render_table(payload, show_policy=args.show_policy)
     return 0
 
 
@@ -262,7 +277,7 @@ def _run_self_test(root: Path, *, json_mode: bool = False) -> int:
     return 0
 
 
-def _render_table(payload: dict[str, Any]) -> None:
+def _render_table(payload: dict[str, Any], *, show_policy: bool = False) -> None:
     """Manual column alignment — stdlib only, no rich/tabulate."""
     tracked = payload.get("tracked_artifacts", [])
     sessions = payload.get("sessions", [])
@@ -320,6 +335,20 @@ def _render_table(payload: dict[str, Any]) -> None:
         for a in tracked:
             print(f"  {a.get('path', ''):<{path_w}}  {a.get('version', 0):>7}")
     print()
+
+    if show_policy:
+        observed_paths = {a.get("path", "") for a in tracked}
+        pending = [
+            p for p in policy.get("user_added_patterns", [])
+            if p not in observed_paths
+        ]
+        if pending:
+            print("Tracked (pending first read):")
+            for p in pending:
+                print(f"  {p}")
+        else:
+            print("Tracked (pending first read): none")
+        print()
 
     if not sessions:
         print("No active sessions.")

--- a/src/ccs/hardening/architecture.py
+++ b/src/ccs/hardening/architecture.py
@@ -24,6 +24,7 @@ _LAYER_BY_NAMESPACE = {
     "adapters": "interface",
     "validation": "interface",
     "diagnose": "interface",
+    "replay": "interface",
 }
 
 _ALLOWED_LAYER_IMPORTS = {

--- a/src/ccs/replay/__init__.py
+++ b/src/ccs/replay/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Replay capture surface for invariant replay (D v1).
+
+This package exposes the producer side of the replay trace contract
+documented in ``docs/proposals/replay_trace_format.md``. Consumers
+(loader, predicates, CLI) land in sibling units; this module owns the
+on-disk write path only.
+
+Public API:
+
+- :class:`UnverifiedAdapterCaptureError` — raised by
+  :func:`record_callbacks` when called without
+  ``accept_unverified=True``. Verified adapters (currently only
+  ``CCSStore``) set the flag automatically.
+- :func:`record_callbacks` — low-level non-LangGraph helper that
+  yields a ``(state_log_cb, content_audit_log_cb)`` tuple ready to be
+  passed into ``CoherenceAdapterCore``. Compose with caller-provided
+  callbacks; never overrides them.
+
+``CCSStore.record_to`` is the LangGraph-shaped thin wrapper over
+:func:`record_callbacks` and lives on the adapter class itself.
+"""
+
+from ccs.replay.recorder import (
+    UnverifiedAdapterCaptureError,
+    record_callbacks,
+)
+
+__all__ = [
+    "UnverifiedAdapterCaptureError",
+    "record_callbacks",
+]

--- a/src/ccs/replay/__init__.py
+++ b/src/ccs/replay/__init__.py
@@ -41,6 +41,10 @@ from ccs.replay.predicates import (
     SummaryFinding,
     run_predicates,
 )
+from ccs.replay.formatters import (
+    emit_human,
+    emit_json,
+)
 from ccs.replay.recorder import (
     UnverifiedAdapterCaptureError,
     record_callbacks,
@@ -60,6 +64,8 @@ __all__ = [
     "SummaryFinding",
     "TraceCorruptionError",
     "UnverifiedAdapterCaptureError",
+    "emit_human",
+    "emit_json",
     "load",
     "record_callbacks",
     "run_predicates",

--- a/src/ccs/replay/__init__.py
+++ b/src/ccs/replay/__init__.py
@@ -23,12 +23,24 @@ Public API:
 :func:`record_callbacks` and lives on the adapter class itself.
 """
 
+from ccs.replay.loader import (
+    LoadedTrace,
+    ManifestMissingOrUnreadableError,
+    MultiInstanceTraceError,
+    TraceCorruptionError,
+    load,
+)
 from ccs.replay.recorder import (
     UnverifiedAdapterCaptureError,
     record_callbacks,
 )
 
 __all__ = [
+    "LoadedTrace",
+    "ManifestMissingOrUnreadableError",
+    "MultiInstanceTraceError",
+    "TraceCorruptionError",
     "UnverifiedAdapterCaptureError",
+    "load",
     "record_callbacks",
 ]

--- a/src/ccs/replay/__init__.py
+++ b/src/ccs/replay/__init__.py
@@ -23,6 +23,8 @@ Public API:
 :func:`record_callbacks` and lives on the adapter class itself.
 """
 
+from __future__ import annotations
+
 from ccs.replay.loader import (
     LoadedTrace,
     ManifestMissingOrUnreadableError,
@@ -46,6 +48,7 @@ from ccs.replay.formatters import (
     emit_json,
 )
 from ccs.replay.recorder import (
+    RecordingSession,
     UnverifiedAdapterCaptureError,
     record_callbacks,
 )
@@ -59,6 +62,7 @@ __all__ = [
     "MonotonicVersionPredicate",
     "MultiInstanceTraceError",
     "Predicate",
+    "RecordingSession",
     "SingleWriterPredicate",
     "StaleReadPredicate",
     "SummaryFinding",

--- a/src/ccs/replay/__init__.py
+++ b/src/ccs/replay/__init__.py
@@ -30,17 +30,37 @@ from ccs.replay.loader import (
     TraceCorruptionError,
     load,
 )
+from ccs.replay.predicates import (
+    CORE_PREDICATES,
+    Finding,
+    LostWritePredicate,
+    MonotonicVersionPredicate,
+    Predicate,
+    SingleWriterPredicate,
+    StaleReadPredicate,
+    SummaryFinding,
+    run_predicates,
+)
 from ccs.replay.recorder import (
     UnverifiedAdapterCaptureError,
     record_callbacks,
 )
 
 __all__ = [
+    "CORE_PREDICATES",
+    "Finding",
     "LoadedTrace",
+    "LostWritePredicate",
     "ManifestMissingOrUnreadableError",
+    "MonotonicVersionPredicate",
     "MultiInstanceTraceError",
+    "Predicate",
+    "SingleWriterPredicate",
+    "StaleReadPredicate",
+    "SummaryFinding",
     "TraceCorruptionError",
     "UnverifiedAdapterCaptureError",
     "load",
     "record_callbacks",
+    "run_predicates",
 ]

--- a/src/ccs/replay/formatters.py
+++ b/src/ccs/replay/formatters.py
@@ -1,0 +1,315 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Human + JSON formatters for the replay CLI (Unit 5 of D v1).
+
+Pure formatting layer over :class:`ccs.replay.predicates.Finding` and
+:class:`ccs.replay.predicates.SummaryFinding`. Decoupled from
+:mod:`ccs.cli.coherence_replay` so the same emitters can back the
+audit-report template (spec §8.1) without re-implementing the schema.
+
+The JSON formatter emits the schema documented in
+``docs/proposals/replay_trace_format.md`` §7.1 (per-finding) and §7.2
+(summary) verbatim — that contract is consumed by downstream audit
+reports and the Survivor-#3 Visualizer, so field shape and ordering
+are load-bearing, not stylistic.
+
+AMBIGUOUS suppression contract (resolved in plan Open Questions P1-B):
+
+- Default behavior suppresses per-finding AMBIGUOUS output from BOTH
+  human and JSON formatters — same-tick intra-collision noise drowns
+  CONFIRMED breaches in trace-heavy pipelines.
+- ``--include-ambiguous`` surfaces them at the per-finding level only;
+  the summary block ALWAYS includes the AMBIGUOUS count + threshold +
+  callout independent of the flag.
+- The callout appears when ``ambiguous_count > ambiguous_threshold``
+  AND must name BOTH remedies (``--include-ambiguous`` + D+1 global
+  sequence_number capture) so partners triaging a noisy trace know
+  exactly what to try next.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Iterable, TextIO
+
+from ccs.replay.predicates import Finding, SummaryFinding
+
+__all__ = [
+    "emit_human",
+    "emit_json",
+]
+
+
+# Stable iteration order across both formatters so per-invariant
+# breakdowns don't depend on dict insertion order from a particular
+# predicate selection.
+_INVARIANT_ORDER: tuple[str, ...] = (
+    "single-writer",
+    "monotonic-version",
+    "stale-read",
+    "lost-write",
+)
+
+
+# ---------------------------------------------------------------------------
+# Human formatter
+# ---------------------------------------------------------------------------
+
+
+def emit_human(
+    findings: Iterable[Finding],
+    summary: Iterable[SummaryFinding],
+    *,
+    include_ambiguous: bool = False,
+    ambiguous_threshold: int = 10,
+    quiet: bool = False,
+    writer: TextIO | None = None,
+) -> None:
+    """Write a human-readable report to ``writer`` (default stdout).
+
+    ``quiet`` suppresses ALL non-breach output: when there are no
+    CONFIRMED findings AND no capture-bug SKIPs (opted_out=False),
+    nothing is written. When breaches OR capture-bug skips exist,
+    only the breach/skip blocks render (no summary header), so cron
+    can scrape the file for content as the failure signal.
+    """
+    writer = writer or sys.stdout
+    findings_list = list(findings)
+    summary_list = list(summary)
+    counts = _count_findings(findings_list, summary_list)
+
+    cron_silent = quiet and counts["CONFIRMED"] == 0 and not _has_capture_bug(summary_list)
+    if cron_silent:
+        return
+
+    for finding in findings_list:
+        if finding.severity == "AMBIGUOUS" and not include_ambiguous:
+            continue
+        _write_finding_block(writer, finding)
+
+    if quiet:
+        # Breaches/capture-bug-skips present but summary suppressed.
+        return
+
+    _write_summary_section(
+        writer,
+        counts=counts,
+        summary_list=summary_list,
+        include_ambiguous=include_ambiguous,
+        ambiguous_threshold=ambiguous_threshold,
+    )
+
+
+def _write_finding_block(writer: TextIO, finding: Finding) -> None:
+    prefix = "[CONFIRMED]" if finding.severity == "CONFIRMED" else "[AMBIGUOUS]"
+    start, end = finding.tick_range
+    ctx = finding.context or {}
+    details = finding.details or {}
+    stream = ctx.get("stream", "?")
+    seq = ctx.get("sequence_number", "?")
+    writer.write(f"{prefix} {finding.invariant}\n")
+    writer.write(f"  Tick range: {start} -> {end}\n")
+    writer.write(f"  Agents:     {', '.join(finding.agents) if finding.agents else '(none)'}\n")
+    writer.write(f"  Artifacts:  {', '.join(finding.artifacts) if finding.artifacts else '(none)'}\n")
+    writer.write(f"  Expected:   {details.get('expected', '')}\n")
+    writer.write(f"  Observed:   {details.get('observed', '')}\n")
+    writer.write(f"  Trace:      {stream}.jsonl seq={seq}\n")
+    writer.write("\n")
+
+
+def _write_summary_section(
+    writer: TextIO,
+    *,
+    counts: dict[str, int],
+    summary_list: list[SummaryFinding],
+    include_ambiguous: bool,
+    ambiguous_threshold: int,
+) -> None:
+    ambig_word = "shown" if include_ambiguous else "suppressed"
+    writer.write(
+        f"Summary: {counts['CONFIRMED']} CONFIRMED, "
+        f"{counts['AMBIGUOUS']} AMBIGUOUS ({ambig_word}), "
+        f"{counts['SKIPPED']} SKIPPED\n"
+    )
+    writer.write("  By invariant:\n")
+    by_inv = counts["by_invariant"]
+    width = max(len(name) for name in _INVARIANT_ORDER)
+    for name in _INVARIANT_ORDER:
+        row = by_inv.get(name, {"CONFIRMED": 0, "AMBIGUOUS": 0, "SKIPPED": 0})
+        writer.write(
+            f"    {name:<{width}} : "
+            f"{row['CONFIRMED']} CONFIRMED, "
+            f"{row['AMBIGUOUS']} AMBIGUOUS, "
+            f"{row['SKIPPED']} SKIPPED\n"
+        )
+    if summary_list:
+        writer.write("  Skipped invariants:\n")
+        for s in summary_list:
+            writer.write(f"    {s.invariant}: {s.reason}\n")
+    if counts["AMBIGUOUS"] > ambiguous_threshold:
+        _write_ambiguous_callout(writer, counts["AMBIGUOUS"], ambiguous_threshold)
+
+
+def _write_ambiguous_callout(writer: TextIO, count: int, threshold: int) -> None:
+    writer.write(
+        f"\nNOTE: AMBIGUOUS findings ({count}) exceed threshold ({threshold}).\n"
+        f"      Intra-tick collisions are common in this pipeline. Either:\n"
+        f"        - Rerun with --include-ambiguous to inspect each candidate.\n"
+        f"        - Wait for D+1's global sequence_number capture to eliminate the ambiguity.\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON formatter
+# ---------------------------------------------------------------------------
+
+
+def emit_json(
+    findings: Iterable[Finding],
+    summary: Iterable[SummaryFinding],
+    *,
+    include_ambiguous: bool = False,
+    ambiguous_threshold: int = 10,
+    manifest: dict[str, Any] | None = None,
+    streams_present: Iterable[str] | None = None,
+    writer: TextIO | None = None,
+) -> None:
+    """Newline-delimited JSON: per-finding lines + one summary object.
+
+    Schema matches ``docs/proposals/replay_trace_format.md`` §7.1
+    (per-finding) and §7.2 (summary) — downstream consumers (audit
+    report template, future Visualizer) depend on field shape.
+    """
+    writer = writer or sys.stdout
+    findings_list = list(findings)
+    summary_list = list(summary)
+
+    for finding in findings_list:
+        if finding.severity == "AMBIGUOUS" and not include_ambiguous:
+            continue
+        writer.write(json.dumps(_finding_to_obj(finding), sort_keys=False))
+        writer.write("\n")
+
+    summary_obj = _build_summary_obj(
+        findings=findings_list,
+        summary_list=summary_list,
+        ambiguous_threshold=ambiguous_threshold,
+        manifest=manifest or {},
+        streams_present=list(streams_present or []),
+    )
+    writer.write(json.dumps(summary_obj, sort_keys=False))
+    writer.write("\n")
+
+
+def _finding_to_obj(finding: Finding) -> dict[str, Any]:
+    return {
+        "kind": "finding",
+        "severity": finding.severity,
+        "invariant": finding.invariant,
+        "agents": list(finding.agents),
+        "artifacts": list(finding.artifacts),
+        "tick_range": {
+            "start": finding.tick_range[0],
+            "end": finding.tick_range[1],
+        },
+        "context": dict(finding.context or {}),
+        "details": dict(finding.details or {}),
+    }
+
+
+def _build_summary_obj(
+    *,
+    findings: list[Finding],
+    summary_list: list[SummaryFinding],
+    ambiguous_threshold: int,
+    manifest: dict[str, Any],
+    streams_present: list[str],
+) -> dict[str, Any]:
+    counts = _count_findings(findings, summary_list)
+    ambiguous_count = counts["AMBIGUOUS"]
+    callout: str | None = None
+    if ambiguous_count > ambiguous_threshold:
+        callout = (
+            f"AMBIGUOUS findings ({ambiguous_count}) exceed threshold "
+            f"({ambiguous_threshold}); intra-tick collisions are common "
+            f"in this pipeline. Rerun with --include-ambiguous to inspect, "
+            f"or capture global sequence_number (D+1)."
+        )
+    return {
+        "kind": "summary",
+        "counts": {
+            "CONFIRMED": counts["CONFIRMED"],
+            "AMBIGUOUS": counts["AMBIGUOUS"],
+            "SKIPPED": counts["SKIPPED"],
+        },
+        "counts_by_invariant": {
+            name: counts["by_invariant"].get(
+                name, {"CONFIRMED": 0, "AMBIGUOUS": 0, "SKIPPED": 0}
+            )
+            for name in _INVARIANT_ORDER
+        },
+        "skipped_reasons": [
+            {
+                "invariant": s.invariant,
+                "reason": s.reason,
+                "stream_required": s.stream_required,
+                "opted_out": s.opted_out,
+            }
+            for s in summary_list
+        ],
+        "ambiguous_threshold": ambiguous_threshold,
+        "ambiguous_callout": callout,
+        "trace_metadata": {
+            "adapter_type": manifest.get("adapter_type"),
+            "start_tick": manifest.get("start_tick"),
+            "end_tick": manifest.get("end_tick"),
+            "instance_id": manifest.get("instance_id"),
+            "streams_present": sorted(streams_present),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _count_findings(
+    findings: list[Finding],
+    summary: list[SummaryFinding],
+) -> dict[str, Any]:
+    """Aggregate counts shared by human + JSON paths."""
+    by_inv: dict[str, dict[str, int]] = {
+        name: {"CONFIRMED": 0, "AMBIGUOUS": 0, "SKIPPED": 0}
+        for name in _INVARIANT_ORDER
+    }
+    confirmed = 0
+    ambiguous = 0
+    for f in findings:
+        bucket = by_inv.setdefault(
+            f.invariant, {"CONFIRMED": 0, "AMBIGUOUS": 0, "SKIPPED": 0}
+        )
+        if f.severity == "CONFIRMED":
+            confirmed += 1
+            bucket["CONFIRMED"] += 1
+        elif f.severity == "AMBIGUOUS":
+            ambiguous += 1
+            bucket["AMBIGUOUS"] += 1
+    for s in summary:
+        bucket = by_inv.setdefault(
+            s.invariant, {"CONFIRMED": 0, "AMBIGUOUS": 0, "SKIPPED": 0}
+        )
+        bucket["SKIPPED"] += 1
+    return {
+        "CONFIRMED": confirmed,
+        "AMBIGUOUS": ambiguous,
+        "SKIPPED": len(summary),
+        "by_invariant": by_inv,
+    }
+
+
+def _has_capture_bug(summary_list: list[SummaryFinding]) -> bool:
+    """True iff any SKIPPED entry is a capture bug (opted_out=False)."""
+    return any(s.opted_out is False for s in summary_list)

--- a/src/ccs/replay/formatters.py
+++ b/src/ccs/replay/formatters.py
@@ -90,7 +90,9 @@ def emit_human(
         _write_finding_block(writer, finding)
 
     if quiet:
-        # Breaches/capture-bug-skips present but summary suppressed.
+        for s in summary_list:
+            if s.opted_out is False:
+                writer.write(f"[CAPTURE-BUG] {s.invariant}: {s.reason}\n")
         return
 
     _write_summary_section(
@@ -172,6 +174,7 @@ def emit_json(
     *,
     include_ambiguous: bool = False,
     ambiguous_threshold: int = 10,
+    quiet: bool = False,
     manifest: dict[str, Any] | None = None,
     streams_present: Iterable[str] | None = None,
     writer: TextIO | None = None,
@@ -181,10 +184,18 @@ def emit_json(
     Schema matches ``docs/proposals/replay_trace_format.md`` §7.1
     (per-finding) and §7.2 (summary) — downstream consumers (audit
     report template, future Visualizer) depend on field shape.
+
+    ``quiet`` mirrors the human formatter's cron-silent contract: when
+    there are no CONFIRMED findings AND no capture-bug SKIPs, emit
+    nothing so CI can treat any output as the failure signal.
     """
     writer = writer or sys.stdout
     findings_list = list(findings)
     summary_list = list(summary)
+    counts = _count_findings(findings_list, summary_list)
+
+    if quiet and counts["CONFIRMED"] == 0 and not _has_capture_bug(summary_list):
+        return
 
     for finding in findings_list:
         if finding.severity == "AMBIGUOUS" and not include_ambiguous:

--- a/src/ccs/replay/loader.py
+++ b/src/ccs/replay/loader.py
@@ -224,21 +224,22 @@ def _declared_streams(manifest: dict[str, Any]) -> list[str]:
 
 
 def _iter_stream_file(path: Path, stream_name: str) -> Iterator[tuple[
-    int, int, int, str, dict[str, Any], Path, int,
+    int, int, int, str, int, dict[str, Any], Path, int,
 ]]:
     """Yield merge-key + entry tuples for one open JSONL file.
 
     The key shape is ``(tick, stream_priority, sequence_number,
-    stream_name)`` — heapq.merge picks the smallest by lexicographic
-    comparison. ``stream_name`` is part of the key so heapq.merge has
-    a total order when two streams collide on (tick, priority, seq);
-    in practice the priority alone is sufficient because no two
-    streams share a priority, but defensive ordering avoids a
-    TypeError if the dict surfaces a duplicate priority by mistake.
+    stream_name, counter)`` — heapq.merge picks the smallest by
+    lexicographic comparison. ``counter`` is a per-stream monotonic
+    integer that guarantees total order without ever comparing the
+    ``dict`` entry at position 5, making the merge TypeError-safe even
+    if a future stream accidentally reuses a priority value.
     """
     priority = _STREAM_PRIORITY[stream_name]
     with path.open("r", encoding="utf-8") as fh:
-        for line_number, line in enumerate(fh, start=1):
+        for counter, (line_number, line) in enumerate(
+            enumerate(fh, start=1), start=0
+        ):
             line = line.strip()
             if not line:
                 continue
@@ -257,7 +258,7 @@ def _iter_stream_file(path: Path, stream_name: str) -> Iterator[tuple[
                     f"is missing required int field 'tick' or "
                     f"'sequence_number'"
                 )
-            yield (tick, priority, seq, stream_name, entry, path, line_number)
+            yield (tick, priority, seq, stream_name, counter, entry, path, line_number)
 
 
 def _iter_merged(
@@ -285,17 +286,22 @@ def _iter_merged(
     #
     # ``seen_seq`` is a dict keyed by ``(stream, instance_id, seq)`` →
     # ``(path, line)`` of first occurrence so the duplicate error can
-    # name both lines. Memory is O(unique seqs), not O(merged entries);
-    # the trace stream itself is still consumed lazily by heapq.merge.
+    # name both lines. Grows O(N) with the number of entries — every
+    # unique (stream, instance_id, seq) triple is retained to detect
+    # late-appearing duplicates anywhere in the trace walk.
     seen_instance_id: dict[str, str] = {}
     seen_seq: dict[tuple[str, str, int], tuple[Path, int]] = {}
 
-    for tick, _priority, seq, stream_name, entry, path, line_no in heapq.merge(
-        *per_stream_iters
-    ):
-        _check_instance_id(stream_name, entry, seen_instance_id)
-        _check_duplicate_seq(stream_name, entry, seq, path, line_no, seen_seq)
-        yield stream_name, entry
+    try:
+        for tick, _priority, seq, stream_name, _counter, entry, path, line_no in heapq.merge(
+            *per_stream_iters
+        ):
+            _check_instance_id(stream_name, entry, seen_instance_id)
+            _check_duplicate_seq(stream_name, entry, seq, path, line_no, seen_seq)
+            yield stream_name, entry
+    finally:
+        for it in per_stream_iters:
+            it.close()
 
 
 def _check_instance_id(

--- a/src/ccs/replay/loader.py
+++ b/src/ccs/replay/loader.py
@@ -1,0 +1,346 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Trace loader — merge engine + corruption detection (Unit 3 of D v1).
+
+Consumer side of the replay-trace contract documented in
+``docs/proposals/replay_trace_format.md``. Reads a captured session
+directory and exposes:
+
+- :class:`LoadedTrace` — parsed manifest + ``streams_present`` set + a
+  ``merged()`` iterator yielding entries in the documented merge order.
+- :func:`load` — opens the manifest, validates stream presence, and
+  returns a :class:`LoadedTrace`.
+
+Three error classes carry actionable next-step pointers (per §5.4 of
+the trace-format spec):
+
+- :class:`ManifestMissingOrUnreadableError` — raised eagerly by
+  :func:`load` when ``manifest.json`` cannot be parsed.
+- :class:`MultiInstanceTraceError` — raised lazily from
+  :meth:`LoadedTrace.merged` when two ``instance_id`` values are
+  observed in the same stream.
+- :class:`TraceCorruptionError` — raised lazily when two entries in a
+  stream share ``(instance_id, sequence_number)``.
+
+The merge is a streaming heap-merge over open file iterators (see
+``_iter_merged``). The full trace is never materialized in memory —
+memory cost is O(open files), not O(events). This is the load-bearing
+invariant for partner traces with hundreds of thousands of entries.
+"""
+
+from __future__ import annotations
+
+import heapq
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator
+
+__all__ = [
+    "LoadedTrace",
+    "ManifestMissingOrUnreadableError",
+    "MultiInstanceTraceError",
+    "TraceCorruptionError",
+    "load",
+]
+
+_STATE_LOG = "state_log"
+_CONTENT_AUDIT_LOG = "content_audit_log"
+_STRICT_DENY_AUDIT = "strict_deny_audit"
+
+# Merge-rule priority per docs/proposals/replay_trace_format.md §5.1:
+# at equal tick, state_log sorts before content_audit_log because
+# intra-tick state transitions logically precede the reads they enable.
+# Predicates compare `tick` fields directly (not merge order) when
+# deciding AMBIGUOUS vs CONFIRMED, so this tiebreaker is purely for
+# replay-walk determinism.
+_STREAM_PRIORITY: dict[str, int] = {
+    _STATE_LOG: 0,
+    _CONTENT_AUDIT_LOG: 1,
+    _STRICT_DENY_AUDIT: 2,
+}
+
+_KNOWN_STREAMS: frozenset[str] = frozenset(_STREAM_PRIORITY)
+
+
+# ---------------------------------------------------------------------------
+# Error classes
+# ---------------------------------------------------------------------------
+
+
+class ManifestMissingOrUnreadableError(RuntimeError):
+    """``manifest.json`` does not exist or fails JSON parse.
+
+    Raised eagerly by :func:`load` — partial walks are not possible
+    without a manifest. Message points at the offending path so partners
+    can re-capture or fix the directory.
+    """
+
+
+class MultiInstanceTraceError(RuntimeError):
+    """Two distinct ``instance_id`` values observed in the same stream.
+
+    v1 supports single-coordinator-instance traces only. Raised lazily
+    from the iterator so partial walks succeed up to the boundary —
+    Unit 5's CLI maps this to exit code 3 and surfaces the D+1
+    roadmap pointer to the operator.
+    """
+
+
+class TraceCorruptionError(RuntimeError):
+    """Two entries in a stream share ``(instance_id, sequence_number)``.
+
+    Defense-in-depth against partner-written callbacks (CrewAI /
+    AutoGen direct wiring) that don't honor fsync per line — when
+    ``ArtifactRegistry._seq`` rolls back on a write failure but the
+    failed entry was already on disk, the next successful entry
+    reuses the rolled-back seq and collides. Caught here so partner
+    traces fail loudly rather than silently mis-classifying.
+
+    Raised lazily from the iterator with the duplicate seq value, the
+    offending file path, and the line number of the second occurrence.
+    """
+
+
+# ---------------------------------------------------------------------------
+# LoadedTrace dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LoadedTrace:
+    """Parsed manifest + open-stream surface for a captured session.
+
+    ``streams_present`` reconciles ``manifest.streams`` against what is
+    actually on disk: a stream declared in the manifest but missing
+    from disk is NOT in this set. Unit 5's CLI uses the divergence
+    between declared-and-present vs declared-but-missing to distinguish
+    user opt-out (exit 0) from capture-bug (exit 2). Loader does not
+    raise on this divergence; reporting is the CLI's job.
+    """
+
+    session_dir: Path
+    manifest: dict[str, Any]
+    streams_present: set[str]
+    # Internal: the on-disk paths for streams that are present. Keyed by
+    # stream name so ``merged()`` can build per-stream file iterators.
+    _stream_paths: dict[str, Path] = field(default_factory=dict, repr=False)
+
+    def merged(self) -> Iterator[tuple[str, dict[str, Any]]]:
+        """Streaming heap-merge across the present streams.
+
+        Yields ``(stream_kind, entry)`` tuples in
+        ``(tick asc, stream_kind_priority asc, sequence_number asc)``
+        order per the trace-format spec §5.1.
+
+        Validation (multi-instance, duplicate-seq) is performed lazily
+        as entries flow through — partial walks succeed up to the
+        first offending entry, matching the spec's lazy-raise contract.
+        """
+        return _iter_merged(self._stream_paths)
+
+
+# ---------------------------------------------------------------------------
+# Loader entry point
+# ---------------------------------------------------------------------------
+
+
+def load(session_dir: Path | str) -> LoadedTrace:
+    """Read ``manifest.json`` and prepare the merged-stream iterator.
+
+    Reconciles the manifest's ``streams`` declaration against on-disk
+    presence; the returned ``streams_present`` is the intersection.
+    """
+    session_dir = Path(session_dir)
+    manifest = _read_manifest(session_dir)
+    declared = _declared_streams(manifest)
+    present_paths = {
+        name: path
+        for name, path in (
+            (name, session_dir / f"{name}.jsonl") for name in declared
+        )
+        if path.exists()
+    }
+    return LoadedTrace(
+        session_dir=session_dir,
+        manifest=manifest,
+        streams_present=set(present_paths),
+        _stream_paths=present_paths,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Manifest reading
+# ---------------------------------------------------------------------------
+
+
+def _read_manifest(session_dir: Path) -> dict[str, Any]:
+    manifest_path = session_dir / "manifest.json"
+    if not manifest_path.exists():
+        raise ManifestMissingOrUnreadableError(
+            f"manifest.json not found at {manifest_path!s}; "
+            f"re-capture with CCSStore.record_to(path) or "
+            f"record_callbacks(path, accept_unverified=True) — see "
+            f"docs/proposals/replay_trace_format.md §1"
+        )
+    try:
+        raw = manifest_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ManifestMissingOrUnreadableError(
+            f"manifest.json at {manifest_path!s} is unreadable: {exc}"
+        ) from exc
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ManifestMissingOrUnreadableError(
+            f"manifest.json at {manifest_path!s} is not valid JSON "
+            f"(line {exc.lineno}, col {exc.colno}): {exc.msg}"
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise ManifestMissingOrUnreadableError(
+            f"manifest.json at {manifest_path!s} must be a JSON object, "
+            f"got {type(parsed).__name__}"
+        )
+    return parsed
+
+
+def _declared_streams(manifest: dict[str, Any]) -> list[str]:
+    raw = manifest.get("streams", [])
+    if not isinstance(raw, list):
+        raise ManifestMissingOrUnreadableError(
+            "manifest.streams must be a list; got "
+            f"{type(raw).__name__}"
+        )
+    # Preserve declaration order from the manifest after filtering to
+    # known stream kinds — strict_deny_audit is reserved in v1 but a
+    # future declaration should not crash the loader.
+    return [name for name in raw if name in _KNOWN_STREAMS]
+
+
+# ---------------------------------------------------------------------------
+# Streaming heap-merge
+# ---------------------------------------------------------------------------
+
+
+def _iter_stream_file(path: Path, stream_name: str) -> Iterator[tuple[
+    int, int, int, str, dict[str, Any], Path, int,
+]]:
+    """Yield merge-key + entry tuples for one open JSONL file.
+
+    The key shape is ``(tick, stream_priority, sequence_number,
+    stream_name)`` — heapq.merge picks the smallest by lexicographic
+    comparison. ``stream_name`` is part of the key so heapq.merge has
+    a total order when two streams collide on (tick, priority, seq);
+    in practice the priority alone is sufficient because no two
+    streams share a priority, but defensive ordering avoids a
+    TypeError if the dict surfaces a duplicate priority by mistake.
+    """
+    priority = _STREAM_PRIORITY[stream_name]
+    with path.open("r", encoding="utf-8") as fh:
+        for line_number, line in enumerate(fh, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise TraceCorruptionError(
+                    f"stream {stream_name!r} contains malformed JSON at "
+                    f"{path!s}:{line_number}: {exc.msg}"
+                ) from exc
+            tick = entry.get("tick")
+            seq = entry.get("sequence_number")
+            if not isinstance(tick, int) or not isinstance(seq, int):
+                raise TraceCorruptionError(
+                    f"stream {stream_name!r} entry at {path!s}:{line_number} "
+                    f"is missing required int field 'tick' or "
+                    f"'sequence_number'"
+                )
+            yield (tick, priority, seq, stream_name, entry, path, line_number)
+
+
+def _iter_merged(
+    stream_paths: dict[str, Path],
+) -> Iterator[tuple[str, dict[str, Any]]]:
+    """Heap-merge open-file iterators and apply lazy validations.
+
+    STREAMING CONTRACT: this function NEVER materializes the merged
+    stream into a list. ``heapq.merge`` consumes the per-file
+    generators on demand; per-stream bookkeeping is O(1) state. Open
+    file handles are closed when the per-stream generators exhaust
+    (via the ``with`` block in :func:`_iter_stream_file`) — partial
+    walks may leak fds until garbage collection, acceptable for v1
+    since the CLI consumes the iterator to completion or aborts the
+    process on error.
+    """
+    per_stream_iters = [
+        _iter_stream_file(path, name)
+        for name, path in sorted(stream_paths.items())
+    ]
+    # Per-stream validation state. Lives outside the generator loop so
+    # each stream's invariants are tracked independently — a multi-
+    # instance jump on state_log does not poison content_audit_log's
+    # tracker, matching the spec's per-stream framing.
+    #
+    # ``seen_seq`` is a dict keyed by ``(stream, instance_id, seq)`` →
+    # ``(path, line)`` of first occurrence so the duplicate error can
+    # name both lines. Memory is O(unique seqs), not O(merged entries);
+    # the trace stream itself is still consumed lazily by heapq.merge.
+    seen_instance_id: dict[str, str] = {}
+    seen_seq: dict[tuple[str, str, int], tuple[Path, int]] = {}
+
+    for tick, _priority, seq, stream_name, entry, path, line_no in heapq.merge(
+        *per_stream_iters
+    ):
+        _check_instance_id(stream_name, entry, seen_instance_id)
+        _check_duplicate_seq(stream_name, entry, seq, path, line_no, seen_seq)
+        yield stream_name, entry
+
+
+def _check_instance_id(
+    stream_name: str,
+    entry: dict[str, Any],
+    seen: dict[str, str],
+) -> None:
+    instance_id = entry.get("instance_id")
+    if instance_id is None:
+        return
+    previous = seen.get(stream_name)
+    if previous is None:
+        seen[stream_name] = instance_id
+        return
+    if instance_id != previous:
+        raise MultiInstanceTraceError(
+            "per-instance-replay is roadmapped for D+1; split the trace "
+            "by instance_id or re-capture from a single coordinator "
+            f"session (stream={stream_name!r} observed "
+            f"instance_id={previous!r} then {instance_id!r})"
+        )
+
+
+def _check_duplicate_seq(
+    stream_name: str,
+    entry: dict[str, Any],
+    seq: int,
+    path: Path,
+    line_no: int,
+    seen: dict[tuple[str, str, int], tuple[Path, int]],
+) -> None:
+    # (stream, instance_id) is the uniqueness scope per the trace-format
+    # spec §5.4 — sequence_number is a per-stream counter that may legally
+    # reset across instance_id changes (though those raise MultiInstance
+    # first; defense in depth).
+    instance_id = entry.get("instance_id") or ""
+    key = (stream_name, instance_id, seq)
+    prior = seen.get(key)
+    if prior is not None:
+        first_path, first_line = prior
+        raise TraceCorruptionError(
+            f"stream {stream_name!r} duplicate sequence_number={seq} "
+            f"detected at {path!s}:{line_no} (first occurrence at "
+            f"{first_path!s}:{first_line}); partner-written callbacks "
+            "must honor fsync-per-line — see "
+            "docs/proposals/replay_trace_format.md §5.4"
+        )
+    seen[key] = (path, line_no)

--- a/src/ccs/replay/predicates.py
+++ b/src/ccs/replay/predicates.py
@@ -1,0 +1,714 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Replay invariant predicates — Core 4 + SKIPPED dispatch (Unit 4 of D v1).
+
+Consumer side of the replay-trace contract documented in
+``docs/proposals/replay_trace_format.md`` §5.2-§5.3. Walks the merged
+stream from :class:`ccs.replay.loader.LoadedTrace` exactly once and
+emits structured findings for breaches of the four v1 invariants:
+
+- ``single-writer`` — at most one agent in MODIFIED or EXCLUSIVE per
+  artifact (reuses :func:`ccs.core.invariants.check_single_writer`).
+- ``monotonic-version`` — committed versions strictly increase per
+  artifact (reuses :func:`ccs.core.invariants.check_monotonic_version`).
+- ``stale-read`` — content-audit reads of versions older than the
+  latest committed version, with AMBIGUOUS carve-out for same-tick
+  collisions (intra-tick ordering undetermined per §5.2).
+- ``lost-write`` — writer commits whose ``from_state`` is not in
+  ``{MODIFIED, EXCLUSIVE}``.
+
+SKIPPED dispatch (§5.3): each predicate declares its
+``required_streams``; predicates whose requirements aren't satisfied by
+``loaded_trace.streams_present`` are omitted from the walk and produce
+a :class:`SummaryFinding` instead. ``opted_out`` distinguishes user
+opt-out (stream not in ``manifest.streams``) from capture bug (stream
+declared but missing on disk) so Unit 5's CLI can pick the right exit
+code.
+
+Two folds shared across predicates keep the walk to a single pass:
+
+- ``per_(agent, artifact)_state`` — updated from every state_log entry.
+  Single-writer scans it after every transition; lost-write reads the
+  writer's pre-commit state from each surviving commit entry's
+  ``from_state``.
+- ``per_artifact_latest_committed_version`` — updated only from
+  state_log entries with ``trigger="commit"`` AND
+  ``to_state ∈ {MODIFIED, EXCLUSIVE}``. Peer-invalidation transitions
+  also carry ``trigger="commit"`` (per ``coordinator/service.py:277``)
+  but resolve to ``to_state=INVALID``; counting them as commits would
+  flood every clean trace with N false-positive lost-writes per commit
+  (the LostWrite ADV-01 v1-blocker fix from document review).
+
+The stale-read predicate compares ``tick`` fields directly (not merge
+order) when deciding AMBIGUOUS vs CONFIRMED — the merge rule places
+state_log before content_audit_log at the same tick, so relying on
+merge order would falsely classify every same-tick collision as
+CONFIRMED.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+from ccs.core.invariants import check_monotonic_version, check_single_writer
+from ccs.core.exceptions import InvariantViolationError
+from ccs.core.states import MESIState
+from ccs.replay.loader import LoadedTrace
+
+__all__ = [
+    "Finding",
+    "SummaryFinding",
+    "Predicate",
+    "SingleWriterPredicate",
+    "MonotonicVersionPredicate",
+    "StaleReadPredicate",
+    "LostWritePredicate",
+    "run_predicates",
+    "CORE_PREDICATES",
+]
+
+_STATE_LOG = "state_log"
+_CONTENT_AUDIT_LOG = "content_audit_log"
+
+# State values that count as "the writer holds the line". Used by
+# single-writer (count agents in this set per artifact) and lost-write
+# (the surviving commit's from_state must be in this set).
+_OWNER_STATES: frozenset[MESIState] = frozenset(
+    {MESIState.MODIFIED, MESIState.EXCLUSIVE}
+)
+
+
+# ---------------------------------------------------------------------------
+# Finding dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One invariant breach. Schema matches §7.1 of the trace-format spec.
+
+    ``severity`` is ``"CONFIRMED"`` for breaches the predicate can
+    attest from observable trace data, and ``"AMBIGUOUS"`` for the
+    stale-read same-tick carve-out only — intra-tick ordering is
+    undetermined per spec §5.2 so the finding is reported but suppressed
+    from default --json output (Unit 5 surfaces it via
+    ``--include-ambiguous``).
+    """
+
+    kind: str  # "single-writer-violation", "monotonic-version-violation", ...
+    severity: str  # "CONFIRMED" or "AMBIGUOUS"
+    invariant: str  # "single-writer", "monotonic-version", "stale-read", "lost-write"
+    agents: tuple[str, ...]
+    artifacts: tuple[str, ...]
+    tick_range: tuple[int, int]  # (start, end) inclusive
+    context: dict[str, Any] = field(default_factory=dict)
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SummaryFinding:
+    """Summary-only entry for a predicate that was skipped.
+
+    Distinct from :class:`Finding` so callers can route per-finding
+    output (the breaches) and summary lines (the skips) separately —
+    Unit 5's --json formatter and exit-code logic both depend on the
+    distinction.
+
+    ``opted_out=True`` means the missing stream is not in
+    ``manifest.streams`` (the caller explicitly opted out, exit 0).
+    ``opted_out=False`` means the stream is declared but absent on disk
+    (capture bug, exit 2).
+    """
+
+    kind: str  # always "skipped" in v1
+    invariant: str
+    reason: str
+    stream_required: str
+    opted_out: bool
+
+
+# ---------------------------------------------------------------------------
+# Shared-fold state container
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SharedState:
+    """Two folds shared across predicates so the merged stream is walked once.
+
+    Lives at engine scope; predicates read/write through reference. Not
+    exported — predicates only access via the engine's ``_apply_state_log``.
+    """
+
+    # Per (agent_id, artifact_id) → current MESI state. Updated from every
+    # state_log entry's to_state.
+    state_by_agent_artifact: dict[tuple[str, str], MESIState] = field(default_factory=dict)
+    # Per artifact_id → latest version committed by trigger="commit" AND
+    # to_state ∈ {MODIFIED, EXCLUSIVE}. Other trigger="commit" entries
+    # (peer invalidations to INVALID) do NOT update this fold.
+    latest_committed_version: dict[str, int] = field(default_factory=dict)
+    # Per artifact_id → tick at which latest_committed_version was last set.
+    # StaleReadPredicate needs this to decide AMBIGUOUS vs CONFIRMED.
+    latest_committed_tick: dict[str, int] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Predicate base class
+# ---------------------------------------------------------------------------
+
+
+class Predicate(abc.ABC):
+    """Abstract base for the four v1 invariant predicates.
+
+    Concrete predicates declare ``name`` (short kebab-case identifier
+    matching the spec, e.g. ``"lost-write"``) and ``required_streams``
+    (set of stream names this predicate needs). The engine intersects
+    ``required_streams`` with ``loaded_trace.streams_present`` to decide
+    whether to dispatch or skip.
+    """
+
+    name: str
+    required_streams: set[str]
+
+    @abc.abstractmethod
+    def process(
+        self,
+        entry: dict[str, Any],
+        stream_kind: str,
+        shared: _SharedState,
+    ) -> Iterable[Finding]:
+        """Inspect one merged-stream entry and yield findings (zero or more).
+
+        Implementations MUST NOT mutate ``shared`` — the engine owns
+        fold updates so they apply uniformly across predicates and
+        survive a SKIPPED predicate being absent from the run.
+        """
+        raise NotImplementedError
+
+    def finalize(self) -> Iterable[Finding]:
+        """Emit any findings deferred until end-of-stream. Default: none.
+
+        v1 invariants are all online (decision per entry); reserved for
+        D+1 invariants like heartbeat-liveness that need the end tick
+        before deciding a finding.
+        """
+        return ()
+
+
+# ---------------------------------------------------------------------------
+# SingleWriterPredicate
+# ---------------------------------------------------------------------------
+
+
+class SingleWriterPredicate(Predicate):
+    """Flag any tick where >1 agent holds M or E for the same artifact.
+
+    Walks state_log entries; after the engine applies the entry to the
+    shared fold, this predicate scans the per-artifact state map for
+    M∪E owners and emits CONFIRMED on overlap. The check delegates the
+    "any owners overlap?" decision to
+    :func:`ccs.core.invariants.check_single_writer` (it raises on
+    overlap; we translate that into a Finding rather than re-running
+    the count locally — the runtime helper is the canonical predicate
+    definition).
+    """
+
+    name = "single-writer"
+    required_streams = {_STATE_LOG}
+
+    def process(
+        self,
+        entry: dict[str, Any],
+        stream_kind: str,
+        shared: _SharedState,
+    ) -> Iterable[Finding]:
+        if stream_kind != _STATE_LOG:
+            return ()
+        artifact_id = entry.get("artifact_id")
+        if not artifact_id:
+            return ()
+        state_by_agent = _collect_agents_for_artifact(
+            shared.state_by_agent_artifact, artifact_id
+        )
+        try:
+            check_single_writer(state_by_agent)
+        except InvariantViolationError:
+            owners = sorted(
+                agent_id
+                for agent_id, state in state_by_agent.items()
+                if state in _OWNER_STATES
+            )
+            return [_make_single_writer_finding(entry, artifact_id, owners)]
+        return ()
+
+
+def _collect_agents_for_artifact(
+    state_map: dict[tuple[str, str], MESIState],
+    artifact_id: str,
+) -> dict[str, MESIState]:
+    """Project the (agent, artifact) fold onto one artifact."""
+    return {
+        agent_id: state
+        for (agent_id, art_id), state in state_map.items()
+        if art_id == artifact_id
+    }
+
+
+def _make_single_writer_finding(
+    entry: dict[str, Any],
+    artifact_id: str,
+    owners: list[str],
+) -> Finding:
+    tick = int(entry["tick"])
+    return Finding(
+        kind="single-writer-violation",
+        severity="CONFIRMED",
+        invariant="single-writer",
+        agents=tuple(owners),
+        artifacts=(artifact_id,),
+        tick_range=(tick, tick),
+        context={
+            "stream": _STATE_LOG,
+            "sequence_number": entry.get("sequence_number"),
+        },
+        details={
+            "expected": "<=1 agent in M or E",
+            "observed": f"{len(owners)} agents in M or E",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# MonotonicVersionPredicate
+# ---------------------------------------------------------------------------
+
+
+class MonotonicVersionPredicate(Predicate):
+    """Flag any commit whose version is not strictly greater than the prior.
+
+    Only inspects state_log entries with ``trigger="commit"`` AND
+    ``to_state ∈ {MODIFIED, EXCLUSIVE}`` — peer-invalidation
+    transitions ALSO carry ``trigger="commit"`` (per
+    ``coordinator/service.py:277``) but reach ``to_state=INVALID`` and
+    do not introduce a new version; treating them as commits would
+    spuriously fire the predicate when a peer is invalidated at the
+    same version.
+
+    Delegates the comparison to
+    :func:`ccs.core.invariants.check_monotonic_version`. Note that
+    helper checks ``current < previous``; the spec asks for *strict*
+    increase (``current > previous``), so we shift previous by +1
+    before calling — keeps the runtime predicate as canonical.
+    """
+
+    name = "monotonic-version"
+    required_streams = {_STATE_LOG}
+
+    def process(
+        self,
+        entry: dict[str, Any],
+        stream_kind: str,
+        shared: _SharedState,
+    ) -> Iterable[Finding]:
+        if stream_kind != _STATE_LOG:
+            return ()
+        if not _is_writer_commit(entry):
+            return ()
+        artifact_id = entry["artifact_id"]
+        version = int(entry["version"])
+        # -1 sentinel: any non-negative version satisfies strict increase
+        # from the initial empty state.
+        previous = shared.latest_committed_version.get(artifact_id, -1)
+        try:
+            # Spec asks for STRICT increase. The runtime helper raises only
+            # on regression (current < previous); shifting previous by +1
+            # turns the runtime check into a strict-monotonic check
+            # without re-implementing it.
+            check_monotonic_version(previous + 1, version)
+        except InvariantViolationError:
+            return [_make_monotonic_version_finding(entry, artifact_id, previous, version)]
+        return ()
+
+
+def _is_writer_commit(entry: dict[str, Any]) -> bool:
+    """True iff this state_log entry is a writer self-transition commit.
+
+    Excludes peer-invalidation transitions that also carry
+    ``trigger="commit"`` per ``coordinator/service.py:277`` — those
+    resolve to ``to_state=INVALID`` and must not advance the
+    latest-version fold or trigger monotonic-version / lost-write.
+    """
+    if entry.get("trigger") != "commit":
+        return False
+    to_state = entry.get("to_state")
+    return to_state in {MESIState.MODIFIED.name, MESIState.EXCLUSIVE.name}
+
+
+def _make_monotonic_version_finding(
+    entry: dict[str, Any],
+    artifact_id: str,
+    previous: int,
+    observed: int,
+) -> Finding:
+    tick = int(entry["tick"])
+    return Finding(
+        kind="monotonic-version-violation",
+        severity="CONFIRMED",
+        invariant="monotonic-version",
+        agents=(entry.get("agent_id") or "",),
+        artifacts=(artifact_id,),
+        tick_range=(tick, tick),
+        context={
+            "stream": _STATE_LOG,
+            "sequence_number": entry.get("sequence_number"),
+        },
+        details={
+            "expected": f"version > {previous}",
+            "observed": f"version = {observed}",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# StaleReadPredicate
+# ---------------------------------------------------------------------------
+
+
+class StaleReadPredicate(Predicate):
+    """Flag content-audit reads of versions older than latest committed.
+
+    Compares ``entry.tick`` to ``latest_committed_tick`` DIRECTLY (not
+    merge order). Merge order at the same tick puts state_log before
+    content_audit_log per the loader's tiebreaker, so a merge-order
+    decision would falsely classify every same-tick collision as
+    CONFIRMED. The spec requires AMBIGUOUS for same-tick collisions
+    (§5.2) and CONFIRMED only when the read tick strictly exceeds the
+    commit tick.
+
+    Entries with ``agent_id=None`` are skipped silently — the
+    CCSStore-local search-miss path emits content_audit entries with
+    null agent_id (spec §4.1); those are not reader activity and must
+    not trigger the predicate.
+    """
+
+    name = "stale-read"
+    required_streams = {_STATE_LOG, _CONTENT_AUDIT_LOG}
+
+    def process(
+        self,
+        entry: dict[str, Any],
+        stream_kind: str,
+        shared: _SharedState,
+    ) -> Iterable[Finding]:
+        if stream_kind != _CONTENT_AUDIT_LOG:
+            return ()
+        if entry.get("outcome") != "content":
+            return ()
+        agent_id = entry.get("agent_id")
+        if agent_id is None:
+            # search-miss path; spec §4.1 says skip silently.
+            return ()
+        artifact_id = entry.get("artifact_id")
+        observed_version = entry.get("version")
+        if artifact_id is None or observed_version is None:
+            return ()
+        latest_version = shared.latest_committed_version.get(artifact_id)
+        if latest_version is None or observed_version >= latest_version:
+            return ()
+        return _classify_stale_read(
+            entry, agent_id, artifact_id,
+            observed_version, latest_version,
+            shared.latest_committed_tick[artifact_id],
+        )
+
+
+def _classify_stale_read(
+    entry: dict[str, Any],
+    agent_id: str,
+    artifact_id: str,
+    observed_version: int,
+    latest_version: int,
+    latest_commit_tick: int,
+) -> Iterable[Finding]:
+    """Decide CONFIRMED vs AMBIGUOUS based on tick comparison.
+
+    AMBIGUOUS is reserved exclusively for same-tick collisions where
+    intra-tick ordering is undetermined per spec §5.2. Strict
+    later-tick reads of older versions are CONFIRMED. Strict
+    earlier-tick reads cannot happen by merge-order construction; we
+    skip silently as defensive code.
+    """
+    read_tick = int(entry["tick"])
+    if read_tick > latest_commit_tick:
+        severity = "CONFIRMED"
+        kind = "stale-read"
+    elif read_tick == latest_commit_tick:
+        severity = "AMBIGUOUS"
+        kind = "stale-read-ambiguous"
+    else:
+        return ()
+    return [Finding(
+        kind=kind,
+        severity=severity,
+        invariant="stale-read",
+        agents=(agent_id,),
+        artifacts=(artifact_id,),
+        tick_range=(latest_commit_tick, read_tick),
+        context={
+            "stream": _CONTENT_AUDIT_LOG,
+            "sequence_number": entry.get("sequence_number"),
+        },
+        details={
+            "expected": f"version >= {latest_version}",
+            "observed": f"version = {observed_version}",
+        },
+    )]
+
+
+# ---------------------------------------------------------------------------
+# LostWritePredicate
+# ---------------------------------------------------------------------------
+
+
+class LostWritePredicate(Predicate):
+    """Flag commit transitions from a non-owner state (M∪E required).
+
+    CRITICAL FILTER: only inspects state_log entries with
+    ``trigger="commit"`` AND ``to_state ∈ {MODIFIED, EXCLUSIVE}``. This
+    excludes peer-invalidation transitions which ALSO carry
+    ``trigger="commit"`` but reach ``to_state=INVALID`` (per
+    ``coordinator/service.py:277``). Without the filter the predicate
+    fires one false-positive finding per peer per commit on every
+    clean trace — the LostWrite ADV-01 v1-blocker fix from document
+    review.
+    """
+
+    name = "lost-write"
+    required_streams = {_STATE_LOG}
+
+    def process(
+        self,
+        entry: dict[str, Any],
+        stream_kind: str,
+        shared: _SharedState,
+    ) -> Iterable[Finding]:
+        if stream_kind != _STATE_LOG:
+            return ()
+        if not _is_writer_commit(entry):
+            return ()
+        from_state = entry.get("from_state")
+        if from_state in {MESIState.MODIFIED.name, MESIState.EXCLUSIVE.name}:
+            return ()
+        return [_make_lost_write_finding(entry, from_state)]
+
+
+def _make_lost_write_finding(
+    entry: dict[str, Any],
+    from_state: str | None,
+) -> Finding:
+    tick = int(entry["tick"])
+    artifact_id = entry["artifact_id"]
+    return Finding(
+        kind="lost-write",
+        severity="CONFIRMED",
+        invariant="lost-write",
+        agents=(entry.get("agent_id") or "",),
+        artifacts=(artifact_id,),
+        tick_range=(tick, tick),
+        context={
+            "stream": _STATE_LOG,
+            "sequence_number": entry.get("sequence_number"),
+        },
+        details={
+            "expected": "from_state in {MODIFIED, EXCLUSIVE}",
+            "observed": f"from_state = {from_state}",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+
+
+CORE_PREDICATES: tuple[type[Predicate], ...] = (
+    SingleWriterPredicate,
+    MonotonicVersionPredicate,
+    StaleReadPredicate,
+    LostWritePredicate,
+)
+
+
+def run_predicates(
+    loaded_trace: LoadedTrace,
+    invariants: Iterable[str] | None = None,
+) -> tuple[list[Finding], list[SummaryFinding]]:
+    """Run the predicate engine over a loaded trace.
+
+    Walks ``loaded_trace.merged()`` exactly once. Predicates whose
+    ``required_streams`` are not a subset of
+    ``loaded_trace.streams_present`` are omitted from the walk and
+    produce SKIPPED summary findings instead.
+
+    Args:
+        loaded_trace: From :func:`ccs.replay.load`.
+        invariants: Optional restriction to a subset of predicate names
+            (e.g. ``["lost-write"]``). Predicates outside the subset
+            are NOT dispatched AND NOT skipped — they're entirely
+            absent from the result.
+
+    Returns:
+        ``(findings, summary_findings)`` — per-breach findings in
+        merge order, plus one summary entry per skipped predicate per
+        missing stream.
+    """
+    selected = _select_predicates(invariants)
+    active, summary = _partition_active(selected, loaded_trace)
+    findings = _walk(loaded_trace, active)
+    return findings, summary
+
+
+def _select_predicates(
+    invariants: Iterable[str] | None,
+) -> list[Predicate]:
+    """Instantiate the predicates the caller asked for (or all four)."""
+    if invariants is None:
+        return [cls() for cls in CORE_PREDICATES]
+    wanted = set(invariants)
+    return [cls() for cls in CORE_PREDICATES if cls.name in wanted]
+
+
+def _partition_active(
+    predicates: list[Predicate],
+    loaded_trace: LoadedTrace,
+) -> tuple[list[Predicate], list[SummaryFinding]]:
+    """Split predicates into active set vs SKIPPED summary findings.
+
+    A predicate is active iff every stream in its ``required_streams``
+    is in ``loaded_trace.streams_present``. Otherwise one
+    SummaryFinding is emitted per missing stream — the spec's --json
+    format keys SKIPPED entries by ``stream_required`` so partners can
+    see exactly which file was absent.
+    """
+    declared_streams = set(loaded_trace.manifest.get("streams") or [])
+    present = loaded_trace.streams_present
+    active: list[Predicate] = []
+    summary: list[SummaryFinding] = []
+    for predicate in predicates:
+        missing = predicate.required_streams - present
+        if not missing:
+            active.append(predicate)
+            continue
+        for stream_name in sorted(missing):
+            summary.append(_make_skipped(predicate, stream_name, declared_streams))
+    return active, summary
+
+
+def _make_skipped(
+    predicate: Predicate,
+    stream_name: str,
+    declared_streams: set[str],
+) -> SummaryFinding:
+    """Build a SKIPPED summary finding.
+
+    ``opted_out=True`` when the missing stream is NOT in
+    ``manifest.streams`` (caller explicitly opted out at capture time —
+    Unit 5 maps this to exit code 0). ``opted_out=False`` when the
+    stream IS declared but absent on disk (capture bug — Unit 5 maps
+    this to exit code 2).
+    """
+    opted_out = stream_name not in declared_streams
+    if opted_out:
+        reason = (
+            f"{predicate.name} requires {stream_name} stream — "
+            f"caller opted out at capture time (not in manifest.streams)"
+        )
+    else:
+        reason = (
+            f"{predicate.name} requires {stream_name} stream — "
+            f"declared in manifest.streams but missing from session "
+            f"directory (capture-side bug)"
+        )
+    return SummaryFinding(
+        kind="skipped",
+        invariant=predicate.name,
+        reason=reason,
+        stream_required=stream_name,
+        opted_out=opted_out,
+    )
+
+
+def _walk(
+    loaded_trace: LoadedTrace,
+    active: list[Predicate],
+) -> list[Finding]:
+    """Walk the merged stream once, dispatching to active predicates.
+
+    Per-entry sequence is load-bearing:
+
+    1. **state map update** (state_log only) — single-writer reads the
+       NEW post-transition state map, so the apply must happen first.
+    2. **predicate dispatch** — every active predicate sees the entry.
+       Monotonic-version + stale-read read the OLD
+       ``latest_committed_version`` here, so the version fold must be
+       stale at this point.
+    3. **version fold update** (state_log writer-commit only) — happens
+       AFTER predicates so step 2's "old" reads are correct. This
+       split is the only way to keep all four predicates correct with
+       a single-pass walk.
+    """
+    findings: list[Finding] = []
+    shared = _SharedState()
+    for stream_kind, entry in loaded_trace.merged():
+        if stream_kind == _STATE_LOG:
+            _apply_state_map(entry, shared)
+        for predicate in active:
+            findings.extend(predicate.process(entry, stream_kind, shared))
+        if stream_kind == _STATE_LOG and _is_writer_commit(entry):
+            _apply_version_fold(entry, shared)
+    for predicate in active:
+        findings.extend(predicate.finalize())
+    return findings
+
+
+def _apply_state_map(entry: dict[str, Any], shared: _SharedState) -> None:
+    """Update ``state_by_agent_artifact`` from one state_log entry.
+
+    Runs BEFORE predicate dispatch so SingleWriterPredicate sees the
+    new state. No-op for entries missing required fields or with an
+    unknown to_state — defensive against partner-shaped traces.
+    """
+    agent_id = entry.get("agent_id")
+    artifact_id = entry.get("artifact_id")
+    to_state_name = entry.get("to_state")
+    if not (agent_id and artifact_id and to_state_name):
+        return
+    try:
+        to_state = MESIState[to_state_name]
+    except KeyError:
+        return
+    shared.state_by_agent_artifact[(agent_id, artifact_id)] = to_state
+
+
+def _apply_version_fold(entry: dict[str, Any], shared: _SharedState) -> None:
+    """Update ``latest_committed_version`` + ``latest_committed_tick``.
+
+    Runs AFTER predicate dispatch so monotonic-version + stale-read
+    see the pre-update snapshot. Caller guarantees
+    ``_is_writer_commit(entry)`` is true. The fold advances only when
+    the new version is strictly greater than the running max — a
+    regression entry (caught by monotonic-version) does NOT poison
+    later reads against the regressed value.
+    """
+    artifact_id = entry.get("artifact_id")
+    version = entry.get("version")
+    tick = entry.get("tick")
+    if not (artifact_id and isinstance(version, int) and isinstance(tick, int)):
+        return
+    previous = shared.latest_committed_version.get(artifact_id, -1)
+    if version > previous:
+        shared.latest_committed_version[artifact_id] = version
+        shared.latest_committed_tick[artifact_id] = tick

--- a/src/ccs/replay/predicates.py
+++ b/src/ccs/replay/predicates.py
@@ -51,7 +51,7 @@ from __future__ import annotations
 
 import abc
 from dataclasses import dataclass, field
-from typing import Any, Iterable
+from typing import Any, ClassVar, Iterable
 
 from ccs.core.invariants import check_monotonic_version, check_single_writer
 from ccs.core.exceptions import InvariantViolationError
@@ -170,8 +170,8 @@ class Predicate(abc.ABC):
     whether to dispatch or skip.
     """
 
-    name: str
-    required_streams: set[str]
+    name: ClassVar[str]
+    required_streams: ClassVar[set[str]]
 
     @abc.abstractmethod
     def process(
@@ -449,7 +449,7 @@ def _classify_stale_read(
         severity = "AMBIGUOUS"
         kind = "stale-read-ambiguous"
     else:
-        return ()
+        return []
     return [Finding(
         kind=kind,
         severity=severity,

--- a/src/ccs/replay/recorder.py
+++ b/src/ccs/replay/recorder.py
@@ -1,0 +1,456 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Capture-side implementation for invariant replay traces (D v1).
+
+Implements the producer contract defined in
+``docs/proposals/replay_trace_format.md``:
+
+- ``manifest.json`` written at ``__enter__`` (header) and re-written
+  atomically at ``__exit__`` (finalized fields).
+- One JSONL file per declared stream (``state_log``,
+  ``content_audit_log``). Each line: ``json.dumps + "\\n"``, flushed,
+  then ``os.fsync(fd)`` so the coordinator's ``_seq`` rollback
+  (registry.py: ``_seq -= 1`` on callback exception) is durable.
+- Caller-supplied callbacks compose with the file-writing callbacks;
+  never overridden. The caller callback fires FIRST so its exception
+  short-circuits the file write (matches existing rollback semantics).
+- Capture-time ``instance_id``-change detection emits a stderr warning
+  naming the ``MULTI_INSTANCE_TRACE`` D+1 roadmap item.
+
+The ``streams=`` opt-out (e.g. ``streams={'state_log'}``) controls
+which JSONL files are opened on disk. The wrapped audit callback
+ALWAYS exists so ``CCSStore.__init__`` keeps ``retain_versions=True``
+(line 88 of ``ccsstore.py``) — the per-stream opt-out only suppresses
+the file write, not the callback wiring.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "UnverifiedAdapterCaptureError",
+    "RecordingSession",
+    "record_callbacks",
+    "DEFAULT_STREAMS",
+    "SCHEMA_VERSION",
+    "SCHEMA_NOTE",
+]
+
+SCHEMA_VERSION = 0
+"""Replay-trace manifest schema version. v1 pins this to ``0`` to signal
+deliberate instability; promotes to ``1`` after the 30-day partner
+retro per the v1 plan §Sequencing Step 6."""
+
+SCHEMA_NOTE = (
+    "experimental replay-contract format; pins to 1 after the Step 6 "
+    "retro if it survives 30-day partner feedback"
+)
+
+DEFAULT_STREAMS: frozenset[str] = frozenset({"state_log", "content_audit_log"})
+
+_STATE_LOG = "state_log"
+_CONTENT_AUDIT_LOG = "content_audit_log"
+_VALID_STREAMS: frozenset[str] = frozenset({_STATE_LOG, _CONTENT_AUDIT_LOG})
+
+# Stderr text emitted on accept_unverified opt-in. Pinned by tests so we
+# can change the body without breaking partner tooling that greps for
+# the leading prefix.
+_UNVERIFIED_WARNING_PREFIX = "CrewAI/AutoGen capture is wired but unverified"
+_UNVERIFIED_WARNING = (
+    "CrewAI/AutoGen capture is wired but unverified in v1; smoke tests "
+    "land in D+1 paired with adapter-specific record_to wrappers; "
+    "please file an issue if you hit problems."
+)
+
+# Stderr text emitted on first observed instance_id change. References the
+# D+1 roadmap item by name so partners can grep for it.
+_MULTI_INSTANCE_WARNING_PREFIX = "MULTI_INSTANCE_TRACE detected at capture time"
+_MULTI_INSTANCE_WARNING = (
+    "MULTI_INSTANCE_TRACE detected at capture time on stream {stream!r}: "
+    "instance_id changed from {old!r} to {new!r}. v1 replay aborts on "
+    "multi-instance traces; per-instance replay loops land in D+1. "
+    "Stop and restart the capture against a single coordinator instance."
+)
+
+
+class UnverifiedAdapterCaptureError(RuntimeError):
+    """Raised by :func:`record_callbacks` when ``accept_unverified=True``
+    was not passed.
+
+    The opt-in gate lives on the low-level helper, not on
+    ``CCSStore.record_to``: CCSStore is verified in v1, so its
+    classmethod sets the flag automatically. CrewAI / AutoGen users
+    invoke the helper directly and MUST acknowledge the unverified
+    status by passing the flag — surfacing the v1 scope boundary at
+    the call site, not buried in README copy.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Stream writers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StreamWriter:
+    """One open JSONL stream + its bookkeeping.
+
+    Owns its file descriptor (not a Python file object) because
+    ``os.fsync`` needs the raw fd and we want to keep the write +
+    flush + fsync sequence on the syscall layer.
+    """
+
+    name: str
+    path: Path | None  # None when stream is opt-ed out (no-op writer)
+    fd: int | None = None
+    last_instance_id: str | None = None
+    first_tick: int | None = None
+    last_tick: int | None = None
+    instance_id_warned: bool = False
+
+    @property
+    def is_active(self) -> bool:
+        return self.fd is not None
+
+    def write(self, entry: dict[str, Any]) -> None:
+        """Append one JSONL line + flush + fsync.
+
+        When ``self.path`` is ``None`` (opt-ed out), do bookkeeping only.
+        Bookkeeping still tracks ticks + instance_id so the manifest
+        finalizer + multi-instance warning fire for caller-supplied
+        callbacks that consume the wrapped no-op writer.
+        """
+        self._update_tracking(entry)
+        if self.fd is None:
+            return
+        payload = (json.dumps(entry, ensure_ascii=False) + "\n").encode("utf-8")
+        os.write(self.fd, payload)
+        os.fsync(self.fd)
+
+    def _update_tracking(self, entry: dict[str, Any]) -> None:
+        tick = entry.get("tick")
+        if isinstance(tick, int):
+            if self.first_tick is None or tick < self.first_tick:
+                self.first_tick = tick
+            if self.last_tick is None or tick > self.last_tick:
+                self.last_tick = tick
+        instance_id = entry.get("instance_id")
+        if instance_id is None:
+            return
+        if self.last_instance_id is None:
+            self.last_instance_id = instance_id
+            return
+        if instance_id != self.last_instance_id and not self.instance_id_warned:
+            self.instance_id_warned = True
+            sys.stderr.write(
+                _MULTI_INSTANCE_WARNING.format(
+                    stream=self.name,
+                    old=self.last_instance_id,
+                    new=instance_id,
+                ) + "\n"
+            )
+            # Update so a third id triggers a second warning (rare but valid).
+            self.last_instance_id = instance_id
+
+    def close(self) -> None:
+        if self.fd is not None:
+            os.close(self.fd)
+            self.fd = None
+
+
+def _open_stream(session_dir: Path, name: str, *, active: bool) -> _StreamWriter:
+    """Open one stream writer. ``active=False`` returns a no-op writer
+    (still consumes events for tracking, but writes nothing to disk)."""
+    if not active:
+        return _StreamWriter(name=name, path=None)
+    path = session_dir / f"{name}.jsonl"
+    # O_APPEND keeps each write atomic at the kernel layer for payloads
+    # below PIPE_BUF (4096 bytes). Mode 0o600 — traces may contain
+    # artifact UUIDs and content hashes; default-deny on read access.
+    fd = os.open(path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+    return _StreamWriter(name=name, path=path, fd=fd)
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_manifest(session_dir: Path, manifest: dict[str, Any]) -> None:
+    """Write ``manifest.json`` via tempfile + ``os.replace`` so a crash
+    mid-rewrite leaves the previous manifest intact."""
+    target = session_dir / "manifest.json"
+    # Same-dir tempfile so os.replace is atomic (rename across filesystems
+    # would not be).
+    fd, tmp_path = tempfile.mkstemp(
+        prefix="manifest.", suffix=".json.tmp", dir=str(session_dir)
+    )
+    try:
+        payload = json.dumps(manifest, indent=2, sort_keys=False).encode("utf-8")
+        os.write(fd, payload)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    os.replace(tmp_path, target)
+
+
+def _header_manifest(streams: list[str], adapter_type: str) -> dict[str, Any]:
+    """Manifest header fields written on ``__enter__``.
+
+    ``end_tick``, ``instance_id``, ``agents``, ``artifacts`` are filled
+    on ``__exit__`` (no MESI activity has fired yet at enter time).
+    """
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "schema_note": SCHEMA_NOTE,
+        "adapter_type": adapter_type,
+        "start_tick": 0,
+        "end_tick": 0,
+        "instance_id": None,
+        "streams": streams,
+        "agents": {},
+        "artifacts": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# RecordingSession — context manager
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RecordingSession:
+    """Manage the on-disk capture session for one ``record_callbacks``
+    or ``CCSStore.record_to`` invocation.
+
+    The session owns its directory, the manifest lifecycle, and the
+    per-stream writers. Composition with caller-supplied callbacks
+    happens in ``record_callbacks`` (the helper builds wrapped
+    callbacks before constructing the session).
+
+    The session does NOT touch a coordinator directly. To populate
+    ``agents`` and ``artifacts`` in the finalized manifest, the caller
+    passes a ``drain_registries`` callable returning ``(agents_map,
+    artifacts_map)``. The helper-level entry point supplies a no-op
+    drain (empty dicts); ``CCSStore.record_to`` supplies a closure
+    over its internal core.
+    """
+
+    session_dir: Path
+    streams: list[str]
+    adapter_type: str
+    drain_registries: Callable[[], tuple[dict[str, str], dict[str, str]]] = field(
+        default=lambda: ({}, {})
+    )
+    _writers: dict[str, _StreamWriter] = field(default_factory=dict, init=False)
+
+    def __enter__(self) -> "RecordingSession":
+        self.session_dir.mkdir(parents=True, exist_ok=True)
+        # streams parameter declares what the manifest advertises; we
+        # always open the audit no-op writer too so caller-supplied
+        # audit callbacks still see the bookkeeping (instance_id tracking,
+        # composition).
+        for stream_name in _VALID_STREAMS:
+            active = stream_name in self.streams
+            self._writers[stream_name] = _open_stream(
+                self.session_dir, stream_name, active=active
+            )
+        _atomic_write_manifest(
+            self.session_dir, _header_manifest(self.streams, self.adapter_type)
+        )
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        try:
+            self._finalize_manifest()
+        finally:
+            for writer in self._writers.values():
+                writer.close()
+
+    def writer(self, stream_name: str) -> _StreamWriter:
+        return self._writers[stream_name]
+
+    def _finalize_manifest(self) -> None:
+        agents_map, artifacts_map = self.drain_registries()
+        start_tick = self._min_first_tick()
+        end_tick = self._max_last_tick()
+        instance_id = self._observed_instance_id()
+        manifest = {
+            "schema_version": SCHEMA_VERSION,
+            "schema_note": SCHEMA_NOTE,
+            "adapter_type": self.adapter_type,
+            "start_tick": start_tick,
+            "end_tick": end_tick,
+            "instance_id": instance_id,
+            "streams": self.streams,
+            "agents": agents_map,
+            "artifacts": artifacts_map,
+        }
+        _atomic_write_manifest(self.session_dir, manifest)
+
+    def _min_first_tick(self) -> int:
+        ticks = [w.first_tick for w in self._writers.values() if w.first_tick is not None]
+        return min(ticks) if ticks else 0
+
+    def _max_last_tick(self) -> int:
+        ticks = [w.last_tick for w in self._writers.values() if w.last_tick is not None]
+        return max(ticks) if ticks else 0
+
+    def _observed_instance_id(self) -> str | None:
+        # First non-None across active writers wins. All writers see
+        # entries from the same coordinator instance in the
+        # well-behaved case; multi-instance is already warned.
+        for writer in self._writers.values():
+            if writer.last_instance_id is not None:
+                return writer.last_instance_id
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Callback composition
+# ---------------------------------------------------------------------------
+
+
+def _compose(
+    caller_cb: Callable[[dict[str, Any]], None] | None,
+    writer: _StreamWriter,
+) -> Callable[[dict[str, Any]], None]:
+    """Build a callback that fires the caller's callback first, then
+    writes to the stream.
+
+    The caller-first order matches the rollback contract: if the
+    caller's callback raises, the file write is skipped AND the
+    coordinator's ``_seq -= 1`` rollback still fires from registry.py.
+    A file-write failure (disk full) likewise propagates and triggers
+    the rollback; fsync-per-line ensures the failed entry is not on
+    disk for the next attempt.
+    """
+    def _wrapped(entry: dict[str, Any]) -> None:
+        if caller_cb is not None:
+            caller_cb(entry)
+        writer.write(entry)
+
+    return _wrapped
+
+
+# ---------------------------------------------------------------------------
+# Public helper
+# ---------------------------------------------------------------------------
+
+
+def _normalize_streams(streams: set[str] | frozenset[str] | None) -> list[str]:
+    """Validate the caller-supplied stream set and freeze its iteration
+    order to the declared spec (state_log first, audit second)."""
+    if streams is None:
+        chosen = DEFAULT_STREAMS
+    else:
+        chosen = frozenset(streams)
+        unknown = chosen - _VALID_STREAMS
+        if unknown:
+            raise ValueError(
+                f"Unknown streams in record_callbacks(streams={chosen!r}); "
+                f"valid set is {sorted(_VALID_STREAMS)!r}"
+            )
+        if _STATE_LOG not in chosen:
+            # state_log carries 3 of 4 invariants; an opt-out would
+            # leave a useless trace. Fail fast at capture time.
+            raise ValueError(
+                "record_callbacks requires 'state_log' in streams= "
+                "(it carries SINGLE_WRITER, MONOTONIC_VERSION, and "
+                "LOST_WRITE invariants in v1)"
+            )
+    return [s for s in (_STATE_LOG, _CONTENT_AUDIT_LOG) if s in chosen]
+
+
+@contextmanager
+def record_callbacks(
+    path: str | Path,
+    *,
+    streams: set[str] | frozenset[str] | None = None,
+    accept_unverified: bool = False,
+    state_log: Callable[[dict[str, Any]], None] | None = None,
+    content_audit_log: Callable[[dict[str, Any]], None] | None = None,
+    adapter_type: str = "coherence-adapter-core",
+    drain_registries: Callable[
+        [], tuple[dict[str, str], dict[str, str]]
+    ] | None = None,
+    _verified_caller: bool = False,
+) -> Iterator[tuple[
+    Callable[[dict[str, Any]], None],
+    Callable[[dict[str, Any]], None],
+]]:
+    """Low-level non-LangGraph recorder helper.
+
+    Yields a ``(state_log_cb, content_audit_log_cb)`` tuple inside a
+    context manager. Callers wire these into
+    ``CoherenceAdapterCore(state_log=..., content_audit_log=...)``.
+
+    The audit callback ALWAYS exists (even when
+    ``streams={'state_log'}``) so downstream
+    ``retain_versions=content_audit_log is not None`` checks stay
+    truthy. The opt-out only suppresses the file write.
+
+    Args:
+        path: Session directory. Created if missing.
+        streams: Subset of ``{"state_log", "content_audit_log"}`` that
+            should land on disk. Default: both. ``state_log`` cannot
+            be opted out.
+        accept_unverified: Required opt-in for direct callers. CCSStore
+            sets this automatically via its ``record_to`` wrapper;
+            CrewAI / AutoGen users must pass it explicitly.
+        state_log: Caller-supplied state-log callback. Composed BEFORE
+            the file writer (caller exception short-circuits write +
+            triggers ``_seq`` rollback).
+        content_audit_log: Same as ``state_log`` for the audit stream.
+        adapter_type: Recorded in the manifest. Default
+            ``coherence-adapter-core`` for direct helper use;
+            ``CCSStore.record_to`` overrides to ``langgraph-ccsstore``.
+        drain_registries: Closure invoked on ``__exit__`` to populate
+            the manifest's ``agents`` / ``artifacts`` maps from the
+            coordinator's registries. Direct callers leave this
+            ``None`` (empty maps).
+
+    Raises:
+        UnverifiedAdapterCaptureError: ``accept_unverified`` not set.
+        ValueError: ``streams=`` contains unknown values or omits
+            ``state_log``.
+    """
+    if not accept_unverified:
+        raise UnverifiedAdapterCaptureError(
+            "record_callbacks requires accept_unverified=True. "
+            "v1 only verifies CCSStore captures end-to-end; CrewAI / "
+            "AutoGen capture is wired but unverified — pass "
+            "accept_unverified=True to acknowledge."
+        )
+
+    # The stderr warning is only emitted when an unverified caller used
+    # the opt-in flag. Verified adapters (CCSStore) pass
+    # _verified_caller=True to suppress it — the flag is a private
+    # signal from the wrapper, not a public knob.
+    if not _verified_caller:
+        sys.stderr.write(_UNVERIFIED_WARNING + "\n")
+
+    session_streams = _normalize_streams(streams)
+    drain = drain_registries if drain_registries is not None else (lambda: ({}, {}))
+    session = RecordingSession(
+        session_dir=Path(path),
+        streams=session_streams,
+        adapter_type=adapter_type,
+        drain_registries=drain,
+    )
+    with session:
+        state_cb = _compose(state_log, session.writer(_STATE_LOG))
+        audit_cb = _compose(content_audit_log, session.writer(_CONTENT_AUDIT_LOG))
+        yield state_cb, audit_cb

--- a/src/ccs/replay/recorder.py
+++ b/src/ccs/replay/recorder.py
@@ -35,6 +35,7 @@ import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import TracebackType
 from typing import Any, Callable, Iterator
 
 logger = logging.getLogger(__name__)
@@ -203,7 +204,14 @@ def _atomic_write_manifest(session_dir: Path, manifest: dict[str, Any]) -> None:
         os.fsync(fd)
     finally:
         os.close(fd)
-    os.replace(tmp_path, target)
+    try:
+        os.replace(tmp_path, target)
+    except OSError:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def _header_manifest(streams: list[str], adapter_type: str) -> dict[str, Any]:
@@ -272,7 +280,12 @@ class RecordingSession:
         )
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         try:
             self._finalize_manifest()
         finally:

--- a/tests/integration/test_replay_e2e.py
+++ b/tests/integration/test_replay_e2e.py
@@ -27,7 +27,6 @@ from typing import Any
 
 import pytest
 
-from ccs.adapters.ccsstore import CCSStore
 from ccs.cli.coherence_replay import main as replay_main
 
 
@@ -133,6 +132,8 @@ def test_e2e_clean_trace(
     coordinator enforces them). Stale-read and lost-write predicates run
     against the captured streams and find no breaches.
     """
+    pytest.importorskip("langgraph")
+    from ccs.adapters.ccsstore import CCSStore
     session_dir = tmp_path / "clean-session"
     with CCSStore.record_to(session_dir, strategy="lazy") as store:
         store.put(("planner", "shared"), "plan", {"v": 1})
@@ -319,6 +320,7 @@ def test_e2e_real_langgraph_capture_and_replay(
     pytest.importorskip("langgraph.graph")
     pytest.importorskip("langgraph.config")
 
+    from ccs.adapters.ccsstore import CCSStore
     from langgraph.config import get_store as lg_get_store
     from langgraph.graph import END, START, StateGraph
     from typing import TypedDict

--- a/tests/integration/test_replay_e2e.py
+++ b/tests/integration/test_replay_e2e.py
@@ -1,0 +1,401 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""End-to-end integration tests for the replay tool (Unit 6 of D v1).
+
+Each test drives the FULL capture → load → run_predicates → emit → exit-code
+pipeline. No layer is mocked; sim-engine-style fixtures produce real state_log
+streams via the actual coordinator/agent runtime, and synthetic JSONL fixtures
+cover scenarios the live coordinator forbids by construction (single-writer +
+monotonic-version are invariants of the coordinator itself, so a "lost-write"
+or "stale-read" breach has to be hand-written).
+
+The fifth test is the **real-LangGraph completion gate** required by the v1
+plan (Unit 6, P1-C resolution). It compiles a real ``langgraph.graph.StateGraph``
+that exercises a write + multiple reads through ``CCSStore.record_to(path)``,
+then replays the captured directory and asserts a clean run.
+
+Tests skip cleanly when ``langgraph`` is not installed only for the real-fixture
+test; the four synthetic e2e tests don't depend on langgraph.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ccs.adapters.ccsstore import CCSStore
+from ccs.cli.coherence_replay import main as replay_main
+
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal fixture builders (mirror the trace-format spec §3 + §4)
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(
+    session_dir: Path,
+    *,
+    streams: list[str],
+    instance_id: str | None = "instance-A",
+    adapter_type: str = "e2e-fixture",
+    start_tick: int = 0,
+    end_tick: int = 10,
+) -> None:
+    session_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schema_version": 0,
+        "schema_note": "e2e fixture",
+        "adapter_type": adapter_type,
+        "start_tick": start_tick,
+        "end_tick": end_tick,
+        "instance_id": instance_id,
+        "streams": streams,
+        "agents": {},
+        "artifacts": {},
+    }
+    (session_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
+def _state_log_entry(
+    *,
+    tick: int,
+    sequence_number: int,
+    agent_id: str = "agent-1",
+    artifact_id: str = "art-1",
+    from_state: str = "INVALID",
+    to_state: str = "EXCLUSIVE",
+    trigger: str = "write",
+    version: int = 1,
+    instance_id: str = "instance-A",
+) -> dict[str, Any]:
+    return {
+        "tick": tick,
+        "artifact_id": artifact_id,
+        "agent_id": agent_id,
+        "agent_name": agent_id,
+        "from_state": from_state,
+        "to_state": to_state,
+        "trigger": trigger,
+        "version": version,
+        "content_hash": "abc",
+        "sequence_number": sequence_number,
+        "instance_id": instance_id,
+        "schema_version": "ccs.state_log.v2",
+    }
+
+
+def _audit_entry(
+    *,
+    tick: int,
+    sequence_number: int,
+    agent_id: str = "reader",
+    artifact_id: str = "art-1",
+    version: int = 1,
+    instance_id: str = "instance-A",
+) -> dict[str, Any]:
+    return {
+        "tick": tick,
+        "agent_id": agent_id,
+        "agent_name": agent_id,
+        "artifact_id": artifact_id,
+        "version": version,
+        "content_hash": "abc",
+        "source": "fetch",
+        "outcome": "content",
+        "sequence_number": sequence_number,
+        "instance_id": instance_id,
+        "schema_version": "ccs.content_audit.v1",
+    }
+
+
+def _write_jsonl(session_dir: Path, name: str, entries: list[dict]) -> None:
+    path = session_dir / f"{name}.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# E2E 1: clean trace
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_clean_trace(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Drive a single CCSStore agent through a clean write + read cycle.
+
+    Single-writer + monotonic-version are honored by construction (the
+    coordinator enforces them). Stale-read and lost-write predicates run
+    against the captured streams and find no breaches.
+    """
+    session_dir = tmp_path / "clean-session"
+    with CCSStore.record_to(session_dir, strategy="lazy") as store:
+        store.put(("planner", "shared"), "plan", {"v": 1})
+        result = store.get(("planner", "shared"), "plan")
+        assert result is not None
+        assert result.value == {"v": 1}
+
+    # Capture artifacts exist + are well-formed.
+    assert (session_dir / "manifest.json").exists()
+    assert (session_dir / "state_log.jsonl").exists()
+    manifest = json.loads((session_dir / "manifest.json").read_text())
+    assert manifest["adapter_type"] == "langgraph-ccsstore"
+    assert manifest["instance_id"] is not None
+
+    rc = replay_main([str(session_dir)])
+    out = capsys.readouterr().out
+    assert rc == 0, f"clean trace should exit 0, got {rc}; stdout:\n{out}"
+    assert "0 CONFIRMED" in out
+    assert "0 AMBIGUOUS" in out
+
+
+# ---------------------------------------------------------------------------
+# E2E 2: breach trace (lost-write — coordinator-forbidden, so synthesized)
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_breach_trace(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Synthesize a single-writer breach and verify CLI exits 1.
+
+    The breach (two agents simultaneously in MODIFIED on the same artifact)
+    is impossible to produce through real coordinator operations — the
+    coordinator's ``check_single_writer`` invariant rejects it. We
+    construct it on-disk to exercise the predicate engine end-to-end.
+    """
+    session_dir = tmp_path / "breach-session"
+    _write_manifest(session_dir, streams=["state_log"])
+    _write_jsonl(
+        session_dir,
+        "state_log",
+        [
+            _state_log_entry(
+                tick=1, sequence_number=1, agent_id="agent-1",
+                from_state="INVALID", to_state="EXCLUSIVE",
+            ),
+            _state_log_entry(
+                tick=2, sequence_number=2, agent_id="agent-1",
+                from_state="EXCLUSIVE", to_state="MODIFIED",
+                trigger="commit", version=1,
+            ),
+            _state_log_entry(
+                tick=3, sequence_number=3, agent_id="agent-2",
+                from_state="INVALID", to_state="EXCLUSIVE",
+            ),
+            _state_log_entry(
+                tick=4, sequence_number=4, agent_id="agent-2",
+                from_state="EXCLUSIVE", to_state="MODIFIED",
+                trigger="commit", version=2,
+            ),
+        ],
+    )
+
+    rc = replay_main([str(session_dir)])
+    out = capsys.readouterr().out
+    assert rc == 1, f"breach trace should exit 1, got {rc}; stdout:\n{out}"
+    assert "[CONFIRMED]" in out
+    assert "single-writer" in out
+
+
+# ---------------------------------------------------------------------------
+# E2E 3: AMBIGUOUS trace (same-tick read + commit)
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_ambiguous_trace(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Same-tick read+commit collision → AMBIGUOUS stale-read.
+
+    Default: suppressed from per-finding output, exits 0, summary shows
+    "1 AMBIGUOUS (suppressed)". ``--include-ambiguous``: shown, still
+    exits 0.
+    """
+    session_dir = tmp_path / "ambig-session"
+    _write_manifest(session_dir, streams=["state_log", "content_audit_log"])
+    state_entries = [
+        # Seed v1 cleanly: writer reaches MODIFIED at tick 1.
+        _state_log_entry(
+            tick=1, sequence_number=1, agent_id="writer",
+            from_state="INVALID", to_state="EXCLUSIVE",
+        ),
+        _state_log_entry(
+            tick=1, sequence_number=2, agent_id="writer",
+            from_state="EXCLUSIVE", to_state="MODIFIED",
+            trigger="commit", version=1,
+        ),
+        # Writer re-acquires EXCLUSIVE at tick 4, then commits v2 at tick 5.
+        _state_log_entry(
+            tick=4, sequence_number=3, agent_id="writer",
+            from_state="MODIFIED", to_state="EXCLUSIVE",
+        ),
+        _state_log_entry(
+            tick=5, sequence_number=4, agent_id="writer",
+            from_state="EXCLUSIVE", to_state="MODIFIED",
+            trigger="commit", version=2,
+        ),
+    ]
+    # Same-tick reader observation of stale version=1 at tick 5: AMBIGUOUS.
+    audit_entries = [
+        _audit_entry(tick=5, sequence_number=10, agent_id="reader-1", version=1),
+    ]
+    _write_jsonl(session_dir, "state_log", state_entries)
+    _write_jsonl(session_dir, "content_audit_log", audit_entries)
+
+    # Default — AMBIGUOUS suppressed.
+    rc = replay_main([str(session_dir)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "[AMBIGUOUS]" not in out
+    assert "1 AMBIGUOUS (suppressed)" in out
+
+    # --include-ambiguous — AMBIGUOUS shown, still exit 0.
+    rc2 = replay_main([str(session_dir), "--include-ambiguous"])
+    out2 = capsys.readouterr().out
+    assert rc2 == 0
+    assert "[AMBIGUOUS]" in out2
+    assert "1 AMBIGUOUS (shown)" in out2
+
+
+# ---------------------------------------------------------------------------
+# E2E 4: multi-instance trace error
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_multi_instance_trace(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Two ``instance_id`` values → CLI exits 3 with MULTI_INSTANCE_TRACE."""
+    session_dir = tmp_path / "multi-instance"
+    _write_manifest(session_dir, streams=["state_log"])
+    _write_jsonl(
+        session_dir,
+        "state_log",
+        [
+            _state_log_entry(tick=1, sequence_number=1, instance_id="instance-A"),
+            _state_log_entry(tick=2, sequence_number=2, instance_id="instance-B"),
+        ],
+    )
+
+    rc = replay_main([str(session_dir)])
+    captured = capsys.readouterr()
+    assert rc == 3
+    # Loader error message references the instance violation + D+1 roadmap.
+    assert "instance" in captured.err.lower()
+    assert "D+1" in captured.err
+    assert "Traceback" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# E2E 5: REAL LANGGRAPH FIXTURE — Unit 6 completion gate
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_real_langgraph_capture_and_replay(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """**Unit 6 completion gate** — capture a real LangGraph cycle and replay.
+
+    Compiles a real ``langgraph.graph.StateGraph`` (planner writes; three
+    reader nodes each read the same artifact multiple times) and routes
+    everything through ``CCSStore.record_to(path)``. Then runs the CLI
+    replay over the captured directory and asserts:
+
+    1. The capture produced a well-formed ``manifest.json`` + non-empty
+       ``state_log.jsonl``.
+    2. Replay loads without trace errors.
+    3. The clean cycle produces zero findings (the LangGraph state-graph
+       paths exercise the coordinator's invariants normally — no breach
+       should surface).
+
+    Skips cleanly when ``langgraph`` is not installed.
+    """
+    pytest.importorskip("langgraph.graph")
+    pytest.importorskip("langgraph.config")
+
+    from langgraph.config import get_store as lg_get_store
+    from langgraph.graph import END, START, StateGraph
+    from typing import TypedDict
+
+    class GraphState(TypedDict):
+        log: list[str]
+
+    artifact_scope = "shared"
+    artifact_key = "plan"
+    plan_content = {
+        "title": "Replay e2e gate",
+        "objectives": ["exercise CCSStore.record_to under real LangGraph"],
+        "owner": "planner",
+    }
+
+    def planner_node(state: GraphState) -> dict:
+        store: CCSStore = lg_get_store()  # type: ignore[assignment]
+        store.put(("planner", artifact_scope), artifact_key, plan_content)
+        return {"log": [*state["log"], "planner: wrote plan"]}
+
+    def _make_reader(agent_name: str):
+        def node(state: GraphState) -> dict:
+            store: CCSStore = lg_get_store()  # type: ignore[assignment]
+            # Multiple reads — first is a coordinator fetch (cache miss),
+            # subsequent are cache hits. Exercises read-side state
+            # transitions captured into the state_log stream.
+            for _ in range(3):
+                item = store.get((agent_name, artifact_scope), artifact_key)
+                assert item is not None
+                assert item.value == plan_content
+            return {"log": [*state["log"], f"{agent_name}: read 3x"]}
+
+        node.__name__ = f"{agent_name}_node"
+        return node
+
+    def build_graph(store: CCSStore):
+        builder = StateGraph(GraphState)
+        builder.add_node("planner", planner_node)
+        for name in ("researcher", "executor", "reviewer"):
+            builder.add_node(name, _make_reader(name))
+        builder.add_edge(START, "planner")
+        builder.add_edge("planner", "researcher")
+        builder.add_edge("researcher", "executor")
+        builder.add_edge("executor", "reviewer")
+        builder.add_edge("reviewer", END)
+        return builder.compile(store=store)
+
+    session_dir = tmp_path / "real-langgraph"
+
+    with CCSStore.record_to(session_dir, strategy="lazy") as store:
+        graph = build_graph(store)
+        final_state = graph.invoke({"log": []})
+
+    # Sanity-check the captured graph actually ran end-to-end.
+    assert "planner: wrote plan" in final_state["log"]
+    assert any("read 3x" in entry for entry in final_state["log"])
+
+    # Capture artifacts exist + are well-formed.
+    manifest_path = session_dir / "manifest.json"
+    state_log_path = session_dir / "state_log.jsonl"
+    assert manifest_path.exists(), "real-LangGraph capture missing manifest.json"
+    assert state_log_path.exists(), "real-LangGraph capture missing state_log.jsonl"
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["adapter_type"] == "langgraph-ccsstore"
+    assert manifest["instance_id"] is not None
+    state_log_lines = [
+        line for line in state_log_path.read_text().splitlines() if line.strip()
+    ]
+    assert state_log_lines, "real-LangGraph capture produced empty state_log.jsonl"
+
+    # Replay the captured directory — clean LangGraph cycle should produce
+    # zero CONFIRMED findings. The reader fan-out (one writer + three
+    # multi-read agents) exercises SHARED-state transitions captured into
+    # the state_log stream.
+    rc = replay_main([str(session_dir)])
+    out = capsys.readouterr().out
+    assert rc == 0, (
+        f"real-LangGraph clean cycle should exit 0, got {rc}; stdout:\n{out}"
+    )
+    assert "0 CONFIRMED" in out

--- a/tests/test_claude_code_cli.py
+++ b/tests/test_claude_code_cli.py
@@ -509,6 +509,88 @@ def test_untrack_rejects_invalid_paths_without_network(
 
 
 # ----------------------------------------------------------------------
+# coherence_status --show-policy
+# ----------------------------------------------------------------------
+
+
+def test_show_policy_renders_pending_section_when_path_not_yet_observed(
+    live_coordinator, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A user-added path that has never been pre-read must appear under
+    'Tracked (pending first read):' — it is in user_added_patterns but
+    not yet in tracked_artifacts."""
+    workspace, port = live_coordinator
+    from ccs.cli._coherence_client import resolve_endpoint, post as _post
+    endpoint = resolve_endpoint(workspace)
+
+    # Add a path via /policy/track so it enters user_added_patterns.
+    path = "pending_first_read_test.md"
+    resp = _post(endpoint, "/policy/track", {"paths": [path]})
+    assert path in resp.get("added", []), f"track failed: {resp}"
+
+    rc = coherence_status.main([
+        "--root", str(workspace), "--show-policy",
+    ])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Tracked (pending first read):" in captured.out
+    assert path in captured.out
+
+
+def test_show_policy_renders_none_after_path_is_observed(
+    live_coordinator, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Once a pre-read fires for every user-added path, the pending list
+    is empty and the 'none' branch renders."""
+    workspace, port = live_coordinator
+    from ccs.cli._coherence_client import resolve_endpoint, post as _post
+    import uuid as _uuid
+    endpoint = resolve_endpoint(workspace)
+
+    path = "observed_test.md"
+    _post(endpoint, "/policy/track", {"paths": [path]})
+
+    # Fire a pre-read to seed the artifact into tracked_artifacts.
+    sid = str(_uuid.uuid4())
+    _post(endpoint, "/hooks/pre-read", {
+        "session_id": sid,
+        "path": path,
+        "content_hash": "a" * 64,
+    })
+
+    rc = coherence_status.main([
+        "--root", str(workspace), "--show-policy",
+    ])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Tracked (pending first read): none" in captured.out
+
+
+def test_show_policy_json_injects_pending_first_read_key(
+    live_coordinator, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--show-policy --json injects 'policy_pending_first_read' into the
+    payload so agent callers get the same data as the table renderer."""
+    workspace, port = live_coordinator
+    from ccs.cli._coherence_client import resolve_endpoint, post as _post
+    endpoint = resolve_endpoint(workspace)
+
+    path = "json_pending_test.md"
+    _post(endpoint, "/policy/track", {"paths": [path]})
+
+    rc = coherence_status.main([
+        "--root", str(workspace), "--show-policy", "--json",
+    ])
+    captured = capsys.readouterr()
+    assert rc == 0
+    data = json.loads(captured.out)
+    assert "policy_pending_first_read" in data, (
+        "--json --show-policy must inject 'policy_pending_first_read' key"
+    )
+    assert path in data["policy_pending_first_read"]
+
+
+# ----------------------------------------------------------------------
 # _coherence_client — endpoint resolution edge cases
 # ----------------------------------------------------------------------
 

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -1775,6 +1775,74 @@ def test_r14_lock_file_created_next_to_yaml(coordinator, client: _Client) -> Non
     assert lock_path.is_file(), "tracked.yaml.lock sidecar was not created"
 
 
+def test_policy_track_idempotent_no_duplicate_entries(coordinator, client: _Client) -> None:
+    """Tracking the same path twice must not produce duplicate lines in
+    tracked.yaml. The second call should still return 200 (idempotent) but
+    the path must appear exactly once in the YAML."""
+    path = "idempotent_test.md"
+    s1, b1 = client.post("/policy/track", {"paths": [path]})
+    s2, b2 = client.post("/policy/track", {"paths": [path]})
+    assert s1 == 200
+    assert s2 == 200
+    # Second call must report zero newly-added patterns \u2014 the path was already
+    # present and _append_policy_yaml must return ([], rejected), not (added, rejected).
+    assert b2.get("added") == [], (
+        f"second /policy/track returned 'added'={b2.get('added')!r}; "
+        "idempotent call must report no additions"
+    )
+
+    yaml_path = coordinator.coordinator_root / ".coherence" / "tracked.yaml"
+    text = yaml_path.read_text()
+    occurrences = text.count(f"- {path}")
+    assert occurrences == 1, (
+        f"path {path!r} appears {occurrences}\xd7 in tracked.yaml after two track calls "
+        f"(expected 1 \u2014 /policy/track must be idempotent)"
+    )
+
+
+# ----------------------------------------------------------------------
+# _parse_yaml_pattern_lines unit tests
+# ----------------------------------------------------------------------
+
+
+def test_parse_yaml_pattern_lines_plain_entries() -> None:
+    """Plain unquoted list items are extracted."""
+    from ccs.adapters.claude_code.coordinator_server import _parse_yaml_pattern_lines
+    text = "- plan.md\n- src/main.py\n"
+    result = _parse_yaml_pattern_lines(text)
+    assert result == {"plan.md", "src/main.py"}
+
+
+def test_parse_yaml_pattern_lines_quoted_entries() -> None:
+    """YAML-quoted values are extracted without the quotes."""
+    from ccs.adapters.claude_code.coordinator_server import _parse_yaml_pattern_lines
+    text = '- "plan.md"\n- \'src/main.py\'\n'
+    result = _parse_yaml_pattern_lines(text)
+    assert result == {"plan.md", "src/main.py"}
+
+
+def test_parse_yaml_pattern_lines_empty_input() -> None:
+    """Empty or whitespace-only input returns empty set."""
+    from ccs.adapters.claude_code.coordinator_server import _parse_yaml_pattern_lines
+    assert _parse_yaml_pattern_lines("") == set()
+    assert _parse_yaml_pattern_lines("   \n  ") == set()
+
+
+def test_parse_yaml_pattern_lines_non_string_items_ignored() -> None:
+    """Non-string items (numbers, null) are silently dropped."""
+    from ccs.adapters.claude_code.coordinator_server import _parse_yaml_pattern_lines
+    text = "- plan.md\n- 42\n- null\n"
+    result = _parse_yaml_pattern_lines(text)
+    assert result == {"plan.md"}
+
+
+def test_parse_yaml_pattern_lines_malformed_yaml_returns_empty() -> None:
+    """Malformed YAML falls back to empty set rather than raising."""
+    from ccs.adapters.claude_code.coordinator_server import _parse_yaml_pattern_lines
+    result = _parse_yaml_pattern_lines("{not: a list}")
+    assert result == set()
+
+
 # ----------------------------------------------------------------------
 # R11 (Unit 6) — ensure_secret bounded O_EXCL retry, fail-closed
 # ----------------------------------------------------------------------

--- a/tests/test_claude_code_policy.py
+++ b/tests/test_claude_code_policy.py
@@ -256,3 +256,10 @@ def test_summary_includes_counts(root: Path) -> None:
     assert summary["user_added_pattern_count"] == 1  # runbook.md
     assert summary["ignored_pattern_count"] == 1  # docs/brainstorms/**/*.md
     assert summary["rejected_pattern_count"] == 1  # /etc/passwd
+    assert summary["user_added_patterns"] == ["runbook.md"]
+
+
+def test_summary_user_added_patterns_empty_by_default(root: Path) -> None:
+    policy = TrackedArtifactPolicy.load(root)
+    summary = policy.summary()
+    assert summary["user_added_patterns"] == []

--- a/tests/test_cli_coherence_replay.py
+++ b/tests/test_cli_coherence_replay.py
@@ -1,0 +1,690 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for ``agent-coherence-replay`` CLI (Unit 5 of D v1).
+
+Covers every test scenario enumerated in plan §Unit 5:
+
+- Exit codes 0/1/2/3 each have ≥1 explicit assertion.
+- AMBIGUOUS suppression default behavior + ``--include-ambiguous``
+  override.
+- AMBIGUOUS callout threshold (exceed → callout present; below → absent).
+- ``--invariant`` restricts both findings AND SKIPPED outputs.
+- ``--quiet`` produces zero stdout on a clean trace.
+- Trace errors (MULTI_INSTANCE, TRACE_CORRUPTION, missing manifest)
+  all map to exit code 3 with NO Python traceback on stderr.
+- ``--json`` schema conformance: structural validation against spec §7.
+
+Fixtures mirror the on-disk trace format documented in
+``docs/proposals/replay_trace_format.md`` (manifest.json + per-stream
+.jsonl files). Helper builders kept short and explicit so each test
+documents its own scenario.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ccs.cli.coherence_replay import build_parser, main
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(
+    session_dir: Path,
+    *,
+    streams: list[str],
+    instance_id: str | None = "instance-A",
+    adapter_type: str = "test-fixture",
+    start_tick: int = 0,
+    end_tick: int = 10,
+) -> None:
+    session_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schema_version": 0,
+        "schema_note": "test fixture",
+        "adapter_type": adapter_type,
+        "start_tick": start_tick,
+        "end_tick": end_tick,
+        "instance_id": instance_id,
+        "streams": streams,
+        "agents": {},
+        "artifacts": {},
+    }
+    (session_dir / "manifest.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+
+
+def _state_log_entry(
+    *,
+    tick: int,
+    sequence_number: int,
+    agent_id: str = "agent-1",
+    artifact_id: str = "art-1",
+    from_state: str = "INVALID",
+    to_state: str = "EXCLUSIVE",
+    trigger: str = "write",
+    version: int = 1,
+    instance_id: str = "instance-A",
+) -> dict[str, Any]:
+    return {
+        "tick": tick,
+        "artifact_id": artifact_id,
+        "agent_id": agent_id,
+        "agent_name": agent_id,
+        "from_state": from_state,
+        "to_state": to_state,
+        "trigger": trigger,
+        "version": version,
+        "content_hash": "abc",
+        "sequence_number": sequence_number,
+        "instance_id": instance_id,
+        "schema_version": "ccs.state_log.v2",
+    }
+
+
+def _audit_entry(
+    *,
+    tick: int,
+    sequence_number: int,
+    agent_id: str | None = "agent-1",
+    artifact_id: str = "art-1",
+    version: int = 1,
+    outcome: str = "content",
+    instance_id: str = "instance-A",
+) -> dict[str, Any]:
+    return {
+        "tick": tick,
+        "agent_id": agent_id,
+        "agent_name": agent_id,
+        "artifact_id": artifact_id,
+        "version": version,
+        "content_hash": "abc",
+        "source": "fetch",
+        "outcome": outcome,
+        "sequence_number": sequence_number,
+        "instance_id": instance_id,
+        "schema_version": "ccs.content_audit.v1",
+    }
+
+
+def _write_jsonl(session_dir: Path, name: str, entries: list[dict]) -> None:
+    path = session_dir / f"{name}.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+
+
+def _clean_session(tmp_path: Path) -> Path:
+    """Single agent acquires E, commits, releases. Zero invariant breaches."""
+    session = tmp_path / "clean"
+    _write_manifest(session, streams=["state_log", "content_audit_log"])
+    _write_jsonl(session, "state_log", [
+        _state_log_entry(
+            tick=1, sequence_number=1,
+            from_state="INVALID", to_state="EXCLUSIVE",
+        ),
+        _state_log_entry(
+            tick=2, sequence_number=2,
+            from_state="EXCLUSIVE", to_state="MODIFIED",
+            trigger="commit", version=1,
+        ),
+        _state_log_entry(
+            tick=3, sequence_number=3,
+            from_state="MODIFIED", to_state="INVALID",
+        ),
+    ])
+    _write_jsonl(session, "content_audit_log", [])
+    return session
+
+
+def _single_writer_breach_session(tmp_path: Path) -> Path:
+    """Both agents hold MODIFIED simultaneously.
+
+    Routed through EXCLUSIVE first so the commit's ``from_state``
+    isn't INVALID — that would also trigger lost-write and the test
+    couldn't assert "exactly one finding". Same routing for
+    monotonic-version: versions 1 then 2 strictly increase.
+    """
+    session = tmp_path / "breach"
+    _write_manifest(session, streams=["state_log"])
+    _write_jsonl(session, "state_log", [
+        _state_log_entry(
+            tick=1, sequence_number=1, agent_id="agent-1",
+            from_state="INVALID", to_state="EXCLUSIVE",
+        ),
+        _state_log_entry(
+            tick=2, sequence_number=2, agent_id="agent-1",
+            from_state="EXCLUSIVE", to_state="MODIFIED",
+            trigger="commit", version=1,
+        ),
+        _state_log_entry(
+            tick=3, sequence_number=3, agent_id="agent-2",
+            from_state="INVALID", to_state="EXCLUSIVE",
+        ),
+        # agent-2 now reaches MODIFIED while agent-1 still holds MODIFIED.
+        _state_log_entry(
+            tick=4, sequence_number=4, agent_id="agent-2",
+            from_state="EXCLUSIVE", to_state="MODIFIED",
+            trigger="commit", version=2,
+        ),
+    ])
+    return session
+
+
+def _ambiguous_session(tmp_path: Path, *, count: int = 1) -> Path:
+    """Same-tick read + commit produces ``count`` AMBIGUOUS stale-reads.
+
+    Writer goes INVALID -> EXCLUSIVE -> MODIFIED so the commit's
+    ``from_state == EXCLUSIVE`` doesn't trip lost-write. Stale-read
+    needs a prior committed version baseline: tick 1 seeds v1, tick 5
+    commits v2; same-tick readers at tick 5 observing v1 produce
+    AMBIGUOUS findings.
+    """
+    session = tmp_path / f"ambig-{count}"
+    _write_manifest(session, streams=["state_log", "content_audit_log"])
+    state_entries = [
+        # Seed v1 cleanly.
+        _state_log_entry(
+            tick=1, sequence_number=1, agent_id="writer",
+            from_state="INVALID", to_state="EXCLUSIVE",
+        ),
+        _state_log_entry(
+            tick=1, sequence_number=2, agent_id="writer",
+            from_state="EXCLUSIVE", to_state="MODIFIED",
+            trigger="commit", version=1,
+        ),
+        _state_log_entry(
+            tick=4, sequence_number=3, agent_id="writer",
+            from_state="MODIFIED", to_state="EXCLUSIVE",
+        ),
+        # Tick 5 commits v2 — the version-2 commit reader collisions race.
+        _state_log_entry(
+            tick=5, sequence_number=4, agent_id="writer",
+            from_state="EXCLUSIVE", to_state="MODIFIED",
+            trigger="commit", version=2,
+        ),
+    ]
+    # Same-tick (tick=5) reader observations of stale version=1: AMBIGUOUS.
+    audit_entries = [
+        _audit_entry(
+            tick=5, sequence_number=10 + i,
+            agent_id=f"reader-{i}", version=1,
+        )
+        for i in range(count)
+    ]
+    _write_jsonl(session, "state_log", state_entries)
+    _write_jsonl(session, "content_audit_log", audit_entries)
+    return session
+
+
+def _opted_out_session(tmp_path: Path) -> Path:
+    """Manifest declares only ``state_log`` — stale-read SKIPPED with opted_out=True."""
+    session = tmp_path / "opted-out"
+    _write_manifest(session, streams=["state_log"])
+    _write_jsonl(session, "state_log", [
+        _state_log_entry(
+            tick=1, sequence_number=1,
+            from_state="INVALID", to_state="EXCLUSIVE",
+        ),
+    ])
+    return session
+
+
+def _capture_bug_session(tmp_path: Path) -> Path:
+    """Manifest declares content_audit_log but the file is missing."""
+    session = tmp_path / "capture-bug"
+    _write_manifest(session, streams=["state_log", "content_audit_log"])
+    _write_jsonl(session, "state_log", [
+        _state_log_entry(
+            tick=1, sequence_number=1,
+            from_state="INVALID", to_state="EXCLUSIVE",
+        ),
+    ])
+    # content_audit_log.jsonl deliberately NOT written.
+    return session
+
+
+def _multi_instance_session(tmp_path: Path) -> Path:
+    session = tmp_path / "multi-instance"
+    _write_manifest(session, streams=["state_log"])
+    _write_jsonl(session, "state_log", [
+        _state_log_entry(tick=1, sequence_number=1, instance_id="instance-A"),
+        _state_log_entry(tick=2, sequence_number=2, instance_id="instance-B"),
+    ])
+    return session
+
+
+def _trace_corruption_session(tmp_path: Path) -> Path:
+    session = tmp_path / "corrupt"
+    _write_manifest(session, streams=["state_log"])
+    _write_jsonl(session, "state_log", [
+        _state_log_entry(tick=1, sequence_number=5),
+        _state_log_entry(tick=2, sequence_number=5),  # duplicate seq
+    ])
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Parser smoke
+# ---------------------------------------------------------------------------
+
+
+def test_build_parser_help_string_mentions_replay_format() -> None:
+    parser = build_parser()
+    help_text = parser.format_help()
+    assert "agent-coherence-replay" in help_text
+    assert "replay_trace_format.md" in help_text
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestCleanTrace:
+    """Exit 0: clean trace + stream opt-outs allowed."""
+
+    def test_clean_human_exits_zero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _clean_session(tmp_path)
+        rc = main([str(session)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "0 CONFIRMED" in out
+        assert "0 AMBIGUOUS" in out
+
+    def test_clean_json_exits_zero_with_summary_only(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _clean_session(tmp_path)
+        rc = main([str(session), "--json"])
+        out = capsys.readouterr().out
+        lines = [line for line in out.strip().split("\n") if line]
+        assert rc == 0
+        # Zero per-finding lines; one summary line.
+        assert len(lines) == 1
+        summary = json.loads(lines[0])
+        assert summary["kind"] == "summary"
+        assert summary["counts"] == {"CONFIRMED": 0, "AMBIGUOUS": 0, "SKIPPED": 0}
+        assert summary["ambiguous_threshold"] == 10
+        assert summary["ambiguous_callout"] is None
+        # Spec §7.2 — trace_metadata must echo manifest fields.
+        meta = summary["trace_metadata"]
+        assert meta["adapter_type"] == "test-fixture"
+        assert meta["instance_id"] == "instance-A"
+        assert "state_log" in meta["streams_present"]
+
+    def test_quiet_clean_emits_nothing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _clean_session(tmp_path)
+        rc = main([str(session), "--quiet"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# CONFIRMED breach (exit 1)
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmedBreach:
+    """Exit 1: at least one CONFIRMED finding."""
+
+    def test_single_writer_breach_exits_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _single_writer_breach_session(tmp_path)
+        rc = main([str(session)])
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "[CONFIRMED]" in out
+        assert "single-writer" in out
+        # Two transitions land overlapping ownership: one when agent-2
+        # takes EXCLUSIVE while agent-1 holds MODIFIED, another when
+        # agent-2 reaches MODIFIED. Both are legitimate CONFIRMED.
+        assert "CONFIRMED" in out
+
+    def test_breach_json_emits_per_finding_line(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _single_writer_breach_session(tmp_path)
+        rc = main([str(session), "--json"])
+        out = capsys.readouterr().out
+        lines = [line for line in out.strip().split("\n") if line]
+        assert rc == 1
+        # At least one finding + summary as last line.
+        assert len(lines) >= 2
+        finding = json.loads(lines[0])
+        assert finding["kind"] == "finding"
+        assert finding["severity"] == "CONFIRMED"
+        assert finding["invariant"] == "single-writer"
+        summary = json.loads(lines[-1])
+        assert summary["kind"] == "summary"
+        assert summary["counts"]["CONFIRMED"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# AMBIGUOUS handling
+# ---------------------------------------------------------------------------
+
+
+class TestAmbiguousSuppression:
+    """Default suppression + --include-ambiguous override."""
+
+    def test_ambiguous_suppressed_by_default(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _ambiguous_session(tmp_path, count=1)
+        rc = main([str(session)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "[AMBIGUOUS]" not in out
+        # Summary still counts the AMBIGUOUS finding.
+        assert "1 AMBIGUOUS (suppressed)" in out
+
+    def test_include_ambiguous_shows_per_finding(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _ambiguous_session(tmp_path, count=1)
+        rc = main([str(session), "--include-ambiguous"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "[AMBIGUOUS]" in out
+        assert "1 AMBIGUOUS (shown)" in out
+
+    def test_ambiguous_json_suppressed_in_per_finding(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _ambiguous_session(tmp_path, count=1)
+        rc = main([str(session), "--json"])
+        out = capsys.readouterr().out
+        lines = [line for line in out.strip().split("\n") if line]
+        assert rc == 0
+        # Only summary; per-finding suppressed.
+        assert len(lines) == 1
+        summary = json.loads(lines[0])
+        assert summary["counts"]["AMBIGUOUS"] == 1
+
+    def test_ambiguous_json_with_flag_shows_finding(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _ambiguous_session(tmp_path, count=1)
+        rc = main([str(session), "--json", "--include-ambiguous"])
+        out = capsys.readouterr().out
+        lines = [line for line in out.strip().split("\n") if line]
+        assert rc == 0
+        assert len(lines) == 2
+        finding = json.loads(lines[0])
+        assert finding["severity"] == "AMBIGUOUS"
+
+
+class TestAmbiguousThreshold:
+    """Callout fires when count exceeds threshold; absent when below."""
+
+    def test_callout_fires_when_exceeding_default(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _ambiguous_session(tmp_path, count=11)
+        rc = main([str(session)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "exceed threshold" in out
+        assert "--include-ambiguous" in out
+        assert "global sequence_number" in out
+
+    def test_callout_absent_when_below_custom_threshold(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _ambiguous_session(tmp_path, count=11)
+        rc = main([str(session), "--ambiguous-threshold", "100"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "exceed threshold" not in out
+
+    def test_callout_in_json_summary(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _ambiguous_session(tmp_path, count=11)
+        rc = main([str(session), "--json"])
+        out = capsys.readouterr().out
+        summary = json.loads(out.strip().split("\n")[-1])
+        assert rc == 0
+        assert summary["ambiguous_callout"] is not None
+        assert "--include-ambiguous" in summary["ambiguous_callout"]
+
+
+# ---------------------------------------------------------------------------
+# --invariant restriction
+# ---------------------------------------------------------------------------
+
+
+class TestInvariantRestriction:
+    """--invariant LIMITS both findings AND skip list."""
+
+    def test_only_named_invariants_run(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _clean_session(tmp_path)
+        rc = main([str(session), "--invariant", "lost-write", "--json"])
+        out = capsys.readouterr().out
+        summary = json.loads(out.strip().split("\n")[-1])
+        # No findings (clean), no skips (stale-read predicate not selected
+        # at all, so its missing-stream is NOT in summary).
+        assert rc == 0
+        assert summary["counts"]["SKIPPED"] == 0
+        assert summary["skipped_reasons"] == []
+
+
+# ---------------------------------------------------------------------------
+# SKIPPED-only paths
+# ---------------------------------------------------------------------------
+
+
+class TestSkippedOptedOut:
+    """Exit 0: stream opt-out declared in manifest."""
+
+    def test_opted_out_skip_exits_zero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _opted_out_session(tmp_path)
+        rc = main([str(session)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "SKIPPED" in out
+        assert "opted out" in out
+
+    def test_opted_out_skip_json_marks_opted_out_true(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _opted_out_session(tmp_path)
+        rc = main([str(session), "--json"])
+        summary = json.loads(capsys.readouterr().out.strip().split("\n")[-1])
+        assert rc == 0
+        skipped = summary["skipped_reasons"]
+        assert len(skipped) == 1
+        assert skipped[0]["invariant"] == "stale-read"
+        assert skipped[0]["opted_out"] is True
+
+
+class TestSkippedCaptureBug:
+    """Exit 2: manifest declared the stream but file is missing."""
+
+    def test_capture_bug_skip_exits_two(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _capture_bug_session(tmp_path)
+        rc = main([str(session)])
+        out = capsys.readouterr().out
+        assert rc == 2
+        # Reason must say "capture-side bug" so triage isn't ambiguous.
+        assert "capture" in out.lower()
+
+    def test_capture_bug_json_marks_opted_out_false(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _capture_bug_session(tmp_path)
+        rc = main([str(session), "--json"])
+        summary = json.loads(capsys.readouterr().out.strip().split("\n")[-1])
+        assert rc == 2
+        skipped = summary["skipped_reasons"]
+        assert any(
+            s["invariant"] == "stale-read" and s["opted_out"] is False
+            for s in skipped
+        )
+
+
+# ---------------------------------------------------------------------------
+# Trace errors (exit 3)
+# ---------------------------------------------------------------------------
+
+
+class TestTraceErrors:
+    """Exit 3 for the three loader/iterator error classes."""
+
+    def test_missing_manifest_exits_three(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = tmp_path / "nonexistent"
+        rc = main([str(session)])
+        captured = capsys.readouterr()
+        assert rc == 3
+        assert "manifest.json" in captured.err
+        # No Python traceback leakage to stderr.
+        assert "Traceback" not in captured.err
+
+    def test_multi_instance_exits_three(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _multi_instance_session(tmp_path)
+        rc = main([str(session)])
+        captured = capsys.readouterr()
+        assert rc == 3
+        assert "instance" in captured.err.lower()
+        # Loader error msg points at D+1 roadmap.
+        assert "D+1" in captured.err
+        assert "Traceback" not in captured.err
+
+    def test_trace_corruption_exits_three(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _trace_corruption_session(tmp_path)
+        rc = main([str(session)])
+        captured = capsys.readouterr()
+        assert rc == 3
+        assert "duplicate" in captured.err.lower() or "sequence_number" in captured.err
+        assert "Traceback" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# JSON schema conformance
+# ---------------------------------------------------------------------------
+
+
+class TestJsonSchemaConformance:
+    """Structural validation of the §7 schema against a synthesized trace."""
+
+    def test_summary_fields_present_and_well_typed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _clean_session(tmp_path)
+        rc = main([str(session), "--json"])
+        out = capsys.readouterr().out
+        summary = json.loads(out.strip().split("\n")[-1])
+        assert rc == 0
+        # §7.2 required fields:
+        for field in (
+            "kind", "counts", "counts_by_invariant", "skipped_reasons",
+            "ambiguous_threshold", "ambiguous_callout", "trace_metadata",
+        ):
+            assert field in summary, f"missing field {field}"
+        assert summary["kind"] == "summary"
+        assert isinstance(summary["counts"], dict)
+        assert isinstance(summary["counts_by_invariant"], dict)
+        assert isinstance(summary["skipped_reasons"], list)
+        assert isinstance(summary["ambiguous_threshold"], int)
+        # ambiguous_callout is string OR null per spec
+        assert summary["ambiguous_callout"] is None or isinstance(
+            summary["ambiguous_callout"], str
+        )
+        assert isinstance(summary["trace_metadata"], dict)
+        # counts_by_invariant must cover all four canonical names
+        for name in (
+            "single-writer", "monotonic-version", "stale-read", "lost-write",
+        ):
+            assert name in summary["counts_by_invariant"]
+            row = summary["counts_by_invariant"][name]
+            for sev in ("CONFIRMED", "AMBIGUOUS", "SKIPPED"):
+                assert sev in row
+                assert isinstance(row[sev], int)
+
+    def test_per_finding_fields_present_and_well_typed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _single_writer_breach_session(tmp_path)
+        rc = main([str(session), "--json"])
+        out = capsys.readouterr().out
+        first_line = out.strip().split("\n")[0]
+        finding = json.loads(first_line)
+        assert rc == 1
+        # §7.1 required fields:
+        for field in (
+            "kind", "severity", "invariant", "agents", "artifacts",
+            "tick_range", "context", "details",
+        ):
+            assert field in finding, f"missing field {field}"
+        assert finding["kind"] == "finding"
+        assert finding["severity"] in {"CONFIRMED", "AMBIGUOUS"}
+        assert isinstance(finding["agents"], list)
+        assert isinstance(finding["artifacts"], list)
+        assert isinstance(finding["tick_range"], dict)
+        assert "start" in finding["tick_range"]
+        assert "end" in finding["tick_range"]
+        assert isinstance(finding["tick_range"]["start"], int)
+        assert isinstance(finding["tick_range"]["end"], int)
+        assert isinstance(finding["context"], dict)
+        assert isinstance(finding["details"], dict)
+
+
+# ---------------------------------------------------------------------------
+# Quiet mode with breaches
+# ---------------------------------------------------------------------------
+
+
+def test_quiet_with_breach_emits_only_findings(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--quiet + CONFIRMED breach: finding block present, summary absent."""
+    session = _single_writer_breach_session(tmp_path)
+    rc = main([str(session), "--quiet"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "[CONFIRMED]" in out
+    # Summary block suppressed under --quiet
+    assert "Summary:" not in out
+
+
+def test_quiet_with_capture_bug_emits_skip_lines(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--quiet + capture-bug SKIP: still exits 2 (cron catches it)."""
+    session = _capture_bug_session(tmp_path)
+    rc = main([str(session), "--quiet"])
+    captured = capsys.readouterr()
+    # Exit code is the load-bearing signal here; stdout content is
+    # secondary under --quiet. The important assertion is that the
+    # capture-bug skip is NOT silenced into a clean exit 0.
+    assert rc == 2
+    assert "Traceback" not in captured.err

--- a/tests/test_cli_coherence_replay.py
+++ b/tests/test_cli_coherence_replay.py
@@ -561,7 +561,8 @@ class TestTraceErrors:
         rc = main([str(session)])
         captured = capsys.readouterr()
         assert rc == 3
-        assert "manifest.json" in captured.err
+        # Pre-flight fires before the loader for a nonexistent directory.
+        assert "session directory not found" in captured.err or str(session) in captured.err
         # No Python traceback leakage to stderr.
         assert "Traceback" not in captured.err
 
@@ -688,3 +689,35 @@ def test_quiet_with_capture_bug_emits_skip_lines(
     # capture-bug skip is NOT silenced into a clean exit 0.
     assert rc == 2
     assert "Traceback" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# --quiet --json combination
+# ---------------------------------------------------------------------------
+
+
+def test_quiet_json_clean_trace_emits_nothing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--quiet --json on a clean trace: no output (cron-friendly zero signal)."""
+    session = _clean_session(tmp_path)
+    rc = main([str(session), "--quiet", "--json"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == "", "clean trace with --quiet --json must produce no output"
+
+
+def test_quiet_json_breach_emits_findings_and_summary(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--quiet --json with CONFIRMED breach: full JSON output still emitted."""
+    session = _single_writer_breach_session(tmp_path)
+    rc = main([str(session), "--quiet", "--json"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    lines = [l for l in out.strip().split("\n") if l]
+    assert len(lines) >= 2, "expected at least one finding line + summary line"
+    objects = [json.loads(l) for l in lines]
+    kinds = {o.get("kind") for o in objects}
+    assert "finding" in kinds
+    assert "summary" in kinds

--- a/tests/test_replay_loader.py
+++ b/tests/test_replay_loader.py
@@ -1,0 +1,464 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for the replay trace loader (Unit 3 of D v1).
+
+Covers the consumer-side contract documented in
+``docs/proposals/replay_trace_format.md`` §§1-5 and the loader
+requirements in
+``docs/plans/2026-05-26-001-feat-langgraph-cycle-replay-tooling-v1-plan.md``
+Unit 3:
+
+- ``load`` happy paths (both streams, state_log only)
+- ``merged()`` order: intra-tick state_log before content_audit_log
+- Lazy ``MultiInstanceTraceError`` from the iterator
+- Lazy ``TraceCorruptionError`` on duplicate ``(instance_id, seq)``
+- Eager ``ManifestMissingOrUnreadableError`` on missing / malformed
+  manifest
+- ``streams_present`` reconciliation when manifest declares a stream
+  that is missing on disk (the "capture bug" signal for Unit 5)
+- Round-trip integration with ``CCSStore.record_to`` (Unit 2)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ccs.replay import (
+    LoadedTrace,
+    ManifestMissingOrUnreadableError,
+    MultiInstanceTraceError,
+    TraceCorruptionError,
+    load,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders — hand-craft on-disk session directories
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(
+    session_dir: Path,
+    *,
+    streams: list[str],
+    instance_id: str | None = "instance-A",
+    start_tick: int = 0,
+    end_tick: int = 0,
+) -> None:
+    session_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schema_version": 0,
+        "schema_note": "test fixture",
+        "adapter_type": "test-fixture",
+        "start_tick": start_tick,
+        "end_tick": end_tick,
+        "instance_id": instance_id,
+        "streams": streams,
+        "agents": {},
+        "artifacts": {},
+    }
+    (session_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
+def _state_log_entry(
+    *,
+    tick: int,
+    sequence_number: int,
+    instance_id: str = "instance-A",
+    artifact_id: str = "art-1",
+    agent_id: str = "agent-1",
+    from_state: str = "INVALID",
+    to_state: str = "EXCLUSIVE",
+    trigger: str = "write",
+    version: int = 1,
+) -> dict:
+    return {
+        "tick": tick,
+        "artifact_id": artifact_id,
+        "agent_id": agent_id,
+        "agent_name": "researcher",
+        "from_state": from_state,
+        "to_state": to_state,
+        "trigger": trigger,
+        "version": version,
+        "content_hash": "abc",
+        "sequence_number": sequence_number,
+        "instance_id": instance_id,
+        "schema_version": "ccs.state_log.v2",
+    }
+
+
+def _audit_entry(
+    *,
+    tick: int,
+    sequence_number: int,
+    instance_id: str = "instance-A",
+    artifact_id: str = "art-1",
+    agent_id: str = "agent-1",
+    version: int = 1,
+) -> dict:
+    return {
+        "tick": tick,
+        "agent_id": agent_id,
+        "agent_name": "researcher",
+        "artifact_id": artifact_id,
+        "version": version,
+        "content_hash": "abc",
+        "source": "fetch",
+        "outcome": "content",
+        "sequence_number": sequence_number,
+        "instance_id": instance_id,
+        "schema_version": "ccs.content_audit.v1",
+    }
+
+
+def _write_jsonl(path: Path, entries: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestLoadHappyPath:
+    """Both streams declared and present — the dominant case."""
+
+    def test_loads_both_streams_and_merges_in_order(self, tmp_path: Path) -> None:
+        session = tmp_path / "session"
+        _write_manifest(session, streams=["state_log", "content_audit_log"])
+        _write_jsonl(
+            session / "state_log.jsonl",
+            [
+                _state_log_entry(tick=1, sequence_number=1),
+                _state_log_entry(tick=3, sequence_number=2, trigger="commit"),
+            ],
+        )
+        _write_jsonl(
+            session / "content_audit_log.jsonl",
+            [
+                _audit_entry(tick=2, sequence_number=1),
+                _audit_entry(tick=4, sequence_number=2),
+            ],
+        )
+
+        loaded = load(session)
+        assert isinstance(loaded, LoadedTrace)
+        assert loaded.streams_present == {"state_log", "content_audit_log"}
+
+        merged = list(loaded.merged())
+        ticks_and_kinds = [(k, e["tick"]) for k, e in merged]
+        assert ticks_and_kinds == [
+            ("state_log", 1),
+            ("content_audit_log", 2),
+            ("state_log", 3),
+            ("content_audit_log", 4),
+        ]
+
+    def test_streams_present_omits_undeclared_streams_on_disk(
+        self, tmp_path: Path
+    ) -> None:
+        """A stream file that exists on disk but is NOT declared in the
+        manifest is treated as absent (defense against partial captures
+        or partners copying only-some-files — per spec §1)."""
+        session = tmp_path / "session"
+        _write_manifest(session, streams=["state_log"])
+        _write_jsonl(
+            session / "state_log.jsonl",
+            [_state_log_entry(tick=1, sequence_number=1)],
+        )
+        # Plant an undeclared stream file on disk.
+        _write_jsonl(
+            session / "content_audit_log.jsonl",
+            [_audit_entry(tick=2, sequence_number=1)],
+        )
+
+        loaded = load(session)
+        assert loaded.streams_present == {"state_log"}
+        merged = list(loaded.merged())
+        assert [k for k, _ in merged] == ["state_log"]
+
+
+class TestStateLogOnly:
+    """Compliance-partner shape: state_log opt-in, audit opted-out."""
+
+    def test_loads_state_log_only_session(self, tmp_path: Path) -> None:
+        session = tmp_path / "session"
+        _write_manifest(session, streams=["state_log"])
+        _write_jsonl(
+            session / "state_log.jsonl",
+            [
+                _state_log_entry(tick=1, sequence_number=1),
+                _state_log_entry(tick=2, sequence_number=2, trigger="commit"),
+            ],
+        )
+
+        loaded = load(session)
+        assert loaded.streams_present == {"state_log"}
+        merged = list(loaded.merged())
+        assert len(merged) == 2
+        assert all(kind == "state_log" for kind, _ in merged)
+
+
+# ---------------------------------------------------------------------------
+# Merge-rule edge: intra-tick ordering
+# ---------------------------------------------------------------------------
+
+
+class TestIntraTickOrdering:
+    """state_log MUST sort before content_audit_log at the same tick.
+
+    The merge order tiebreaker is structural (per spec §5.1); predicates
+    decide AMBIGUOUS vs CONFIRMED by comparing tick fields directly, so
+    the AMBIGUOUS carve-out remains correct.
+    """
+
+    def test_state_log_before_audit_at_same_tick(self, tmp_path: Path) -> None:
+        session = tmp_path / "session"
+        _write_manifest(session, streams=["state_log", "content_audit_log"])
+        _write_jsonl(
+            session / "state_log.jsonl",
+            [_state_log_entry(tick=5, sequence_number=1, trigger="commit")],
+        )
+        _write_jsonl(
+            session / "content_audit_log.jsonl",
+            [_audit_entry(tick=5, sequence_number=1)],
+        )
+
+        loaded = load(session)
+        merged = list(loaded.merged())
+        kinds = [k for k, _ in merged]
+        assert kinds == ["state_log", "content_audit_log"]
+
+
+# ---------------------------------------------------------------------------
+# Lazy multi-instance detection
+# ---------------------------------------------------------------------------
+
+
+class TestMultiInstanceDetection:
+    """Two distinct ``instance_id`` values in one stream → lazy raise."""
+
+    def test_raises_with_d_plus_one_roadmap_pointer(self, tmp_path: Path) -> None:
+        session = tmp_path / "session"
+        _write_manifest(session, streams=["state_log"])
+        _write_jsonl(
+            session / "state_log.jsonl",
+            [
+                _state_log_entry(tick=1, sequence_number=1, instance_id="A"),
+                _state_log_entry(tick=2, sequence_number=2, instance_id="B"),
+            ],
+        )
+
+        loaded = load(session)
+        # load() itself does NOT raise.
+        assert loaded.streams_present == {"state_log"}
+
+        with pytest.raises(MultiInstanceTraceError) as exc_info:
+            list(loaded.merged())
+        assert "per-instance-replay is roadmapped for D+1" in str(exc_info.value)
+
+    def test_partial_walk_succeeds_until_boundary(self, tmp_path: Path) -> None:
+        session = tmp_path / "session"
+        _write_manifest(session, streams=["state_log"])
+        _write_jsonl(
+            session / "state_log.jsonl",
+            [
+                _state_log_entry(tick=1, sequence_number=1, instance_id="A"),
+                _state_log_entry(tick=2, sequence_number=2, instance_id="A"),
+                _state_log_entry(tick=3, sequence_number=3, instance_id="B"),
+            ],
+        )
+
+        loaded = load(session)
+        it = loaded.merged()
+        first = next(it)
+        second = next(it)
+        assert first[1]["instance_id"] == "A"
+        assert second[1]["instance_id"] == "A"
+        with pytest.raises(MultiInstanceTraceError):
+            next(it)
+
+
+# ---------------------------------------------------------------------------
+# Lazy duplicate-seq detection
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateSequenceDetection:
+    """Defense in depth against partner-written callbacks that don't fsync."""
+
+    def test_raises_with_seq_path_and_line_number(self, tmp_path: Path) -> None:
+        session = tmp_path / "session"
+        _write_manifest(session, streams=["state_log"])
+        state_log_path = session / "state_log.jsonl"
+        _write_jsonl(
+            state_log_path,
+            [
+                _state_log_entry(tick=1, sequence_number=7),
+                _state_log_entry(tick=2, sequence_number=8),
+                _state_log_entry(tick=3, sequence_number=7),  # duplicate
+            ],
+        )
+
+        loaded = load(session)
+        with pytest.raises(TraceCorruptionError) as exc_info:
+            list(loaded.merged())
+        message = str(exc_info.value)
+        assert "sequence_number=7" in message
+        assert str(state_log_path) in message
+        # The third entry is on line 3 in the JSONL file.
+        assert ":3" in message
+
+
+# ---------------------------------------------------------------------------
+# Eager manifest errors
+# ---------------------------------------------------------------------------
+
+
+class TestManifestErrors:
+    """Manifest problems surface eagerly with clear messages."""
+
+    def test_nonexistent_session_dir_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ManifestMissingOrUnreadableError) as exc_info:
+            load(tmp_path / "does-not-exist")
+        # Must NOT be a bare FileNotFoundError traceback.
+        assert "manifest.json not found" in str(exc_info.value)
+
+    def test_existing_dir_without_manifest_raises(self, tmp_path: Path) -> None:
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        with pytest.raises(ManifestMissingOrUnreadableError):
+            load(empty_dir)
+
+    def test_malformed_manifest_raises_clear_error(self, tmp_path: Path) -> None:
+        session = tmp_path / "session"
+        session.mkdir()
+        (session / "manifest.json").write_text("{not valid json", encoding="utf-8")
+        with pytest.raises(ManifestMissingOrUnreadableError) as exc_info:
+            load(session)
+        assert "not valid JSON" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Capture-bug signal for Unit 5
+# ---------------------------------------------------------------------------
+
+
+class TestStreamPresenceReconciliation:
+    """Manifest declares a stream but the file is missing on disk.
+
+    Loader does NOT raise — this is the signal Unit 5's CLI surfaces
+    as exit code 2 (vs. user opt-out which is exit 0).
+    """
+
+    def test_declared_but_missing_stream_omitted_from_streams_present(
+        self, tmp_path: Path
+    ) -> None:
+        session = tmp_path / "session"
+        _write_manifest(session, streams=["state_log", "content_audit_log"])
+        _write_jsonl(
+            session / "state_log.jsonl",
+            [_state_log_entry(tick=1, sequence_number=1)],
+        )
+        # NOTE: content_audit_log.jsonl is NOT written.
+
+        loaded = load(session)
+        assert loaded.streams_present == {"state_log"}
+        # Manifest still records the declaration — that's how Unit 5
+        # distinguishes "capture bug" from "user opt-out".
+        assert loaded.manifest["streams"] == ["state_log", "content_audit_log"]
+        merged = list(loaded.merged())
+        assert [k for k, _ in merged] == ["state_log"]
+
+
+# ---------------------------------------------------------------------------
+# Round-trip integration with the recorder (Unit 2)
+# ---------------------------------------------------------------------------
+
+
+class TestRecorderRoundTrip:
+    """Capture from CCSStore.record_to, load with load(), assert entries
+    match one-to-one with the emitted events."""
+
+    def setup_method(self) -> None:
+        pytest.importorskip("langgraph.store.base")
+
+    def test_round_trip_matches_emitted_events(self, tmp_path: Path) -> None:
+        from langgraph.store.base import GetOp, PutOp
+
+        from ccs.adapters.ccsstore import CCSStore
+
+        emitted_state: list[dict] = []
+        emitted_audit: list[dict] = []
+        session = tmp_path / "session"
+
+        with CCSStore.record_to(
+            session,
+            state_log=emitted_state.append,
+            content_audit_log=emitted_audit.append,
+        ) as store:
+            for i in range(5):
+                store.batch([
+                    PutOp(
+                        namespace=("planner", "shared"),
+                        key=f"k{i}",
+                        value={"v": i},
+                    ),
+                ])
+            store.batch([GetOp(namespace=("planner", "shared"), key="k0")])
+
+        loaded = load(session)
+        assert loaded.streams_present == {"state_log", "content_audit_log"}
+
+        merged = list(loaded.merged())
+        on_disk_state = [e for k, e in merged if k == "state_log"]
+        on_disk_audit = [e for k, e in merged if k == "content_audit_log"]
+
+        # The composed caller callbacks saw exactly what the file writers
+        # wrote — that's the round-trip contract.
+        assert len(on_disk_state) == len(emitted_state)
+        assert len(on_disk_audit) == len(emitted_audit)
+        # Entries match field-by-field (JSON round-trip preserves equality
+        # because the recorder uses json.dumps with default settings).
+        for emitted, loaded_entry in zip(emitted_state, on_disk_state):
+            assert emitted == loaded_entry
+        for emitted, loaded_entry in zip(emitted_audit, on_disk_audit):
+            assert emitted == loaded_entry
+
+    def test_round_trip_yields_state_log_first_at_same_tick(
+        self, tmp_path: Path
+    ) -> None:
+        """A single batched put produces both a state_log commit and
+        a content_audit entry at the same tick — merged() must yield
+        state_log first."""
+        from langgraph.store.base import PutOp
+
+        from ccs.adapters.ccsstore import CCSStore
+
+        session = tmp_path / "session"
+        with CCSStore.record_to(session) as store:
+            store.batch([PutOp(namespace=("ns", "shared"), key="k", value={"v": 1})])
+
+        loaded = load(session)
+        merged = list(loaded.merged())
+
+        # Group by tick; for any tick with both kinds, state_log must
+        # appear before content_audit_log.
+        seen_audit_at_tick: dict[int, bool] = {}
+        for kind, entry in merged:
+            tick = entry["tick"]
+            if kind == "content_audit_log":
+                seen_audit_at_tick[tick] = True
+            elif kind == "state_log":
+                assert not seen_audit_at_tick.get(tick, False), (
+                    f"state_log entry at tick {tick} appeared after a "
+                    "content_audit_log entry at the same tick"
+                )

--- a/tests/test_replay_predicates.py
+++ b/tests/test_replay_predicates.py
@@ -1,0 +1,739 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for the replay predicate engine (Unit 4 of D v1).
+
+Covers the contract documented in
+``docs/proposals/replay_trace_format.md`` §5.2-§5.3 and the predicate
+requirements in
+``docs/plans/2026-05-26-001-feat-langgraph-cycle-replay-tooling-v1-plan.md``
+Unit 4:
+
+- Single-writer happy + violation paths.
+- Monotonic-version happy + regression paths.
+- Stale-read CONFIRMED / AMBIGUOUS / clean / null-agent_id / earlier-tick.
+- Lost-write happy + violation + the peer-invalidation regression
+  (the LostWrite ADV-01 v1-blocker fix from document review).
+- SKIPPED dispatch: opt-out (caller dropped a stream), capture bug
+  (declared stream missing on disk), all-streams-missing degenerate.
+- Integration with the sim engine via Unit 3's loader.
+- ``invariants=`` restriction omits unselected predicates from BOTH
+  findings AND skips.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ccs.replay import (
+    Finding,
+    LoadedTrace,
+    SummaryFinding,
+    load,
+    run_predicates,
+)
+
+
+# ---------------------------------------------------------------------------
+# On-disk fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(
+    session_dir: Path,
+    *,
+    streams: list[str],
+    instance_id: str | None = "instance-A",
+) -> None:
+    session_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schema_version": 0,
+        "schema_note": "test fixture",
+        "adapter_type": "test-fixture",
+        "start_tick": 0,
+        "end_tick": 0,
+        "instance_id": instance_id,
+        "streams": streams,
+        "agents": {},
+        "artifacts": {},
+    }
+    (session_dir / "manifest.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+
+
+def _state_log_line(
+    *,
+    tick: int,
+    sequence_number: int,
+    agent_id: str = "agent-1",
+    artifact_id: str = "art-1",
+    from_state: str = "INVALID",
+    to_state: str = "EXCLUSIVE",
+    trigger: str = "write",
+    version: int = 1,
+    instance_id: str = "instance-A",
+) -> dict:
+    return {
+        "tick": tick,
+        "artifact_id": artifact_id,
+        "agent_id": agent_id,
+        "agent_name": agent_id,
+        "from_state": from_state,
+        "to_state": to_state,
+        "trigger": trigger,
+        "version": version,
+        "content_hash": "abc",
+        "sequence_number": sequence_number,
+        "instance_id": instance_id,
+        "schema_version": "ccs.state_log.v2",
+    }
+
+
+def _audit_line(
+    *,
+    tick: int,
+    sequence_number: int,
+    agent_id: str | None = "agent-1",
+    artifact_id: str = "art-1",
+    version: int | None = 1,
+    outcome: str = "content",
+    instance_id: str = "instance-A",
+) -> dict:
+    return {
+        "tick": tick,
+        "agent_id": agent_id,
+        "agent_name": agent_id if agent_id else None,
+        "artifact_id": artifact_id,
+        "version": version,
+        "content_hash": "abc",
+        "source": "fetch",
+        "outcome": outcome,
+        "sequence_number": sequence_number,
+        "instance_id": instance_id,
+        "schema_version": "ccs.content_audit.v1",
+    }
+
+
+def _write_state_log(session_dir: Path, entries: list[dict]) -> None:
+    path = session_dir / "state_log.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+
+
+def _write_audit_log(session_dir: Path, entries: list[dict]) -> None:
+    path = session_dir / "content_audit_log.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+
+
+def _make_session(
+    tmp_path: Path,
+    *,
+    streams: list[str],
+    state_entries: list[dict] | None = None,
+    audit_entries: list[dict] | None = None,
+) -> LoadedTrace:
+    session = tmp_path / "session"
+    _write_manifest(session, streams=streams)
+    if "state_log" in streams and state_entries is not None:
+        _write_state_log(session, state_entries)
+    if "content_audit_log" in streams and audit_entries is not None:
+        _write_audit_log(session, audit_entries)
+    return load(session)
+
+
+# ---------------------------------------------------------------------------
+# Single-writer predicate
+# ---------------------------------------------------------------------------
+
+
+class TestSingleWriter:
+    """Single-writer: at most one M∪E owner per artifact at any tick."""
+
+    def test_clean_trace_emits_no_findings(self, tmp_path: Path) -> None:
+        # One writer at a time: agent-1 takes E, transitions to I, then
+        # agent-2 takes E. Single-writer holds across the full transcript.
+        entries = [
+            _state_log_line(
+                tick=1, sequence_number=1, agent_id="agent-1",
+                from_state="INVALID", to_state="EXCLUSIVE",
+            ),
+            _state_log_line(
+                tick=2, sequence_number=2, agent_id="agent-1",
+                from_state="EXCLUSIVE", to_state="INVALID",
+            ),
+            _state_log_line(
+                tick=3, sequence_number=3, agent_id="agent-2",
+                from_state="INVALID", to_state="EXCLUSIVE",
+            ),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log"], state_entries=entries,
+        )
+        findings, summary = run_predicates(loaded)
+        assert findings == []
+        # state_log-only manifest skips stale-read; assert ONLY stale-read
+        # is in summary (not single-writer / monotonic-version / lost-write).
+        assert {s.invariant for s in summary} == {"stale-read"}
+
+    def test_double_owner_emits_confirmed(self, tmp_path: Path) -> None:
+        # agent-1 takes M; agent-2 ALSO reaches M for the same artifact —
+        # impossible under a correct coordinator but the trace stream
+        # records it. The predicate must catch it at tick 2.
+        entries = [
+            _state_log_line(
+                tick=1, sequence_number=1, agent_id="agent-1",
+                from_state="INVALID", to_state="MODIFIED",
+                trigger="commit", version=1,
+            ),
+            _state_log_line(
+                tick=2, sequence_number=2, agent_id="agent-2",
+                from_state="INVALID", to_state="MODIFIED",
+                trigger="commit", version=2,
+            ),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log"], state_entries=entries,
+        )
+        findings, _ = run_predicates(loaded, invariants=["single-writer"])
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.invariant == "single-writer"
+        assert f.severity == "CONFIRMED"
+        assert set(f.agents) == {"agent-1", "agent-2"}
+        assert f.artifacts == ("art-1",)
+        assert f.tick_range == (2, 2)
+
+
+# ---------------------------------------------------------------------------
+# Monotonic-version predicate
+# ---------------------------------------------------------------------------
+
+
+class TestMonotonicVersion:
+    """Monotonic-version: committed versions strictly increase per artifact."""
+
+    def test_clean_trace_emits_no_findings(self, tmp_path: Path) -> None:
+        entries = [
+            _state_log_line(
+                tick=1, sequence_number=1,
+                from_state="INVALID", to_state="MODIFIED",
+                trigger="commit", version=1,
+            ),
+            _state_log_line(
+                tick=2, sequence_number=2,
+                from_state="MODIFIED", to_state="MODIFIED",
+                trigger="commit", version=2,
+            ),
+            _state_log_line(
+                tick=3, sequence_number=3,
+                from_state="MODIFIED", to_state="MODIFIED",
+                trigger="commit", version=3,
+            ),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log"], state_entries=entries,
+        )
+        findings, _ = run_predicates(loaded, invariants=["monotonic-version"])
+        assert findings == []
+
+    def test_version_regression_emits_confirmed(
+        self, tmp_path: Path,
+    ) -> None:
+        entries = [
+            _state_log_line(
+                tick=1, sequence_number=1,
+                from_state="INVALID", to_state="MODIFIED",
+                trigger="commit", version=5,
+            ),
+            _state_log_line(
+                tick=2, sequence_number=2,
+                from_state="MODIFIED", to_state="MODIFIED",
+                trigger="commit", version=3,  # regression
+            ),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log"], state_entries=entries,
+        )
+        findings, _ = run_predicates(loaded, invariants=["monotonic-version"])
+        assert len(findings) == 1
+        assert findings[0].invariant == "monotonic-version"
+        assert findings[0].severity == "CONFIRMED"
+        assert findings[0].artifacts == ("art-1",)
+        assert findings[0].tick_range == (2, 2)
+
+
+# ---------------------------------------------------------------------------
+# Stale-read predicate
+# ---------------------------------------------------------------------------
+
+
+class TestStaleRead:
+    """Stale-read with CONFIRMED / AMBIGUOUS carve-out (spec §5.2)."""
+
+    def test_current_read_emits_no_findings(self, tmp_path: Path) -> None:
+        state_entries = [
+            _state_log_line(
+                tick=1, sequence_number=1,
+                from_state="INVALID", to_state="MODIFIED",
+                trigger="commit", version=1,
+            ),
+        ]
+        audit_entries = [
+            _audit_line(tick=1, sequence_number=1, version=1),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log", "content_audit_log"],
+            state_entries=state_entries, audit_entries=audit_entries,
+        )
+        findings, _ = run_predicates(loaded, invariants=["stale-read"])
+        assert findings == []
+
+    def test_later_read_of_older_version_confirmed(
+        self, tmp_path: Path,
+    ) -> None:
+        # v2 committed at tick 5; read of v1 at tick 8. CONFIRMED.
+        state_entries = [
+            _state_log_line(
+                tick=2, sequence_number=1, agent_id="writer",
+                from_state="INVALID", to_state="MODIFIED",
+                trigger="commit", version=1,
+            ),
+            _state_log_line(
+                tick=5, sequence_number=2, agent_id="writer",
+                from_state="MODIFIED", to_state="MODIFIED",
+                trigger="commit", version=2,
+            ),
+        ]
+        audit_entries = [
+            _audit_line(
+                tick=8, sequence_number=1, agent_id="reader", version=1,
+            ),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log", "content_audit_log"],
+            state_entries=state_entries, audit_entries=audit_entries,
+        )
+        findings, _ = run_predicates(loaded, invariants=["stale-read"])
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.severity == "CONFIRMED"
+        assert f.kind == "stale-read"
+        assert f.agents == ("reader",)
+        assert f.tick_range == (5, 8)
+
+    def test_same_tick_collision_ambiguous(self, tmp_path: Path) -> None:
+        # v2 committed at tick 5; read of v1 ALSO at tick 5. Spec §5.2
+        # requires AMBIGUOUS (intra-tick ordering undetermined).
+        state_entries = [
+            _state_log_line(
+                tick=2, sequence_number=1,
+                from_state="INVALID", to_state="MODIFIED",
+                trigger="commit", version=1,
+            ),
+            _state_log_line(
+                tick=5, sequence_number=2,
+                from_state="MODIFIED", to_state="MODIFIED",
+                trigger="commit", version=2,
+            ),
+        ]
+        audit_entries = [
+            _audit_line(
+                tick=5, sequence_number=1, agent_id="reader", version=1,
+            ),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log", "content_audit_log"],
+            state_entries=state_entries, audit_entries=audit_entries,
+        )
+        findings, _ = run_predicates(loaded, invariants=["stale-read"])
+        assert len(findings) == 1
+        assert findings[0].severity == "AMBIGUOUS"
+        assert findings[0].kind == "stale-read-ambiguous"
+        assert findings[0].tick_range == (5, 5)
+
+    def test_earlier_read_of_current_version_clean(
+        self, tmp_path: Path,
+    ) -> None:
+        # Read at tick t of v_n; v_{n+1} committed at tick t+1. The read
+        # was current at the time; later commit does not make it stale.
+        state_entries = [
+            _state_log_line(
+                tick=2, sequence_number=1,
+                from_state="INVALID", to_state="MODIFIED",
+                trigger="commit", version=1,
+            ),
+            _state_log_line(
+                tick=10, sequence_number=2,
+                from_state="MODIFIED", to_state="MODIFIED",
+                trigger="commit", version=2,
+            ),
+        ]
+        audit_entries = [
+            _audit_line(
+                tick=5, sequence_number=1, agent_id="reader", version=1,
+            ),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log", "content_audit_log"],
+            state_entries=state_entries, audit_entries=audit_entries,
+        )
+        findings, _ = run_predicates(loaded, invariants=["stale-read"])
+        assert findings == []
+
+    def test_null_agent_id_skipped_silently(self, tmp_path: Path) -> None:
+        state_entries = [
+            _state_log_line(
+                tick=2, sequence_number=1,
+                from_state="INVALID", to_state="MODIFIED",
+                trigger="commit", version=2,
+            ),
+        ]
+        # CCSStore search-miss path emits agent_id=null with an older
+        # version field. Predicate MUST NOT fire (spec §4.1).
+        audit_entries = [
+            _audit_line(
+                tick=5, sequence_number=1, agent_id=None, version=1,
+            ),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log", "content_audit_log"],
+            state_entries=state_entries, audit_entries=audit_entries,
+        )
+        findings, _ = run_predicates(loaded, invariants=["stale-read"])
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Lost-write predicate (includes the v1-blocker peer-invalidation test)
+# ---------------------------------------------------------------------------
+
+
+class TestLostWrite:
+    """Lost-write: writer commits from non-owner state."""
+
+    def test_clean_e_to_m_emits_no_findings(self, tmp_path: Path) -> None:
+        entries = [
+            _state_log_line(
+                tick=1, sequence_number=1,
+                from_state="INVALID", to_state="EXCLUSIVE",
+                trigger="write",
+            ),
+            _state_log_line(
+                tick=2, sequence_number=2,
+                from_state="EXCLUSIVE", to_state="MODIFIED",
+                trigger="commit", version=1,
+            ),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log"], state_entries=entries,
+        )
+        findings, _ = run_predicates(loaded, invariants=["lost-write"])
+        assert findings == []
+
+    def test_s_to_m_commit_emits_confirmed(self, tmp_path: Path) -> None:
+        # SHARED → MODIFIED via commit: the writer never held E. Lost write.
+        entries = [
+            _state_log_line(
+                tick=1, sequence_number=1,
+                from_state="SHARED", to_state="MODIFIED",
+                trigger="commit", version=1,
+            ),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log"], state_entries=entries,
+        )
+        findings, _ = run_predicates(loaded, invariants=["lost-write"])
+        assert len(findings) == 1
+        assert findings[0].invariant == "lost-write"
+        assert findings[0].severity == "CONFIRMED"
+        assert findings[0].details["observed"] == "from_state = SHARED"
+
+    def test_peer_invalidations_not_counted_as_lost_writes(
+        self, tmp_path: Path,
+    ) -> None:
+        """ADV-01 regression — the v1-blocker fix from document review.
+
+        Scenario: writer commits with N=3 peers in S. coordinator/service.py
+        emits N=3 state_log entries with trigger="commit",
+        from_state="SHARED", to_state="INVALID" (the peer invalidations,
+        line 277) plus ONE writer self-transition (E→M, line 289). The
+        predicate MUST inspect only the writer commit (which is clean
+        E→M) and IGNORE the three peer entries.
+
+        Without the trigger="commit" + to_state ∈ {M, E} filter, the
+        predicate would fire 3 false-positive LostWrite findings on
+        EVERY clean trace with peers — torpedoing first-touch partner
+        trust. Zero findings is the only acceptable outcome.
+        """
+        entries = [
+            # Peers all S, writer holds E
+            _state_log_line(
+                tick=1, sequence_number=1, agent_id="writer",
+                from_state="INVALID", to_state="EXCLUSIVE",
+                trigger="write",
+            ),
+            # Peer A invalidation: S → I, trigger="commit"
+            _state_log_line(
+                tick=2, sequence_number=2, agent_id="peer-a",
+                from_state="SHARED", to_state="INVALID",
+                trigger="commit", version=1,
+            ),
+            # Peer B invalidation: S → I, trigger="commit"
+            _state_log_line(
+                tick=2, sequence_number=3, agent_id="peer-b",
+                from_state="SHARED", to_state="INVALID",
+                trigger="commit", version=1,
+            ),
+            # Peer C invalidation: S → I, trigger="commit"
+            _state_log_line(
+                tick=2, sequence_number=4, agent_id="peer-c",
+                from_state="SHARED", to_state="INVALID",
+                trigger="commit", version=1,
+            ),
+            # Writer self-transition: E → M, trigger="commit"
+            _state_log_line(
+                tick=2, sequence_number=5, agent_id="writer",
+                from_state="EXCLUSIVE", to_state="MODIFIED",
+                trigger="commit", version=1,
+            ),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log"], state_entries=entries,
+        )
+        findings, _ = run_predicates(loaded, invariants=["lost-write"])
+        assert findings == [], (
+            "ADV-01 regression: peer-invalidation transitions must not be "
+            "counted as lost writes. Got findings: " + repr(findings)
+        )
+
+
+# ---------------------------------------------------------------------------
+# SKIPPED dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestSkippedDispatch:
+    """SKIPPED dispatch (spec §5.3) — opt-out vs capture bug."""
+
+    def test_opt_out_when_audit_not_declared(self, tmp_path: Path) -> None:
+        # Manifest declares only state_log. Stale-read needs both
+        # streams → SKIPPED with opted_out=True. Other three run.
+        # Clean E→M commit so the three running predicates emit nothing.
+        entries = [
+            _state_log_line(
+                tick=1, sequence_number=1,
+                from_state="INVALID", to_state="EXCLUSIVE",
+                trigger="write",
+            ),
+            _state_log_line(
+                tick=2, sequence_number=2,
+                from_state="EXCLUSIVE", to_state="MODIFIED",
+                trigger="commit", version=1,
+            ),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log"], state_entries=entries,
+        )
+        findings, summary = run_predicates(loaded)
+        assert findings == []
+        skipped_invariants = {s.invariant for s in summary}
+        assert skipped_invariants == {"stale-read"}
+        stale_skip = next(s for s in summary if s.invariant == "stale-read")
+        assert stale_skip.kind == "skipped"
+        assert stale_skip.stream_required == "content_audit_log"
+        assert stale_skip.opted_out is True
+
+    def test_capture_bug_when_declared_but_missing_on_disk(
+        self, tmp_path: Path,
+    ) -> None:
+        # Manifest declares BOTH streams; only state_log lands on disk.
+        # streams_present excludes content_audit_log → SKIPPED with
+        # opted_out=False (the capture-bug signal for Unit 5).
+        session = tmp_path / "session"
+        _write_manifest(session, streams=["state_log", "content_audit_log"])
+        _write_state_log(
+            session,
+            [
+                _state_log_line(
+                    tick=1, sequence_number=1,
+                    from_state="INVALID", to_state="MODIFIED",
+                    trigger="commit", version=1,
+                ),
+            ],
+        )
+        # Deliberately DO NOT write content_audit_log.jsonl
+        loaded = load(session)
+
+        _, summary = run_predicates(loaded)
+        stale_skip = next(s for s in summary if s.invariant == "stale-read")
+        assert stale_skip.stream_required == "content_audit_log"
+        assert stale_skip.opted_out is False
+
+    def test_no_streams_skips_all_predicates(self, tmp_path: Path) -> None:
+        # Empty streams_present → every predicate is skipped, no findings.
+        session = tmp_path / "session"
+        _write_manifest(session, streams=[])
+        loaded = load(session)
+        findings, summary = run_predicates(loaded)
+        assert findings == []
+        skipped_invariants = {s.invariant for s in summary}
+        assert skipped_invariants == {
+            "single-writer", "monotonic-version", "stale-read", "lost-write",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Invariant restriction
+# ---------------------------------------------------------------------------
+
+
+class TestInvariantRestriction:
+    """``invariants=`` parameter restricts predicates entirely.
+
+    Unselected predicates do NOT appear in findings AND do NOT appear
+    in skips — they're never dispatched, never inspected.
+    """
+
+    def test_only_selected_predicate_runs(self, tmp_path: Path) -> None:
+        # Trace would breach single-writer AND lost-write. With
+        # invariants=["lost-write"], only lost-write findings appear.
+        entries = [
+            _state_log_line(
+                tick=1, sequence_number=1, agent_id="agent-1",
+                from_state="INVALID", to_state="MODIFIED",
+                trigger="commit", version=1,
+            ),
+            # Double-owner (would trigger single-writer)
+            _state_log_line(
+                tick=2, sequence_number=2, agent_id="agent-2",
+                from_state="INVALID", to_state="MODIFIED",
+                trigger="commit", version=2,
+            ),
+            # Lost write from S
+            _state_log_line(
+                tick=3, sequence_number=3, agent_id="agent-3",
+                from_state="SHARED", to_state="MODIFIED",
+                trigger="commit", version=3,
+            ),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log"], state_entries=entries,
+        )
+        findings, summary = run_predicates(loaded, invariants=["lost-write"])
+        assert all(f.invariant == "lost-write" for f in findings)
+        assert all(s.invariant == "lost-write" for s in summary)
+        # Stale-read needs content_audit_log so it WOULD have been
+        # skipped — but it was filtered out of the dispatch entirely.
+        assert "stale-read" not in {s.invariant for s in summary}
+
+
+# ---------------------------------------------------------------------------
+# Integration with sim-engine via Unit 3 loader
+# ---------------------------------------------------------------------------
+
+
+class TestSimEngineIntegration:
+    """End-to-end: hand-crafted multi-breach trace via the public loader."""
+
+    def test_mixed_clean_and_breach_counts(self, tmp_path: Path) -> None:
+        # Construct a trace with:
+        # - 1 clean E→M commit (no findings)
+        # - 1 monotonic-version regression (v3→v2)
+        # - 1 lost-write (S→M)
+        # - 1 stale-read CONFIRMED (v1 read at tick 10 of v2 committed
+        #   at tick 5)
+        state_entries = [
+            _state_log_line(
+                tick=1, sequence_number=1, agent_id="writer-a",
+                artifact_id="art-1",
+                from_state="INVALID", to_state="EXCLUSIVE",
+                trigger="write",
+            ),
+            _state_log_line(
+                tick=2, sequence_number=2, agent_id="writer-a",
+                artifact_id="art-1",
+                from_state="EXCLUSIVE", to_state="MODIFIED",
+                trigger="commit", version=1,
+            ),
+            _state_log_line(
+                tick=5, sequence_number=3, agent_id="writer-a",
+                artifact_id="art-1",
+                from_state="MODIFIED", to_state="MODIFIED",
+                trigger="commit", version=3,
+            ),
+            # Monotonic-version regression: v3 → v2
+            _state_log_line(
+                tick=6, sequence_number=4, agent_id="writer-a",
+                artifact_id="art-1",
+                from_state="MODIFIED", to_state="MODIFIED",
+                trigger="commit", version=2,
+            ),
+            # Lost-write on DIFFERENT artifact to avoid single-writer noise
+            _state_log_line(
+                tick=7, sequence_number=5, agent_id="writer-b",
+                artifact_id="art-2",
+                from_state="SHARED", to_state="MODIFIED",
+                trigger="commit", version=1,
+            ),
+        ]
+        audit_entries = [
+            # Stale read at tick 10 of v1 (v3 was already committed at tick 5)
+            _audit_line(
+                tick=10, sequence_number=1, agent_id="reader",
+                artifact_id="art-1", version=1,
+            ),
+        ]
+        loaded = _make_session(
+            tmp_path, streams=["state_log", "content_audit_log"],
+            state_entries=state_entries, audit_entries=audit_entries,
+        )
+        findings, summary = run_predicates(loaded)
+
+        by_invariant: dict[str, int] = {}
+        for f in findings:
+            by_invariant[f.invariant] = by_invariant.get(f.invariant, 0) + 1
+        # Single-writer should NOT fire (only one writer holds M∪E per
+        # artifact at a time).
+        assert by_invariant.get("single-writer", 0) == 0
+        assert by_invariant["monotonic-version"] == 1
+        assert by_invariant["lost-write"] == 1
+        assert by_invariant["stale-read"] == 1
+        # No SKIPPED in summary — both streams present.
+        assert summary == []
+
+
+# ---------------------------------------------------------------------------
+# Finding dataclass shape sanity (frozen, hashable)
+# ---------------------------------------------------------------------------
+
+
+def test_finding_is_frozen() -> None:
+    f = Finding(
+        kind="lost-write",
+        severity="CONFIRMED",
+        invariant="lost-write",
+        agents=("a",),
+        artifacts=("art-1",),
+        tick_range=(1, 1),
+    )
+    with pytest.raises(Exception):
+        f.severity = "AMBIGUOUS"  # type: ignore[misc]
+
+
+def test_summary_finding_is_frozen() -> None:
+    s = SummaryFinding(
+        kind="skipped",
+        invariant="stale-read",
+        reason="x",
+        stream_required="content_audit_log",
+        opted_out=True,
+    )
+    with pytest.raises(Exception):
+        s.opted_out = False  # type: ignore[misc]

--- a/tests/test_replay_recorder.py
+++ b/tests/test_replay_recorder.py
@@ -1,0 +1,469 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for the replay capture surface (Unit 2 of D v1).
+
+Covers the contract documented in
+``docs/proposals/replay_trace_format.md`` from the producer side:
+
+- ``record_callbacks`` helper opt-in gate + composition + tuple yield
+- ``CCSStore.record_to`` thin wrapper
+- Manifest header + finalize on enter/exit
+- fsync-per-line discipline (call-count assertion, not subprocess kill)
+- ``streams=`` opt-out preserving ``retain_versions=True`` on CCSStore
+- Multi-instance ``instance_id`` stderr warning at capture time
+- Rollback durability via fsync-before-failure
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ccs.replay import UnverifiedAdapterCaptureError, record_callbacks
+from ccs.replay.recorder import (
+    DEFAULT_STREAMS,
+    SCHEMA_NOTE,
+    SCHEMA_VERSION,
+    _STATE_LOG,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _state_log_entry(
+    *,
+    tick: int = 1,
+    instance_id: str = "instance-A",
+    sequence_number: int = 1,
+) -> dict:
+    """Synthetic state_log entry shaped per replay_trace_format §3."""
+    return {
+        "tick": tick,
+        "artifact_id": "art-1",
+        "agent_id": "agent-1",
+        "agent_name": "researcher",
+        "from_state": "INVALID",
+        "to_state": "EXCLUSIVE",
+        "trigger": "write",
+        "version": 1,
+        "content_hash": "abc",
+        "sequence_number": sequence_number,
+        "instance_id": instance_id,
+        "schema_version": "ccs.state_log.v2",
+    }
+
+
+def _audit_entry(
+    *,
+    tick: int = 1,
+    instance_id: str = "instance-A",
+    sequence_number: int = 1,
+) -> dict:
+    """Synthetic content_audit_log entry shaped per replay_trace_format §4."""
+    return {
+        "tick": tick,
+        "agent_id": "agent-1",
+        "agent_name": "researcher",
+        "artifact_id": "art-1",
+        "version": 1,
+        "content_hash": "abc",
+        "source": "fetch",
+        "outcome": "content",
+        "sequence_number": sequence_number,
+        "instance_id": instance_id,
+        "schema_version": "ccs.content_audit.v1",
+    }
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    with path.open("r") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# record_callbacks — opt-in gate
+# ---------------------------------------------------------------------------
+
+
+class TestUnverifiedOptIn:
+    """The opt-in gate lives on the helper, not the CCSStore wrapper."""
+
+    def test_helper_without_opt_in_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(UnverifiedAdapterCaptureError):
+            with record_callbacks(tmp_path / "session"):
+                pass
+
+    def test_helper_with_opt_in_succeeds(self, tmp_path: Path) -> None:
+        with record_callbacks(
+            tmp_path / "session", accept_unverified=True
+        ) as (state_cb, audit_cb):
+            assert callable(state_cb)
+            assert callable(audit_cb)
+
+    def test_helper_emits_unverified_stderr(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with record_callbacks(tmp_path / "session", accept_unverified=True):
+            pass
+        captured = capsys.readouterr()
+        assert "unverified" in captured.err
+        assert "CrewAI/AutoGen" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Manifest header + finalize
+# ---------------------------------------------------------------------------
+
+
+class TestManifestLifecycle:
+    """Manifest written on enter (header), rewritten atomically on exit."""
+
+    def test_header_written_on_enter(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "session"
+        with record_callbacks(session_dir, accept_unverified=True):
+            manifest = json.loads((session_dir / "manifest.json").read_text())
+            assert manifest["schema_version"] == SCHEMA_VERSION
+            assert manifest["schema_note"] == SCHEMA_NOTE
+            assert manifest["adapter_type"] == "coherence-adapter-core"
+            assert set(manifest["streams"]) == DEFAULT_STREAMS
+
+    def test_finalized_fields_on_exit(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "session"
+        with record_callbacks(
+            session_dir, accept_unverified=True
+        ) as (state_cb, _audit_cb):
+            state_cb(_state_log_entry(tick=5, instance_id="inst-X"))
+            state_cb(_state_log_entry(tick=11, instance_id="inst-X", sequence_number=2))
+
+        manifest = json.loads((session_dir / "manifest.json").read_text())
+        assert manifest["start_tick"] == 5
+        assert manifest["end_tick"] == 11
+        assert manifest["instance_id"] == "inst-X"
+
+    def test_no_events_yields_zero_ticks(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "session"
+        with record_callbacks(session_dir, accept_unverified=True):
+            pass
+        manifest = json.loads((session_dir / "manifest.json").read_text())
+        assert manifest["start_tick"] == 0
+        assert manifest["end_tick"] == 0
+        assert manifest["instance_id"] is None
+        assert manifest["agents"] == {}
+        assert manifest["artifacts"] == {}
+
+
+# ---------------------------------------------------------------------------
+# fsync-per-line contract
+# ---------------------------------------------------------------------------
+
+
+class TestFsyncContract:
+    """Each JSONL line write triggers exactly one fsync.
+
+    Per the plan: durability proof via call-count, not subprocess kill.
+    A failed callback raises before the next write, but the fsync that
+    fired on prior lines means those entries are durably on disk.
+    """
+
+    def test_fsync_once_per_line(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "session"
+        line_count = 5
+        with patch("ccs.replay.recorder.os.fsync", wraps=os.fsync) as mock_fsync:
+            with record_callbacks(
+                session_dir, accept_unverified=True
+            ) as (state_cb, audit_cb):
+                # Reset after enter (manifest open may have fsync'd via the
+                # tempfile + replace path — count only stream-line syncs).
+                mock_fsync.reset_mock()
+                for i in range(line_count):
+                    state_cb(_state_log_entry(tick=i + 1, sequence_number=i + 1))
+                for i in range(line_count):
+                    audit_cb(_audit_entry(tick=i + 1, sequence_number=i + 1))
+                stream_call_count = mock_fsync.call_count
+
+        # Each of the 10 line writes (5 state + 5 audit) triggered one fsync.
+        # Additional fsync calls after this point come from manifest atomic
+        # rewrite on __exit__ — not counted here.
+        assert stream_call_count == 2 * line_count
+
+
+# ---------------------------------------------------------------------------
+# streams= opt-out semantics
+# ---------------------------------------------------------------------------
+
+
+class TestStreamsOptOut:
+    """streams={'state_log'} suppresses the audit JSONL file but keeps
+    the callback live for composition + bookkeeping."""
+
+    def test_state_log_only_skips_audit_file(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "session"
+        with record_callbacks(
+            session_dir, streams={"state_log"}, accept_unverified=True
+        ) as (state_cb, audit_cb):
+            state_cb(_state_log_entry())
+            # Audit callback still callable; bookkeeping fires but no disk write.
+            audit_cb(_audit_entry())
+
+        assert (session_dir / "state_log.jsonl").exists()
+        assert not (session_dir / "content_audit_log.jsonl").exists()
+
+        manifest = json.loads((session_dir / "manifest.json").read_text())
+        assert manifest["streams"] == ["state_log"]
+
+    def test_audit_callback_is_no_op_when_opted_out(self, tmp_path: Path) -> None:
+        """Wrapped audit callback exists (truthy) even when opted out —
+        this preserves CCSStore's retain_versions=True semantics."""
+        with record_callbacks(
+            tmp_path / "session",
+            streams={"state_log"},
+            accept_unverified=True,
+        ) as (_state_cb, audit_cb):
+            assert audit_cb is not None
+            assert callable(audit_cb)
+            # Calling does not raise; bookkeeping only.
+            audit_cb(_audit_entry())
+
+    def test_state_log_opt_out_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="state_log"):
+            with record_callbacks(
+                tmp_path / "session",
+                streams={"content_audit_log"},
+                accept_unverified=True,
+            ):
+                pass
+
+    def test_unknown_stream_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Unknown streams"):
+            with record_callbacks(
+                tmp_path / "session",
+                streams={"state_log", "transient_state_log"},
+                accept_unverified=True,
+            ):
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Callback composition
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackComposition:
+    """Caller callbacks compose with file writers — neither overrides."""
+
+    def test_caller_state_log_fires_alongside_file_write(self, tmp_path: Path) -> None:
+        captured: list[dict] = []
+        session_dir = tmp_path / "session"
+        with record_callbacks(
+            session_dir,
+            accept_unverified=True,
+            state_log=captured.append,
+        ) as (state_cb, _audit_cb):
+            entry = _state_log_entry()
+            state_cb(entry)
+
+        assert captured == [_state_log_entry()]
+        on_disk = _read_jsonl(session_dir / "state_log.jsonl")
+        assert on_disk == [_state_log_entry()]
+
+    def test_caller_audit_log_fires_alongside_file_write(self, tmp_path: Path) -> None:
+        captured: list[dict] = []
+        session_dir = tmp_path / "session"
+        with record_callbacks(
+            session_dir,
+            accept_unverified=True,
+            content_audit_log=captured.append,
+        ) as (_state_cb, audit_cb):
+            audit_cb(_audit_entry())
+
+        assert len(captured) == 1
+        on_disk = _read_jsonl(session_dir / "content_audit_log.jsonl")
+        assert on_disk == captured
+
+
+# ---------------------------------------------------------------------------
+# Multi-instance warning
+# ---------------------------------------------------------------------------
+
+
+class TestMultiInstanceDetection:
+    """A new instance_id mid-capture emits a stderr warning naming the
+    MULTI_INSTANCE_TRACE D+1 roadmap item."""
+
+    def test_instance_id_change_warns(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        session_dir = tmp_path / "session"
+        with record_callbacks(
+            session_dir, accept_unverified=True
+        ) as (state_cb, _audit_cb):
+            state_cb(_state_log_entry(instance_id="inst-A", sequence_number=1))
+            state_cb(_state_log_entry(instance_id="inst-B", sequence_number=2))
+
+        captured = capsys.readouterr()
+        assert "MULTI_INSTANCE_TRACE" in captured.err
+
+    def test_stable_instance_id_does_not_warn(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        session_dir = tmp_path / "session"
+        with record_callbacks(
+            session_dir, accept_unverified=True
+        ) as (state_cb, _audit_cb):
+            state_cb(_state_log_entry(instance_id="inst-A", sequence_number=1))
+            state_cb(_state_log_entry(instance_id="inst-A", sequence_number=2))
+
+        captured = capsys.readouterr()
+        assert "MULTI_INSTANCE_TRACE" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Rollback durability
+# ---------------------------------------------------------------------------
+
+
+class TestRollbackDurability:
+    """A file-writer IOError propagates so the coordinator's _seq
+    rollback fires. Prior successful writes are durable thanks to fsync."""
+
+    def test_fsync_before_failure_keeps_prior_writes_durable(
+        self, tmp_path: Path
+    ) -> None:
+        """Simulate: 1st line succeeds (fsync fires), 2nd line's
+        os.write raises IOError; the helper propagates so the caller
+        (coordinator) can roll back _seq. The 1st line is on disk."""
+        session_dir = tmp_path / "session"
+
+        # Track fsync — must fire on the durable first write.
+        fsync_calls: list[int] = []
+        original_fsync = os.fsync
+
+        def tracking_fsync(fd: int) -> None:
+            fsync_calls.append(fd)
+            original_fsync(fd)
+
+        original_write = os.write
+
+        with record_callbacks(
+            session_dir, accept_unverified=True
+        ) as (state_cb, _audit_cb):
+            with patch(
+                "ccs.replay.recorder.os.fsync", side_effect=tracking_fsync
+            ):
+                # First line: real write + fsync.
+                state_cb(_state_log_entry(sequence_number=1))
+                fsync_after_first = len(fsync_calls)
+
+                # Second line: os.write raises before fsync can fire.
+                def flaky_write(fd: int, data: bytes) -> int:
+                    raise OSError("disk full")
+
+                with patch(
+                    "ccs.replay.recorder.os.write", side_effect=flaky_write
+                ):
+                    with pytest.raises(OSError, match="disk full"):
+                        state_cb(_state_log_entry(sequence_number=2))
+
+                # No additional fsync between failed write and now —
+                # fsync did NOT fire for the failed entry.
+                assert len(fsync_calls) == fsync_after_first
+                assert fsync_after_first >= 1
+
+        # First write made it; second did not.
+        on_disk = _read_jsonl(session_dir / "state_log.jsonl")
+        assert len(on_disk) == 1
+        assert on_disk[0]["sequence_number"] == 1
+        # Suppress unused-name warning for original_write (kept available
+        # if a future variant of this test wants to mix flaky/real writes).
+        _ = original_write
+
+
+# ---------------------------------------------------------------------------
+# CCSStore.record_to thin wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestCCSStoreRecordTo:
+    """CCSStore.record_to is the verified LangGraph-shaped wrapper.
+
+    It sets accept_unverified=True automatically and does NOT emit the
+    unverified-adapter warning (CCSStore is verified in v1).
+    """
+
+    def setup_method(self) -> None:
+        pytest.importorskip("langgraph.store.base")
+
+    def test_yields_ccsstore_and_writes_manifest(self, tmp_path: Path) -> None:
+        from ccs.adapters.ccsstore import CCSStore
+
+        session_dir = tmp_path / "session"
+        with CCSStore.record_to(session_dir) as store:
+            from langgraph.store.base import PutOp
+
+            store.batch([PutOp(namespace=("planner", "shared"), key="plan", value={"v": 1})])
+
+        manifest = json.loads((session_dir / "manifest.json").read_text())
+        assert manifest["adapter_type"] == "langgraph-ccsstore"
+        assert set(manifest["streams"]) == DEFAULT_STREAMS
+        assert manifest["instance_id"] is not None
+        # The put registered an agent and an artifact — both must be
+        # drained into the finalized manifest.
+        assert manifest["agents"]
+        assert manifest["artifacts"]
+        assert (session_dir / "state_log.jsonl").exists()
+        assert (session_dir / "content_audit_log.jsonl").exists()
+
+    def test_does_not_emit_unverified_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from ccs.adapters.ccsstore import CCSStore
+
+        with CCSStore.record_to(tmp_path / "session"):
+            pass
+
+        captured = capsys.readouterr()
+        assert "unverified" not in captured.err
+        assert "CrewAI/AutoGen" not in captured.err
+
+    def test_retain_versions_preserved_when_audit_opted_out(self, tmp_path: Path) -> None:
+        """streams={'state_log'} must not break retain_versions=True on
+        the constructed CCSStore — the wrapped audit callback always
+        exists even though it's a no-op writer."""
+        from ccs.adapters.ccsstore import CCSStore
+
+        session_dir = tmp_path / "session"
+        with CCSStore.record_to(
+            session_dir, streams={"state_log"}
+        ) as store:
+            assert store.core.registry._retain_versions is True
+
+        assert not (session_dir / "content_audit_log.jsonl").exists()
+        manifest = json.loads((session_dir / "manifest.json").read_text())
+        assert manifest["streams"] == ["state_log"]
+
+    def test_caller_state_log_composes(self, tmp_path: Path) -> None:
+        """Caller-supplied state_log callback composes with the file
+        writer — both fire, neither is overridden."""
+        from ccs.adapters.ccsstore import CCSStore
+        from langgraph.store.base import PutOp
+
+        captured: list[dict] = []
+        session_dir = tmp_path / "session"
+        with CCSStore.record_to(
+            session_dir, state_log=captured.append
+        ) as store:
+            store.batch([PutOp(namespace=("planner", "shared"), key="k", value={"v": 1})])
+
+        assert captured, "caller state_log was not invoked"
+        on_disk = _read_jsonl(session_dir / "state_log.jsonl")
+        assert on_disk, "file writer did not produce on-disk entries"
+        # Both saw the same entries (composition, not override).
+        assert len(captured) == len(on_disk)


### PR DESCRIPTION
## Summary

Resolves all 17 actionable findings from the `fix/cli` ce-review pass (run ID `20260527-113359-150c50f5`, 11 reviewers). Zero advisory items deferred; 4 explicitly advisory findings left for a later pass.

**P1 (8 items — all fixed):**
- `_append_policy_yaml` idempotent early-return returned the wrong `added` list to callers; fixed to `([], rejected)` + switched YAML parsing from manual prefix stripping to `yaml.safe_load` (handles `- "plan.md"` quoted entries)
- `heapq.merge` tuple could reach a `dict` at position 4 on equal keys; fixed by inserting a per-stream monotonic counter
- `_iter_merged` leaked file descriptors on early abort; wrapped in `try/finally` to close generators
- `_atomic_write_manifest` left orphaned temp files on `os.replace` failure; now unlinks before re-raising
- `--show-policy` was silently ignored in `--json` mode; now injects `policy_pending_first_read` into the payload
- `--quiet` had no effect in `--json` mode; `emit_json` now respects the cron-silent contract

**P2 (9 items — all fixed):**
- TOCTOU `is_file()` + `read_text()` inside held flock replaced with `try/except FileNotFoundError`
- `emit_human` quiet mode silently dropped capture-bug SKIP output; now prints `[CAPTURE-BUG]` lines before returning
- `OSError` from `load()` escaped the `_TRACE_ERRORS` catch; added to guard + session_dir pre-flight
- `user_added_patterns` (path strings) leaked at `minimal`/`metrics` `/status` tiers; stripped to `full`-only
- `seen_seq` docstring claimed O(bounded) memory; corrected to O(N)
- `RecordingSession` missing from `ccs.replay` package `__all__`
- `ClassVar` annotations, `__exit__` type hints, `_classify_stale_read` return type

## Test plan

- [ ] `_parse_yaml_pattern_lines`: 5 unit tests (plain, quoted, empty, non-string, malformed YAML)
- [ ] Idempotent `/policy/track`: asserts `b2.get("added") == []`
- [ ] `--show-policy`: pending section renders; none branch; `--json` injects `policy_pending_first_read`
- [ ] `--quiet --json`: clean trace emits nothing; breach emits findings + summary
- [ ] `test_missing_manifest_exits_three`: updated assertion matches pre-flight message
- [ ] Full suite: `pytest -q` → 1436 passed, 0 failed