### PR TITLE
feat: OpenAI Agents adapter — RunHooks lifecycle, crash-recovery parity, live smoke test

### DIFF
--- a/src/ccs/adapters/__init__.py
+++ b/src/ccs/adapters/__init__.py
@@ -16,6 +16,7 @@ from typing import Any
 __all__ = [
     "CCSStore",
     "CoherenceDegradedWarning",
+    "CoherenceTopologyWarning",
     "CoherenceAdapterCore",
     "LangGraphAdapter",
     "CrewAIAdapter",
@@ -34,6 +35,7 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "AutoGenAdapter": (".autogen", "AutoGenAdapter"),
     "CCSStore": (".ccsstore", "CCSStore"),
     "CoherenceDegradedWarning": (".base", "CoherenceDegradedWarning"),
+    "CoherenceTopologyWarning": (".base", "CoherenceTopologyWarning"),
     "CoherenceAdapterCore": (".base", "CoherenceAdapterCore"),
     "CoherenceSession": (".openai_agents", "CoherenceSession"),
     "CrewAIAdapter": (".crewai", "CrewAIAdapter"),

--- a/src/ccs/adapters/base.py
+++ b/src/ccs/adapters/base.py
@@ -19,12 +19,15 @@ from ccs.coordinator.service import (
     _default_disabled_config,
     validate_crash_recovery_config,
 )
-from ccs.core.exceptions import CoherenceDegradedWarning  # re-exported; langgraph-free export point
+from ccs.core.exceptions import (  # re-exported; langgraph-free export point
+    CoherenceDegradedWarning,
+    CoherenceTopologyWarning,
+)
 from ccs.core.types import Artifact, FetchResponse
 from ccs.strategies.base import SyncStrategy
 from ccs.strategies.selector import build_strategy
 
-__all__ = ["AgentBinding", "CoherenceAdapterCore", "CoherenceDegradedWarning"]
+__all__ = ["AgentBinding", "CoherenceAdapterCore", "CoherenceDegradedWarning", "CoherenceTopologyWarning"]
 
 logger = logging.getLogger(__name__)
 

--- a/src/ccs/adapters/openai_agents.py
+++ b/src/ccs/adapters/openai_agents.py
@@ -21,6 +21,25 @@ implementing the four-method protocol.
 Scope (v1): in-process multi-agent coherence — peers registered on one
 ``CoherenceAdapterCore``/process (the same boundary as the LangGraph/CrewAI/
 AutoGen adapters). Cross-service coherence needs the out-of-process coordinator.
+
+**Status: experimental (0.x).** The OpenAI Agents SDK is itself 0.x and churns;
+this surface may change with it. Pinned to ``openai-agents>=0.17,<0.18``.
+
+Install::
+
+    pip install "agent-coherence[openai-agents]"
+
+Usage::
+
+    from agents import Runner, SQLiteSession
+    from ccs.adapters.openai_agents import OpenAIAgentsAdapter
+
+    adapter = OpenAIAgentsAdapter()
+    session = adapter.wrap_session(SQLiteSession("chat-1"), agent_name="planner", session_id="chat-1")
+    # Drive the run; the optional RunHooks track identity + refresh coherence:
+    await Runner.run(agent, "...", session=session, hooks=adapter.run_hooks(session_id="chat-1"))
+    if session.peer_mutated_since_read():  # a peer changed the conversation
+        ...  # re-read before acting
 """
 
 from __future__ import annotations
@@ -33,7 +52,7 @@ from uuid import UUID
 
 from ccs.adapters.base import CoherenceAdapterCore
 from ccs.coordinator.service import CrashRecoveryConfig
-from ccs.core.exceptions import CoherenceDegradedWarning, CoherenceError
+from ccs.core.exceptions import CoherenceDegradedWarning, CoherenceError, CoherenceTopologyWarning
 from ccs.core.states import MESIState
 from ccs.core.types import Artifact
 
@@ -95,6 +114,20 @@ class OpenAIAgentsAdapter:
 
     # --- Session coherence (the primary surface) ----------------------------
 
+    def _session_artifact_id(self, session_id: str) -> UUID:
+        """Resolve (registering once) the shared coherence artifact for a session_id.
+
+        All agents and the RunHooks that touch the same ``session_id`` through this
+        adapter resolve the same artifact id, so their reads/writes coordinate.
+        """
+        with self._lock:
+            artifact_id = self._sessions.get(session_id)
+            if artifact_id is None:
+                artifact = self.core.register_artifact(name=f"session:{session_id}", content="")
+                artifact_id = artifact.id
+                self._sessions[session_id] = artifact_id
+        return artifact_id
+
     def wrap_session(self, underlying: Any, *, agent_name: str, session_id: str) -> CoherenceSession:
         """Wrap a caller-provided Session so peer mutations invalidate this agent.
 
@@ -103,19 +136,34 @@ class OpenAIAgentsAdapter:
         artifact-id trick required because the adapter coordinates registration.
         """
         self.core.register_agent(agent_name)
-        with self._lock:
-            artifact_id = self._sessions.get(session_id)
-            if artifact_id is None:
-                artifact = self.core.register_artifact(name=f"session:{session_id}", content="")
-                artifact_id = artifact.id
-                self._sessions[session_id] = artifact_id
         return CoherenceSession(
             underlying=underlying,
             adapter=self,
             agent_name=agent_name,
-            artifact_id=artifact_id,
+            artifact_id=self._session_artifact_id(session_id),
             session_id=session_id,
         )
+
+    def run_hooks(self, *, session_id: str, server_conversation: bool = False) -> Any:
+        """Build a ``RunHooks`` that threads coherence accounting through a run.
+
+        Attach the returned object to ``Runner.run(..., hooks=...)``. It tracks the
+        active agent across handoffs and refreshes that agent's coherence view at
+        agent-start and tool-start, so a peer's mutation of the shared session
+        surfaces before the agent acts. Writes remain the ``CoherenceSession``'s job
+        (this coordinates *awareness and identity*, not arbitrary tool side effects).
+
+        Set ``server_conversation=True`` when the run uses a server-side
+        ``conversation_id``; combined with multi-agent handoffs the SDK disables
+        ``input_filter`` / nested handoff history, and the hooks warn once that
+        handoff-history coherence is unavailable in that mode.
+
+        Importing ``agents.RunHooks`` is deferred to here so this module stays
+        importable (and ``CoherenceSession`` usable) without the ``openai-agents``
+        extra installed.
+        """
+        hooks_cls = _coherence_run_hooks_class()
+        return hooks_cls(adapter=self, session_id=session_id, server_conversation=server_conversation)
 
     # --- degradation contract ----------------------------------------------
 
@@ -245,3 +293,98 @@ class CoherenceSession:
         if self._adapter._on_error == "strict":
             raise  # bare re-raise preserves the original traceback from core
         self._adapter._record_degraded(exc)
+
+
+# --- RunHooks lifecycle integration (Unit 7) -------------------------------
+#
+# Defined lazily so importing this module never pulls `agents` — the SDK-free
+# CoherenceSession surface stays importable on a bare `[dev]` install. The class
+# subclasses agents.RunHooks (needed for the Runner's default-method contract)
+# and is built once, on first `OpenAIAgentsAdapter.run_hooks(...)`.
+
+_RUN_HOOKS_CLASS: type | None = None
+
+
+def _coherence_run_hooks_class() -> type:
+    global _RUN_HOOKS_CLASS
+    if _RUN_HOOKS_CLASS is not None:
+        return _RUN_HOOKS_CLASS
+
+    try:
+        from agents import RunHooks  # deferred third-party import
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise ImportError(
+            "OpenAIAgentsAdapter.run_hooks requires the OpenAI Agents SDK. "
+            'Install it with: pip install "agent-coherence[openai-agents]"'
+        ) from exc
+
+    class CoherenceRunHooks(RunHooks):
+        """Threads coherence accounting through an Agents SDK run (Unit 7).
+
+        Tracks the active agent across handoffs and refreshes that agent's
+        coherence view at agent-start and tool-start, so a peer's mutation of the
+        shared session surfaces *before* the agent acts. Writes stay the
+        ``CoherenceSession``'s job — these hooks coordinate awareness and identity,
+        not arbitrary tool side effects (the coherence surface is session state,
+        not every tool call).
+
+        Supported topology: concurrent independent agents sharing one
+        ``conversation_id`` within one process. With ``server_conversation=True``
+        plus a handoff, the SDK disables ``input_filter`` / nested handoff history;
+        the first handoff then warns once (``CoherenceTopologyWarning``) that
+        handoff-history coherence is unavailable — never a silent assumption.
+
+        The coordinator handle is carried by this hooks instance (runtime-only,
+        never serialized to the model), which satisfies the "don't send the
+        coordinator to the LLM" goal the same way ``RunContextWrapper.context``
+        would.
+        """
+
+        def __init__(self, *, adapter: OpenAIAgentsAdapter, session_id: str, server_conversation: bool = False) -> None:
+            self._adapter = adapter
+            self._session_id = session_id
+            self._server_conversation = server_conversation
+            self.active_agent: str | None = None
+            self.read_count = 0
+            self._handoff_topology_warned = False
+
+        def _refresh(self, agent_name: str) -> None:
+            """Refresh one agent's coherence view of the shared session (a peer write
+            shows up as a cache miss). Honours the adapter's on_error contract."""
+            self._adapter.register_agent(agent_name)
+            artifact_id = self._adapter._session_artifact_id(self._session_id)
+            try:
+                self._adapter.core.read(
+                    agent_name=agent_name,
+                    artifact_id=artifact_id,
+                    now_tick=self._adapter._next_tick(),
+                )
+                self.read_count += 1
+            except CoherenceError as exc:
+                if self._adapter._on_error == "strict":
+                    raise
+                self._adapter._record_degraded(exc)
+
+        async def on_agent_start(self, context: Any, agent: Any) -> None:
+            self.active_agent = agent.name
+            self._refresh(agent.name)
+
+        async def on_tool_start(self, context: Any, agent: Any, tool: Any) -> None:
+            self._refresh(agent.name)
+
+        async def on_handoff(self, context: Any, from_agent: Any, to_agent: Any) -> None:
+            self.active_agent = to_agent.name
+            if self._server_conversation and not self._handoff_topology_warned:
+                self._handoff_topology_warned = True
+                warnings.warn(
+                    "OpenAI Agents handoff with a server-side conversation_id: the SDK "
+                    "disables input_filter / nested handoff history, so handoff-history "
+                    "coherence is unavailable. Use concurrent agents sharing one "
+                    "conversation_id (no handoff history rewriting) instead.",
+                    CoherenceTopologyWarning,
+                    stacklevel=2,
+                )
+            self._refresh(to_agent.name)
+
+    _RUN_HOOKS_CLASS = CoherenceRunHooks
+    return _RUN_HOOKS_CLASS

--- a/src/ccs/adapters/openai_agents.py
+++ b/src/ccs/adapters/openai_agents.py
@@ -47,7 +47,7 @@ from __future__ import annotations
 import logging
 import threading
 import warnings
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID
 
 from ccs.adapters.base import CoherenceAdapterCore
@@ -55,6 +55,9 @@ from ccs.coordinator.service import CrashRecoveryConfig
 from ccs.core.exceptions import CoherenceDegradedWarning, CoherenceError, CoherenceTopologyWarning
 from ccs.core.states import MESIState
 from ccs.core.types import Artifact
+
+if TYPE_CHECKING:  # annotation-only; never imported at runtime (keeps the module SDK-free)
+    from agents import RunHooks
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +147,7 @@ class OpenAIAgentsAdapter:
             session_id=session_id,
         )
 
-    def run_hooks(self, *, session_id: str, server_conversation: bool = False) -> Any:
+    def run_hooks(self, *, session_id: str, server_conversation: bool = False) -> RunHooks:
         """Build a ``RunHooks`` that threads coherence accounting through a run.
 
         Attach the returned object to ``Runner.run(..., hooks=...)``. It tracks the
@@ -190,6 +193,17 @@ class OpenAIAgentsAdapter:
         if first:
             warnings.warn(f"OpenAI Agents adapter degraded: {exc}", CoherenceDegradedWarning, stacklevel=3)
             logger.warning("OpenAI Agents adapter degraded under on_error='degrade': %s", exc)
+
+    def _handle_coherence_error(self, exc: CoherenceError) -> None:
+        """Single on_error dispatch shared by the Session wrapper and RunHooks.
+
+        ``strict`` re-raises (``raise exc`` — explicit, and preserves the original
+        traceback); ``degrade`` records + warns once and lets the real work stand.
+        Must be called from within the ``except`` block that caught ``exc``.
+        """
+        if self._on_error == "strict":
+            raise exc
+        self._record_degraded(exc)
 
 
 class CoherenceSession:
@@ -290,9 +304,7 @@ class CoherenceSession:
     def _degrade_or_raise(self, exc: CoherenceError) -> None:
         # The underlying Session op already succeeded — under degrade, coherence is
         # best-effort and we never swallow the real work, only the accounting.
-        if self._adapter._on_error == "strict":
-            raise  # bare re-raise preserves the original traceback from core
-        self._adapter._record_degraded(exc)
+        self._adapter._handle_coherence_error(exc)
 
 
 # --- RunHooks lifecycle integration (Unit 7) -------------------------------
@@ -303,6 +315,7 @@ class CoherenceSession:
 # and is built once, on first `OpenAIAgentsAdapter.run_hooks(...)`.
 
 _RUN_HOOKS_CLASS: type | None = None
+_RUN_HOOKS_CLASS_LOCK = threading.Lock()
 
 
 def _coherence_run_hooks_class() -> type:
@@ -310,6 +323,16 @@ def _coherence_run_hooks_class() -> type:
     if _RUN_HOOKS_CLASS is not None:
         return _RUN_HOOKS_CLASS
 
+    # Lock the build so two threads racing the first call can't define two distinct
+    # class objects (matters under free-threaded Python; harmless under the GIL).
+    with _RUN_HOOKS_CLASS_LOCK:
+        if _RUN_HOOKS_CLASS is not None:
+            return _RUN_HOOKS_CLASS
+        return _build_run_hooks_class()
+
+
+def _build_run_hooks_class() -> type:
+    global _RUN_HOOKS_CLASS
     try:
         from agents import RunHooks  # deferred third-party import
     except ImportError as exc:  # pragma: no cover - exercised only without the extra
@@ -340,17 +363,26 @@ def _coherence_run_hooks_class() -> type:
         would.
         """
 
+        active_agent: str | None
+        read_count: int
+
         def __init__(self, *, adapter: OpenAIAgentsAdapter, session_id: str, server_conversation: bool = False) -> None:
+            super().__init__()
             self._adapter = adapter
             self._session_id = session_id
             self._server_conversation = server_conversation
-            self.active_agent: str | None = None
+            self.active_agent = None
             self.read_count = 0
             self._handoff_topology_warned = False
 
         def _refresh(self, agent_name: str) -> None:
             """Refresh one agent's coherence view of the shared session (a peer write
-            shows up as a cache miss). Honours the adapter's on_error contract."""
+            shows up as a cache miss). Honours the adapter's on_error contract.
+
+            ``read_count`` counts *successful* coordinator reads; it stays flat while a
+            refresh is degrading. The coordinator read is in-process (pure dict work),
+            so calling it synchronously from these async hooks does not block the loop.
+            """
             self._adapter.register_agent(agent_name)
             artifact_id = self._adapter._session_artifact_id(self._session_id)
             try:
@@ -361,9 +393,7 @@ def _coherence_run_hooks_class() -> type:
                 )
                 self.read_count += 1
             except CoherenceError as exc:
-                if self._adapter._on_error == "strict":
-                    raise
-                self._adapter._record_degraded(exc)
+                self._adapter._handle_coherence_error(exc)
 
         async def on_agent_start(self, context: Any, agent: Any) -> None:
             self.active_agent = agent.name

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -19,6 +19,15 @@ class CoherenceDegradedWarning(UserWarning):
     """
 
 
+class CoherenceTopologyWarning(UserWarning):
+    """Emitted when an adapter is used in a topology its coherence model can't fully cover.
+
+    Example: an OpenAI Agents run that combines a server-side ``conversation_id`` with
+    multi-agent handoffs, where the SDK disables ``input_filter`` / nested handoff
+    history — so handoff-history coherence is unavailable. Surfaced once, never silent.
+    """
+
+
 class InvalidTransitionError(CoherenceError):
     """Raised when the MESI transition table rejects a state transition."""
 

--- a/tests/adapters/test_openai_agents.py
+++ b/tests/adapters/test_openai_agents.py
@@ -338,6 +338,32 @@ def test_run_hooks_degrade_swallows_refresh_error():
     assert asyncio.run(scenario()) == "a"  # identity still tracked despite degrade
 
 
+def test_run_hooks_strict_reraises_on_handoff_refresh_error():
+    pytest.importorskip("agents")
+    adapter = OpenAIAgentsAdapter(on_error="strict")
+    hooks = adapter.run_hooks(session_id="c1")
+
+    async def scenario():
+        with patch.object(adapter.core, "read", side_effect=CoherenceError("boom")):
+            with pytest.raises(CoherenceError):
+                await hooks.on_handoff(None, _FakeAgent("a"), _FakeAgent("b"))
+
+    asyncio.run(scenario())
+
+
+def test_run_hooks_strict_reraises_on_tool_start_refresh_error():
+    pytest.importorskip("agents")
+    adapter = OpenAIAgentsAdapter(on_error="strict")
+    hooks = adapter.run_hooks(session_id="c1")
+
+    async def scenario():
+        with patch.object(adapter.core, "read", side_effect=CoherenceError("boom")):
+            with pytest.raises(CoherenceError):
+                await hooks.on_tool_start(None, _FakeAgent("a"), object())
+
+    asyncio.run(scenario())
+
+
 # --- integration: real SQLiteSession ---------------------------------------
 
 

--- a/tests/adapters/test_openai_agents.py
+++ b/tests/adapters/test_openai_agents.py
@@ -12,6 +12,7 @@ behind ``pytest.importorskip`` to prove delegation against the actual SDK.
 from __future__ import annotations
 
 import asyncio
+import warnings
 from unittest.mock import patch
 
 import pytest
@@ -232,6 +233,109 @@ def test_heartbeat_and_recover_passthrough_are_noops_when_disabled():
     adapter.register_agent("a")
     adapter.heartbeat(agent_name="a", now_tick=1)  # must not raise
     adapter.recover(agent_name="a", now_tick=2)  # must not raise
+
+
+# --- Unit 7: RunHooks lifecycle integration ---------------------------------
+
+
+class _FakeAgent:
+    """Stand-in for an Agents SDK Agent (only `.name` is used by the hooks)."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+
+def test_run_hooks_tracks_active_agent_and_refreshes_on_lifecycle():
+    pytest.importorskip("agents")  # run_hooks pulls the SDK
+    adapter = OpenAIAgentsAdapter()
+    hooks = adapter.run_hooks(session_id="c1")
+
+    async def scenario():
+        await hooks.on_agent_start(None, _FakeAgent("planner"))
+        assert hooks.active_agent == "planner"
+        await hooks.on_tool_start(None, _FakeAgent("planner"), object())
+        return hooks.read_count
+
+    # agent_start + tool_start each refresh the active agent's coherence view.
+    assert asyncio.run(scenario()) == 2
+
+
+def test_run_hooks_handoff_advances_identity():
+    pytest.importorskip("agents")
+    adapter = OpenAIAgentsAdapter()
+    hooks = adapter.run_hooks(session_id="c1")
+
+    async def scenario():
+        await hooks.on_agent_start(None, _FakeAgent("planner"))
+        await hooks.on_handoff(None, _FakeAgent("planner"), _FakeAgent("executor"))
+        return hooks.active_agent
+
+    assert asyncio.run(scenario()) == "executor"
+
+
+def test_run_hooks_warns_once_on_server_conversation_handoff():
+    from ccs.core.exceptions import CoherenceTopologyWarning
+
+    pytest.importorskip("agents")
+    adapter = OpenAIAgentsAdapter()
+    hooks = adapter.run_hooks(session_id="c1", server_conversation=True)
+
+    async def scenario():
+        with pytest.warns(CoherenceTopologyWarning):
+            await hooks.on_handoff(None, _FakeAgent("a"), _FakeAgent("b"))
+        # second handoff must NOT warn again (warn-once)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", CoherenceTopologyWarning)
+            await hooks.on_handoff(None, _FakeAgent("b"), _FakeAgent("c"))
+
+    asyncio.run(scenario())
+
+
+def test_run_hooks_no_warning_without_server_conversation():
+    pytest.importorskip("agents")
+    adapter = OpenAIAgentsAdapter()
+    hooks = adapter.run_hooks(session_id="c1")  # server_conversation defaults False
+
+    async def scenario():
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning fails the test
+            await hooks.on_handoff(None, _FakeAgent("a"), _FakeAgent("b"))
+
+    asyncio.run(scenario())
+
+
+def test_run_hooks_refresh_observes_peer_write():
+    # Integration: hooks + CoherenceSession compose. A's session write invalidates
+    # B; B's tool-start refresh re-fetches, clearing the stale signal.
+    pytest.importorskip("agents")
+    adapter = OpenAIAgentsAdapter()
+    store: dict[str, list] = {}
+    a = adapter.wrap_session(FakeSession(store, "c1"), agent_name="a", session_id="c1")
+    b = adapter.wrap_session(FakeSession(store, "c1"), agent_name="b", session_id="c1")
+    hooks_b = adapter.run_hooks(session_id="c1")
+
+    async def scenario():
+        await b.get_items()  # B establishes a baseline
+        await a.add_items([{"v": 2}])  # A mutates -> invalidates B
+        assert b.peer_mutated_since_read() is True
+        await hooks_b.on_tool_start(None, _FakeAgent("b"), object())  # hooks refresh B
+        return b.peer_mutated_since_read()
+
+    assert asyncio.run(scenario()) is False  # B's view was refreshed by the hooks
+
+
+def test_run_hooks_degrade_swallows_refresh_error():
+    pytest.importorskip("agents")
+    adapter = OpenAIAgentsAdapter(on_error="degrade")
+    hooks = adapter.run_hooks(session_id="c1")
+
+    async def scenario():
+        with patch.object(adapter.core, "read", side_effect=CoherenceError("boom")):
+            with pytest.warns(CoherenceDegradedWarning):
+                await hooks.on_agent_start(None, _FakeAgent("a"))  # refresh degrades, no raise
+        return hooks.active_agent
+
+    assert asyncio.run(scenario()) == "a"  # identity still tracked despite degrade
 
 
 # --- integration: real SQLiteSession ---------------------------------------

--- a/tests/adapters/test_openai_agents_live.py
+++ b/tests/adapters/test_openai_agents_live.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Live-API smoke tests for the OpenAI Agents adapter (Unit 8).
+
+Gated three ways so the default ``pytest -q`` loop stays fast, offline, and free:
+  1. ``pytest.importorskip("agents"/"openai")`` — skips on a bare ``[dev]`` install.
+  2. module ``pytestmark = live_api`` — excluded from the default ``addopts``.
+  3. ``skipif(not OPENAI_API_KEY)`` — skips when no key is present.
+
+Run explicitly: ``pytest -m live_api`` with ``OPENAI_API_KEY`` set and
+``pip install "agent-coherence[openai-agents]"``.
+
+Scope: proves the adapter's Session-cache coherence works over a *real*
+Conversations-API-backed Session (``OpenAIConversationsSession``). The adapter
+wraps a caller-provided Session and governs coherence accounting only — it does
+not wrap the underlying Session's own SDK/network errors (the caller owns their
+Session), so there is no adapter-error-wrapping scenario to assert here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+pytest.importorskip("openai")
+agents = pytest.importorskip("agents")
+
+from ccs.adapters.openai_agents import OpenAIAgentsAdapter  # noqa: E402
+
+pytestmark = [
+    pytest.mark.live_api,
+    pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"),
+]
+
+
+def test_round_trip_over_real_conversations_session():
+    """A wrapped real Conversations Session round-trips an item through the live API."""
+    adapter = OpenAIAgentsAdapter()
+    underlying = agents.OpenAIConversationsSession()  # creates a real conversation_id
+    session = adapter.wrap_session(underlying, agent_name="a", session_id="live-round-trip")
+
+    async def scenario():
+        await session.add_items([{"role": "user", "content": "coherence live smoke"}])
+        items = await session.get_items()
+        await underlying.clear_session()  # cleanup server-side state
+        return items
+
+    items = asyncio.run(scenario())
+    assert items and items[-1]["content"] == "coherence live smoke"
+
+
+def test_cross_agent_invalidation_over_one_real_conversation():
+    """Two agents on one live conversation_id: A's write invalidates B's cached view."""
+    adapter = OpenAIAgentsAdapter()
+    underlying = agents.OpenAIConversationsSession()
+    conversation_id = underlying.session_id  # the shared conversation
+    a = adapter.wrap_session(underlying, agent_name="a", session_id=conversation_id)
+    b = adapter.wrap_session(
+        agents.OpenAIConversationsSession(conversation_id=conversation_id),
+        agent_name="b",
+        session_id=conversation_id,
+    )
+
+    async def scenario():
+        await b.get_items()  # B establishes a baseline over the live session
+        assert b.peer_mutated_since_read() is False
+        await a.add_items([{"role": "user", "content": "A revises the plan"}])  # invalidates B
+        stale = b.peer_mutated_since_read()  # B's cached view is now INVALID
+        fresh = await b.get_items()  # re-fetch from the live conversation
+        await a._underlying.clear_session()  # cleanup
+        return stale, fresh
+
+    stale, fresh = asyncio.run(scenario())
+    assert stale is True
+    assert any(item.get("content") == "A revises the plan" for item in fresh)

--- a/tests/adapters/test_openai_agents_live.py
+++ b/tests/adapters/test_openai_agents_live.py
@@ -43,10 +43,11 @@ def test_round_trip_over_real_conversations_session():
     session = adapter.wrap_session(underlying, agent_name="a", session_id="live-round-trip")
 
     async def scenario():
-        await session.add_items([{"role": "user", "content": "coherence live smoke"}])
-        items = await session.get_items()
-        await underlying.clear_session()  # cleanup server-side state
-        return items
+        try:
+            await session.add_items([{"role": "user", "content": "coherence live smoke"}])
+            return await session.get_items()
+        finally:
+            await underlying.clear_session()  # cleanup server-side state even on failure
 
     items = asyncio.run(scenario())
     assert items and items[-1]["content"] == "coherence live smoke"
@@ -55,23 +56,26 @@ def test_round_trip_over_real_conversations_session():
 def test_cross_agent_invalidation_over_one_real_conversation():
     """Two agents on one live conversation_id: A's write invalidates B's cached view."""
     adapter = OpenAIAgentsAdapter()
-    underlying = agents.OpenAIConversationsSession()
-    conversation_id = underlying.session_id  # the shared conversation
-    a = adapter.wrap_session(underlying, agent_name="a", session_id=conversation_id)
-    b = adapter.wrap_session(
-        agents.OpenAIConversationsSession(conversation_id=conversation_id),
-        agent_name="b",
-        session_id=conversation_id,
-    )
 
     async def scenario():
-        await b.get_items()  # B establishes a baseline over the live session
-        assert b.peer_mutated_since_read() is False
-        await a.add_items([{"role": "user", "content": "A revises the plan"}])  # invalidates B
-        stale = b.peer_mutated_since_read()  # B's cached view is now INVALID
-        fresh = await b.get_items()  # re-fetch from the live conversation
-        await a._underlying.clear_session()  # cleanup
-        return stale, fresh
+        # OpenAIConversationsSession.session_id raises until the session is lazily
+        # initialized by a method call, so seed one item first to obtain the id.
+        underlying_a = agents.OpenAIConversationsSession()
+        await underlying_a.add_items([{"role": "user", "content": "seed"}])
+        conversation_id = underlying_a.session_id
+        underlying_b = agents.OpenAIConversationsSession(conversation_id=conversation_id)
+        a = adapter.wrap_session(underlying_a, agent_name="a", session_id=conversation_id)
+        b = adapter.wrap_session(underlying_b, agent_name="b", session_id=conversation_id)
+        try:
+            await b.get_items()  # B establishes a baseline over the live session
+            assert b.peer_mutated_since_read() is False
+            await a.add_items([{"role": "user", "content": "A revises the plan"}])  # invalidates B
+            stale = b.peer_mutated_since_read()  # B's cached view is now INVALID
+            fresh = await b.get_items()  # re-fetch from the live conversation
+            return stale, fresh
+        finally:
+            await underlying_a.clear_session()
+            await underlying_b.clear_session()
 
     stale, fresh = asyncio.run(scenario())
     assert stale is True

--- a/tests/test_adapter_crash_recovery.py
+++ b/tests/test_adapter_crash_recovery.py
@@ -10,16 +10,38 @@ enforce_stable_grant_timeouts between adapter calls.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from ccs.adapters.autogen import AutoGenAdapter
 from ccs.adapters.crewai import CrewAIAdapter
 from ccs.adapters.langgraph import LangGraphAdapter
+from ccs.adapters.openai_agents import OpenAIAgentsAdapter
 from ccs.coordinator.service import CrashRecoveryConfig
 from ccs.core.exceptions import CoherenceError
 from ccs.core.states import MESIState
 
 CR_CFG = CrashRecoveryConfig(enabled=True, heartbeat_timeout_ticks=10, max_hold_ticks=1000)
+
+
+class _FakeSession:
+    """Minimal in-memory Session (the four async methods) for adapter parity tests."""
+
+    def __init__(self):
+        self._items: list = []
+
+    async def get_items(self, limit=None):
+        return list(self._items)
+
+    async def add_items(self, items):
+        self._items.extend(items)
+
+    async def pop_item(self):
+        return self._items.pop() if self._items else None
+
+    async def clear_session(self):
+        self._items.clear()
 
 
 def _langgraph(**overrides):
@@ -279,6 +301,45 @@ class TestCCSStoreParity:
 
 
 # ---------------------------------------------------------------------------
+# OpenAIAgentsAdapter parity: heartbeat piggyback, reclamation, recover flush
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIAgentsParity:
+    """OpenAIAgentsAdapter heartbeat/recover/reclamation behaves like the others.
+
+    The adapter is SDK-free (CoherenceSession composes a caller-provided Session),
+    so these run in the default offline suite with a _FakeSession.
+    """
+
+    def test_openai_agents_oom_kill(self) -> None:
+        adapter = OpenAIAgentsAdapter(crash_recovery=CR_CFG)
+        a = adapter.wrap_session(_FakeSession(), agent_name="A", session_id="s")
+        b = adapter.wrap_session(_FakeSession(), agent_name="B", session_id="s")
+
+        # A acquires a grant (MODIFIED) and piggybacks a heartbeat via the write.
+        asyncio.run(a.add_items([{"v": 1}]))
+
+        # A goes silent; the sweep reclaims its stale grant.
+        reclaimed = _reclaim(adapter, current_tick=13)
+        assert reclaimed == 1
+
+        # B can now write where A's stranded grant would otherwise have blocked it.
+        asyncio.run(b.add_items([{"v": 2}]))
+
+    def test_openai_agents_recover_flushes_cache(self) -> None:
+        adapter = OpenAIAgentsAdapter(crash_recovery=CR_CFG)
+        a = adapter.wrap_session(_FakeSession(), agent_name="A", session_id="s")
+        asyncio.run(a.get_items())  # A caches the session artifact
+        artifact_id = adapter._session_artifact_id("s")
+        assert adapter.core.runtime("A").cache.get(artifact_id) is not None
+        adapter.recover(agent_name="A", now_tick=5)  # post-restart flush
+        # recover invalidates A's local view: the next read is a coordinator miss.
+        entry = adapter.core.runtime("A").cache.get(artifact_id)
+        assert entry is None or entry.state == MESIState.INVALID
+
+
+# ---------------------------------------------------------------------------
 # Composition fail-fast at adapter level (R5/R8)
 # ---------------------------------------------------------------------------
 
@@ -289,6 +350,14 @@ class TestCompositionFailFast:
     def test_langgraph_raises(self) -> None:
         with pytest.raises(ValueError, match="composition violation"):
             LangGraphAdapter(
+                strategy_name="lease",
+                lease_ttl_ticks=300,
+                crash_recovery=CrashRecoveryConfig(enabled=True, max_hold_ticks=300),
+            )
+
+    def test_openai_agents_raises(self) -> None:
+        with pytest.raises(ValueError, match="composition violation"):
+            OpenAIAgentsAdapter(
                 strategy_name="lease",
                 lease_ttl_ticks=300,
                 crash_recovery=CrashRecoveryConfig(enabled=True, max_hold_ticks=300),

--- a/tests/test_adapter_crash_recovery.py
+++ b/tests/test_adapter_crash_recovery.py
@@ -316,6 +316,7 @@ class TestOpenAIAgentsParity:
         adapter = OpenAIAgentsAdapter(crash_recovery=CR_CFG)
         a = adapter.wrap_session(_FakeSession(), agent_name="A", session_id="s")
         b = adapter.wrap_session(_FakeSession(), agent_name="B", session_id="s")
+        artifact_id = adapter._session_artifact_id("s")
 
         # A acquires a grant (MODIFIED) and piggybacks a heartbeat via the write.
         asyncio.run(a.add_items([{"v": 1}]))
@@ -323,9 +324,13 @@ class TestOpenAIAgentsParity:
         # A goes silent; the sweep reclaims its stale grant.
         reclaimed = _reclaim(adapter, current_tick=13)
         assert reclaimed == 1
+        # A's grant is now INVALID at the coordinator (matches the sibling adapter tests).
+        assert adapter.core.registry.get_agent_state(artifact_id, adapter.core.agent_id_for("A")) == MESIState.INVALID
 
-        # B can now write where A's stranded grant would otherwise have blocked it.
+        # B can now write where A's stranded grant would otherwise have blocked it,
+        # and B holds the grant (write committed, not silently degraded).
         asyncio.run(b.add_items([{"v": 2}]))
+        assert adapter.core.registry.get_agent_state(artifact_id, adapter.core.agent_id_for("B")) == MESIState.MODIFIED
 
     def test_openai_agents_recover_flushes_cache(self) -> None:
         adapter = OpenAIAgentsAdapter(crash_recovery=CR_CFG)


### PR DESCRIPTION
## Summary

Completes the OpenAI Agents SDK coherence adapter with lifecycle-hook integration, crash-recovery parity, and a live-API smoke test.

- **`CoherenceRunHooks`** (built via `OpenAIAgentsAdapter.run_hooks(...)`) threads coherence accounting through an Agents SDK run: tracks the active agent across `on_agent_start`/`on_handoff`, refreshes that agent's coherence view at agent-start and tool-start so a peer's mutation of the shared session surfaces before the agent acts, and warns once (`CoherenceTopologyWarning`) when a server-side `conversation_id` is combined with a handoff — the SDK disables `input_filter`/nested handoff history in that mode, so handoff-history coherence is unavailable. The hooks coordinate awareness and identity, not arbitrary tool side effects. `agents.RunHooks` is imported lazily so the module stays importable without the SDK.
- **Crash-recovery parity** — `TestOpenAIAgentsParity` (heartbeat piggyback, stale-grant reclamation, `recover` cache flush) and a composition fail-fast case, mirroring the LangGraph/CrewAI/AutoGen/CCSStore adapters.
- **Live-API smoke test** — wraps a real `OpenAIConversationsSession`: item round-trip + cross-agent invalidation over one live `conversation_id`. Triple-gated (`importorskip`, `live_api` marker excluded from the default run, `skipif` no key).
- **Try-in-prod surface** — experimental/0.x marker, install path, and a usage snippet in the module docstring.

## Test Plan

- [x] Full suite: 1542 passed, 41 deselected
- [x] Architecture boundary check clean
- [x] `ruff check src/ tests/` clean
- [x] Bare `[dev]` collection verified (SDKs blocked) — live test skips, everything else collects
- [ ] `pytest -m live_api` with a key — exercises the real Conversations API (run by the maintainer)