### PR TITLE
fix(replay): record_to refuse-if-exists when session_dir contains manifest.json (Gated #2)

### DIFF
--- a/src/ccs/replay/__init__.py
+++ b/src/ccs/replay/__init__.py
@@ -71,6 +71,7 @@ from ccs.replay.formatters import (
 )
 from ccs.replay.recorder import (
     RecordingSession,
+    SessionDirectoryNotEmptyError,
     UnverifiedAdapterCaptureError,
     record_callbacks,
 )
@@ -88,6 +89,7 @@ __all__ = [
     "ReplayConfigurationError",
     "ReplayError",
     "ReplayTraceError",
+    "SessionDirectoryNotEmptyError",
     "SingleWriterPredicate",
     "StaleReadPredicate",
     "SummaryFinding",

--- a/src/ccs/replay/recorder.py
+++ b/src/ccs/replay/recorder.py
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "UnverifiedAdapterCaptureError",
+    "SessionDirectoryNotEmptyError",
     "RecordingSession",
     "record_callbacks",
     "DEFAULT_STREAMS",
@@ -102,6 +103,25 @@ class UnverifiedAdapterCaptureError(ReplayConfigurationError):
     Inherits from :class:`ccs.replay.ReplayConfigurationError` (API
     misuse) rather than :class:`ccs.replay.ReplayTraceError` — the
     trace itself never got written.
+    """
+
+
+class SessionDirectoryNotEmptyError(RuntimeError):
+    """Raised by ``RecordingSession.__enter__`` when ``session_dir`` already
+    contains a ``manifest.json``.
+
+    The capture path is append-mode on the JSONL files, so a second
+    ``record_to(path)`` against an existing session would silently
+    interleave entries from two coordinator instances. Replay would
+    later raise ``MultiInstanceTraceError`` or ``TraceCorruptionError``
+    *after* findings from the mixed session were already emitted —
+    a confusing, hard-to-diagnose failure mode for partners.
+
+    Refusing at capture time forces the caller to explicitly delete the
+    directory (``shutil.rmtree(path)``) or choose a different path. No
+    ``overwrite=True`` opt-in is offered in v1: the explicit imperative
+    is clearer than a flag, and the operation is rare enough that the
+    extra line is harmless.
     """
 
 
@@ -272,6 +292,21 @@ class RecordingSession:
 
     def __enter__(self) -> "RecordingSession":
         self.session_dir.mkdir(parents=True, exist_ok=True)
+        # Refuse-if-exists (Gated #2): a prior capture's manifest at this
+        # path means a second record_to would silently interleave JSONL
+        # entries from two coordinator instances; replay would later
+        # raise MultiInstance/TraceCorruption *after* findings from the
+        # mixed session had already been emitted. Force the caller to
+        # explicitly delete (shutil.rmtree) or choose a different path.
+        manifest_path = self.session_dir / "manifest.json"
+        if manifest_path.exists():
+            raise SessionDirectoryNotEmptyError(
+                f"session directory already contains a manifest.json: "
+                f"{self.session_dir}. Delete the directory or choose a "
+                f"different path before capturing — appending to an "
+                f"existing session would silently produce a "
+                f"multi-instance trace."
+            )
         # streams parameter declares what the manifest advertises; we
         # always open the audit no-op writer too so caller-supplied
         # audit callbacks still see the bookkeeping (instance_id tracking,

--- a/tests/test_replay_recorder.py
+++ b/tests/test_replay_recorder.py
@@ -24,7 +24,11 @@ from unittest.mock import patch
 
 import pytest
 
-from ccs.replay import UnverifiedAdapterCaptureError, record_callbacks
+from ccs.replay import (
+    SessionDirectoryNotEmptyError,
+    UnverifiedAdapterCaptureError,
+    record_callbacks,
+)
 from ccs.replay.recorder import (
     DEFAULT_STREAMS,
     SCHEMA_NOTE,
@@ -158,6 +162,81 @@ class TestManifestLifecycle:
         assert manifest["instance_id"] is None
         assert manifest["agents"] == {}
         assert manifest["artifacts"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Existing-path safety (Gated #2) — refuse-if-exists
+# ---------------------------------------------------------------------------
+
+
+class TestExistingPathSafety:
+    """A pre-existing manifest.json in session_dir means a second capture
+    would silently interleave entries from two coordinator instances.
+    Refuse at __enter__ so the failure surfaces before any new entries
+    land on disk."""
+
+    def test_pre_existing_manifest_raises(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "session"
+        # First capture completes normally — leaves a manifest behind.
+        with record_callbacks(session_dir, accept_unverified=True):
+            pass
+        assert (session_dir / "manifest.json").exists()
+
+        # Second capture against the same path must refuse.
+        with pytest.raises(SessionDirectoryNotEmptyError) as exc_info:
+            with record_callbacks(session_dir, accept_unverified=True):
+                pass
+        msg = str(exc_info.value)
+        assert "manifest.json" in msg
+        assert str(session_dir) in msg
+        assert "delete" in msg.lower() or "choose a different path" in msg.lower()
+
+    def test_pre_existing_manifest_does_not_overwrite_state_log(
+        self, tmp_path: Path,
+    ) -> None:
+        # Regression guard: the refuse-if-exists check fires BEFORE any
+        # stream writers open, so the prior state_log.jsonl is untouched
+        # when the second capture is rejected.
+        session_dir = tmp_path / "session"
+        with record_callbacks(
+            session_dir, accept_unverified=True
+        ) as (state_cb, _audit_cb):
+            state_cb(_state_log_entry(tick=1, instance_id="inst-original"))
+        original_state = (session_dir / "state_log.jsonl").read_bytes()
+
+        with pytest.raises(SessionDirectoryNotEmptyError):
+            with record_callbacks(session_dir, accept_unverified=True):
+                pass
+
+        # state_log.jsonl is byte-identical to what the first capture
+        # wrote — no append from the rejected second attempt.
+        assert (session_dir / "state_log.jsonl").read_bytes() == original_state
+
+    def test_empty_directory_succeeds(self, tmp_path: Path) -> None:
+        # Pre-existing empty directory is fine — only manifest.json
+        # presence triggers the refusal.
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        with record_callbacks(session_dir, accept_unverified=True):
+            pass
+        assert (session_dir / "manifest.json").exists()
+
+    def test_pre_existing_jsonl_without_manifest_succeeds(
+        self, tmp_path: Path,
+    ) -> None:
+        # A stray state_log.jsonl without a manifest is treated as
+        # incidental clutter — the manifest is the authoritative
+        # "session exists" marker. (The session's __enter__ opens the
+        # JSONL in append mode, so a partner pre-staging garbage data
+        # there would corrupt the trace, but that's a partner-side
+        # documentation matter, not something the refuse-if-exists
+        # gate is for.)
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        (session_dir / "state_log.jsonl").write_text("preexisting garbage\n")
+        with record_callbacks(session_dir, accept_unverified=True):
+            pass
+        assert (session_dir / "manifest.json").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A second \`record_to(path)\` against an existing session silently interleaves JSONL entries from two coordinator instances (append-mode file open + new manifest overwrite). Replay later raises \`MultiInstanceTraceError\` / \`TraceCorruptionError\` *after* findings from the mixed session have already been emitted.

Resolution: **refuse-if-exists**. \`RecordingSession.__enter__\` checks for \`manifest.json\` BEFORE opening stream writers; raises new \`SessionDirectoryNotEmptyError\` with an actionable message. The check fires before any file writes, so a rejected second attempt leaves the original \`state_log.jsonl\` byte-identical (regression-tested).

No \`overwrite=True\` flag in v1 — the explicit \`shutil.rmtree(path)\` imperative is clearer than a feature flag, and the rare clobber case is one line.

Origin: \`docs/plans/2026-05-27-001-fix-d-v1-ce-review-gated-findings-plan.md\` (Gated #2)
Review run: \`.context/compound-engineering/ce-review/20260526-201844-d6ba0dc4/\` — adversarial ADV-01 (0.92), reliability residual

## Test plan

- [x] Pre-existing manifest → raises with actionable message
- [x] Regression guard: state_log.jsonl byte-identical after refusal (no partial overwrite)
- [x] Empty pre-existing directory → succeeds (refusal is scoped to manifest.json only)
- [x] Pre-existing JSONL without manifest → succeeds (manifest is the authoritative "session exists" marker)
- [x] Suite: 1428 passed, 2 skipped (1424 baseline + 4 new); architecture check clean