### PR TITLE
docs(guide): add missing Replay section to table of contents

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -33,10 +33,11 @@ full command-line toolset, and the API reference.
 13. [Real-workload benchmarks](#real-workload-benchmarks)
 14. [Benchmarking your own workload](#benchmarking-your-own-workload)
 15. [`ccs-diagnose` — detect stale reads](#ccs-diagnose--detect-stale-reads)
-16. [Command-line tools](#command-line-tools)
-17. [API reference](#api-reference)
-18. [Low-level adapter API](#low-level-adapter-api)
-19. [CrewAI and AutoGen adapters](#crewai-and-autogen-adapters)
+16. [Replay (v0.8.2+)](#replay-v082)
+17. [Command-line tools](#command-line-tools)
+18. [API reference](#api-reference)
+19. [Low-level adapter API](#low-level-adapter-api)
+20. [CrewAI and AutoGen adapters](#crewai-and-autogen-adapters)
 
 ---
 


### PR DESCRIPTION
## Summary

The user guide's **Contents** list (`docs/guide.md#contents`) was missing the **Replay (v0.8.2+)** section — the `agent-coherence-replay` invariant-replay tool that shipped in v0.8.2. The section has existed in the body (~150 lines: quickstart, exit codes, flags, PII opt-out, refuse-if-exists, exception hierarchy, non-LangGraph notes) but was never added to the TOC.

- Inserts `16. [Replay (v0.8.2+)](#replay-v082)` after `ccs-diagnose`.
- Renumbers the trailing entries (Command-line tools … CrewAI/AutoGen → 17–20).
- Anchor `#replay-v082` verified against GitHub's slug rules (parentheses/dots/`+` stripped, spaces → hyphens) — consistent with the existing `#ccs-diagnose--detect-stale-reads` entry in the same list.

Audit result: this was the **only** discrepancy — every other heading has a matching TOC entry, and there are no stale/extra entries.

## Test plan

- [x] TOC entry count now matches the 20 `##` content sections in the body (was 19, body has 20).
- [ ] Reviewer: confirm the `#replay-v082` anchor resolves on the GitHub-rendered page after merge.