### PR TITLE
fix(replay): ReplayError base class for unified except clauses (Gated #11)

### DIFF
--- a/src/ccs/cli/coherence_replay.py
+++ b/src/ccs/cli/coherence_replay.py
@@ -35,9 +35,7 @@ from pathlib import Path
 from typing import Sequence
 
 from ccs.replay import (
-    ManifestMissingOrUnreadableError,
-    MultiInstanceTraceError,
-    TraceCorruptionError,
+    ReplayTraceError,
     load,
     run_predicates,
 )
@@ -51,19 +49,14 @@ _VALID_INVARIANTS: tuple[str, ...] = (
     "lost-write",
 )
 
-# Trace-format spec maps these three loader/iterator errors to exit
-# code 3. Tuple lives at module scope so the except clause in main()
-# and any future helper share one definition (drift would silently
-# route a trace error to a Python traceback).
-_TRACE_ERRORS: tuple[
-    type[ManifestMissingOrUnreadableError],
-    type[MultiInstanceTraceError],
-    type[TraceCorruptionError],
-] = (
-    ManifestMissingOrUnreadableError,
-    MultiInstanceTraceError,
-    TraceCorruptionError,
-)
+# Trace-format spec maps every ``ReplayTraceError`` subclass
+# (ManifestMissingOrUnreadableError, MultiInstanceTraceError,
+# TraceCorruptionError, and any future trace-defect subclass) to exit
+# code 3. Catching the base class instead of an explicit tuple means a
+# new trace-error subclass auto-routes correctly without touching this
+# handler — the previous tuple-based shape needed to be edited each
+# time a new error class was added.
+_TRACE_ERRORS: tuple[type[ReplayTraceError], ...] = (ReplayTraceError,)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -141,7 +134,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         return _run(args)
-    except (*_TRACE_ERRORS, OSError) as exc:
+    except (ReplayTraceError, OSError) as exc:
         print(f"agent-coherence-replay: {exc}", file=sys.stderr)
         return 3
 

--- a/src/ccs/replay/__init__.py
+++ b/src/ccs/replay/__init__.py
@@ -21,10 +21,32 @@ Public API:
 
 ``CCSStore.record_to`` is the LangGraph-shaped thin wrapper over
 :func:`record_callbacks` and lives on the adapter class itself.
+
+Error hierarchy:
+
+All exceptions raised by ``ccs.replay`` inherit from
+:class:`ReplayError`, split into two semantic categories so callers
+can write a single ``except`` clause per intent:
+
+- :class:`ReplayConfigurationError` — API misuse / wrong-entry-point
+  errors. Currently: :class:`UnverifiedAdapterCaptureError`.
+- :class:`ReplayTraceError` — trace structural defects detected at
+  read time. Currently: :class:`ManifestMissingOrUnreadableError`,
+  :class:`MultiInstanceTraceError`, :class:`TraceCorruptionError`.
+  CLI maps the whole category to exit code 3.
+
+Base classes live in ``ccs.replay.errors`` so concrete subclasses in
+``recorder`` / ``loader`` can import them without forming an import
+cycle through this ``__init__``.
 """
 
 from __future__ import annotations
 
+from ccs.replay.errors import (
+    ReplayConfigurationError,
+    ReplayError,
+    ReplayTraceError,
+)
 from ccs.replay.loader import (
     LoadedTrace,
     ManifestMissingOrUnreadableError,
@@ -63,6 +85,9 @@ __all__ = [
     "MultiInstanceTraceError",
     "Predicate",
     "RecordingSession",
+    "ReplayConfigurationError",
+    "ReplayError",
+    "ReplayTraceError",
     "SingleWriterPredicate",
     "StaleReadPredicate",
     "SummaryFinding",

--- a/src/ccs/replay/errors.py
+++ b/src/ccs/replay/errors.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Base exception classes for ``ccs.replay``.
+
+Lives in its own module (rather than ``__init__.py``) so concrete
+subclasses in ``recorder`` / ``loader`` can import the base classes
+without forming an import cycle through the package ``__init__``.
+
+The hierarchy is a two-tier semantic split so callers can write a
+single ``except`` clause matching the failure category:
+
+::
+
+    ReplayError                       (base — catches everything)
+    ├── ReplayConfigurationError      (API misuse — fix the call)
+    │   └── UnverifiedAdapterCaptureError
+    └── ReplayTraceError              (trace defect — fix the data; CLI exit 3)
+        ├── ManifestMissingOrUnreadableError
+        ├── MultiInstanceTraceError
+        └── TraceCorruptionError
+
+Future trace-defect subclasses inherit ``ReplayTraceError`` and
+auto-route to CLI exit code 3 without touching the handler.
+"""
+
+from __future__ import annotations
+
+
+class ReplayError(Exception):
+    """Base class for all errors raised by the ``ccs.replay`` module."""
+
+
+class ReplayConfigurationError(ReplayError):
+    """Configuration / API misuse — caller passed wrong arguments or used
+    the wrong entry point. Examples: ``UnverifiedAdapterCaptureError``
+    (caller forgot ``accept_unverified=True``). Not a trace defect.
+    """
+
+
+class ReplayTraceError(ReplayError):
+    """Errors raised when reading or interpreting a captured trace.
+    The trace is structurally invalid (multi-instance, duplicate seq,
+    missing manifest, or unreadable manifest). Maps to CLI exit code 3.
+    """

--- a/src/ccs/replay/loader.py
+++ b/src/ccs/replay/loader.py
@@ -37,6 +37,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterator
 
+from ccs.replay.errors import ReplayTraceError
+
 __all__ = [
     "LoadedTrace",
     "ManifestMissingOrUnreadableError",
@@ -69,26 +71,32 @@ _KNOWN_STREAMS: frozenset[str] = frozenset(_STREAM_PRIORITY)
 # ---------------------------------------------------------------------------
 
 
-class ManifestMissingOrUnreadableError(RuntimeError):
+class ManifestMissingOrUnreadableError(ReplayTraceError):
     """``manifest.json`` does not exist or fails JSON parse.
 
     Raised eagerly by :func:`load` — partial walks are not possible
     without a manifest. Message points at the offending path so partners
     can re-capture or fix the directory.
+
+    Inherits from :class:`ccs.replay.ReplayTraceError` so CLI callers
+    can catch all trace-defect errors with one ``except`` clause and
+    route them to exit code 3.
     """
 
 
-class MultiInstanceTraceError(RuntimeError):
+class MultiInstanceTraceError(ReplayTraceError):
     """Two distinct ``instance_id`` values observed in the same stream.
 
     v1 supports single-coordinator-instance traces only. Raised lazily
     from the iterator so partial walks succeed up to the boundary —
     Unit 5's CLI maps this to exit code 3 and surfaces the D+1
     roadmap pointer to the operator.
+
+    Inherits from :class:`ccs.replay.ReplayTraceError`.
     """
 
 
-class TraceCorruptionError(RuntimeError):
+class TraceCorruptionError(ReplayTraceError):
     """Two entries in a stream share ``(instance_id, sequence_number)``.
 
     Defense-in-depth against partner-written callbacks (CrewAI /
@@ -100,6 +108,8 @@ class TraceCorruptionError(RuntimeError):
 
     Raised lazily from the iterator with the duplicate seq value, the
     offending file path, and the line number of the second occurrence.
+
+    Inherits from :class:`ccs.replay.ReplayTraceError`.
     """
 
 

--- a/src/ccs/replay/recorder.py
+++ b/src/ccs/replay/recorder.py
@@ -38,6 +38,8 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any, Callable, Iterator
 
+from ccs.replay.errors import ReplayConfigurationError
+
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -86,7 +88,7 @@ _MULTI_INSTANCE_WARNING = (
 )
 
 
-class UnverifiedAdapterCaptureError(RuntimeError):
+class UnverifiedAdapterCaptureError(ReplayConfigurationError):
     """Raised by :func:`record_callbacks` when ``accept_unverified=True``
     was not passed.
 
@@ -96,6 +98,10 @@ class UnverifiedAdapterCaptureError(RuntimeError):
     invoke the helper directly and MUST acknowledge the unverified
     status by passing the flag — surfacing the v1 scope boundary at
     the call site, not buried in README copy.
+
+    Inherits from :class:`ccs.replay.ReplayConfigurationError` (API
+    misuse) rather than :class:`ccs.replay.ReplayTraceError` — the
+    trace itself never got written.
     """
 
 

--- a/tests/test_replay_errors.py
+++ b/tests/test_replay_errors.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for the ``ccs.replay`` exception hierarchy (Gated #11).
+
+Verifies the two-tier semantic split:
+
+- :class:`ReplayConfigurationError` — API misuse (caller fault)
+- :class:`ReplayTraceError` — trace structural defect (data fault;
+  CLI exit code 3)
+
+Both inherit from :class:`ReplayError` so partner callers can write a
+single ``except ReplayError`` if they want everything, or narrow to
+one of the two semantic categories. The CLI relies on the
+``ReplayTraceError`` umbrella so future trace-defect subclasses
+auto-route to exit code 3 without touching the handler.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ccs.replay import (
+    ManifestMissingOrUnreadableError,
+    MultiInstanceTraceError,
+    ReplayConfigurationError,
+    ReplayError,
+    ReplayTraceError,
+    TraceCorruptionError,
+    UnverifiedAdapterCaptureError,
+)
+
+
+def test_multi_instance_trace_error_is_replay_trace_error() -> None:
+    assert issubclass(MultiInstanceTraceError, ReplayTraceError)
+    assert issubclass(MultiInstanceTraceError, ReplayError)
+
+
+def test_trace_corruption_error_is_replay_trace_error() -> None:
+    assert issubclass(TraceCorruptionError, ReplayTraceError)
+    assert issubclass(TraceCorruptionError, ReplayError)
+
+
+def test_manifest_missing_error_is_replay_trace_error() -> None:
+    assert issubclass(ManifestMissingOrUnreadableError, ReplayTraceError)
+    assert issubclass(ManifestMissingOrUnreadableError, ReplayError)
+
+
+def test_unverified_adapter_error_is_replay_configuration_error() -> None:
+    assert issubclass(UnverifiedAdapterCaptureError, ReplayConfigurationError)
+    assert issubclass(UnverifiedAdapterCaptureError, ReplayError)
+    # Explicitly NOT a trace error — accept_unverified is a call-site
+    # mistake, not a defective trace on disk.
+    assert not issubclass(UnverifiedAdapterCaptureError, ReplayTraceError)
+
+
+def test_configuration_and_trace_are_disjoint() -> None:
+    """The two semantic categories share only ``ReplayError`` —
+    callers can rely on the disjointness when picking which one to
+    catch.
+    """
+    assert not issubclass(ReplayConfigurationError, ReplayTraceError)
+    assert not issubclass(ReplayTraceError, ReplayConfigurationError)
+
+
+def test_except_replay_trace_error_catches_all_trace_errors() -> None:
+    """Single ``except`` clause replaces the old 3-tuple workaround
+    in ``ccs.cli.coherence_replay``. Catches every trace-defect
+    subclass via the umbrella base, so a future subclass routes to
+    exit 3 without touching the CLI handler.
+    """
+    errors_to_catch: tuple[ReplayTraceError, ...] = (
+        MultiInstanceTraceError("test"),
+        TraceCorruptionError("test"),
+        ManifestMissingOrUnreadableError("test"),
+    )
+    for err in errors_to_catch:
+        try:
+            raise err
+        except ReplayTraceError:
+            pass  # expected
+        else:
+            pytest.fail(
+                f"{type(err).__name__} not caught by ReplayTraceError"
+            )
+
+
+def test_except_replay_error_catches_both_categories() -> None:
+    """``ReplayError`` is the single top-level umbrella — useful for
+    partners who want to catch any replay-module failure with one
+    clause.
+    """
+    errors_to_catch: tuple[ReplayError, ...] = (
+        MultiInstanceTraceError("test"),
+        TraceCorruptionError("test"),
+        ManifestMissingOrUnreadableError("test"),
+        UnverifiedAdapterCaptureError("test"),
+    )
+    for err in errors_to_catch:
+        try:
+            raise err
+        except ReplayError:
+            pass  # expected
+        else:
+            pytest.fail(f"{type(err).__name__} not caught by ReplayError")
+
+
+def test_replay_error_is_distinct_from_runtime_error() -> None:
+    """Previously every replay exception inherited ``RuntimeError`` —
+    catching ``RuntimeError`` in partner code would have caught a
+    grab-bag including replay errors. Post-fix, partners should catch
+    ``ReplayError`` (or a subclass) explicitly.
+    """
+    # ReplayError inherits directly from Exception, not RuntimeError.
+    assert not issubclass(ReplayError, RuntimeError)
+    # And the concrete subclasses no longer carry the RuntimeError tag
+    # either — the inheritance was reparented.
+    assert not issubclass(UnverifiedAdapterCaptureError, RuntimeError)
+    assert not issubclass(MultiInstanceTraceError, RuntimeError)
+    assert not issubclass(TraceCorruptionError, RuntimeError)
+    assert not issubclass(ManifestMissingOrUnreadableError, RuntimeError)


### PR DESCRIPTION
## Summary

Adds `ReplayError` base class with two-tier semantic split:
- `ReplayConfigurationError` — API misuse / wrong-entry-point errors
- `ReplayTraceError` — trace structural defects (CLI exit code 3)

Existing four exceptions reparent:
- `UnverifiedAdapterCaptureError` → `ReplayConfigurationError`
- `ManifestMissingOrUnreadableError` → `ReplayTraceError`
- `MultiInstanceTraceError` → `ReplayTraceError`
- `TraceCorruptionError` → `ReplayTraceError`

CLI handler simplified: `except (ReplayTraceError, OSError)` replaces the 4-tuple workaround. Future trace-error subclasses (e.g. for Gated #5 if ever extended) auto-route to exit 3.

### Design note: base classes live in a new ``ccs/replay/errors.py``

`recorder.py` and `loader.py` both need to import the base classes. Defining them in `__init__.py` would form an import cycle (the `__init__` re-exports concrete subclasses from those same modules). The spec called this out and authorized the dedicated `errors.py` module as the fallback — which is what shipped. The package `__init__` re-exports `ReplayError` / `ReplayConfigurationError` / `ReplayTraceError` so partner code keeps importing from `ccs.replay`.

Origin: `docs/plans/2026-05-27-001-fix-d-v1-ce-review-gated-findings-plan.md` (Gated #11)
Review run: `.context/compound-engineering/ce-review/20260526-201844-d6ba0dc4/api-contract.json` (AC-01, 0.90)

## Test plan

- [x] New `tests/test_replay_errors.py` (8 tests) verifies the inheritance hierarchy and that the single ``except ReplayTraceError`` clause catches all three trace errors
- [x] Also verifies `ReplayError` is NOT a `RuntimeError` subclass (prevents partner code that catches `RuntimeError` from accidentally swallowing replay-module exceptions)
- [x] Existing exit-3 CLI tests pass unchanged (behavior preserved end-to-end)
- [x] Full suite: 1432 passed, 2 skipped (baseline 1424 passed + 8 new tests; same 2 skips)
- [x] Architecture check clean (`tools/check_architecture.py`)
- [x] `agent-coherence-replay --help` smoke test passes (no CLI surface change)