### PR TITLE
fix(otel): add opentelemetry-sdk to otel extra, guard test collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,11 @@ agent-coherence-replay = "ccs.cli.coherence_replay:main"
 dev = ["pytest>=7.0"]
 langgraph = ["langgraph>=0.2"]
 crewai = ["crewai>=0.80"]
-otel = ["opentelemetry-api>=1.0"]
+# `opentelemetry-api` is the runtime dep (the OtelExporter no-ops without an
+# SDK). `opentelemetry-sdk` is required for metrics to actually be collected/
+# exported — and for tests/adapters/telemetry/test_otel_exporter.py to read
+# them back via MeterProvider + InMemoryMetricReader.
+otel = ["opentelemetry-api>=1.0", "opentelemetry-sdk>=1.0"]
 langsmith = ["langsmith>=0.1"]
 benchmark = ["langchain-core>=0.2"]
 diagnose = ["agent-coherence[langgraph]", "jinja2>=3.1", "langchain-core>=0.2"]

--- a/tests/adapters/telemetry/test_otel_exporter.py
+++ b/tests/adapters/telemetry/test_otel_exporter.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("opentelemetry")
+# Guard on `opentelemetry.sdk`, not the bare `opentelemetry` api: a `[otel]`
+# install before this fix carried only `opentelemetry-api`, so importing the
+# api succeeded while the `opentelemetry.sdk.*` imports below raised at
+# collection time. Skipping on the sdk submodule degrades gracefully on any
+# env without `opentelemetry-sdk` (e.g. a bare `[dev]` install).
+pytest.importorskip("opentelemetry.sdk")
 
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader


### PR DESCRIPTION
## Summary
- The `otel` optional-dependency extra declared only `opentelemetry-api`, but `tests/adapters/telemetry/test_otel_exporter.py` imports `opentelemetry.sdk.metrics`. A bare `pip install -e ".[otel]"` (or any env without `opentelemetry-sdk`) failed **pytest collection** with `ModuleNotFoundError: No module named 'opentelemetry.sdk'`, aborting the whole run.
- Same "collection fails on missing optional extra" class already guarded for the `langchain_core` (diagnose) and live-API tests in `tests/conftest.py`.

## Changes
- **`pyproject.toml`** — add `opentelemetry-sdk>=1.0` to the `otel` extra. The API is the runtime dep (`OtelExporter` no-ops without an SDK); the SDK is what actually collects/exports metrics and what the test reads back via `MeterProvider` + `InMemoryMetricReader`.
- **`test_otel_exporter.py`** — guard on `opentelemetry.sdk` instead of the bare `opentelemetry` api, so collection degrades to a **skip** on any env lacking the SDK (in-file `importorskip`, self-contained, no conftest coupling).

## Test Plan
- [x] Bare env (no `opentelemetry-sdk`): `pytest -q` on the file → **1 skipped**, no collection error.
- [x] `[otel]` installed: `pytest tests/adapters/telemetry/test_otel_exporter.py -q` → **16 passed**.
- [x] Full-suite `--collect-only` → no collection errors.
- [x] `pyproject.toml` parses; `otel` → `['opentelemetry-api>=1.0', 'opentelemetry-sdk>=1.0']`.

Scope is intentionally limited to these two files (atomic).