### PR TITLE
fix(adapters): public agent_names_snapshot + artifact_names_snapshot (Gated #17)

### DIFF
--- a/src/ccs/adapters/base.py
+++ b/src/ccs/adapters/base.py
@@ -116,6 +116,30 @@ class CoherenceAdapterCore:
         """Register a shared artifact in the coordinator directory."""
         return self.coordinator.register_artifact(name=name, content=content, size_tokens=size_tokens)
 
+    def agent_names_snapshot(self) -> dict[UUID, str]:
+        """Return a snapshot copy of the agent_id → name registry.
+
+        Stable public accessor for callers that need to enumerate
+        registered agents (e.g., replay-recorder manifest finalization).
+        Returns a fresh dict — mutation by the caller does NOT affect
+        the coordinator's internal state.
+        """
+        return dict(self._agent_names)
+
+    def artifact_names_snapshot(self) -> dict[UUID, str]:
+        """Return a snapshot copy of the artifact_id → name registry.
+
+        Mirrors ``agent_names_snapshot`` for symmetry. Drains the
+        artifact registry via the public ``registry.artifact_ids()`` +
+        ``registry.get_artifact()`` chain; returns a fresh dict.
+        """
+        names: dict[UUID, str] = {}
+        for artifact_id in self.registry.artifact_ids():
+            meta = self.registry.get_artifact(artifact_id)
+            if meta is not None:
+                names[artifact_id] = meta.name
+        return names
+
     def read(self, *, agent_name: str, artifact_id: UUID, now_tick: int) -> FetchResponse:
         """Read artifact through one registered runtime."""
         binding = self._binding(agent_name)

--- a/src/ccs/adapters/ccsstore.py
+++ b/src/ccs/adapters/ccsstore.py
@@ -632,16 +632,15 @@ def _drain_store_registries(store: CCSStore) -> tuple[dict[str, str], dict[str, 
     ``__exit__``. Returns ``(agents_by_uuid, artifacts_by_uuid)`` —
     UUID strings to display names. Empty dicts when no MESI activity
     has fired.
+
+    Routes through the public ``CoherenceAdapterCore`` snapshot accessors
+    (``agent_names_snapshot`` / ``artifact_names_snapshot``) so a rename
+    inside the coordinator surfaces at import time, not at manifest-
+    finalization time.
     """
     core = store.core
-    # agent_id (UUID) → name; sourced from the same dict that ArtifactRegistry
-    # uses for state_log entry naming.
-    agents = {str(uid): name for uid, name in core._agent_names.items()}
-    artifacts: dict[str, str] = {}
-    for artifact_id in core.registry.artifact_ids():
-        meta = core.registry.get_artifact(artifact_id)
-        if meta is not None:
-            artifacts[str(artifact_id)] = meta.name
+    agents = {str(uid): name for uid, name in core.agent_names_snapshot().items()}
+    artifacts = {str(uid): name for uid, name in core.artifact_names_snapshot().items()}
     return agents, artifacts
 
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -129,6 +129,59 @@ def test_agent_id_for_unknown_name_raises_key_error() -> None:
         pass
 
 
+# --- Public registry snapshot accessors (Gated #17) ---
+
+
+def test_agent_names_snapshot_empty_when_no_registrations() -> None:
+    core = CoherenceAdapterCore(strategy_name="lazy")
+    assert core.agent_names_snapshot() == {}
+
+
+def test_agent_names_snapshot_reflects_registrations() -> None:
+    core = CoherenceAdapterCore(strategy_name="lazy")
+    core.register_agent("planner")
+    core.register_agent("reviewer")
+    snapshot = core.agent_names_snapshot()
+    assert set(snapshot.values()) == {"planner", "reviewer"}
+    assert all(isinstance(k, type(core.agent_id_for("planner"))) for k in snapshot)
+
+
+def test_agent_names_snapshot_mutation_does_not_affect_core() -> None:
+    # Snapshot is a fresh dict — mutating it must not corrupt the
+    # coordinator's internal registry.
+    core = CoherenceAdapterCore(strategy_name="lazy")
+    core.register_agent("planner")
+    snapshot = core.agent_names_snapshot()
+    snapshot.clear()
+    snapshot["bogus"] = "injected"  # type: ignore[index]
+    fresh = core.agent_names_snapshot()
+    assert "injected" not in fresh.values()
+    assert "planner" in fresh.values()
+
+
+def test_artifact_names_snapshot_empty_when_no_artifacts() -> None:
+    core = CoherenceAdapterCore(strategy_name="lazy")
+    assert core.artifact_names_snapshot() == {}
+
+
+def test_artifact_names_snapshot_reflects_registrations() -> None:
+    core = CoherenceAdapterCore(strategy_name="lazy")
+    a = core.register_artifact(name="outline.md", content="x")
+    b = core.register_artifact(name="draft.md", content="y")
+    snapshot = core.artifact_names_snapshot()
+    assert snapshot[a.id] == "outline.md"
+    assert snapshot[b.id] == "draft.md"
+
+
+def test_artifact_names_snapshot_mutation_does_not_affect_core() -> None:
+    core = CoherenceAdapterCore(strategy_name="lazy")
+    core.register_artifact(name="outline.md", content="x")
+    snapshot = core.artifact_names_snapshot()
+    snapshot.clear()
+    fresh = core.artifact_names_snapshot()
+    assert "outline.md" in fresh.values()
+
+
 # --- Crash recovery adapter tests (Unit 2) ---
 
 


### PR DESCRIPTION
## Summary

\`CCSStore._drain_store_registries\` was reaching into \`core._agent_names\` — a private attribute of \`CoherenceAdapterCore\`. A rename inside the coordinator would silently break manifest agent population at trace-capture time (when partner sessions exit), not at import time.

Adds two public snapshot methods to \`CoherenceAdapterCore\`:

- \`agent_names_snapshot() -> dict[UUID, str]\`
- \`artifact_names_snapshot() -> dict[UUID, str]\`

Both return fresh dict copies; mutation by the caller does not affect coordinator state. Tested via explicit mutation-isolation regression guards.

\`_drain_store_registries\` now routes through both public accessors. A future rename of \`_agent_names\` would fail at import time (AttributeError) instead of at manifest-finalization.

Origin: \`docs/plans/2026-05-27-001-fix-d-v1-ce-review-gated-findings-plan.md\` (Gated #17)
Review run: \`.context/compound-engineering/ce-review/20260526-201844-d6ba0dc4/\` — maintainability MNT-04 (0.75)

## Test plan

- [x] Snapshot empty when no registrations
- [x] Snapshot reflects registrations (agents + artifacts)
- [x] Mutating the snapshot does NOT corrupt core's internal state (regression guards on both methods)
- [x] Existing CCSStore.record_to manifest finalization tests still pass (downstream consumer)
- [x] Suite: 1430 passed, 2 skipped (1424 baseline + 6 new); architecture check clean