### PR TITLE
feat(coordinator): v0.8.3 crash-recovery default-flip deprecation cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Alpha — APIs may change before `v1.0`.
 
 ## [Unreleased]
 
-(No unreleased work at the moment — v0.8.3 was tagged 2026-05-29.)
+(No unreleased work beyond the v0.8.3 entry below, which is prepared on
+this branch but not yet tagged — it ships via the dev → main → tag-push
+release flow.)
 
 ## [0.8.3] — 2026-05-29
 
@@ -52,11 +54,21 @@ for the underlying sweep semantics.
 ### Internal
 
 - `CrashRecoveryConfig` distinguishes bare construction from explicit
-  `enabled=False` via a module-level sentinel default and a
+  `enabled=False` via a *falsy* module-level sentinel default and a
   `__post_init__` normalization step that uses `object.__setattr__` to
-  satisfy the `frozen=True` constraint. A module-level emit-once flag
-  ensures the deprecation warning fires at most once per process.
-  Both the sentinel mechanism and the flag are removed in v0.9.0.
+  satisfy the `frozen=True` constraint. The sentinel is deliberately
+  falsy so that any path which skips normalization — `importlib.reload`
+  rebinding the module sentinel (gunicorn/uvicorn `--reload`, Jupyter
+  autoreload), or a subclass `__post_init__` that omits `super()` —
+  still reads as disabled rather than silently activating the sweep.
+- The deprecation signal fires at most once per process (a thread-safe
+  emit-once guard) on **two** channels: the `warnings` system *and* a
+  WARNING-level log record on the `ccs.coordinator.service` logger. The
+  second channel ensures the migration signal survives CPython's default
+  `DeprecationWarning` filter, which suppresses warnings raised from
+  non-`__main__` importers — i.e. virtually every SDK consumer. The
+  sentinel, the guard, and the dual-channel emit are all removed in
+  v0.9.0.
 - A library-internal helper (in `ccs.coordinator.service`) lets
   library code paths (`ccs.simulation.engine`, `ccs.adapters.base`)
   construct the v0.8.x default-disabled config object without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,66 @@ Alpha — APIs may change before `v1.0`.
 
 ## [Unreleased]
 
-(No unreleased work at the moment — v0.8.2 was tagged 2026-05-28.)
+(No unreleased work at the moment — v0.8.3 was tagged 2026-05-29.)
+
+## [0.8.3] — 2026-05-29
+
+**First behavioral default-flip in the library's history.** v0.8.3 is a
+deprecation-only release: it adds a one-shot `DeprecationWarning` to bare
+`CrashRecoveryConfig()` construction announcing the v0.9.0 default flip
+from `enabled=False` to `enabled=True`. **No behavior changes ship in
+v0.8.3.** Downstream consumers get one release cycle to surface false-
+reclaim issues under their own workloads before the flip lands.
+
+This is novel for this repo — the only prior deprecation precedent
+(`coordinator_uptime_s` rename + alias in v0.8.0) was a field rename, not
+a behavior default change. Operators who depend on the v0.8.x
+default-disabled behavior have two clear paths to silence the warning:
+
+- **Recommended migration**: pass `CrashRecoveryConfig(enabled=True)` to
+  opt in now and surface any false-reclaim issues under your workload
+  before v0.9.0 ships.
+- **Preserve current behavior**: pass `CrashRecoveryConfig(enabled=False)`
+  explicitly. Crash recovery stays off; the warning stays silent.
+
+See [`docs/plans/2026-05-28-001-feat-c-flip-crash-recovery-default-on-plan.md`](docs/plans/2026-05-28-001-feat-c-flip-crash-recovery-default-on-plan.md)
+for the full two-release migration plan (v0.8.3 deprecation → v0.9.0 flip +
+sweep wiring) and [`docs/specs/crash-recovery.md`](docs/specs/crash-recovery.md)
+for the underlying sweep semantics.
+
+### Changed
+
+- **Behavior change preview — v0.9.0 will flip
+  `CrashRecoveryConfig().enabled` from `False` to `True`.** v0.8.3
+  emits `DeprecationWarning` exactly once per process on the first
+  bare `CrashRecoveryConfig()` construction. The warning names both
+  silence paths (`enabled=True` opt-in or `enabled=False` opt-out) and
+  the target release.
+- Composition rule (R11) is unaffected: explicit
+  `CrashRecoveryConfig(enabled=True, max_hold_ticks=…)` continues to
+  validate against the longest inspectable strategy lease TTL via
+  `validate_crash_recovery_config`. v0.9.0 will additionally retune
+  `heartbeat_timeout_ticks` and `max_hold_ticks` from sim-anchor values
+  (10 / 1000) to batch-tick-realistic defaults (120 / 900) — see the
+  plan above for the calibration rationale.
+
+### Internal
+
+- `CrashRecoveryConfig.enabled` is now declared as
+  `field(default=_DEFAULT_ENABLED_SENTINEL)` so `__post_init__` can
+  distinguish bare construction from explicit `enabled=False`. The
+  dataclass remains `frozen=True`; normalization uses
+  `object.__setattr__`. Both the sentinel and the module-level
+  `_BARE_CONSTRUCTION_WARNED` flag are removed in v0.9.0.
+- New internal helper `_default_disabled_config()` in
+  `ccs.coordinator.service` lets library-internal code paths
+  (`ccs.simulation.engine`, `ccs.adapters.base`) construct the
+  v0.8.x default-disabled config object without surfacing the
+  deprecation warning to users. Removed in v0.9.0.
+- Architecture-level regression gate
+  (`tests/test_architecture.py::test_no_bare_crash_recovery_config_construction_in_src`)
+  asserts no bare `CrashRecoveryConfig()` call sites exist in `src/`.
+  Catches accidental re-introduction in future patches.
 
 ## [0.8.2] — 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,17 +51,16 @@ for the underlying sweep semantics.
 
 ### Internal
 
-- `CrashRecoveryConfig.enabled` is now declared as
-  `field(default=_DEFAULT_ENABLED_SENTINEL)` so `__post_init__` can
-  distinguish bare construction from explicit `enabled=False`. The
-  dataclass remains `frozen=True`; normalization uses
-  `object.__setattr__`. Both the sentinel and the module-level
-  `_BARE_CONSTRUCTION_WARNED` flag are removed in v0.9.0.
-- New internal helper `_default_disabled_config()` in
-  `ccs.coordinator.service` lets library-internal code paths
-  (`ccs.simulation.engine`, `ccs.adapters.base`) construct the
-  v0.8.x default-disabled config object without surfacing the
-  deprecation warning to users. Removed in v0.9.0.
+- `CrashRecoveryConfig` distinguishes bare construction from explicit
+  `enabled=False` via a module-level sentinel default and a
+  `__post_init__` normalization step that uses `object.__setattr__` to
+  satisfy the `frozen=True` constraint. A module-level emit-once flag
+  ensures the deprecation warning fires at most once per process.
+  Both the sentinel mechanism and the flag are removed in v0.9.0.
+- A library-internal helper (in `ccs.coordinator.service`) lets
+  library code paths (`ccs.simulation.engine`, `ccs.adapters.base`)
+  construct the v0.8.x default-disabled config object without
+  surfacing the deprecation warning to users. Removed in v0.9.0.
 - Architecture-level regression gate
   (`tests/test_architecture.py::test_no_bare_crash_recovery_config_construction_in_src`)
   asserts no bare `CrashRecoveryConfig()` call sites exist in `src/`.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -319,6 +319,16 @@ When an agent crashes (OOM-kill, segfault) or livelocks (holds a grant indefinit
 its `MODIFIED` or `EXCLUSIVE` grant blocks all other agents from writing to that artifact.
 The crash-recovery extension reclaims stale grants automatically.
 
+> **Deprecation — default flips in v0.9.0.** As of **v0.8.3**, constructing
+> `CrashRecoveryConfig()` without an explicit `enabled=` emits a one-shot
+> `DeprecationWarning`: the default changes from `enabled=False` to
+> `enabled=True` in **v0.9.0**. Pass `enabled=` explicitly to silence the
+> warning and pin your intended behavior — `CrashRecoveryConfig(enabled=True)`
+> to opt in now, or `CrashRecoveryConfig(enabled=False)` to keep crash
+> recovery off. See [CHANGELOG.md](../CHANGELOG.md) for the full migration
+> notes (including the v0.9.0 `heartbeat_timeout_ticks` / `max_hold_ticks`
+> retuning).
+
 ### Enabling
 
 ```python

--- a/src/ccs/adapters/base.py
+++ b/src/ccs/adapters/base.py
@@ -16,6 +16,7 @@ from ccs.coordinator.registry import ArtifactRegistry
 from ccs.coordinator.service import (
     CoordinatorService,
     CrashRecoveryConfig,
+    _default_disabled_config,
     validate_crash_recovery_config,
 )
 from ccs.core.types import Artifact, FetchResponse
@@ -56,7 +57,14 @@ class CoherenceAdapterCore:
         self._instance_id = instance_id
         self._content_audit_log = content_audit_log
         self._audit_seq = audit_seq
-        self._crash_recovery = crash_recovery if crash_recovery is not None else CrashRecoveryConfig()
+        # Use _default_disabled_config() to avoid surfacing the v0.8.3
+        # DeprecationWarning on every bare CoherenceAdapterCore() / CCSStore()
+        # construction. The user did not pass crash_recovery=; their bare
+        # adapter call should not look like a misconfigured CrashRecoveryConfig
+        # site to them.
+        self._crash_recovery = (
+            crash_recovery if crash_recovery is not None else _default_disabled_config()
+        )
         self.registry = ArtifactRegistry(
             state_log=state_log,
             agent_names=self._agent_names,

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -26,6 +26,18 @@ from .registry import ArtifactRegistry
 # Module-level sentinel distinguishes bare CrashRecoveryConfig() from
 # explicit CrashRecoveryConfig(enabled=False). Both the sentinel and the
 # emit-once flag are removed in v0.9.0 when the default flips to True.
+#
+# Test-isolation contract: ``_BARE_CONSTRUCTION_WARNED`` is module-level
+# mutable state that persists across pytest test functions in the same
+# process. Tests that assert on warning emission MUST reset it to ``False``
+# before the bare construction (either directly via
+# ``service._BARE_CONSTRUCTION_WARNED = False`` or via the
+# ``reset_bare_construction_flag`` pytest fixture in
+# ``tests/test_coordinator.py``). Without the reset, test ordering
+# determines whether the first test sees the warning and later tests do
+# not — a silent-degrade failure mode under pytest-xdist or randomized
+# ordering. The reset is paired with the flag's lifecycle by intent: this
+# whole block is removed in v0.9.0 along with the test fixture.
 _DEFAULT_ENABLED_SENTINEL: object = object()
 _BARE_CONSTRUCTION_WARNED: bool = False
 
@@ -73,7 +85,9 @@ class CrashRecoveryConfig:
                     "surface any false-reclaim issues under your workload. "
                     "If you have a specific reason to keep crash recovery "
                     "off, pass CrashRecoveryConfig(enabled=False) "
-                    "explicitly. See CHANGELOG v0.8.3 for migration details.",
+                    "explicitly. See CHANGELOG.md (section: [0.8.3]) at "
+                    "https://github.com/hipvlady/agent-coherence/blob/main/CHANGELOG.md "
+                    "for migration details.",
                     DeprecationWarning,
                     stacklevel=3,
                 )

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable, Optional
 from uuid import UUID
 
@@ -22,16 +22,26 @@ from ccs.core.types import Artifact, FetchRequest, FetchResponse, InvalidationSi
 from .registry import ArtifactRegistry
 
 
+# v0.8.3 deprecation cycle — see docs/plans/2026-05-28-001-feat-c-flip-...
+# Module-level sentinel distinguishes bare CrashRecoveryConfig() from
+# explicit CrashRecoveryConfig(enabled=False). Both the sentinel and the
+# emit-once flag are removed in v0.9.0 when the default flips to True.
+_DEFAULT_ENABLED_SENTINEL: object = object()
+_BARE_CONSTRUCTION_WARNED: bool = False
+
+
 @dataclass(frozen=True)
 class CrashRecoveryConfig:
     """Configuration knobs for the stable-grant reclamation sweep.
 
-    The sweep ships disabled by default (R10) and is gated on the TLA+
-    amendment before any default-on flip.
+    The sweep ships disabled by default in v0.8.x (R10). The default
+    will flip to ``enabled=True`` in v0.9.0; bare ``CrashRecoveryConfig()``
+    in v0.8.3 emits a ``DeprecationWarning`` once per process to warn
+    downstream consumers ahead of the flip.
 
     Attributes:
-        enabled: Master flag. When ``False`` (default), the sweep is never
-            invoked and no heartbeat is required.
+        enabled: Master flag. When ``False`` (v0.8.x default), the sweep
+            is never invoked and no heartbeat is required.
         heartbeat_timeout_ticks: Sweep reclaims any M∪E grant whose holder
             has not heartbeated within this many ticks.
         max_hold_ticks: Sweep reclaims any M∪E grant held for at least this
@@ -39,9 +49,55 @@ class CrashRecoveryConfig:
             inspectable strategy lease TTL when ``enabled=True`` (R11).
     """
 
-    enabled: bool = False
+    # field(default=_DEFAULT_ENABLED_SENTINEL) lets __post_init__ distinguish
+    # bare construction from explicit False; the type-ignore is necessary
+    # because the runtime sentinel is not a bool but the public type is.
+    enabled: bool = field(default=_DEFAULT_ENABLED_SENTINEL)  # type: ignore[assignment]
     heartbeat_timeout_ticks: int = 10
     max_hold_ticks: int = 1000
+
+    def __post_init__(self) -> None:
+        """Detect bare construction; emit one-shot DeprecationWarning.
+
+        The dataclass is ``frozen=True``, so we normalize the sentinel-typed
+        ``enabled`` field via ``object.__setattr__`` (direct assignment would
+        raise ``FrozenInstanceError``).
+        """
+        global _BARE_CONSTRUCTION_WARNED
+        if self.enabled is _DEFAULT_ENABLED_SENTINEL:
+            if not _BARE_CONSTRUCTION_WARNED:
+                warnings.warn(
+                    "CrashRecoveryConfig() default will flip to "
+                    "`enabled=True` in v0.9.0. Recommended migration: pass "
+                    "CrashRecoveryConfig(enabled=True) to opt in now and "
+                    "surface any false-reclaim issues under your workload. "
+                    "If you have a specific reason to keep crash recovery "
+                    "off, pass CrashRecoveryConfig(enabled=False) "
+                    "explicitly. See CHANGELOG v0.8.3 for migration details.",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+                _BARE_CONSTRUCTION_WARNED = True
+            # frozen dataclass — direct assignment raises FrozenInstanceError.
+            # object.__setattr__ is the documented escape for __post_init__
+            # normalization on frozen dataclasses.
+            object.__setattr__(self, "enabled", False)
+
+
+def _default_disabled_config() -> CrashRecoveryConfig:
+    """Internal helper: construct ``CrashRecoveryConfig(enabled=False)``
+    without triggering the v0.8.3 bare-construction ``DeprecationWarning``.
+
+    Used by library-internal code paths (``simulation.engine``,
+    ``adapters.base``) that need the v0.8.x default-disabled config object
+    but should not surface the deprecation warning to end users — the bare
+    construction is the library's own, not the user's, so it would be a
+    false alarm.
+
+    Removed in v0.9.0 when the default flips to ``enabled=True`` and the
+    sentinel mechanism is unwound.
+    """
+    return CrashRecoveryConfig(enabled=False)
 
 
 def validate_crash_recovery_config(

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 import warnings
 from dataclasses import dataclass, field
 from typing import Callable, Optional
@@ -23,10 +24,42 @@ from .registry import ArtifactRegistry
 
 
 # v0.8.3 deprecation cycle — see docs/plans/2026-05-28-001-feat-c-flip-...
-# Module-level sentinel distinguishes bare CrashRecoveryConfig() from
-# explicit CrashRecoveryConfig(enabled=False). Both the sentinel and the
-# emit-once flag are removed in v0.9.0 when the default flips to True.
-#
+# A module-level sentinel distinguishes bare ``CrashRecoveryConfig()`` from
+# explicit ``CrashRecoveryConfig(enabled=False)``. The sentinel, the
+# emit-once flag, the lock, and the message constant are all removed in
+# v0.9.0 when the default flips to ``enabled=True``.
+
+
+class _DefaultEnabledSentinel:
+    """Falsy marker for an unspecified ``enabled`` in ``CrashRecoveryConfig``.
+
+    ``__post_init__`` uses identity (``is``) to detect bare construction and
+    normalize ``enabled`` to ``False``. The sentinel is deliberately *falsy*
+    so that on the rare paths where normalization is skipped, the value still
+    reads as disabled — matching the v0.8.x default and keeping the crash
+    recovery sweep from silently activating:
+
+    * ``importlib.reload`` (gunicorn/uvicorn ``--reload``, Jupyter autoreload)
+      re-executes this module in place, rebinding ``_DEFAULT_ENABLED_SENTINEL``
+      to a fresh instance. An instance of the *pre-reload* class still carries
+      the old sentinel as its field default, so the ``is`` check fails and
+      normalization is skipped (ce:review ADV-01).
+    * A subclass whose ``__post_init__`` overrides ours without calling
+      ``super().__post_init__()`` never normalizes at all (ce:review ADV-03).
+
+    In both cases ``bool(enabled)`` is ``False``, so production checks of the
+    form ``if self._crash_recovery.enabled:`` stay correct. Removed in v0.9.0.
+    """
+
+    __slots__ = ()
+
+    def __bool__(self) -> bool:
+        return False
+
+    def __repr__(self) -> str:
+        return "<CrashRecoveryConfig.enabled unset>"
+
+
 # Test-isolation contract: ``_BARE_CONSTRUCTION_WARNED`` is module-level
 # mutable state that persists across pytest test functions in the same
 # process. Tests that assert on warning emission MUST reset it to ``False``
@@ -38,8 +71,31 @@ from .registry import ArtifactRegistry
 # not — a silent-degrade failure mode under pytest-xdist or randomized
 # ordering. The reset is paired with the flag's lifecycle by intent: this
 # whole block is removed in v0.9.0 along with the test fixture.
-_DEFAULT_ENABLED_SENTINEL: object = object()
+#
+# ``_BARE_CONSTRUCTION_LOCK`` makes the check-then-set atomic so two threads
+# constructing bare configs concurrently cannot both emit. The GIL made the
+# naive check incidentally safe; free-threaded Python 3.13+ removes it. This
+# mirrors the ``threading.Lock`` pattern the plan's KD-4 specifies for the
+# v0.9.0 first-use guard (ce:review ADV-02).
+_DEFAULT_ENABLED_SENTINEL = _DefaultEnabledSentinel()
 _BARE_CONSTRUCTION_WARNED: bool = False
+_BARE_CONSTRUCTION_LOCK = threading.Lock()
+
+# Emitted on BOTH the warnings channel (visible under ``-W`` / pytest) and the
+# logging channel (visible under any ``logging.basicConfig()`` — the common
+# case CPython's default ``DeprecationWarning`` filter hides for non-__main__
+# importers). These are two of the three RM-9 belt-and-suspenders layers; the
+# third is the v0.9.0 transitional first-use warning. Removed in v0.9.0.
+_BARE_CONSTRUCTION_MESSAGE = (
+    "CrashRecoveryConfig() default will flip to `enabled=True` in v0.9.0. "
+    "Recommended migration: pass CrashRecoveryConfig(enabled=True) to opt in "
+    "now and surface any false-reclaim issues under your workload. If you "
+    "have a specific reason to keep crash recovery off, pass "
+    "CrashRecoveryConfig(enabled=False) explicitly. See CHANGELOG.md "
+    "(section: [0.8.3]) at "
+    "https://github.com/hipvlady/agent-coherence/blob/main/CHANGELOG.md "
+    "for migration details."
+)
 
 
 @dataclass(frozen=True)
@@ -69,7 +125,7 @@ class CrashRecoveryConfig:
     max_hold_ticks: int = 1000
 
     def __post_init__(self) -> None:
-        """Detect bare construction; emit one-shot DeprecationWarning.
+        """Detect bare construction; emit the one-shot deprecation signal.
 
         The dataclass is ``frozen=True``, so we normalize the sentinel-typed
         ``enabled`` field via ``object.__setattr__`` (direct assignment would
@@ -77,21 +133,23 @@ class CrashRecoveryConfig:
         """
         global _BARE_CONSTRUCTION_WARNED
         if self.enabled is _DEFAULT_ENABLED_SENTINEL:
-            if not _BARE_CONSTRUCTION_WARNED:
+            # Claim the one-shot emission atomically under the lock, then emit
+            # OUTSIDE it: warning filters and logging handlers can run arbitrary
+            # user code, and we never hold the lock across that (ADV-02).
+            should_emit = False
+            with _BARE_CONSTRUCTION_LOCK:
+                if not _BARE_CONSTRUCTION_WARNED:
+                    _BARE_CONSTRUCTION_WARNED = True
+                    should_emit = True
+            if should_emit:
+                # logging first, so the migration signal is recorded even when
+                # ``-W error`` escalates the DeprecationWarning into a raise
+                # (and so it survives CPython's default filter — RM-9 Layer 2).
+                logger.warning(_BARE_CONSTRUCTION_MESSAGE)
+                # stacklevel=3: warn() -> __post_init__ -> __init__ -> caller.
                 warnings.warn(
-                    "CrashRecoveryConfig() default will flip to "
-                    "`enabled=True` in v0.9.0. Recommended migration: pass "
-                    "CrashRecoveryConfig(enabled=True) to opt in now and "
-                    "surface any false-reclaim issues under your workload. "
-                    "If you have a specific reason to keep crash recovery "
-                    "off, pass CrashRecoveryConfig(enabled=False) "
-                    "explicitly. See CHANGELOG.md (section: [0.8.3]) at "
-                    "https://github.com/hipvlady/agent-coherence/blob/main/CHANGELOG.md "
-                    "for migration details.",
-                    DeprecationWarning,
-                    stacklevel=3,
+                    _BARE_CONSTRUCTION_MESSAGE, DeprecationWarning, stacklevel=3
                 )
-                _BARE_CONSTRUCTION_WARNED = True
             # frozen dataclass — direct assignment raises FrozenInstanceError.
             # object.__setattr__ is the documented escape for __post_init__
             # normalization on frozen dataclasses.

--- a/src/ccs/simulation/engine.py
+++ b/src/ccs/simulation/engine.py
@@ -15,6 +15,7 @@ from ccs.coordinator.registry import ArtifactRegistry
 from ccs.coordinator.service import (
     CoordinatorService,
     CrashRecoveryConfig,
+    _default_disabled_config,
     validate_crash_recovery_config,
 )
 from ccs.core.clock import LogicalClock
@@ -43,9 +44,14 @@ class _FailureEvent:
 
 
 def _build_crash_recovery_config(scenario_config: Mapping[str, Any]) -> CrashRecoveryConfig:
-    """Read optional ``crash_recovery`` block from scenario; default to safe values."""
+    """Read optional ``crash_recovery`` block from scenario; default to safe values.
+
+    Uses ``_default_disabled_config()`` (not bare ``CrashRecoveryConfig()``)
+    to avoid surfacing the v0.8.3 ``DeprecationWarning`` on every
+    ``SimulationEngine`` instantiation that omits a ``crash_recovery`` block.
+    """
     block = scenario_config.get("crash_recovery") or {}
-    defaults = CrashRecoveryConfig()
+    defaults = _default_disabled_config()
     return CrashRecoveryConfig(
         enabled=bool(block.get("enabled", defaults.enabled)),
         heartbeat_timeout_ticks=int(

--- a/tests/adapters/test_ccsstore.py
+++ b/tests/adapters/test_ccsstore.py
@@ -1040,3 +1040,29 @@ def test_ccsstore_flag_off_heartbeat_noop() -> None:
 
     agent_id = store.core.agent_id_for("planner")
     assert store.core.registry.last_heartbeat_tick(agent_id) is None
+
+
+# ---- v0.8.3 C-flip Unit 2 — R2 internal-bare-construction hygiene ------------
+#
+# See docs/plans/2026-05-28-001-feat-c-flip-crash-recovery-default-on-plan.md
+# Unit 2. The most-common adapter construction path (bare CCSStore() with no
+# crash_recovery= argument) traverses CoherenceAdapterCore.__init__ which used
+# to bare-construct CrashRecoveryConfig() — that emitted the v0.8.3
+# DeprecationWarning from inside library code, indistinguishable to users
+# from their own code. Test that the helper fix removed this.
+
+
+def test_bare_ccsstore_emits_no_deprecation_warning() -> None:
+    """R2: CCSStore() with no crash_recovery= must not surface the v0.8.3 warning."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        store = CCSStore(strategy="lazy")
+    deprecation_warnings = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert deprecation_warnings == [], (
+        f"bare CCSStore construction must not emit DeprecationWarning, got: "
+        f"{[str(w.message) for w in deprecation_warnings]}"
+    )
+    # And the v0.8.x default behavior is preserved.
+    assert store.core._crash_recovery.enabled is False

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -422,3 +422,43 @@ def test_flag_off_heartbeat_is_noop() -> None:
     core.heartbeat(agent_name="A", now_tick=42)
 
     assert core.registry.last_heartbeat_tick(core.agent_id_for("A")) is None
+
+
+# ---- v0.8.3 C-flip Unit 2 — R2 internal-bare-construction hygiene ------------
+#
+# See docs/plans/2026-05-28-001-feat-c-flip-crash-recovery-default-on-plan.md
+# Unit 2. The library's own adapter __init__ fallbacks must not surface the
+# v0.8.3 deprecation warning to users who construct adapters without passing
+# crash_recovery=. The user's bare CoherenceAdapterCore() / CCSStore() call
+# should not look like a misconfigured CrashRecoveryConfig site to them.
+
+
+def test_bare_coherence_adapter_core_emits_no_deprecation_warning() -> None:
+    """R2: CoherenceAdapterCore() with no crash_recovery= must not warn."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        core = CoherenceAdapterCore(strategy_name="lazy")
+    deprecation_warnings = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert deprecation_warnings == [], (
+        f"bare CoherenceAdapterCore construction must not emit "
+        f"DeprecationWarning, got: {[str(w.message) for w in deprecation_warnings]}"
+    )
+    # And the v0.8.x default behavior is preserved.
+    assert core._crash_recovery.enabled is False
+
+
+def test_explicit_crash_recovery_kwarg_emits_no_deprecation_warning() -> None:
+    """Passing an explicit CrashRecoveryConfig must not warn either."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        core = CoherenceAdapterCore(
+            strategy_name="lazy",
+            crash_recovery=CrashRecoveryConfig(enabled=True),
+        )
+    deprecation_warnings = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert deprecation_warnings == []
+    assert core._crash_recovery.enabled is True

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -38,3 +38,78 @@ def test_boundary_violation_detection_reports_forbidden_edge() -> None:
     assert len(violations) == 1
     assert "ccs.core.types" in violations[0]
     assert "ccs.simulation.engine" in violations[0]
+
+
+# ---- v0.8.3 C-flip Unit 3 grep-gate -----------------------------------------
+#
+# See docs/plans/2026-05-28-001-feat-c-flip-crash-recovery-default-on-plan.md
+# Unit 3. During the v0.8.3 → v0.9.0 deprecation window, library-internal
+# bare ``CrashRecoveryConfig()`` calls would surface the DeprecationWarning
+# from inside library code (per R2). This regression gate codifies the
+# guarantee: no bare construction sites in src/ outside the helper itself.
+#
+# This entire test (and its helper) is REMOVED in v0.9.0 when the deprecation
+# warning is also removed and bare ``CrashRecoveryConfig()`` becomes safe again.
+
+
+import ast  # noqa: E402
+
+
+def _find_bare_crash_recovery_config_sites(src_root: Path) -> list[str]:
+    """Return repo-relative paths + line numbers of bare CrashRecoveryConfig()
+    call sites in src/, EXCLUDING the helper definition in service.py.
+
+    A "bare" call is ``CrashRecoveryConfig()`` with zero positional and zero
+    keyword arguments. Explicit constructions like ``CrashRecoveryConfig(
+    enabled=False)`` or ``CrashRecoveryConfig(enabled=True, ...)`` are
+    permitted because they bypass the sentinel detection.
+    """
+    findings: list[str] = []
+    for py_path in src_root.rglob("*.py"):
+        # Skip the helper definition itself — _default_disabled_config builds
+        # CrashRecoveryConfig(enabled=False) which has kwargs, so it is not
+        # bare; nothing to exclude here, but kept for clarity.
+        try:
+            tree = ast.parse(py_path.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            # Match `CrashRecoveryConfig(...)` (Name) and
+            # `module.CrashRecoveryConfig(...)` (Attribute).
+            name = None
+            if isinstance(func, ast.Name):
+                name = func.id
+            elif isinstance(func, ast.Attribute):
+                name = func.attr
+            if name != "CrashRecoveryConfig":
+                continue
+            if node.args or node.keywords:
+                continue  # explicit construction — bypasses the sentinel
+            rel = py_path.relative_to(src_root.parent)
+            findings.append(f"{rel}:{node.lineno}")
+    return sorted(findings)
+
+
+def test_no_bare_crash_recovery_config_construction_in_src() -> None:
+    """v0.8.3 R2 regression gate: zero bare CrashRecoveryConfig() in src/.
+
+    Library-internal code must use _default_disabled_config() or pass
+    enabled= explicitly. This test prevents a future patch from silently
+    re-introducing a bare construction site that would surface the
+    v0.8.3 DeprecationWarning to users from inside library code.
+
+    REMOVED in v0.9.0 when the deprecation warning is also removed.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    src_root = repo_root / "src"
+    sites = _find_bare_crash_recovery_config_sites(src_root)
+    assert sites == [], (
+        "Bare CrashRecoveryConfig() construction sites found in src/. "
+        "During the v0.8.3 deprecation window, these surface a "
+        "DeprecationWarning to users from library-internal code. "
+        "Use _default_disabled_config() or pass enabled= explicitly.\n"
+        f"Sites: {sites}"
+    )

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 from ccs.hardening.architecture import find_boundary_violations, find_cycles, run_architecture_checks
@@ -50,9 +51,6 @@ def test_boundary_violation_detection_reports_forbidden_edge() -> None:
 #
 # This entire test (and its helper) is REMOVED in v0.9.0 when the deprecation
 # warning is also removed and bare ``CrashRecoveryConfig()`` becomes safe again.
-
-
-import ast  # noqa: E402
 
 
 def _find_bare_crash_recovery_config_sites(src_root: Path) -> list[str]:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -624,6 +624,12 @@ class TestCrashRecoveryDeprecationWarning:
         with _warnings.catch_warnings(record=True) as caught:
             _warnings.simplefilter("always")
             CrashRecoveryConfig()
+        # Length guard before indexing — without it, a regression that drops
+        # the warning emission entirely surfaces as IndexError instead of an
+        # informative AssertionError, masking the actual failure mode.
+        assert len(caught) >= 1, (
+            "bare CrashRecoveryConfig() must emit a warning; got 0 warnings"
+        )
         msg = str(caught[0].message)
         assert "enabled=True" in msg, "warning must name the recommended opt-in"
         assert "enabled=False" in msg, "warning must name the explicit opt-out"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -712,3 +712,169 @@ class TestCrashRecoveryDeprecationWarning:
         assert "frozen" in str(exc_info.value).lower() or "FrozenInstanceError" in type(
             exc_info.value
         ).__name__
+
+    # ---- RM-9 Layer 2: logging channel (ce:review AN-1) ---------------------
+
+    def test_bare_construction_logs_warning_on_service_logger(
+        self, reset_bare_construction_flag, caplog
+    ) -> None:
+        """RM-9 Layer 2: bare construction also logs a WARNING on
+        ``ccs.coordinator.service`` so the migration signal survives CPython's
+        default ``DeprecationWarning`` filter (which hides it for non-__main__
+        importers — i.e. virtually every SDK consumer).
+        """
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="ccs.coordinator.service"):
+            with _warnings.catch_warnings():
+                _warnings.simplefilter("ignore", DeprecationWarning)
+                CrashRecoveryConfig()
+        records = [
+            r
+            for r in caplog.records
+            if r.name == "ccs.coordinator.service" and r.levelno == logging.WARNING
+        ]
+        assert len(records) == 1, "bare construction must log exactly one WARNING"
+        message = records[0].getMessage()
+        assert "enabled=True" in message, "log must name the recommended opt-in"
+        assert "enabled=False" in message, "log must name the explicit opt-out"
+        assert "v0.9.0" in message, "log must name the target release"
+
+    def test_logger_channel_honors_emit_once(
+        self, reset_bare_construction_flag, caplog
+    ) -> None:
+        """The logging channel shares the emit-once gate with warnings.warn:
+        three bare constructions log exactly one WARNING."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="ccs.coordinator.service"):
+            with _warnings.catch_warnings():
+                _warnings.simplefilter("ignore", DeprecationWarning)
+                CrashRecoveryConfig()
+                CrashRecoveryConfig()
+                CrashRecoveryConfig()
+        records = [
+            r
+            for r in caplog.records
+            if r.name == "ccs.coordinator.service" and r.levelno == logging.WARNING
+        ]
+        assert len(records) == 1
+
+
+# ---- ce:review ADV-01 / ADV-03 — skipped-normalization robustness -----------
+#
+# The sentinel marking an unspecified ``enabled`` is falsy, so any path that
+# skips __post_init__ normalization (importlib.reload identity mismatch, or a
+# subclass __post_init__ that omits super()) still reads as disabled rather
+# than truthy-enabled. Removed in v0.9.0 with the rest of the sentinel
+# mechanism.
+
+from ccs.coordinator.service import _DefaultEnabledSentinel  # noqa: E402
+
+
+class TestSentinelNormalizationRobustness:
+    """ADV-01/ADV-03 — skipped normalization must read as disabled, not enabled."""
+
+    def test_sentinel_is_falsy(self) -> None:
+        """The unset-enabled sentinel evaluates falsy."""
+        assert bool(_service_module._DEFAULT_ENABLED_SENTINEL) is False
+        assert not _service_module._DEFAULT_ENABLED_SENTINEL
+
+    def test_subclass_post_init_override_without_super_reads_disabled(self) -> None:
+        """ADV-03: a frozen subclass overriding __post_init__ without calling
+        super() skips normalization — enabled stays the sentinel, which must be
+        falsy so ``if config.enabled:`` does not misfire the sweep.
+        """
+        from dataclasses import dataclass as _dataclass
+
+        @_dataclass(frozen=True)
+        class _NoSuperConfig(CrashRecoveryConfig):
+            def __post_init__(self) -> None:  # deliberately omits super()
+                pass
+
+        cfg = _NoSuperConfig()
+        # enabled is the un-normalized sentinel object, not a real bool ...
+        assert cfg.enabled is _service_module._DEFAULT_ENABLED_SENTINEL
+        # ... but it reads as disabled, which is what production checks rely on.
+        assert bool(cfg.enabled) is False
+        assert not cfg.enabled
+
+    def test_reload_identity_mismatch_reads_disabled(self) -> None:
+        """ADV-01: simulate importlib.reload rebinding the module sentinel. An
+        instance carrying a *different* (pre-reload) sentinel fails the ``is``
+        check, skips normalization, and must still read as disabled.
+        """
+        stale_sentinel = _DefaultEnabledSentinel()  # distinct identity
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            cfg = CrashRecoveryConfig(enabled=stale_sentinel)  # type: ignore[arg-type]
+        # Identity check fails → normalization skipped → enabled keeps the stale
+        # sentinel, and no warning fires (the bare path keys on the *current*
+        # module sentinel).
+        assert cfg.enabled is stale_sentinel
+        assert bool(cfg.enabled) is False
+        assert [w for w in caught if issubclass(w.category, DeprecationWarning)] == []
+
+
+# ---- ce:review ADV-02 — concurrent emit-once --------------------------------
+
+
+class TestConcurrentEmitOnce:
+    """ADV-02 — the lock keeps emit-once intact under thread contention."""
+
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    def test_concurrent_bare_construction_emits_one_log(
+        self, reset_bare_construction_flag
+    ) -> None:
+        """Eight threads constructing bare configs simultaneously produce exactly
+        one WARNING log. Asserts via the logging channel (thread-safe by design)
+        rather than warnings.catch_warnings, which mutates global filter state and
+        is itself not thread-safe. The expected DeprecationWarning is filtered at
+        the mark (thread-safe) since this test cannot wrap workers in
+        catch_warnings; the log assertion is the real contract.
+        """
+        import logging
+        import threading
+
+        captured: list[logging.LogRecord] = []
+        capture_lock = threading.Lock()
+
+        class _CountingHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                with capture_lock:
+                    captured.append(record)
+
+        svc_logger = logging.getLogger("ccs.coordinator.service")
+        handler = _CountingHandler()
+        handler.setLevel(logging.WARNING)
+        svc_logger.addHandler(handler)
+        previous_level = svc_logger.level
+        svc_logger.setLevel(logging.WARNING)
+
+        thread_count = 8
+        barrier = threading.Barrier(thread_count)
+
+        def worker() -> None:
+            barrier.wait()  # release all threads together to maximize contention
+            try:
+                CrashRecoveryConfig()
+            except DeprecationWarning:
+                # Under -W error the single emitting thread raises *after* the
+                # log record is emitted (logging precedes warnings.warn).
+                pass
+
+        try:
+            threads = [threading.Thread(target=worker) for _ in range(thread_count)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+        finally:
+            svc_logger.removeHandler(handler)
+            svc_logger.setLevel(previous_level)
+
+        warning_records = [r for r in captured if r.levelno == logging.WARNING]
+        assert len(warning_records) == 1, (
+            f"expected exactly one WARNING across {thread_count} concurrent bare "
+            f"constructions, got {len(warning_records)}"
+        )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -404,7 +404,18 @@ from ccs.strategies.lease import LeaseStrategy  # noqa: E402
 
 
 def test_crash_recovery_config_defaults_are_safe() -> None:
-    cfg = CrashRecoveryConfig()
+    """v0.8.3: bare CrashRecoveryConfig() construction is an intentional API
+    surface and asserts both the v0.8.x default-disabled behavior AND the
+    presence of the deprecation warning. The pytest.warns wrapper makes the
+    warning part of the test contract, not collateral CI noise.
+    """
+    # Reset the module-level emit-once flag so this test sees the warning
+    # regardless of test ordering. (The TestCrashRecoveryDeprecationWarning
+    # class below also resets it; this standalone test predates that class.)
+    from ccs.coordinator import service as _service_mod
+    _service_mod._BARE_CONSTRUCTION_WARNED = False
+    with pytest.warns(DeprecationWarning, match="enabled=True"):
+        cfg = CrashRecoveryConfig()
     assert cfg.enabled is False
     assert cfg.heartbeat_timeout_ticks == 10
     assert cfg.max_hold_ticks == 1000
@@ -563,3 +574,135 @@ def test_set_agent_state_failed_log_emit_consistent_for_me_exit_too() -> None:
     # Bookkeeping cleanup ran even though log emit raised.
     assert registry.get_agent_state(artifact.id, agent_id) == MESIState.INVALID
     assert registry.granted_at_tick(agent_id, artifact.id) is None
+
+
+# ---- v0.8.3 C-flip deprecation cycle ----------------------------------------
+#
+# See docs/plans/2026-05-28-001-feat-c-flip-crash-recovery-default-on-plan.md
+# Unit 1. The bare CrashRecoveryConfig() construction must emit a one-shot
+# DeprecationWarning naming the v0.9.0 default flip. Tests below assert both
+# the emission behavior and the silence paths.
+
+
+import warnings as _warnings  # noqa: E402
+
+from ccs.coordinator import service as _service_module  # noqa: E402
+
+
+@pytest.fixture
+def reset_bare_construction_flag():
+    """Reset the module-level emit-once flag between tests.
+
+    Without this, the first test to construct CrashRecoveryConfig() would
+    set _BARE_CONSTRUCTION_WARNED=True for the entire pytest session and
+    later tests in this class would see zero warnings (false negatives).
+    """
+    _service_module._BARE_CONSTRUCTION_WARNED = False
+    yield
+    _service_module._BARE_CONSTRUCTION_WARNED = False
+
+
+class TestCrashRecoveryDeprecationWarning:
+    """Unit 1 — bare CrashRecoveryConfig() emits one-shot DeprecationWarning."""
+
+    def test_bare_construction_emits_deprecation_warning(
+        self, reset_bare_construction_flag
+    ) -> None:
+        """Happy path: bare construction in fresh process emits one warning."""
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            CrashRecoveryConfig()
+        deprecation_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert len(deprecation_warnings) == 1
+
+    def test_warning_message_names_both_silence_paths(
+        self, reset_bare_construction_flag
+    ) -> None:
+        """Warning prose must give users BOTH the opt-in and opt-out recipes."""
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            CrashRecoveryConfig()
+        msg = str(caught[0].message)
+        assert "enabled=True" in msg, "warning must name the recommended opt-in"
+        assert "enabled=False" in msg, "warning must name the explicit opt-out"
+        assert "v0.9.0" in msg, "warning must name the target release"
+
+    def test_bare_construction_preserves_v0_8_x_default(
+        self, reset_bare_construction_flag
+    ) -> None:
+        """After bare construction, enabled is False (v0.8.x behavior preserved)."""
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("ignore", DeprecationWarning)
+            cfg = CrashRecoveryConfig()
+        assert cfg.enabled is False
+        assert cfg.heartbeat_timeout_ticks == 10
+        assert cfg.max_hold_ticks == 1000
+
+    def test_emit_once_dedupes_consecutive_bare_constructions(
+        self, reset_bare_construction_flag
+    ) -> None:
+        """Module-level flag means two bare constructions emit exactly ONE warning."""
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            CrashRecoveryConfig()
+            CrashRecoveryConfig()
+            CrashRecoveryConfig()
+        deprecation_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert len(deprecation_warnings) == 1, (
+            f"expected 1 warning across three bare constructions, "
+            f"got {len(deprecation_warnings)}"
+        )
+
+    def test_explicit_false_emits_no_warning(
+        self, reset_bare_construction_flag
+    ) -> None:
+        """User passes enabled=False explicitly → no warning, enabled stays False."""
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            cfg = CrashRecoveryConfig(enabled=False)
+        deprecation_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert deprecation_warnings == []
+        assert cfg.enabled is False
+
+    def test_explicit_true_emits_no_warning(
+        self, reset_bare_construction_flag
+    ) -> None:
+        """User passes enabled=True explicitly → no warning, enabled stays True."""
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            cfg = CrashRecoveryConfig(enabled=True)
+        deprecation_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert deprecation_warnings == []
+        assert cfg.enabled is True
+
+    def test_composition_validation_unchanged_for_explicit_true(
+        self, reset_bare_construction_flag
+    ) -> None:
+        """R11 composition rule still works on explicit-True configs after Unit 1."""
+        cfg = CrashRecoveryConfig(
+            enabled=True, heartbeat_timeout_ticks=10, max_hold_ticks=1000
+        )
+        # Should not raise — 1000 > 300.
+        validate_crash_recovery_config(cfg, LeaseStrategy(ttl_ticks=300))
+
+    def test_dataclass_remains_frozen(
+        self, reset_bare_construction_flag
+    ) -> None:
+        """frozen=True invariant — sentinel mechanism must not break immutability."""
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("ignore", DeprecationWarning)
+            cfg = CrashRecoveryConfig()
+        # Direct assignment must still raise FrozenInstanceError.
+        with pytest.raises(Exception) as exc_info:
+            cfg.enabled = True  # type: ignore[misc]
+        assert "frozen" in str(exc_info.value).lower() or "FrozenInstanceError" in type(
+            exc_info.value
+        ).__name__

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -145,8 +145,24 @@ from ccs.coordinator.service import CrashRecoveryConfig  # noqa: E402
 
 
 def test_engine_uses_default_crash_recovery_config_when_block_absent() -> None:
-    engine = SimulationEngine(_scenario(), strategy_name="lazy", seed=5)
-    assert engine._crash_recovery == CrashRecoveryConfig()
+    """R2: omitting the YAML block must produce the v0.8.x default-disabled config
+    WITHOUT emitting the v0.8.3 bare-construction DeprecationWarning from the
+    library's own engine code path.
+    """
+    import warnings as _w
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        engine = SimulationEngine(_scenario(), strategy_name="lazy", seed=5)
+    deprecation_warnings = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert deprecation_warnings == [], (
+        f"engine construction must not emit DeprecationWarning, got: "
+        f"{[str(w.message) for w in deprecation_warnings]}"
+    )
+    # Compare against explicit-False (not bare CrashRecoveryConfig()) so the
+    # comparison itself does not emit the warning.
+    assert engine._crash_recovery == CrashRecoveryConfig(enabled=False)
     assert engine._crash_recovery.enabled is False
 
 


### PR DESCRIPTION
## Summary

Phase 1 of the **C-flip** feature: prepares the v0.8.3 *deprecation-only* release that announces the v0.9.0 flip of `CrashRecoveryConfig().enabled` from `False` → `True`. **No production behavior changes ship in v0.8.3** — downstream consumers get one release cycle to surface false-reclaim issues under their own workloads before the flip lands.

Three commits:
- `ed99021` — deprecation cycle: one-shot `DeprecationWarning` on bare `CrashRecoveryConfig()`, internal bare-construction sites routed through a non-warning helper, src/ AST grep-gate, CHANGELOG.
- `3b2fab2` — ce:review safe-auto fixes (test-isolation contract docs, CHANGELOG anchor URL in the warning, test length-guards).
- `d05f73b` — ce:review residual hardening (this branch's final pass):
  - **RM-9 Layer 2** — dual-channel emit: a WARNING-level record on the `ccs.coordinator.service` logger fires *before* `warnings.warn`, so the migration signal survives CPython's default `DeprecationWarning` filter (which hides warnings from non-`__main__` importers — i.e. virtually every SDK consumer) and survives `-W error`.
  - **Falsy sentinel** (ADV-01 + ADV-03) — the unset-`enabled` marker is now a class whose `__bool__` is `False`. Any path that *skips* normalization — `importlib.reload` rebinding the module sentinel (gunicorn/uvicorn `--reload`, Jupyter autoreload), or a subclass `__post_init__` omitting `super()` — now reads as **disabled** rather than silently activating the sweep.
  - **Thread-safe emit-once** (ADV-02 / KD-4) — the emit-once guard is claimed under a `threading.Lock` (free-threaded Python 3.13+ removes the GIL protection the original check-then-set relied on); emission happens *outside* the lock so user warning-filters / log handlers can't deadlock.

## Behavior

- Bare `CrashRecoveryConfig()` → emits the deprecation signal once per process, then normalizes `enabled` to `False` (unchanged v0.8.x default).
- `CrashRecoveryConfig(enabled=True)` / `(enabled=False)` → explicit, no warning.
- Library-internal construction (`ccs.simulation.engine`, `ccs.adapters.base`) routes through `_default_disabled_config()` → no user-facing warning.
- Sentinel, guard, dual-channel emit, and the helper are all removed in v0.9.0.

## Test plan

- [x] `pytest -W error::DeprecationWarning` — full suite green (1486 passed; +6 new tests over the v0.8.2 baseline), zero `DeprecationWarning` escapes from internal sites.
- [x] New coverage: dual-channel logger emit + emit-once on the logger channel; sentinel falsiness; subclass-without-`super()` reads disabled; reload identity-mismatch reads disabled (no spurious warning); 8-thread barrier concurrency asserts exactly one WARNING record (thread-safe custom handler, not `catch_warnings`).
- [x] `tests/test_architecture.py::test_no_bare_crash_recovery_config_construction_in_src` — grep-gate still passes (sentinel class is not a call; helper uses `enabled=False`).
- [ ] Tag-push deferred to the dev → main → tag-push release flow (v0.8.3 is **not** yet tagged).