### PR TITLE
fix(replay): RecordingSession.__enter__ fd cleanup on manifest write failure (Gated #4)

### DIFF
--- a/src/ccs/replay/recorder.py
+++ b/src/ccs/replay/recorder.py
@@ -275,9 +275,24 @@ class RecordingSession:
             self._writers[stream_name] = _open_stream(
                 self.session_dir, stream_name, active=active
             )
-        _atomic_write_manifest(
-            self.session_dir, _header_manifest(self.streams, self.adapter_type)
-        )
+        # __exit__ is NOT called when __enter__ raises (Python context-
+        # manager protocol), so any failure between opening fds above and
+        # the manifest write below would leak the open fds. Guard the
+        # manifest write and close any already-opened writers before
+        # re-raising (Gated #4).
+        try:
+            _atomic_write_manifest(
+                self.session_dir,
+                _header_manifest(self.streams, self.adapter_type),
+            )
+        except Exception:
+            for writer in self._writers.values():
+                try:
+                    writer.close()
+                except OSError:
+                    pass  # best-effort cleanup; original exception is what matters
+            self._writers.clear()
+            raise
         return self
 
     def __exit__(

--- a/tests/test_replay_recorder.py
+++ b/tests/test_replay_recorder.py
@@ -161,6 +161,64 @@ class TestManifestLifecycle:
 
 
 # ---------------------------------------------------------------------------
+# __enter__ fd cleanup on manifest write failure (Gated #4)
+# ---------------------------------------------------------------------------
+
+
+class TestEnterFdCleanup:
+    """If _atomic_write_manifest raises during __enter__, opened stream
+    writers must be closed before re-raising. Python's context-manager
+    protocol does NOT call __exit__ when __enter__ raises, so without
+    explicit cleanup the file descriptors would leak.
+    """
+
+    def test_manifest_write_failure_closes_opened_writers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Patch _atomic_write_manifest to raise on the __enter__ call
+        # (after writers are opened). The fix must close every writer
+        # in self._writers before re-raising.
+        from ccs.replay import recorder as recorder_mod
+
+        opened_writers: list[object] = []
+        original_open_stream = recorder_mod._open_stream
+
+        def tracking_open_stream(*args: Any, **kwargs: Any) -> object:
+            writer = original_open_stream(*args, **kwargs)
+            opened_writers.append(writer)
+            return writer
+
+        monkeypatch.setattr(recorder_mod, "_open_stream", tracking_open_stream)
+
+        def raise_on_manifest(*_a: Any, **_kw: Any) -> None:
+            raise OSError("simulated disk full on manifest tempfile")
+
+        monkeypatch.setattr(
+            recorder_mod, "_atomic_write_manifest", raise_on_manifest
+        )
+
+        session_dir = tmp_path / "session"
+        try:
+            with record_callbacks(session_dir, accept_unverified=True):
+                pytest.fail("__enter__ should have raised before yielding")
+        except OSError as exc:
+            assert "simulated disk full" in str(exc)
+
+        # Writers were opened (the fixture proves __enter__ reached the
+        # _atomic_write_manifest call) AND every writer is now closed.
+        assert len(opened_writers) > 0, "no writers were opened — fixture bug"
+        for writer in opened_writers:
+            # _StreamWriter.close() is idempotent; we assert closed-state
+            # via the underlying file handle attribute (active writers
+            # carry a non-None handle; closed ones are None).
+            handle = getattr(writer, "_handle", None)
+            assert handle is None or handle.closed, (
+                f"writer {writer!r} left an open file descriptor after "
+                f"__enter__ failure — fd leak"
+            )
+
+
+# ---------------------------------------------------------------------------
 # fsync-per-line contract
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

\`RecordingSession.__enter__\` opens stream writers (fds), then calls \`_atomic_write_manifest\`. If the manifest write raises (disk full, permission error, IO bug), Python's context-manager protocol does NOT call \`__exit__\` — opened fds in \`self._writers\` leak.

Fix: wrap the manifest write in try/except inside \`__enter__\`. On exception, best-effort close every writer (try/except around each \`close()\`, since the original exception is what matters), clear the dict, and re-raise.

One regression test patches \`_open_stream\` to track opened writers + \`_atomic_write_manifest\` to raise \`OSError\`. After the exception propagates out, every tracked writer's underlying handle must be closed.

Origin: \`docs/plans/2026-05-27-001-fix-d-v1-ce-review-gated-findings-plan.md\` (Gated #4)
Review run: \`.context/compound-engineering/ce-review/20260526-201844-d6ba0dc4/\` — reliability REL-02 (0.85) + kieran-python KP-2 (0.87), cross-reviewer agreement boost

## Test plan

- [x] Patched-OSError test confirms all opened writers closed after \`__enter__\` failure
- [x] Existing \`TestManifestLifecycle\` tests still pass (happy-path manifest write)
- [x] Suite: 1425 passed, 2 skipped (1424 baseline + 1 new); architecture check clean