### PR TITLE
fix(replay,cli): CLI exception envelope — BrokenPipeError + internal-error guards (Gated #1)

### DIFF
--- a/src/ccs/cli/coherence_replay.py
+++ b/src/ccs/cli/coherence_replay.py
@@ -20,6 +20,14 @@ Exit-code mapping resolved in plan Open Question P1-A (mirrors
   exception's message is printed to stderr verbatim; tracebacks are
   caught so partners get the actionable next-step pointer instead of
   Python internals.
+- ``4`` — internal error (any other uncaught exception). Decouples
+  CLI bugs from CONFIRMED breach (exit 1) so agents triage cleanly.
+  The exception type + message land on stderr; Python tracebacks are
+  swallowed.
+
+Pipe-close handling: ``BrokenPipeError`` (e.g., from ``| head -5``)
+exits ``0`` — consumer-closed-pipe is not a failure mode and should
+not poison exit-code-driven CI pipelines.
 
 AMBIGUOUS suppression resolved in plan Open Question P1-B: per-finding
 output suppresses AMBIGUOUS by default; ``--include-ambiguous`` opts
@@ -66,6 +74,18 @@ def build_parser() -> argparse.ArgumentParser:
             "Replay a captured coordinator session and report invariant "
             "breaches. Consumes the trace format documented in "
             "docs/proposals/replay_trace_format.md."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Exit codes:\n"
+            "  0  Clean OR all SKIPPED reasons opted out via manifest streams=\n"
+            "     (also: BrokenPipeError — consumer closed the pipe early)\n"
+            "  1  >=1 CONFIRMED invariant breach\n"
+            "  2  >=1 SKIPPED for a stream declared but absent on disk "
+            "(capture bug)\n"
+            "  3  Trace error (manifest missing, MULTI_INSTANCE_TRACE, "
+            "TRACE_CORRUPTION_DUPLICATE_SEQ)\n"
+            "  4  Internal error (uncaught exception; CLI bug — file an issue)\n"
         ),
     )
     parser.add_argument(
@@ -126,17 +146,46 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Entry point — returns the exit code; never calls ``sys.exit``.
 
-    The full trace-error guard wraps load + walk + emit because the
-    loader's iterator is lazy: MultiInstance / TraceCorruption raise
-    mid-walk, not at ``load()`` time. Catching only ``load()`` would
-    leak a traceback when the corruption hides past the manifest.
+    Three guards in order of specificity:
+
+    - ``_TRACE_ERRORS + OSError`` (exit 3): the documented corrupted-
+      trace family + general read-time IO errors. The full guard wraps
+      load + walk + emit because the loader's iterator is lazy:
+      MultiInstance / TraceCorruption raise mid-walk, not at ``load()``
+      time. Catching only ``load()`` would leak a traceback when the
+      corruption hides past the manifest.
+    - ``BrokenPipeError`` (exit 0): consumer closed the pipe (e.g.
+      ``| head -5``). Not a failure; exit cleanly so CI scripts that
+      compose us with pagers / line-limiters don't accumulate false
+      positives. The ``__main__`` wrapper also guards a residual
+      BrokenPipeError during interpreter shutdown when Python tries to
+      flush stdout to the already-torn-down pipe.
+    - ``Exception`` (exit 4): anything else uncaught. Surfaces the
+      exception type + message on stderr; the traceback is swallowed
+      so partners get an actionable signal instead of Python internals.
+      Distinct from exit 1 (CONFIRMED breach) so agents triage cleanly.
     """
     args = build_parser().parse_args(argv)
     try:
         return _run(args)
+    except BrokenPipeError:
+        # Specific catch FIRST — BrokenPipeError inherits from OSError,
+        # so the broader except below would otherwise swallow it into
+        # exit 3. Consumer closed the pipe (e.g. ``| head``). Return
+        # cleanly; do NOT call sys.stderr.close() — it breaks pytest
+        # capture. The __main__ wrapper handles the residual
+        # shutdown-time BrokenPipeError via os._exit.
+        return 0
     except (ReplayTraceError, OSError) as exc:
         print(f"agent-coherence-replay: {exc}", file=sys.stderr)
         return 3
+    except Exception as exc:  # noqa: BLE001 — intentional translate-and-return
+        print(
+            f"agent-coherence-replay: internal error: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 4
 
 
 def _run(args: argparse.Namespace) -> int:
@@ -191,4 +240,14 @@ def _exit_code(
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    # Belt-and-suspenders for the entry point: a BrokenPipeError can
+    # still surface during interpreter shutdown if Python tries to flush
+    # stdout to a torn-down pipe after ``main()`` returns. Catching it
+    # here and exiting via ``os._exit`` skips the second flush attempt
+    # that would otherwise print "Exception ignored in: ..." to stderr.
+    import os
+
+    try:
+        raise SystemExit(main())
+    except BrokenPipeError:
+        os._exit(0)

--- a/tests/test_cli_coherence_replay.py
+++ b/tests/test_cli_coherence_replay.py
@@ -590,6 +590,77 @@ class TestTraceErrors:
 
 
 # ---------------------------------------------------------------------------
+# Exception envelope (Gated #1) — BrokenPipeError + uncaught Exception
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionEnvelope:
+    """BrokenPipeError -> exit 0; any other uncaught Exception -> exit 4.
+
+    Decouples CLI bugs / pipe-close from the CONFIRMED breach signal
+    (exit 1) so agent consumers can triage cleanly.
+    """
+
+    def test_broken_pipe_exits_zero(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A consumer that closes the pipe early (e.g. ``| head -1``)
+        # surfaces as BrokenPipeError on the next write. Replay treats
+        # it as benign — exit 0, not a failure.
+        session = _clean_session(tmp_path)
+
+        def raise_broken_pipe(*_args: Any, **_kwargs: Any) -> int:
+            raise BrokenPipeError(32, "Broken pipe")
+
+        monkeypatch.setattr("ccs.cli.coherence_replay._run", raise_broken_pipe)
+        rc = main([str(session)])
+        assert rc == 0
+
+    def test_internal_error_exits_four_with_stderr_message(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # An uncaught exception inside _run (loader bug, predicate
+        # crash, etc.) maps to exit 4 with a typed stderr line and
+        # no Python traceback.
+        session = _clean_session(tmp_path)
+
+        def raise_internal(*_args: Any, **_kwargs: Any) -> int:
+            raise RuntimeError("simulated CLI internal error")
+
+        monkeypatch.setattr("ccs.cli.coherence_replay._run", raise_internal)
+        rc = main([str(session)])
+        captured = capsys.readouterr()
+        assert rc == 4
+        assert "internal error" in captured.err
+        assert "RuntimeError" in captured.err
+        assert "simulated CLI internal error" in captured.err
+        assert "Traceback" not in captured.err
+
+    def test_internal_error_distinct_from_confirmed_breach(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Regression guard: exit 4 must not collide with exit 1
+        # (CONFIRMED breach) so agents distinguish "tool crashed" from
+        # "real coordination defect found."
+        session = _clean_session(tmp_path)
+
+        def raise_internal(*_args: Any, **_kwargs: Any) -> int:
+            raise ValueError("predicate fold bug")
+
+        monkeypatch.setattr("ccs.cli.coherence_replay._run", raise_internal)
+        rc = main([str(session)])
+        assert rc != 1
+        assert rc == 4
+
+
+# ---------------------------------------------------------------------------
 # JSON schema conformance
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Three guards in order of specificity inside `agent-coherence-replay:main`:

1. **`BrokenPipeError` FIRST → exit 0.** Consumer-closed-pipe (`| head -5`) is not a failure. Must come before the broader `OSError` catch because `BrokenPipeError` inherits `OSError` — without ordering, the broader handler swallows it into exit 3.
2. **`(*_TRACE_ERRORS, OSError)` → exit 3.** Existing dev behavior preserved.
3. **Generic `Exception` → exit 4** (new "internal error" tier). Surfaces type + message on stderr; traceback swallowed. Distinct from exit 1 (CONFIRMED breach) so agents triage cleanly between "tool crashed" and "real coordination defect found."

The `__main__` wrapper also catches the residual `BrokenPipeError` during interpreter shutdown and exits via `os._exit` to skip the second stdout-flush attempt that would otherwise print "Exception ignored in: ..." on stderr.

Module docstring + `--help` epilog updated to document exit 4 + the BrokenPipe note. Epilog rendered via `RawDescriptionHelpFormatter` so line breaks survive.

Origin: `docs/plans/2026-05-27-001-fix-d-v1-ce-review-gated-findings-plan.md` (Gated #1)
Review run: `.context/compound-engineering/ce-review/20260526-201844-d6ba0dc4/` — adversarial (0.97), reliability (0.88), cli-readiness (0.82)

## Test plan

- [x] `test_broken_pipe_exits_zero` — patches `_run` to raise `BrokenPipeError`; asserts exit 0
- [x] `test_internal_error_exits_four_with_stderr_message` — asserts format `agent-coherence-replay: internal error: <ExcType>: <msg>` and no traceback
- [x] `test_internal_error_distinct_from_confirmed_breach` — regression guard that exit 4 ≠ exit 1
- [x] Suite: 1427 passed, 2 skipped (1424 baseline + 3 new)
- [x] Architecture check clean
- [x] `--help` epilog renders all 5 exit codes