### PR TITLE
fix(replay,cli): JSON error envelope on exit 3 (Gated #15)

### DIFF
--- a/src/ccs/cli/coherence_replay.py
+++ b/src/ccs/cli/coherence_replay.py
@@ -25,17 +25,31 @@ AMBIGUOUS suppression resolved in plan Open Question P1-B: per-finding
 output suppresses AMBIGUOUS by default; ``--include-ambiguous`` opts
 in. Summary ALWAYS counts AMBIGUOUS, and the callout fires when count
 exceeds ``--ambiguous-threshold`` (default 10), naming both remedies.
+
+JSON error envelope (Gated #15 resolution): when ``--json`` is active
+and a trace error fires (exit 3), a final NDJSON object is written to
+stdout before the human prose hits stderr::
+
+    {"kind": "error", "exit_code": 3, "exception": "<ClassName>",
+     "message": "..."}
+
+Keeps stdout self-contained for ``--json`` consumers; the stderr line
+remains for human log tailing. The pre-flight session-directory check
+raises ``SessionDirectoryNotFoundError`` (a ``ReplayTraceError``
+subclass) so the envelope logic stays centralized in the outer catch.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 from typing import Sequence
 
 from ccs.replay import (
     ReplayTraceError,
+    SessionDirectoryNotFoundError,
     load,
     run_predicates,
 )
@@ -135,6 +149,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         return _run(args)
     except (ReplayTraceError, OSError) as exc:
+        # JSON consumers need a self-contained stdout — emit the error
+        # envelope BEFORE the human prose so an agent capturing stdout
+        # can parse a single NDJSON stream end-to-end. Use write+flush
+        # rather than print so a downstream BrokenPipeError surfaces
+        # cleanly (Gated #1 handles BrokenPipeError end-to-end).
+        if args.json:
+            sys.stdout.write(json.dumps({
+                "kind": "error",
+                "exit_code": 3,
+                "exception": type(exc).__name__,
+                "message": str(exc),
+            }) + "\n")
+            sys.stdout.flush()
         print(f"agent-coherence-replay: {exc}", file=sys.stderr)
         return 3
 
@@ -147,12 +174,12 @@ def _run(args: argparse.Namespace) -> int:
     the style-guide line ceiling.
     """
     if not args.session_dir.exists():
-        print(
-            f"agent-coherence-replay: session directory not found: "
-            f"{args.session_dir}",
-            file=sys.stderr,
+        # Raise rather than print+return so the outer trace-error catch
+        # in main() handles both the stderr prose and the --json error
+        # envelope in one place (Gated #15).
+        raise SessionDirectoryNotFoundError(
+            f"session directory not found: {args.session_dir}"
         )
-        return 3
     loaded = load(args.session_dir)
     findings, summary = run_predicates(loaded, invariants=args.invariant)
     if args.json:

--- a/src/ccs/replay/__init__.py
+++ b/src/ccs/replay/__init__.py
@@ -32,8 +32,9 @@ can write a single ``except`` clause per intent:
   errors. Currently: :class:`UnverifiedAdapterCaptureError`.
 - :class:`ReplayTraceError` — trace structural defects detected at
   read time. Currently: :class:`ManifestMissingOrUnreadableError`,
-  :class:`MultiInstanceTraceError`, :class:`TraceCorruptionError`.
-  CLI maps the whole category to exit code 3.
+  :class:`MultiInstanceTraceError`, :class:`SessionDirectoryNotFoundError`,
+  :class:`TraceCorruptionError`. CLI maps the whole category to exit
+  code 3.
 
 Base classes live in ``ccs.replay.errors`` so concrete subclasses in
 ``recorder`` / ``loader`` can import them without forming an import
@@ -46,6 +47,7 @@ from ccs.replay.errors import (
     ReplayConfigurationError,
     ReplayError,
     ReplayTraceError,
+    SessionDirectoryNotFoundError,
 )
 from ccs.replay.loader import (
     LoadedTrace,
@@ -88,6 +90,7 @@ __all__ = [
     "ReplayConfigurationError",
     "ReplayError",
     "ReplayTraceError",
+    "SessionDirectoryNotFoundError",
     "SingleWriterPredicate",
     "StaleReadPredicate",
     "SummaryFinding",

--- a/src/ccs/replay/errors.py
+++ b/src/ccs/replay/errors.py
@@ -18,6 +18,7 @@ single ``except`` clause matching the failure category:
     └── ReplayTraceError              (trace defect — fix the data; CLI exit 3)
         ├── ManifestMissingOrUnreadableError
         ├── MultiInstanceTraceError
+        ├── SessionDirectoryNotFoundError
         └── TraceCorruptionError
 
 Future trace-defect subclasses inherit ``ReplayTraceError`` and
@@ -42,4 +43,13 @@ class ReplayTraceError(ReplayError):
     """Errors raised when reading or interpreting a captured trace.
     The trace is structurally invalid (multi-instance, duplicate seq,
     missing manifest, or unreadable manifest). Maps to CLI exit code 3.
+    """
+
+
+class SessionDirectoryNotFoundError(ReplayTraceError):
+    """Raised by the CLI pre-flight when the session directory does not
+    exist on disk. Modeled as a ``ReplayTraceError`` subclass so the
+    outer trace-error catch in ``main()`` handles it uniformly with the
+    loader/iterator errors — keeps the exit-3 envelope logic in one
+    place (Gated #15 resolution).
     """

--- a/tests/test_cli_coherence_replay.py
+++ b/tests/test_cli_coherence_replay.py
@@ -588,6 +588,87 @@ class TestTraceErrors:
         assert "duplicate" in captured.err.lower() or "sequence_number" in captured.err
         assert "Traceback" not in captured.err
 
+    # ----- Gated #15: --json error envelope on exit 3 -----
+
+    def test_multi_instance_json_emits_error_envelope_on_stdout(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _multi_instance_session(tmp_path)
+        rc = main([str(session), "--json"])
+        captured = capsys.readouterr()
+        assert rc == 3
+        # stdout has exactly one JSON line — the error envelope.
+        stdout_lines = [line for line in captured.out.splitlines() if line.strip()]
+        assert len(stdout_lines) == 1
+        envelope = json.loads(stdout_lines[0])
+        assert envelope["kind"] == "error"
+        assert envelope["exit_code"] == 3
+        assert envelope["exception"] == "MultiInstanceTraceError"
+        assert isinstance(envelope["message"], str)
+        # Carries the actionable D+1 roadmap pointer surfaced by the loader.
+        assert "D+1" in envelope["message"]
+        # stderr prose retained for human log tailers.
+        assert "agent-coherence-replay" in captured.err
+        assert "Traceback" not in captured.err
+
+    def test_trace_corruption_json_emits_error_envelope_on_stdout(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _trace_corruption_session(tmp_path)
+        rc = main([str(session), "--json"])
+        captured = capsys.readouterr()
+        assert rc == 3
+        stdout_lines = [line for line in captured.out.splitlines() if line.strip()]
+        assert len(stdout_lines) == 1
+        envelope = json.loads(stdout_lines[0])
+        assert envelope["kind"] == "error"
+        assert envelope["exit_code"] == 3
+        assert envelope["exception"] == "TraceCorruptionError"
+        assert isinstance(envelope["message"], str)
+        assert "agent-coherence-replay" in captured.err
+        assert "Traceback" not in captured.err
+
+    def test_missing_session_dir_json_emits_error_envelope_on_stdout(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = tmp_path / "nonexistent"
+        rc = main([str(session), "--json"])
+        captured = capsys.readouterr()
+        assert rc == 3
+        stdout_lines = [line for line in captured.out.splitlines() if line.strip()]
+        assert len(stdout_lines) == 1
+        envelope = json.loads(stdout_lines[0])
+        assert envelope["kind"] == "error"
+        assert envelope["exit_code"] == 3
+        # Route (a): pre-flight raises SessionDirectoryNotFoundError so
+        # the envelope class name is consistent with the trace-error catch.
+        assert envelope["exception"] == "SessionDirectoryNotFoundError"
+        assert "session directory not found" in envelope["message"]
+        assert "agent-coherence-replay" in captured.err
+        assert "Traceback" not in captured.err
+
+    def test_no_json_flag_keeps_stdout_empty_on_trace_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Regression guard: WITHOUT ``--json``, stdout stays empty on
+        exit 3 — the envelope is a ``--json``-only addition; no behavior
+        change for the default human path.
+        """
+        session = _multi_instance_session(tmp_path)
+        rc = main([str(session)])  # no --json
+        captured = capsys.readouterr()
+        assert rc == 3
+        assert captured.out.strip() == ""  # stdout still empty
+        assert "agent-coherence-replay" in captured.err  # prose still on stderr
+
+    def test_session_dir_not_found_is_replay_trace_error_subclass(self) -> None:
+        """``SessionDirectoryNotFoundError`` must inherit
+        ``ReplayTraceError`` so the outer catch and the JSON envelope
+        both fire (Gated #15 route (a) invariant).
+        """
+        from ccs.replay import ReplayTraceError, SessionDirectoryNotFoundError
+        assert issubclass(SessionDirectoryNotFoundError, ReplayTraceError)
+
 
 # ---------------------------------------------------------------------------
 # JSON schema conformance


### PR DESCRIPTION
## Summary

When `--json` is active and a trace error fires (exit 3), emit a final NDJSON object to stdout before the existing stderr prose:

```json
{"kind": "error", "exit_code": 3, "exception": "<ClassName>", "message": "..."}
```

Keeps stdout self-contained for `--json` consumers so an agent capturing stdout can parse a single NDJSON stream end-to-end without special-casing the error path. Stderr prose retained for human log tailers.

Without `--json`, stdout stays empty on exit 3 — no behavior change for the default human path (regression guard test included).

### Route taken: (a) — centralize via subclass

Added `SessionDirectoryNotFoundError(ReplayTraceError)` and replaced the inline pre-flight `print+return 3` with `raise`. Outer `except (ReplayTraceError, OSError)` in `main()` now handles all four trace-error classes uniformly through one envelope code path.

Stacked on PR #69 (Gated #11 — `ReplayError` base class). Once #69 merges to `dev`, this branch rebases cleanly onto `dev`.

## Test plan

- [x] All three trace-error classes (`MultiInstanceTraceError`, `TraceCorruptionError`, `SessionDirectoryNotFoundError`) emit the envelope under `--json`
- [x] No-`--json` invocations keep stdout empty on exit 3 (regression guard)
- [x] `SessionDirectoryNotFoundError` inherits `ReplayTraceError` (route-(a) invariant test)
- [x] `D+1` roadmap pointer carries through to envelope `message` for multi-instance traces
- [x] Full suite green: 1437 passed, 2 skipped (was 1432; +5 new tests)
- [x] Architecture check clean (`tools/check_architecture.py`)
- [x] Manual smoke: `agent-coherence-replay <empty-dir> --json` emits one JSON line + stderr prose + exit 3

Origin: `docs/plans/2026-05-27-001-fix-d-v1-ce-review-gated-findings-plan.md` (Gated #15)
Review run: `.context/compound-engineering/ce-review/20260526-201844-d6ba0dc4/` — agent-native-reviewer warning 2 (confidence 0.85)