### PR TITLE
feat(crash-recovery): enable crash recovery by default (v0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,67 @@ Alpha — APIs may change before `v1.0`.
 
 ## [Unreleased]
 
-(Nothing yet.)
+The **[0.9.0]** entry below is prepared on the C-flip Phase 2 feature branch but
+**not yet tagged**. It ships via the dev → main → tag-push release flow no earlier
+than **2026-06-09** (the day after the Claude Code plugin Phase E monitoring window
+closes), or earlier only with written confirmation that the plugin pins
+`agent-coherence` below v0.9.0. The release date is filled in at tag time.
+
+## [0.9.0] — UNRELEASED (gated ≥ 2026-06-09)
+
+**The crash-recovery default flips ON.** This completes the deprecation cycle begun
+in v0.8.3: `CrashRecoveryConfig().enabled` changes from `False` to `True`, so a bare
+`CCSStore()` / `CoherenceAdapterCore()` now reclaims stale `MODIFIED`/`EXCLUSIVE`
+grants automatically. Operators who depend on the v0.8.x default-disabled behavior
+**must pass `CrashRecoveryConfig(enabled=False)` explicitly** to opt out.
+
+### Changed
+
+- **Breaking default — crash recovery is now ON.** `CrashRecoveryConfig.enabled`
+  flipped `False` → `True`. Bare `CrashRecoveryConfig()`, `CCSStore()`, and
+  `CoherenceAdapterCore()` now run the reclamation sweep. **Migration to keep
+  v0.8.x behavior: pass `CrashRecoveryConfig(enabled=False)` explicitly.**
+- **Default thresholds retuned** from simulation-anchored to batch-tick-realistic
+  values: `heartbeat_timeout_ticks` 10 → 120, `max_hold_ticks` 1000 → 900. The old
+  values remain settable explicitly. Calibrated so a bare `CCSStore` under realistic
+  LLM workloads does not false-reclaim live agents. Benchmark token reductions are
+  unchanged — see [`benchmarks/results/v0.9.0/attestation.md`](benchmarks/results/v0.9.0/attestation.md).
+- **Migration caveat — `lease` strategy with `lease_ttl_ticks` ≥ 900.** Because the
+  default is now enabled, the R11 composition rule (`max_hold_ticks` must exceed the
+  strategy's inspectable lease TTL) is enforced at construction for bare `CCSStore()`
+  / `CoherenceAdapterCore()`. A `lease` strategy with `lease_ttl_ticks` ≥ 900 (the new
+  default `max_hold_ticks`) now raises `ValueError` at startup where v0.8.x silently
+  skipped the check. Fix: pass `CrashRecoveryConfig(max_hold_ticks=…)` above your lease
+  TTL, or `CrashRecoveryConfig(enabled=False)`.
+- **Breaking — state-log byte-identity inverted (direction only).** A state-log produced with
+  the `crash_recovery` block omitted is now byte-identical to one with an explicit
+  `{enabled: true}` block, and diverges from `{enabled: false}`. CI that gates on
+  state-log byte equality against v0.8.x output must now set `enabled=False`
+  explicitly. The contract itself is unchanged — only which default it maps to.
+
+### Added
+
+- **Rate-limited reclamation sweep wired into `CoherenceAdapterCore`.** `read()` /
+  `write()` invoke a thread-safe `_maybe_sweep(now_tick)` after recording the
+  heartbeat; it reclaims stale grants at most once per `heartbeat_timeout_ticks // 2`
+  ticks. `CCSStore.batch()` inherits once-per-batch sweep semantics from its shared
+  per-batch tick — no separate state. The sweep is best-effort: a failure is logged
+  and never crashes the adapter's read/write path.
+- **Per-instance reclamation diagnostic.** The first time an adapter instance
+  reclaims, it logs a one-shot `WARNING` on the `ccs.adapters.base` logger with
+  structured `extra` fields (`trigger`, `agent_id_short`, `artifact_id_short`,
+  `reclaim_count`); a companion `DEBUG` carries full UUIDs. Field names are stable
+  for the v0.9 series. See the [crash-recovery guide](docs/guide.md#crash-recovery).
+- **Transitional first-use warning.** The first `CrashRecoveryConfig` construction
+  per process emits a one-shot `RuntimeWarning` naming the default change — a
+  migration heads-up for anyone upgrading straight from v0.8.2 who skipped the v0.8.3
+  `DeprecationWarning`. Removed in v0.10.0.
+
+### Removed
+
+- The v0.8.3 deprecation machinery: the falsy `_DefaultEnabledSentinel`, the
+  bare-construction `DeprecationWarning`, and the internal `_default_disabled_config`
+  helper. Bare `CrashRecoveryConfig()` is safe again — it now means "enabled".
 
 ## [0.8.4] — 2026-06-02
 

--- a/benchmarks/results/v0.9.0/attestation.md
+++ b/benchmarks/results/v0.9.0/attestation.md
@@ -1,0 +1,74 @@
+---
+title: v0.9.0 crash-recovery default-flip benchmark attestation
+date: 2026-06-03
+requirement: R10 (D-bench three-step)
+plan: docs/plans/2026-05-28-001-feat-c-flip-crash-recovery-default-on-plan.md (Unit 10)
+---
+
+# v0.9.0 Benchmark Validation Attestation
+
+This attests that the v0.9.0 crash-recovery default flip (`CrashRecoveryConfig.enabled`
+`False` → `True`, with retuned `heartbeat_timeout_ticks=120` / `max_hold_ticks=900`,
+plus the rate-limited `_maybe_sweep` wiring in `CoherenceAdapterCore`) introduces
+**zero unexplained drift** in `benchmarks/expected.json` and **zero unexplained
+`reclaim_*` events** under the real-workload benchmarks.
+
+## 1. Baseline (main) vs C-flip branch — zero drift
+
+The committed `benchmarks/expected.json` is the frozen main baseline. The benchmark
+generator (`tools/run_benchmarks.py`) is fully deterministic — no RNG seeding variance,
+no wall-clock dependence — so a single capture suffices for the noise check (the
+"two identical runs" step of D-bench is trivially satisfied by determinism, and a second
+run was confirmed identical during development).
+
+- Raw C-flip-branch run: [`c_flip_branch_run.txt`](c_flip_branch_run.txt)
+- Drift check vs committed baseline: [`drift_check_vs_expected.txt`](drift_check_vs_expected.txt)
+
+| Workload | Expected | Actual | Delta |
+|---|---|---|---|
+| 4-agent planning pipeline (read-heavy) | 68.73% | 68.73% | **0.00pp** |
+| 3-agent code review (write-moderate) | 46.71% | 46.71% | **0.00pp** |
+| 4-agent high-churn (write-heavy) | 28.71% | 28.71% | **0.00pp** |
+
+`expected.json` is therefore **unchanged** — no re-anchoring was performed, and none
+was warranted (ADV-07 / RM-3: never silently rebaseline).
+
+## 2. Why there is zero drift (source attribution)
+
+The flip makes the simulation engine and the bare adapters enabled-by-default, so the
+engine now emits a per-tick heartbeat for every *alive* agent and runs the reclamation
+sweep. Two reasons this does not move the benchmark token counts:
+
+1. **Heartbeats are not coherence traffic.** The benchmark measures `ccs_tokens` =
+   invalidation signals + pointer updates. `record_heartbeat` is coordinator-internal
+   state and emits no inter-agent message, so it contributes zero tokens.
+2. **Zero reclamations in the benchmark scenarios.** The benchmark workloads contain no
+   agent kills or stalls; every agent is heartbeated every tick, so no heartbeat gap ever
+   reaches the 120-tick timeout and no grant is held past the 900-tick max-hold. The
+   sweep runs but reclaims nothing — no `reclaim_*` event is emitted on any of
+   `bench_planner.py`, `bench_code_review.py`, `bench_high_churn.py`.
+
+## 3. Reclamation correctness (empirical, OOM-kill shape — RM-10 fallback)
+
+The contributed `cron-fan-out` fixture is not yet in-repo (RM-10). Its OOM-kill fallback —
+"construct one M/E grant-holder, kill it mid-run so its heartbeat gaps past the timeout,
+assert the sweep reclaims exactly that agent and no live agent" — is exercised
+deterministically and as CI-runnable tests rather than as a standalone benchmark fixture:
+
+- `tests/test_adapter_crash_recovery.py::TestMaybeSweepEndToEnd::test_stale_grant_reclaimed_on_read_diagnostic_once`
+  — a stalled MODIFIED grant-holder is reclaimed on a peer's read; the diagnostic emits once.
+- `tests/adapters/test_ccsstore.py::test_ccsstore_default_thresholds_no_false_reclaim_then_reclaims`
+  — with the **default** 120/900 thresholds, a held grant is NOT reclaimed within the
+  heartbeat window (gap 60 < 120) and IS reclaimed once past it (gap 120 ≥ 120).
+- `tests/test_engine.py::test_engine_flag_on_diverges_from_explicit_false_via_reclaim`
+  — a killed grant-holder is reclaimed by the engine sweep after its heartbeat gaps past
+  the timeout; the divergence from the disabled path is attributable to a `reclaim_*` event.
+
+Each asserts reclamation fires on exactly the stale grant and never on a live agent.
+
+## 4. Sign-off
+
+Zero unexplained `expected.json` drift; zero unexplained reclamations under the
+real-workload benchmarks; reclamation correctness covered by the CI-runnable tests above.
+
+Author: Vlad (hipvlady) — prepared ahead of the v0.9.0 release gate (≥ 2026-06-09, R13).

--- a/benchmarks/results/v0.9.0/c_flip_branch_run.txt
+++ b/benchmarks/results/v0.9.0/c_flip_branch_run.txt
@@ -1,0 +1,55 @@
+/Users/vladparakhin/projects/agent-coherence/.venv/lib/python3.13/site-packages/langgraph/checkpoint/serde/encrypted.py:5: LangChainPendingDeprecationWarning: The default value of `allowed_objects` will change in a future version. Pass an explicit value (e.g., allowed_objects='messages' or allowed_objects='core') to suppress this warning.
+  from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+/Users/vladparakhin/projects/agent-coherence/src/ccs/adapters/base.py:72: RuntimeWarning: CrashRecoveryConfig default changed in v0.9.0: enabled=True is now the default (was False in v0.8.x). If you intend the new behavior, you can silence this by passing CrashRecoveryConfig(enabled=True) explicitly. If you need v0.8.x behavior, pass CrashRecoveryConfig(enabled=False) to opt out. See CHANGELOG.md (section: [0.9.0]) at https://github.com/hipvlady/agent-coherence/blob/main/CHANGELOG.md for migration details.
+  crash_recovery if crash_recovery is not None else CrashRecoveryConfig()
+
+Benchmark: 4-agent planning pipeline (read-heavy)
+Content: ~320 tokens per artifact
+
+  InMemoryStore:    4160 tokens   (13 ops × 320)
+  CCSStore lazy:    1301 tokens   (1 write + 3 misses) × 320 + 9 hits × 1
+
+  Cache hit rate:   9 / 12 = 75%    ← fraction of reads served from cache
+  Token reduction:  69%            ← actual savings vs no-cache baseline
+  Elapsed (CCS):    0.018s
+
+  Results saved to: /Users/vladparakhin/projects/agent-coherence/benchmarks/results/langgraph_real/4-agent_planning_pipeline_(read-heavy).json
+
+
+Benchmark: 3-agent code review (write-moderate)
+Content: ~280 tokens per artifact
+
+  InMemoryStore:    5320 tokens   (19 ops × 280)
+  CCSStore lazy:    2835 tokens   (4 write + 6 misses) × 280 + 9 hits × 1
+
+  Cache hit rate:   9 / 15 = 60%    ← fraction of reads served from cache
+  Token reduction:  47%            ← actual savings vs no-cache baseline
+  Elapsed (CCS):    0.012s
+
+  Results saved to: /Users/vladparakhin/projects/agent-coherence/benchmarks/results/langgraph_real/3-agent_code_review_(write-moderate).json
+
+
+Benchmark: 4-agent high-churn (write-heavy)
+Content: ~250 tokens per artifact
+
+  InMemoryStore:    3250 tokens   (13 ops × 250)
+  CCSStore lazy:    2317 tokens   (5 write + 4 misses) × 250 + 4 hits × 1
+
+  Cache hit rate:   4 / 8 = 50%    ← fraction of reads served from cache
+  Token reduction:  29%            ← actual savings vs no-cache baseline
+  Elapsed (CCS):    0.015s
+
+  Results saved to: /Users/vladparakhin/projects/agent-coherence/benchmarks/results/langgraph_real/4-agent_high-churn_(write-heavy).json
+
+
+========================================================================
+  Consolidated benchmark results
+  Workload                                   Baseline       CCS  Savings
+------------------------------------------------------------------------
+  4-agent planning pipeline (read-heavy)         4160      1301    68.7%
+  3-agent code review (write-moderate)           5320      2835    46.7%
+  4-agent high-churn (write-heavy)               3250      2317    28.7%
+========================================================================
+
+Results written to: benchmarks/results/latest.json
+

--- a/benchmarks/results/v0.9.0/drift_check_vs_expected.txt
+++ b/benchmarks/results/v0.9.0/drift_check_vs_expected.txt
@@ -1,0 +1,7 @@
+  Workload                                   Expected    Actual    Delta
+------------------------------------------------------------------------
+  4-agent planning pipeline (read-heavy)       68.73%    68.73%    0.00pp
+  3-agent code review (write-moderate)         46.71%    46.71%    0.00pp
+  4-agent high-churn (write-heavy)             28.71%    28.71%    0.00pp
+
+Benchmark regression check passed.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -324,15 +324,16 @@ When an agent crashes (OOM-kill, segfault) or livelocks (holds a grant indefinit
 its `MODIFIED` or `EXCLUSIVE` grant blocks all other agents from writing to that artifact.
 The crash-recovery extension reclaims stale grants automatically.
 
-> **Deprecation — default flips in v0.9.0.** As of **v0.8.3**, constructing
-> `CrashRecoveryConfig()` without an explicit `enabled=` emits a one-shot
-> `DeprecationWarning`: the default changes from `enabled=False` to
-> `enabled=True` in **v0.9.0**. Pass `enabled=` explicitly to silence the
-> warning and pin your intended behavior — `CrashRecoveryConfig(enabled=True)`
-> to opt in now, or `CrashRecoveryConfig(enabled=False)` to keep crash
-> recovery off. See [CHANGELOG.md](../CHANGELOG.md) for the full migration
-> notes (including the v0.9.0 `heartbeat_timeout_ticks` / `max_hold_ticks`
-> retuning).
+> **Default flipped in v0.9.0.** As of **v0.9.0**, `CrashRecoveryConfig()`
+> defaults to `enabled=True` (it was `enabled=False` through v0.8.x), so a bare
+> `CCSStore()` / `CoherenceAdapterCore()` now runs crash recovery. The first
+> `CrashRecoveryConfig` construction per process emits a one-shot transitional
+> `RuntimeWarning` flagging the change for anyone upgrading straight from
+> v0.8.2 (removed in v0.10.0). To pin behavior and silence it, pass `enabled=`
+> explicitly — `CrashRecoveryConfig(enabled=True)` to keep the new default, or
+> `CrashRecoveryConfig(enabled=False)` to opt out. The v0.9.0 defaults were
+> also retuned (`heartbeat_timeout_ticks` 10 → 120, `max_hold_ticks` 1000 →
+> 900); see [CHANGELOG.md](../CHANGELOG.md) for the full migration notes.
 
 ### Enabling
 
@@ -356,9 +357,9 @@ The same `crash_recovery=` kwarg works on `LangGraphAdapter`, `CrewAIAdapter`,
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enabled` | `bool` | `False` | Master switch. When `False`, `heartbeat()` and `recover()` are silent no-ops; the per-tick sweep does not run. |
-| `heartbeat_timeout_ticks` | `int` | `10` | Reclaim a holder's grant if the gap between `now_tick` and the holder's last heartbeat is `>= heartbeat_timeout_ticks`. |
-| `max_hold_ticks` | `int` | `1000` | Reclaim a holder's grant if it has been continuously held in `MODIFIED`/`EXCLUSIVE` for `>= max_hold_ticks`, regardless of how recently the holder heartbeated. Bound the worst-case lock duration. |
+| `enabled` | `bool` | `True` | Master switch (**default-on as of v0.9.0**). When `False`, `heartbeat()` and `recover()` are silent no-ops and the sweep does not run. |
+| `heartbeat_timeout_ticks` | `int` | `120` | Reclaim a holder's grant if the gap between `now_tick` and the holder's last heartbeat is `>= heartbeat_timeout_ticks`. |
+| `max_hold_ticks` | `int` | `900` | Reclaim a holder's grant if it has been continuously held in `MODIFIED`/`EXCLUSIVE` for `>= max_hold_ticks`, regardless of how recently the holder heartbeated. Bound the worst-case lock duration. |
 
 **Tick semantics.** Ticks are a logical clock — the unit is whatever `now_tick` your application advances. For LangGraph, one node invocation per tick is a sensible default. For long-running tool calls or LLM calls, advance ticks at the granularity at which you can call `heartbeat()` or expect grants to be released.
 
@@ -393,23 +394,35 @@ exceed `lease_ttl_ticks`. Equal or smaller values raise `ValueError` at startup.
 
 ### Flag-off behavior
 
-With `enabled=False` (the default), `heartbeat()` and `recover()` are silent no-ops.
-State-transition log output is byte-identical to v0.5. No behavior change for existing
-users.
+With `enabled=False` (the opt-out — the v0.9.0 default is `enabled=True`),
+`heartbeat()` and `recover()` are silent no-ops and the sweep never runs.
+State-transition log output is then byte-identical to a build without crash
+recovery (R5). Note the inversion: omitting the `crash_recovery=` argument no
+longer reproduces that output — pass `CrashRecoveryConfig(enabled=False)`
+explicitly to get it.
 
 ### Disabling / rollback
 
-To turn crash recovery off, omit `crash_recovery=` (it defaults to disabled) or pass
-`CrashRecoveryConfig(enabled=False)`. This is the rollback path if a default-on
-release ever surfaces an issue in your workload — flip the kwarg back to disabled
-and the sweep stops immediately. No data migration, no protocol incompatibility:
-the protocol behavior with `enabled=False` is byte-identical to a build without
-crash recovery.
+To turn crash recovery off, pass `CrashRecoveryConfig(enabled=False)` explicitly.
+(As of v0.9.0 the default is enabled, so omitting `crash_recovery=` no longer
+disables it.) This is the rollback path if the default-on behavior ever surfaces
+an issue in your workload — set `enabled=False` and the sweep stops immediately.
+No data migration, no protocol incompatibility: the protocol behavior with
+`enabled=False` is byte-identical to a build without crash recovery.
 
-If you've enabled crash recovery and want to verify it isn't reclaiming benign
-holders, watch the state-transition log for `reclaim_heartbeat` and
-`reclaim_max_hold` triggers. If they fire on agents that were healthy, raise
-`heartbeat_timeout_ticks` or `max_hold_ticks` rather than disabling the feature.
+If you want to verify the sweep isn't reclaiming benign holders, watch the
+state-transition log for `reclaim_heartbeat` and `reclaim_max_hold` triggers. If
+they fire on agents that were healthy, raise `heartbeat_timeout_ticks` or
+`max_hold_ticks` rather than disabling the feature.
+
+### Reclamation diagnostics
+
+When the sweep reclaims a grant, `CoherenceAdapterCore` logs a one-shot `WARNING`
+on the `ccs.adapters.base` logger the **first** time that adapter instance
+reclaims, with structured `extra` fields `trigger`, `agent_id_short`,
+`artifact_id_short`, and `reclaim_count`. Subsequent reclamations on the same
+instance are silent; a companion `DEBUG` log carries the full UUIDs. Bind a
+handler to `ccs.adapters.base` to surface or ingest these events.
 
 ### Reference
 
@@ -886,7 +899,7 @@ Designed for CI gating; runs on every push. The companion script `tools/check_re
 | `on_error` | `str` | `"strict"` | `"strict"` to propagate `CoherenceError`; `"degrade"` to fall back silently |
 | `state_log` | `Callable[[dict], None] \| None` | `None` | Callback fired on every stable MESI state transition; see [State transitions log](#state-transitions-log) |
 | `content_audit_log` | `Callable[[dict], None] \| None` | `None` | Callback fired on every content delivery; see [Content audit log](#content-audit-log). Enables version retention. |
-| `crash_recovery` | `CrashRecoveryConfig \| None` | `None` | Crash-recovery configuration; see [Crash recovery](#crash-recovery). `None` uses `CrashRecoveryConfig(enabled=False)`. |
+| `crash_recovery` | `CrashRecoveryConfig \| None` | `None` | Crash-recovery configuration; see [Crash recovery](#crash-recovery). `None` uses `CrashRecoveryConfig()` — enabled by default as of v0.9.0. |
 | `**strategy_kwargs` | `Any` | — | Forwarded to the strategy constructor (`lease_ticks`, `threshold`, etc.) |
 
 ### Public imports

--- a/src/ccs/adapters/__init__.py
+++ b/src/ccs/adapters/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "CoherenceDegradedWarning",
     "CoherenceTopologyWarning",
     "CoherenceAdapterCore",
+    "CrashRecoveryConfig",
     "LangGraphAdapter",
     "CrewAIAdapter",
     "AutoGenAdapter",
@@ -37,6 +38,10 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "CoherenceDegradedWarning": (".base", "CoherenceDegradedWarning"),
     "CoherenceTopologyWarning": (".base", "CoherenceTopologyWarning"),
     "CoherenceAdapterCore": (".base", "CoherenceAdapterCore"),
+    # Re-exported from the coordinator package so the v0.9.0 opt-out
+    # (CrashRecoveryConfig(enabled=False)) is reachable from ccs.adapters,
+    # alongside the adapters whose default it now governs.
+    "CrashRecoveryConfig": ("..coordinator.service", "CrashRecoveryConfig"),
     "CoherenceSession": (".openai_agents", "CoherenceSession"),
     "CrewAIAdapter": (".crewai", "CrewAIAdapter"),
     "LangGraphAdapter": (".langgraph", "LangGraphAdapter"),

--- a/src/ccs/adapters/base.py
+++ b/src/ccs/adapters/base.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from dataclasses import dataclass
 from typing import Any, Callable
 from uuid import NAMESPACE_URL, UUID, uuid5
@@ -16,7 +17,6 @@ from ccs.coordinator.registry import ArtifactRegistry
 from ccs.coordinator.service import (
     CoordinatorService,
     CrashRecoveryConfig,
-    _default_disabled_config,
     validate_crash_recovery_config,
 )
 from ccs.core.exceptions import (  # re-exported; langgraph-free export point
@@ -63,13 +63,13 @@ class CoherenceAdapterCore:
         self._instance_id = instance_id
         self._content_audit_log = content_audit_log
         self._audit_seq = audit_seq
-        # Use _default_disabled_config() to avoid surfacing the v0.8.3
-        # DeprecationWarning on every bare CoherenceAdapterCore() / CCSStore()
-        # construction. The user did not pass crash_recovery=; their bare
-        # adapter call should not look like a misconfigured CrashRecoveryConfig
-        # site to them.
+        # Bare CoherenceAdapterCore() / CCSStore() adopt the v0.9.0
+        # enabled-by-default crash recovery: with no crash_recovery= argument,
+        # construct a default CrashRecoveryConfig() (enabled=True). The first
+        # such construction in a process emits the one-shot v0.9.0 transitional
+        # RuntimeWarning — the migration heads-up for jump-upgraders.
         self._crash_recovery = (
-            crash_recovery if crash_recovery is not None else _default_disabled_config()
+            crash_recovery if crash_recovery is not None else CrashRecoveryConfig()
         )
         self.registry = ArtifactRegistry(
             state_log=state_log,
@@ -86,6 +86,19 @@ class CoherenceAdapterCore:
         validate_crash_recovery_config(self._crash_recovery, self.strategy)
         self.event_bus = event_bus if event_bus is not None else InMemoryEventBus()
         self._agents_by_name: dict[str, AgentBinding] = {}
+        # Rate-limited crash-recovery sweep state (v0.9.0, KD-4). The sweep is
+        # invoked from read()/write() via _maybe_sweep; _sweep_lock serializes
+        # the check-then-set so concurrent callers (e.g. LangGraph parallel
+        # branches) cannot double-EMIT the diagnostic. The coordinator sweep
+        # itself runs OUTSIDE the lock, so it may execute concurrently under
+        # contention — any persistent on_reclaim consumer must be idempotent
+        # for a repeated (artifact_id, agent_id, trigger) at the same tick.
+        # _last_sweep_tick is None until the first sweep so the first eligible
+        # call always fires; thereafter the gate rate-limits to once per
+        # ``heartbeat_timeout_ticks // 2`` ticks.
+        self._last_sweep_tick: int | None = None
+        self._first_reclamation_emitted: bool = False
+        self._sweep_lock: threading.Lock = threading.Lock()
 
     def register_agent(self, name: str, *, now_tick: int = 0) -> UUID:
         """Register one agent runtime and subscribe it to bus events."""
@@ -154,11 +167,109 @@ class CoherenceAdapterCore:
                 names[artifact_id] = meta.name
         return names
 
+    def _maybe_sweep(self, now_tick: int) -> None:
+        """Rate-limited crash-recovery sweep (v0.9.0, KD-4 / KD-9).
+
+        Invoked from read()/write() after heartbeat recording. Skips fast when
+        crash recovery is disabled or when fewer than ``heartbeat_timeout_ticks
+        // 2`` ticks have elapsed since the last sweep — so a CCSStore batch
+        (which shares one tick across all ops) sweeps once on its first op and
+        skips the rest. Three-phase, thread-safe (Finding #6 + ce:review ADV-01):
+
+          1. Check the gate AND claim the slot under the lock (advance
+             ``_last_sweep_tick`` before releasing). Claiming under the lock is
+             what makes the coordinator sweep run AT MOST ONCE per gate window
+             under contention: a concurrent caller at the same tick sees the
+             advanced tick and skips, so the sweep / ``on_reclaim`` is not
+             double-fired.
+          2. Run the sweep WITHOUT holding the lock (arbitrary registry work).
+          3. Re-acquire only to gate the one-shot per-instance diagnostic.
+
+        Best-effort: a sweep failure is logged and never propagates into the
+        adapter's read/write path (mirrors the plugin lifecycle sweep). Because
+        the slot is claimed in Phase 1, a FAILED sweep is rate-limited — the next
+        attempt waits for the gate window instead of retrying on every call.
+        """
+        if not self._crash_recovery.enabled:
+            return
+
+        gate = self._crash_recovery.heartbeat_timeout_ticks // 2
+
+        # Fast path (no lock): a lock-free read of the last-sweep tick lets the
+        # common "swept recently" case skip without contending on _sweep_lock —
+        # this runs on every read()/write(). A stale read is benign: it can only
+        # cause a skip this tick (the next eligible tick sweeps); the
+        # authoritative gate check + claim still happens under the lock below.
+        last = self._last_sweep_tick
+        if last is not None and now_tick - last < gate:
+            return
+
+        # Phase 1: gate check + claim, under the lock (None == never swept ->
+        # always fire). Advancing the tick here (the "claim") is what serializes
+        # concurrent callers to a single coordinator sweep per gate window and
+        # rate-limits retries after a failure. The max() keeps the claim
+        # monotonic against a caller-supplied non-monotonic now_tick.
+        with self._sweep_lock:
+            if (
+                self._last_sweep_tick is not None
+                and now_tick - self._last_sweep_tick < gate
+            ):
+                return
+            self._last_sweep_tick = (
+                now_tick
+                if self._last_sweep_tick is None
+                else max(self._last_sweep_tick, now_tick)
+            )
+
+        # Phase 2: sweep WITHOUT holding the lock. Capture reclamations via the
+        # existing on_reclaim callback — no service-layer signature change.
+        reclaimed: list[tuple[UUID, UUID, str]] = []
+
+        def _capture(artifact_id: UUID, agent_id: UUID, trigger: str) -> None:
+            reclaimed.append((artifact_id, agent_id, trigger))
+
+        try:
+            self.coordinator.enforce_stable_grant_timeouts(
+                current_tick=now_tick,
+                heartbeat_timeout_ticks=self._crash_recovery.heartbeat_timeout_ticks,
+                max_hold_ticks=self._crash_recovery.max_hold_ticks,
+                on_reclaim=_capture,
+            )
+        except Exception:  # noqa: BLE001 — sweep is best-effort
+            # logger.exception() already attaches the message + traceback via
+            # exc_info. The slot was claimed in Phase 1, so the failed sweep is
+            # rate-limited (retry waits for the gate window, not every call).
+            logger.exception("agent-coherence: sweep tick failed")
+            return
+
+        # Phase 3: gate the one-shot per-instance diagnostic under the lock
+        # (_last_sweep_tick was already advanced by Phase 1's claim).
+        with self._sweep_lock:
+            should_emit = bool(reclaimed) and not self._first_reclamation_emitted
+            if should_emit:
+                self._first_reclamation_emitted = True
+
+        if should_emit:
+            artifact_id, agent_id, trigger = reclaimed[0]
+            logger.warning(
+                "agent-coherence: sweep reclaimed %d agent(s); first reclamation "
+                "per adapter instance is reported, subsequent are silent",
+                len(reclaimed),
+                extra={
+                    "trigger": trigger,
+                    "agent_id_short": str(agent_id)[:8],
+                    "artifact_id_short": str(artifact_id)[:8],
+                    "reclaim_count": len(reclaimed),
+                },
+            )
+            logger.debug("sweep reclaimed (full tuples): %s", reclaimed)
+
     def read(self, *, agent_name: str, artifact_id: UUID, now_tick: int) -> FetchResponse:
         """Read artifact through one registered runtime."""
         binding = self._binding(agent_name)
         if self._crash_recovery.enabled:
             self.coordinator.record_heartbeat(agent_id=binding.agent_id, now_tick=now_tick)
+        self._maybe_sweep(now_tick)
         return binding.runtime.read(artifact_id, now_tick=now_tick)
 
     def write(
@@ -173,6 +284,7 @@ class CoherenceAdapterCore:
         writer = self._binding(agent_name)
         if self._crash_recovery.enabled:
             self.coordinator.record_heartbeat(agent_id=writer.agent_id, now_tick=now_tick)
+        self._maybe_sweep(now_tick)
         updated, invalidation_signals = writer.runtime.write(
             artifact_id=artifact_id,
             content=content,

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import threading
 import warnings
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Callable, Optional
 from uuid import UUID
 
@@ -23,76 +23,36 @@ from .registry import ArtifactRegistry
 logger = logging.getLogger(__name__)
 
 
-# v0.8.3 deprecation cycle — see docs/plans/2026-05-28-001-feat-c-flip-...
-# A module-level sentinel distinguishes bare ``CrashRecoveryConfig()`` from
-# explicit ``CrashRecoveryConfig(enabled=False)``. The sentinel, the
-# emit-once flag, the lock, and the message constant are all removed in
-# v0.9.0 when the default flips to ``enabled=True``.
-
-
-class _DefaultEnabledSentinel:
-    """Falsy marker for an unspecified ``enabled`` in ``CrashRecoveryConfig``.
-
-    ``__post_init__`` uses identity (``is``) to detect bare construction and
-    normalize ``enabled`` to ``False``. The sentinel is deliberately *falsy*
-    so that on the rare paths where normalization is skipped, the value still
-    reads as disabled — matching the v0.8.x default and keeping the crash
-    recovery sweep from silently activating:
-
-    * ``importlib.reload`` (gunicorn/uvicorn ``--reload``, Jupyter autoreload)
-      re-executes this module in place, rebinding ``_DEFAULT_ENABLED_SENTINEL``
-      to a fresh instance. An instance of the *pre-reload* class still carries
-      the old sentinel as its field default, so the ``is`` check fails and
-      normalization is skipped (ce:review ADV-01).
-    * A subclass whose ``__post_init__`` overrides ours without calling
-      ``super().__post_init__()`` never normalizes at all (ce:review ADV-03).
-
-    In both cases ``bool(enabled)`` is ``False``, so production checks of the
-    form ``if self._crash_recovery.enabled:`` stay correct. Removed in v0.9.0.
-    """
-
-    __slots__ = ()
-
-    def __bool__(self) -> bool:
-        return False
-
-    def __repr__(self) -> str:
-        return "<CrashRecoveryConfig.enabled unset>"
-
-
-# Test-isolation contract: ``_BARE_CONSTRUCTION_WARNED`` is module-level
-# mutable state that persists across pytest test functions in the same
-# process. Tests that assert on warning emission MUST reset it to ``False``
-# before the bare construction (either directly via
-# ``service._BARE_CONSTRUCTION_WARNED = False`` or via the
-# ``reset_bare_construction_flag`` pytest fixture in
-# ``tests/test_coordinator.py``). Without the reset, test ordering
-# determines whether the first test sees the warning and later tests do
-# not — a silent-degrade failure mode under pytest-xdist or randomized
-# ordering. The reset is paired with the flag's lifecycle by intent: this
-# whole block is removed in v0.9.0 along with the test fixture.
+# v0.9.0 transitional first-use warning — see
+# docs/plans/2026-05-28-001-feat-c-flip-crash-recovery-default-on-plan.md.
+# The v0.8.3 deprecation cycle (falsy sentinel + DeprecationWarning) is gone
+# now that the default has flipped to ``enabled=True``. A single transitional
+# ``RuntimeWarning`` fires once per process on the first ``CrashRecoveryConfig``
+# construction so jump-upgraders (v0.8.2 -> v0.9.0) who skipped the v0.8.3
+# cycle still get a migration heads-up. Removed entirely in v0.10.0.
 #
-# ``_BARE_CONSTRUCTION_LOCK`` makes the check-then-set atomic so two threads
-# constructing bare configs concurrently cannot both emit. The GIL made the
-# naive check incidentally safe; free-threaded Python 3.13+ removes it. This
-# mirrors the ``threading.Lock`` pattern the plan's KD-4 specifies for the
-# v0.9.0 first-use guard (ce:review ADV-02).
-_DEFAULT_ENABLED_SENTINEL = _DefaultEnabledSentinel()
-_BARE_CONSTRUCTION_WARNED: bool = False
-_BARE_CONSTRUCTION_LOCK = threading.Lock()
+# Test-isolation contract: ``_V090_FIRST_USE_WARNED`` is module-level mutable
+# state that persists across instances and pytest test functions in the same
+# process. Tests that assert on the warning MUST reset it to ``False`` before
+# construction (via ``service._V090_FIRST_USE_WARNED = False`` or the
+# ``reset_v090_first_use_flag`` fixture in ``tests/test_coordinator.py``).
+#
+# ``_V090_FIRST_USE_LOCK`` makes the check-then-set atomic so two threads
+# constructing configs concurrently cannot both emit. The GIL made the naive
+# check incidentally safe; free-threaded Python 3.13+ removes it (mirrors the
+# v0.8.3 ADV-02 lock). The warning is emitted OUTSIDE the lock because warning
+# filters can run arbitrary user code.
+_V090_FIRST_USE_WARNED: bool = False
+_V090_FIRST_USE_LOCK = threading.Lock()
 
-# Emitted on BOTH the warnings channel (visible under ``-W`` / pytest) and the
-# logging channel (visible under any ``logging.basicConfig()`` — the common
-# case CPython's default ``DeprecationWarning`` filter hides for non-__main__
-# importers). These are two of the three RM-9 belt-and-suspenders layers; the
-# third is the v0.9.0 transitional first-use warning. Removed in v0.9.0.
-_BARE_CONSTRUCTION_MESSAGE = (
-    "CrashRecoveryConfig() default will flip to `enabled=True` in v0.9.0. "
-    "Recommended migration: pass CrashRecoveryConfig(enabled=True) to opt in "
-    "now and surface any false-reclaim issues under your workload. If you "
-    "have a specific reason to keep crash recovery off, pass "
-    "CrashRecoveryConfig(enabled=False) explicitly. See CHANGELOG.md "
-    "(section: [0.8.3]) at "
+_V090_FIRST_USE_MESSAGE = (
+    "CrashRecoveryConfig default changed in v0.9.0: enabled=True is now the "
+    "default (was False in v0.8.x), so crash recovery runs by default. Pass "
+    "CrashRecoveryConfig(enabled=True) to keep the new behavior or "
+    "CrashRecoveryConfig(enabled=False) to opt out. This notice fires once per "
+    "process on the first construction regardless of the value passed; to "
+    "suppress it, filter RuntimeWarning from the 'ccs.coordinator.service' "
+    "logger. See CHANGELOG.md (section: [0.9.0]) at "
     "https://github.com/hipvlady/agent-coherence/blob/main/CHANGELOG.md "
     "for migration details."
 )
@@ -102,14 +62,16 @@ _BARE_CONSTRUCTION_MESSAGE = (
 class CrashRecoveryConfig:
     """Configuration knobs for the stable-grant reclamation sweep.
 
-    The sweep ships disabled by default in v0.8.x (R10). The default
-    will flip to ``enabled=True`` in v0.9.0; bare ``CrashRecoveryConfig()``
-    in v0.8.3 emits a ``DeprecationWarning`` once per process to warn
-    downstream consumers ahead of the flip.
+    The sweep ships **enabled by default** as of v0.9.0 (R10 — the default
+    flipped from ``False`` to ``True``, so bare ``CrashRecoveryConfig()`` now
+    activates crash recovery). A one-shot transitional ``RuntimeWarning`` fires
+    on the first construction per process to flag the change for jump-upgraders
+    who skipped the v0.8.3 deprecation cycle. Pass
+    ``CrashRecoveryConfig(enabled=False)`` to restore v0.8.x behavior.
 
     Attributes:
-        enabled: Master flag. When ``False`` (v0.8.x default), the sweep
-            is never invoked and no heartbeat is required.
+        enabled: Master flag. When ``True`` (v0.9.0 default), the sweep
+            reclaims stale M∪E grants. Pass ``enabled=False`` to opt out.
         heartbeat_timeout_ticks: Sweep reclaims any M∪E grant whose holder
             has not heartbeated within this many ticks.
         max_hold_ticks: Sweep reclaims any M∪E grant held for at least this
@@ -117,59 +79,31 @@ class CrashRecoveryConfig:
             inspectable strategy lease TTL when ``enabled=True`` (R11).
     """
 
-    # field(default=_DEFAULT_ENABLED_SENTINEL) lets __post_init__ distinguish
-    # bare construction from explicit False; the type-ignore is necessary
-    # because the runtime sentinel is not a bool but the public type is.
-    enabled: bool = field(default=_DEFAULT_ENABLED_SENTINEL)  # type: ignore[assignment]
-    heartbeat_timeout_ticks: int = 10
-    max_hold_ticks: int = 1000
+    enabled: bool = True
+    heartbeat_timeout_ticks: int = 120
+    max_hold_ticks: int = 900
 
     def __post_init__(self) -> None:
-        """Detect bare construction; emit the one-shot deprecation signal.
+        """Emit the one-shot v0.9.0 transitional first-use warning.
 
-        The dataclass is ``frozen=True``, so we normalize the sentinel-typed
-        ``enabled`` field via ``object.__setattr__`` (direct assignment would
-        raise ``FrozenInstanceError``).
+        With the v0.8.3 sentinel removed, bare ``CrashRecoveryConfig()`` and
+        explicit ``CrashRecoveryConfig(enabled=True)`` are indistinguishable,
+        so the warning fires once per process on the FIRST construction
+        regardless of how ``enabled`` was supplied — catching jump-upgraders
+        (v0.8.2 -> v0.9.0) who skipped the v0.8.3 cycle. Removed in v0.10.0.
         """
-        global _BARE_CONSTRUCTION_WARNED
-        if self.enabled is _DEFAULT_ENABLED_SENTINEL:
-            # Claim the one-shot emission atomically under the lock, then emit
-            # OUTSIDE it: warning filters and logging handlers can run arbitrary
-            # user code, and we never hold the lock across that (ADV-02).
-            should_emit = False
-            with _BARE_CONSTRUCTION_LOCK:
-                if not _BARE_CONSTRUCTION_WARNED:
-                    _BARE_CONSTRUCTION_WARNED = True
-                    should_emit = True
-            if should_emit:
-                # logging first, so the migration signal is recorded even when
-                # ``-W error`` escalates the DeprecationWarning into a raise
-                # (and so it survives CPython's default filter — RM-9 Layer 2).
-                logger.warning(_BARE_CONSTRUCTION_MESSAGE)
-                # stacklevel=3: warn() -> __post_init__ -> __init__ -> caller.
-                warnings.warn(
-                    _BARE_CONSTRUCTION_MESSAGE, DeprecationWarning, stacklevel=3
-                )
-            # frozen dataclass — direct assignment raises FrozenInstanceError.
-            # object.__setattr__ is the documented escape for __post_init__
-            # normalization on frozen dataclasses.
-            object.__setattr__(self, "enabled", False)
-
-
-def _default_disabled_config() -> CrashRecoveryConfig:
-    """Internal helper: construct ``CrashRecoveryConfig(enabled=False)``
-    without triggering the v0.8.3 bare-construction ``DeprecationWarning``.
-
-    Used by library-internal code paths (``simulation.engine``,
-    ``adapters.base``) that need the v0.8.x default-disabled config object
-    but should not surface the deprecation warning to end users — the bare
-    construction is the library's own, not the user's, so it would be a
-    false alarm.
-
-    Removed in v0.9.0 when the default flips to ``enabled=True`` and the
-    sentinel mechanism is unwound.
-    """
-    return CrashRecoveryConfig(enabled=False)
+        global _V090_FIRST_USE_WARNED
+        # Claim the one-shot emission atomically under the lock, then emit
+        # OUTSIDE it: warning filters can run arbitrary user code, and we never
+        # hold the lock across that (mirrors the v0.8.3 ADV-02 discipline).
+        should_emit = False
+        with _V090_FIRST_USE_LOCK:
+            if not _V090_FIRST_USE_WARNED:
+                _V090_FIRST_USE_WARNED = True
+                should_emit = True
+        if should_emit:
+            # stacklevel=3: warn() -> __post_init__ -> __init__ -> caller.
+            warnings.warn(_V090_FIRST_USE_MESSAGE, RuntimeWarning, stacklevel=3)
 
 
 def validate_crash_recovery_config(

--- a/src/ccs/simulation/engine.py
+++ b/src/ccs/simulation/engine.py
@@ -15,7 +15,6 @@ from ccs.coordinator.registry import ArtifactRegistry
 from ccs.coordinator.service import (
     CoordinatorService,
     CrashRecoveryConfig,
-    _default_disabled_config,
     validate_crash_recovery_config,
 )
 from ccs.core.clock import LogicalClock
@@ -44,14 +43,18 @@ class _FailureEvent:
 
 
 def _build_crash_recovery_config(scenario_config: Mapping[str, Any]) -> CrashRecoveryConfig:
-    """Read optional ``crash_recovery`` block from scenario; default to safe values.
+    """Read optional ``crash_recovery`` block from scenario.
 
-    Uses ``_default_disabled_config()`` (not bare ``CrashRecoveryConfig()``)
-    to avoid surfacing the v0.8.3 ``DeprecationWarning`` on every
-    ``SimulationEngine`` instantiation that omits a ``crash_recovery`` block.
+    A scenario that omits the ``crash_recovery`` block inherits the library
+    default — which flipped to ``enabled=True`` (with retuned 120/900
+    thresholds) in v0.9.0 (R4/R6). The engine therefore emits heartbeats and
+    runs the reclamation sweep by default; scenarios opt out with
+    ``crash_recovery: {enabled: false}``. Per R5, byte-identity now holds
+    between an omitted block and an explicit ``{enabled: true}`` block (and
+    DIVERGES from ``{enabled: false}``) — see ``tests/test_engine.py``.
     """
     block = scenario_config.get("crash_recovery") or {}
-    defaults = _default_disabled_config()
+    defaults = CrashRecoveryConfig()
     return CrashRecoveryConfig(
         enabled=bool(block.get("enabled", defaults.enabled)),
         heartbeat_timeout_ticks=int(

--- a/tests/adapters/test_ccsstore.py
+++ b/tests/adapters/test_ccsstore.py
@@ -6,9 +6,10 @@
 from __future__ import annotations
 
 import json
+import logging
 import warnings
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from uuid import NAMESPACE_URL, uuid5
 
 import pytest
@@ -1044,7 +1045,11 @@ def test_ccsstore_recover_checkpoint_restore_flow() -> None:
 
 
 def test_ccsstore_flag_off_heartbeat_noop() -> None:
-    store = _store()
+    # Explicit enabled=False: post-v0.9.0 the bare default is enabled, so the
+    # "flag off" contract requires opting out explicitly.
+    from ccs.coordinator.service import CrashRecoveryConfig
+
+    store = _store(crash_recovery=CrashRecoveryConfig(enabled=False))
     _put(store, ("planner", "shared"), "plan", {"v": 1})
 
     store.heartbeat(agent_name="planner", now_tick=42)
@@ -1053,18 +1058,25 @@ def test_ccsstore_flag_off_heartbeat_noop() -> None:
     assert store.core.registry.last_heartbeat_tick(agent_id) is None
 
 
-# ---- v0.8.3 C-flip Unit 2 — R2 internal-bare-construction hygiene ------------
+# ---- v0.9.0 C-flip — bare CCSStore adopts enabled-by-default ----------------
 #
 # See docs/plans/2026-05-28-001-feat-c-flip-crash-recovery-default-on-plan.md
-# Unit 2. The most-common adapter construction path (bare CCSStore() with no
-# crash_recovery= argument) traverses CoherenceAdapterCore.__init__ which used
-# to bare-construct CrashRecoveryConfig() — that emitted the v0.8.3
-# DeprecationWarning from inside library code, indistinguishable to users
-# from their own code. Test that the helper fix removed this.
+# Units 5 + 6. Post-flip, bare CCSStore() (no crash_recovery= argument) adopts
+# the enabled-by-default crash recovery. The v0.8.3 DeprecationWarning is gone;
+# the only warning that may surface is the one-shot v0.9.0 transitional
+# RuntimeWarning (suppressed suite-wide by the conftest neutralizer except in
+# the dedicated tests/test_coordinator.py assertions).
 
 
-def test_bare_ccsstore_emits_no_deprecation_warning() -> None:
-    """R2: CCSStore() with no crash_recovery= must not surface the v0.8.3 warning."""
+def test_bare_ccsstore_adopts_enabled_default_no_deprecation_warning() -> None:
+    """v0.9.0: bare CCSStore() emits no DeprecationWarning (the v0.8.3 warning is
+    removed) and adopts the enabled-by-default crash recovery; at most one
+    transitional RuntimeWarning may surface."""
+    from ccs.coordinator import service as _service_mod
+
+    # Reset the once-per-process flag so we deterministically observe the
+    # transitional warning here (the conftest neutralizer otherwise pre-sets it).
+    _service_mod._V090_FIRST_USE_WARNED = False
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         store = CCSStore(strategy="lazy")
@@ -1075,5 +1087,110 @@ def test_bare_ccsstore_emits_no_deprecation_warning() -> None:
         f"bare CCSStore construction must not emit DeprecationWarning, got: "
         f"{[str(w.message) for w in deprecation_warnings]}"
     )
-    # And the v0.8.x default behavior is preserved.
-    assert store.core._crash_recovery.enabled is False
+    runtime_warnings = [
+        w for w in caught if issubclass(w.category, RuntimeWarning)
+    ]
+    assert len(runtime_warnings) <= 1
+    # The flip: bare construction now enables crash recovery.
+    assert store.core._crash_recovery.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# v0.9.0 Unit 9: CCSStore once-per-batch sweep (KD-9) + Unit 6 default-threshold
+# false-reclaim regression. No production code changes — once-per-batch emerges
+# from batch()'s shared per-batch tick + CoherenceAdapterCore's rate-limited
+# _maybe_sweep (the sweep seam lives on store.core, not on CCSStore).
+# ---------------------------------------------------------------------------
+
+
+def _enabled_store(**overrides):
+    from ccs.coordinator.service import CrashRecoveryConfig
+
+    cfg = CrashRecoveryConfig(enabled=True, heartbeat_timeout_ticks=10, max_hold_ticks=1000)
+    return _store(crash_recovery=cfg, **overrides)
+
+
+def test_ccsstore_batch_sweeps_once_per_batch() -> None:
+    """KD-9: a multi-op batch shares one tick, so the rate-limited sweep fires on
+    the first op and skips the rest — exactly ONE coordinator sweep per batch."""
+    store = _enabled_store()  # heartbeat_timeout=10 -> gate=5
+    _put(store, ("planner", "shared"), "plan", {"v": 1})  # creates artifact; sweeps at tick 1
+    # Spy AFTER setup so we count only the test batch's sweeps.
+    store.core.coordinator.enforce_stable_grant_timeouts = Mock(return_value=0)
+    store._tick = 100  # next batch runs at tick 101, well past the gate from tick 1
+    store.batch([
+        GetOp(namespace=("planner", "shared"), key="plan"),
+        GetOp(namespace=("planner", "shared"), key="plan"),
+        GetOp(namespace=("planner", "shared"), key="plan"),
+    ])
+    assert store.core.coordinator.enforce_stable_grant_timeouts.call_count == 1
+
+
+def test_ccsstore_sweep_rate_limited_across_batches() -> None:
+    """Per-batch rate-limit: consecutive batches at ticks 1, 2, 6 sweep on the
+    first and third only (the second is within the gate=5 window)."""
+    store = _enabled_store()  # gate = 5
+    _put(store, ("planner", "shared"), "plan", {"v": 1})
+    store.core.coordinator.enforce_stable_grant_timeouts = Mock(return_value=0)
+    # Reset the sweep gate so the batch timing below is exactly what we control.
+    store.core._last_sweep_tick = None
+    store._tick = 0
+    _get(store, ("planner", "shared"), "plan")  # batch -> tick 1; first ever -> fire
+    _get(store, ("planner", "shared"), "plan")  # batch -> tick 2; 2-1=1 < gate -> skip
+    store._tick = 5
+    _get(store, ("planner", "shared"), "plan")  # batch -> tick 6; 6-1=5 >= gate -> fire
+    assert store.core.coordinator.enforce_stable_grant_timeouts.call_count == 2
+
+
+def test_ccsstore_disabled_never_sweeps() -> None:
+    from ccs.coordinator.service import CrashRecoveryConfig
+
+    store = _store(crash_recovery=CrashRecoveryConfig(enabled=False))
+    store.core.coordinator.enforce_stable_grant_timeouts = Mock(return_value=0)
+    _put(store, ("planner", "shared"), "plan", {"v": 1})
+    for _ in range(10):
+        _get(store, ("planner", "shared"), "plan")
+    store.core.coordinator.enforce_stable_grant_timeouts.assert_not_called()
+
+
+def test_ccsstore_first_reclamation_diagnostic(caplog) -> None:
+    """First reclamation through a CCSStore batch emits the diagnostic exactly
+    once on the ``ccs.adapters.base`` logger; subsequent batches do not re-emit."""
+    store = _enabled_store()  # hb=10, gate=5
+    _put(store, ("holder", "shared"), "doc", {"v": 1})  # holder MODIFIED on 'doc' at tick 1
+    with caplog.at_level(logging.WARNING, logger="ccs.adapters.base"):
+        # A different agent operates on a DIFFERENT artifact to advance the tick
+        # without disturbing holder's grant via the coherence protocol; only the
+        # sweep can reclaim it.
+        store._tick = 50
+        _put(store, ("other", "shared"), "scratch", {"v": 1})  # tick 51: sweep reclaims holder (gap 50 >= 10)
+        store._tick = 100
+        _put(store, ("other", "shared"), "scratch", {"v": 2})  # tick 101: holder already reclaimed -> no re-emit
+    records = [
+        r for r in caplog.records
+        if r.name == "ccs.adapters.base" and r.levelno == logging.WARNING
+    ]
+    assert len(records) == 1
+    assert records[0].reclaim_count == 1
+
+
+def test_ccsstore_default_thresholds_no_false_reclaim_then_reclaims() -> None:
+    """Unit 6 CI-runnable false-reclaim regression (R10 supplement), exercised via
+    CCSStore batch semantics with the v0.9.0 DEFAULT thresholds (heartbeat_timeout
+    =120, gate=60). A held grant is NOT reclaimed while the holder's heartbeat gap
+    is within the timeout, and IS reclaimed once it crosses. Guards future tuning
+    patches against silently regressing the safety floor."""
+    store = _store()  # bare -> enabled-by-default: hb=120, max_hold=900, gate=60
+    _put(store, ("holder", "shared"), "doc", {"v": 1})  # holder MODIFIED at tick 1, last hb=1
+    artifact_id = store._artifact_map[(("shared",), "doc")]
+    holder_id = store.core.agent_id_for("holder")
+
+    # Within the heartbeat window: drive a sweep at tick 61 (gap 60 < 120). Kept.
+    store._tick = 60
+    _put(store, ("other", "shared"), "scratch", {"v": 1})  # tick 61: sweep fires, holder gap 60 < 120
+    assert store.core.registry.get_agent_state(artifact_id, holder_id) == MESIState.MODIFIED
+
+    # Past the window: drive a sweep at tick 121 (gap 120 >= 120). Reclaimed.
+    store._tick = 120
+    _put(store, ("other", "shared"), "scratch", {"v": 2})  # tick 121: sweep fires, holder gap 120 >= 120
+    assert store.core.registry.get_agent_state(artifact_id, holder_id) == MESIState.INVALID

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import importlib.util
 
+import pytest
+
 collect_ignore_glob: list[str] = []
 
 if importlib.util.find_spec("langchain_core") is None:
@@ -30,3 +32,41 @@ if importlib.util.find_spec("langchain_core") is None:
 # `live_api` marker keeps them out of the default `pytest -q` run regardless.
 if importlib.util.find_spec("openai") is None or importlib.util.find_spec("mistralai") is None:
     collect_ignore_glob.append("test_*_live.py")
+
+
+def pytest_configure(config):
+    """Neutralize the v0.9.0 transitional RuntimeWarning at COLLECTION time.
+
+    Module-level ``CrashRecoveryConfig`` constructions in test files (e.g. the
+    ``CR_CFG`` constant in test_adapter_crash_recovery.py) run at import /
+    collection — before the autouse fixture below ever fires. Pre-setting the
+    flag here keeps a ``-W error::RuntimeWarning`` run from failing collection
+    on that first construction. Dedicated warning-assertion tests still reset
+    the flag to ``False`` to observe the warning.
+    """
+    from ccs.coordinator import service as _service
+
+    _service._V090_FIRST_USE_WARNED = True
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_v090_first_use_warning():
+    """Suite-wide neutralizer for the v0.9.0 ``CrashRecoveryConfig`` transitional
+    ``RuntimeWarning`` (C-flip plan, Unit 5).
+
+    The warning fires once per process on the FIRST ``CrashRecoveryConfig``
+    construction — including explicit ones. Without this, whichever test
+    constructs a config first (especially under ``warnings.simplefilter
+    ("error")``) would observe the warning order-dependently. We mark the
+    module-level flag "already warned" before every test so the warning is a
+    no-op by default.
+
+    The dedicated tests in ``tests/test_coordinator.py`` that ASSERT the
+    warning opt back in via their own ``reset_v090_first_use_flag`` fixture
+    (or an inline reset), which pytest runs after this autouse fixture and
+    flips the flag to ``False`` so the warning fires for those tests only.
+    """
+    from ccs.coordinator import service as _service
+
+    _service._V090_FIRST_USE_WARNED = True
+    yield

--- a/tests/test_adapter_crash_recovery.py
+++ b/tests/test_adapter_crash_recovery.py
@@ -11,10 +11,15 @@ enforce_stable_grant_timeouts between adapter calls.
 from __future__ import annotations
 
 import asyncio
+import logging
+import threading
+from unittest.mock import Mock
+from uuid import uuid4
 
 import pytest
 
 from ccs.adapters.autogen import AutoGenAdapter
+from ccs.adapters.base import CoherenceAdapterCore
 from ccs.adapters.crewai import CrewAIAdapter
 from ccs.adapters.langgraph import LangGraphAdapter
 from ccs.adapters.openai_agents import OpenAIAgentsAdapter
@@ -367,3 +372,235 @@ class TestCompositionFailFast:
                 lease_ttl_ticks=300,
                 crash_recovery=CrashRecoveryConfig(enabled=True, max_hold_ticks=300),
             )
+
+
+# ---- v0.9.0 Unit 8: rate-limited _maybe_sweep + structured-log diagnostic ----
+#
+# See docs/plans/2026-05-28-001-feat-c-flip-crash-recovery-default-on-plan.md
+# Unit 8. CR_CFG uses heartbeat_timeout_ticks=10, so the rate-limit gate is
+# ``10 // 2 == 5`` ticks. Diagnostic is logged on the ``ccs.adapters.base``
+# logger at WARNING with structured ``extra`` fields.
+
+_GATE = CR_CFG.heartbeat_timeout_ticks // 2  # == 5
+
+
+def _core(**overrides) -> CoherenceAdapterCore:
+    defaults = dict(strategy_name="lazy", crash_recovery=CR_CFG)
+    defaults.update(overrides)
+    return CoherenceAdapterCore(**defaults)
+
+
+def _reclaiming_enforce(*, current_tick, heartbeat_timeout_ticks, max_hold_ticks, on_reclaim):
+    """Mock side_effect simulating the sweep reclaiming exactly one grant."""
+    on_reclaim(uuid4(), uuid4(), "reclaim_heartbeat")
+    return 1
+
+
+class TestMaybeSweepRateLimit:
+    """KD-4 rate-limit gate + monotonicity defense + disabled short-circuit."""
+
+    def test_first_call_fires_then_gate_skips_within_window(self) -> None:
+        core = _core()
+        core.coordinator.enforce_stable_grant_timeouts = Mock(return_value=0)
+        core._maybe_sweep(now_tick=0)  # first call fires (never-swept sentinel)
+        core._maybe_sweep(now_tick=_GATE - 1)  # within window -> skip
+        assert core.coordinator.enforce_stable_grant_timeouts.call_count == 1
+
+    def test_fires_again_on_second_eligible_tick(self) -> None:
+        core = _core()
+        core.coordinator.enforce_stable_grant_timeouts = Mock(return_value=0)
+        core._maybe_sweep(now_tick=0)
+        core._maybe_sweep(now_tick=_GATE)  # exactly at the gate -> fire
+        assert core.coordinator.enforce_stable_grant_timeouts.call_count == 2
+        assert core._last_sweep_tick == _GATE
+
+    def test_disabled_short_circuits(self) -> None:
+        core = _core(crash_recovery=CrashRecoveryConfig(enabled=False))
+        core.coordinator.enforce_stable_grant_timeouts = Mock(return_value=0)
+        core._maybe_sweep(now_tick=100)
+        core.coordinator.enforce_stable_grant_timeouts.assert_not_called()
+
+    def test_non_monotonic_tick_defense(self) -> None:
+        core = _core()
+        core.coordinator.enforce_stable_grant_timeouts = Mock(return_value=0)
+        core._maybe_sweep(now_tick=100)  # fire -> _last_sweep_tick = 100
+        core._maybe_sweep(now_tick=50)  # backward jump (50 - 100 < gate) -> skip
+        assert core._last_sweep_tick == 100
+        assert core.coordinator.enforce_stable_grant_timeouts.call_count == 1
+
+    def test_read_invokes_maybe_sweep(self) -> None:
+        core = _core()
+        core.register_agent("A")
+        artifact = core.register_artifact(name="x.md", content="v1")
+        core._maybe_sweep = Mock()  # type: ignore[method-assign]
+        core.read(agent_name="A", artifact_id=artifact.id, now_tick=7)
+        core._maybe_sweep.assert_called_once_with(7)
+
+    def test_write_invokes_maybe_sweep(self) -> None:
+        core = _core()
+        core.register_agent("A")
+        artifact = core.register_artifact(name="x.md", content="v1")
+        core._maybe_sweep = Mock()  # type: ignore[method-assign]
+        core.write(agent_name="A", artifact_id=artifact.id, content="v2", now_tick=9)
+        core._maybe_sweep.assert_called_once_with(9)
+
+
+class TestMaybeSweepDiagnostic:
+    """R9 first-reclamation diagnostic: logger.warning + structured extras."""
+
+    def test_first_reclamation_emits_structured_diagnostic(self, caplog) -> None:
+        core = _core()
+        aid, agid = uuid4(), uuid4()
+
+        def _enforce(*, current_tick, heartbeat_timeout_ticks, max_hold_ticks, on_reclaim):
+            on_reclaim(aid, agid, "reclaim_heartbeat")
+            return 1
+
+        core.coordinator.enforce_stable_grant_timeouts = Mock(side_effect=_enforce)
+        with caplog.at_level(logging.WARNING, logger="ccs.adapters.base"):
+            core._maybe_sweep(now_tick=10)
+        records = [
+            r for r in caplog.records
+            if r.name == "ccs.adapters.base" and r.levelno == logging.WARNING
+        ]
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.trigger == "reclaim_heartbeat"
+        assert rec.agent_id_short == str(agid)[:8]
+        assert rec.artifact_id_short == str(aid)[:8]
+        assert rec.reclaim_count == 1
+        assert "sweep reclaimed 1 agent(s)" in rec.getMessage()
+
+    def test_diagnostic_dedupes_per_instance(self, caplog) -> None:
+        core = _core()
+        core.coordinator.enforce_stable_grant_timeouts = Mock(side_effect=_reclaiming_enforce)
+        with caplog.at_level(logging.WARNING, logger="ccs.adapters.base"):
+            core._maybe_sweep(now_tick=0)  # fires + reclaims + emits
+            core._maybe_sweep(now_tick=10)  # fires + reclaims, but no second emit
+        records = [
+            r for r in caplog.records
+            if r.name == "ccs.adapters.base" and r.levelno == logging.WARNING
+        ]
+        assert len(records) == 1
+
+    def test_diagnostic_is_per_instance_not_per_process(self, caplog) -> None:
+        c1, c2 = _core(), _core()
+        c1.coordinator.enforce_stable_grant_timeouts = Mock(side_effect=_reclaiming_enforce)
+        c2.coordinator.enforce_stable_grant_timeouts = Mock(side_effect=_reclaiming_enforce)
+        with caplog.at_level(logging.WARNING, logger="ccs.adapters.base"):
+            c1._maybe_sweep(now_tick=10)
+            c2._maybe_sweep(now_tick=10)
+        records = [
+            r for r in caplog.records
+            if r.name == "ccs.adapters.base" and r.levelno == logging.WARNING
+        ]
+        assert len(records) == 2
+
+    def test_sweep_failure_is_best_effort_and_rate_limits_retry(self, caplog) -> None:
+        core = _core()  # heartbeat_timeout=10 -> gate=5
+        core.register_agent("A")
+        artifact = core.register_artifact(name="x.md", content="v1")
+        core.coordinator.enforce_stable_grant_timeouts = Mock(
+            side_effect=RuntimeError("synthetic")
+        )
+        with caplog.at_level(logging.ERROR, logger="ccs.adapters.base"):
+            # read must complete despite the sweep raising.
+            core.read(agent_name="A", artifact_id=artifact.id, now_tick=10)
+        assert any(r.levelno == logging.ERROR for r in caplog.records)
+        # The slot was CLAIMED in Phase 1, so the failed sweep is rate-limited:
+        # _last_sweep_tick advanced to 10, and a call within the gate window
+        # does NOT retry (no hot loop against a persistently-failing coordinator).
+        assert core._last_sweep_tick == 10
+        core._maybe_sweep(now_tick=11)  # 11 - 10 = 1 < gate(5) -> skip
+        assert core.coordinator.enforce_stable_grant_timeouts.call_count == 1
+        # A call past the gate window does retry.
+        core._maybe_sweep(now_tick=20)  # 20 - 10 = 10 >= gate -> retry
+        assert core.coordinator.enforce_stable_grant_timeouts.call_count == 2
+
+
+class TestMaybeSweepConcurrency:
+    """Finding #6 + ce:review ADV-01 — the Phase-1 claim under _sweep_lock
+    serializes concurrent callers at the same tick to a SINGLE coordinator
+    sweep per gate window (and therefore a single diagnostic). A start-barrier
+    maximizes lock contention; the inside-sweep barrier of the old design would
+    now deadlock, since only one thread reaches the coordinator call."""
+
+    def test_concurrent_sweep_invokes_coordinator_and_emits_exactly_once(self, caplog) -> None:
+        core = _core()
+        start = threading.Barrier(2)
+        calls: list[int] = []
+        calls_lock = threading.Lock()
+
+        def _enforce(*, current_tick, heartbeat_timeout_ticks, max_hold_ticks, on_reclaim):
+            with calls_lock:
+                calls.append(current_tick)
+            on_reclaim(uuid4(), uuid4(), "reclaim_heartbeat")
+            return 1
+
+        core.coordinator.enforce_stable_grant_timeouts = Mock(side_effect=_enforce)
+
+        def worker() -> None:
+            start.wait()  # release both threads together to contend on _sweep_lock
+            core._maybe_sweep(now_tick=10)
+
+        with caplog.at_level(logging.WARNING, logger="ccs.adapters.base"):
+            threads = [threading.Thread(target=worker) for _ in range(2)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+        records = [
+            r for r in caplog.records
+            if r.name == "ccs.adapters.base" and r.levelno == logging.WARNING
+        ]
+        # The Phase-1 claim serializes: exactly one thread sweeps the coordinator
+        # and exactly one diagnostic is emitted — no double sweep, no double emit.
+        assert len(calls) == 1
+        assert len(records) == 1
+
+    def test_concurrent_gate_invokes_sweep_exactly_once(self) -> None:
+        core = _core()
+        start = threading.Barrier(2)
+
+        def _enforce(*, current_tick, heartbeat_timeout_ticks, max_hold_ticks, on_reclaim):
+            return 0
+
+        core.coordinator.enforce_stable_grant_timeouts = Mock(side_effect=_enforce)
+
+        def worker() -> None:
+            start.wait()  # contend on _sweep_lock at the same tick
+            core._maybe_sweep(now_tick=10)
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        # The Phase-1 claim (advancing _last_sweep_tick under the lock) means the
+        # second caller sees the advanced tick and skips: exactly one sweep.
+        assert core.coordinator.enforce_stable_grant_timeouts.call_count == 1
+        assert core._last_sweep_tick == 10
+
+
+class TestMaybeSweepEndToEnd:
+    """Integration: a real stale grant is reclaimed on the next read, the
+    diagnostic emits exactly once, and subsequent reads do not re-emit."""
+
+    def test_stale_grant_reclaimed_on_read_diagnostic_once(self, caplog) -> None:
+        core = _core()  # heartbeat_timeout_ticks=10, gate=5
+        core.register_agent("A", now_tick=0)
+        core.register_agent("B", now_tick=0)
+        artifact = core.register_artifact(name="x.md", content="v1")
+        # A acquires MODIFIED then goes silent (no further heartbeat).
+        core.write(agent_name="A", artifact_id=artifact.id, content="v2", now_tick=0)
+        with caplog.at_level(logging.WARNING, logger="ccs.adapters.base"):
+            # B reads far past A's heartbeat timeout -> sweep reclaims A.
+            core.read(agent_name="B", artifact_id=artifact.id, now_tick=50)
+            # A second read does not re-reclaim or re-emit.
+            core.read(agent_name="B", artifact_id=artifact.id, now_tick=100)
+        records = [
+            r for r in caplog.records
+            if r.name == "ccs.adapters.base" and r.levelno == logging.WARNING
+        ]
+        assert len(records) == 1
+        assert records[0].trigger in ("reclaim_heartbeat", "reclaim_max_hold")

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -275,7 +275,11 @@ def test_recover_invalidates_cache_before_heartbeat() -> None:
 
 
 def test_flag_off_write_does_not_heartbeat() -> None:
-    core = CoherenceAdapterCore(strategy_name="lazy")
+    # Explicit enabled=False: post-v0.9.0 bare construction enables the sweep,
+    # so the "flag off" contract requires opting out explicitly.
+    core = CoherenceAdapterCore(
+        strategy_name="lazy", crash_recovery=CrashRecoveryConfig(enabled=False)
+    )
     core.register_agent("A")
     artifact = core.register_artifact(name="x.md", content="v1")
     core.read(agent_name="A", artifact_id=artifact.id, now_tick=1)
@@ -302,7 +306,9 @@ def test_recover_anti_trap_after_recovery_not_immediately_reclaimed() -> None:
 
 
 def test_recover_flag_off_invalidates_cache_no_heartbeat() -> None:
-    core = CoherenceAdapterCore(strategy_name="lazy")
+    core = CoherenceAdapterCore(
+        strategy_name="lazy", crash_recovery=CrashRecoveryConfig(enabled=False)
+    )
     core.register_agent("A")
     artifact = core.register_artifact(name="x.md", content="v1")
     core.read(agent_name="A", artifact_id=artifact.id, now_tick=1)
@@ -322,7 +328,9 @@ def test_register_agent_seeds_heartbeat_when_enabled() -> None:
 
 
 def test_register_agent_no_seed_when_disabled() -> None:
-    core = CoherenceAdapterCore(strategy_name="lazy")
+    core = CoherenceAdapterCore(
+        strategy_name="lazy", crash_recovery=CrashRecoveryConfig(enabled=False)
+    )
     core.register_agent("A")
 
     assert core.registry.last_heartbeat_tick(core.agent_id_for("A")) is None
@@ -395,7 +403,12 @@ def test_framework_adapter_passthrough_autogen_raises() -> None:
 
 
 def test_framework_adapter_external_core_ignores_crash_recovery_kwarg() -> None:
-    external_core = CoherenceAdapterCore(strategy_name="lazy")
+    # External core built with enabled=False so it is distinct from the kwarg's
+    # enabled=True; the assertion below proves the adapter uses the external
+    # core's config and ignores its own crash_recovery= kwarg.
+    external_core = CoherenceAdapterCore(
+        strategy_name="lazy", crash_recovery=CrashRecoveryConfig(enabled=False)
+    )
     adapter = LangGraphAdapter(
         core=external_core,
         crash_recovery=CrashRecoveryConfig(enabled=True, max_hold_ticks=300),
@@ -405,7 +418,9 @@ def test_framework_adapter_external_core_ignores_crash_recovery_kwarg() -> None:
 
 
 def test_flag_off_read_does_not_heartbeat() -> None:
-    core = CoherenceAdapterCore(strategy_name="lazy")
+    core = CoherenceAdapterCore(
+        strategy_name="lazy", crash_recovery=CrashRecoveryConfig(enabled=False)
+    )
     core.register_agent("A")
     artifact = core.register_artifact(name="x.md", content="v1")
 
@@ -415,7 +430,9 @@ def test_flag_off_read_does_not_heartbeat() -> None:
 
 
 def test_flag_off_heartbeat_is_noop() -> None:
-    core = CoherenceAdapterCore(strategy_name="lazy")
+    core = CoherenceAdapterCore(
+        strategy_name="lazy", crash_recovery=CrashRecoveryConfig(enabled=False)
+    )
     core.register_agent("A")
 
     core.heartbeat(agent_name="A", now_tick=42)
@@ -423,17 +440,25 @@ def test_flag_off_heartbeat_is_noop() -> None:
     assert core.registry.last_heartbeat_tick(core.agent_id_for("A")) is None
 
 
-# ---- v0.8.3 C-flip Unit 2 — R2 internal-bare-construction hygiene ------------
+# ---- v0.9.0 C-flip — bare adapter adopts enabled-by-default -----------------
 #
 # See docs/plans/2026-05-28-001-feat-c-flip-crash-recovery-default-on-plan.md
-# Unit 2. The library's own adapter __init__ fallbacks must not surface the
-# v0.8.3 deprecation warning to users who construct adapters without passing
-# crash_recovery=. The user's bare CoherenceAdapterCore() / CCSStore() call
-# should not look like a misconfigured CrashRecoveryConfig site to them.
+# Units 5 + 6. Post-flip, a bare CoherenceAdapterCore() / CCSStore() (no
+# crash_recovery= argument) adopts the enabled-by-default crash recovery. The
+# v0.8.3 DeprecationWarning is gone; at most one v0.9.0 transitional
+# RuntimeWarning may surface (suppressed suite-wide by the conftest neutralizer
+# except in the dedicated tests/test_coordinator.py assertions).
 
 
-def test_bare_coherence_adapter_core_emits_no_deprecation_warning() -> None:
-    """R2: CoherenceAdapterCore() with no crash_recovery= must not warn."""
+def test_bare_coherence_adapter_core_adopts_enabled_default() -> None:
+    """v0.9.0: bare CoherenceAdapterCore() emits no DeprecationWarning and adopts
+    the enabled-by-default crash recovery; at most one transitional
+    RuntimeWarning may surface."""
+    from ccs.coordinator import service as _service_mod
+
+    # Reset the once-per-process flag so we deterministically observe the
+    # transitional warning here (the conftest neutralizer otherwise pre-sets it).
+    _service_mod._V090_FIRST_USE_WARNED = False
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         core = CoherenceAdapterCore(strategy_name="lazy")
@@ -444,12 +469,16 @@ def test_bare_coherence_adapter_core_emits_no_deprecation_warning() -> None:
         f"bare CoherenceAdapterCore construction must not emit "
         f"DeprecationWarning, got: {[str(w.message) for w in deprecation_warnings]}"
     )
-    # And the v0.8.x default behavior is preserved.
-    assert core._crash_recovery.enabled is False
+    runtime_warnings = [
+        w for w in caught if issubclass(w.category, RuntimeWarning)
+    ]
+    assert len(runtime_warnings) <= 1
+    # The flip: bare construction now enables crash recovery.
+    assert core._crash_recovery.enabled is True
 
 
 def test_explicit_crash_recovery_kwarg_emits_no_deprecation_warning() -> None:
-    """Passing an explicit CrashRecoveryConfig must not warn either."""
+    """Passing an explicit CrashRecoveryConfig must not surface a DeprecationWarning."""
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         core = CoherenceAdapterCore(

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import ast
 from pathlib import Path
 
 from ccs.hardening.architecture import find_boundary_violations, find_cycles, run_architecture_checks
@@ -41,73 +40,32 @@ def test_boundary_violation_detection_reports_forbidden_edge() -> None:
     assert "ccs.simulation.engine" in violations[0]
 
 
-# ---- v0.8.3 C-flip Unit 3 grep-gate -----------------------------------------
+# ---- v0.9.0 Unit 10: benchmark-attestation merge gate (Finding #2) ----------
 #
-# See docs/plans/2026-05-28-001-feat-c-flip-crash-recovery-default-on-plan.md
-# Unit 3. During the v0.8.3 → v0.9.0 deprecation window, library-internal
-# bare ``CrashRecoveryConfig()`` calls would surface the DeprecationWarning
-# from inside library code (per R2). This regression gate codifies the
-# guarantee: no bare construction sites in src/ outside the helper itself.
-#
-# This entire test (and its helper) is REMOVED in v0.9.0 when the deprecation
-# warning is also removed and bare ``CrashRecoveryConfig()`` becomes safe again.
+# The C-flip plan requires a machine-checkable artifact set so a v0.9.0 release
+# cannot merge without the documented benchmark validation. This is the
+# enforceable complement to the reviewer-checked attestation content.
 
 
-def _find_bare_crash_recovery_config_sites(src_root: Path) -> list[str]:
-    """Return repo-relative paths + line numbers of bare CrashRecoveryConfig()
-    call sites in src/, EXCLUDING the helper definition in service.py.
-
-    A "bare" call is ``CrashRecoveryConfig()`` with zero positional and zero
-    keyword arguments. Explicit constructions like ``CrashRecoveryConfig(
-    enabled=False)`` or ``CrashRecoveryConfig(enabled=True, ...)`` are
-    permitted because they bypass the sentinel detection.
-    """
-    findings: list[str] = []
-    for py_path in src_root.rglob("*.py"):
-        # Skip the helper definition itself — _default_disabled_config builds
-        # CrashRecoveryConfig(enabled=False) which has kwargs, so it is not
-        # bare; nothing to exclude here, but kept for clarity.
-        try:
-            tree = ast.parse(py_path.read_text(encoding="utf-8"))
-        except SyntaxError:
-            continue
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            # Match `CrashRecoveryConfig(...)` (Name) and
-            # `module.CrashRecoveryConfig(...)` (Attribute).
-            name = None
-            if isinstance(func, ast.Name):
-                name = func.id
-            elif isinstance(func, ast.Attribute):
-                name = func.attr
-            if name != "CrashRecoveryConfig":
-                continue
-            if node.args or node.keywords:
-                continue  # explicit construction — bypasses the sentinel
-            rel = py_path.relative_to(src_root.parent)
-            findings.append(f"{rel}:{node.lineno}")
-    return sorted(findings)
-
-
-def test_no_bare_crash_recovery_config_construction_in_src() -> None:
-    """v0.8.3 R2 regression gate: zero bare CrashRecoveryConfig() in src/.
-
-    Library-internal code must use _default_disabled_config() or pass
-    enabled= explicitly. This test prevents a future patch from silently
-    re-introducing a bare construction site that would surface the
-    v0.8.3 DeprecationWarning to users from inside library code.
-
-    REMOVED in v0.9.0 when the deprecation warning is also removed.
-    """
+def test_v090_benchmark_attestation_artifacts_present() -> None:
+    """The v0.9.0 benchmark attestation directory exists with non-empty raw
+    runs and an attestation.md covering the zero-drift + zero-reclaim claims."""
     repo_root = Path(__file__).resolve().parents[1]
-    src_root = repo_root / "src"
-    sites = _find_bare_crash_recovery_config_sites(src_root)
-    assert sites == [], (
-        "Bare CrashRecoveryConfig() construction sites found in src/. "
-        "During the v0.8.3 deprecation window, these surface a "
-        "DeprecationWarning to users from library-internal code. "
-        "Use _default_disabled_config() or pass enabled= explicitly.\n"
-        f"Sites: {sites}"
-    )
+    attestation_dir = repo_root / "benchmarks" / "results" / "v0.9.0"
+    assert attestation_dir.is_dir(), "missing benchmarks/results/v0.9.0/ attestation dir"
+
+    required = [
+        "attestation.md",
+        "c_flip_branch_run.txt",
+        "drift_check_vs_expected.txt",
+    ]
+    for name in required:
+        path = attestation_dir / name
+        assert path.is_file(), f"missing attestation artifact: {name}"
+        assert path.stat().st_size > 0, f"empty attestation artifact: {name}"
+
+    attestation = (attestation_dir / "attestation.md").read_text(encoding="utf-8").lower()
+    # Required sections / claims (kept loose so prose can evolve).
+    assert "drift" in attestation
+    assert "reclaim" in attestation
+    assert "0.00pp" in attestation

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -404,21 +404,19 @@ from ccs.strategies.lease import LeaseStrategy  # noqa: E402
 
 
 def test_crash_recovery_config_defaults_are_safe() -> None:
-    """v0.8.3: bare CrashRecoveryConfig() construction is an intentional API
-    surface and asserts both the v0.8.x default-disabled behavior AND the
-    presence of the deprecation warning. The pytest.warns wrapper makes the
-    warning part of the test contract, not collateral CI noise.
+    """v0.9.0: bare CrashRecoveryConfig() is enabled-by-default with the
+    retuned production thresholds (R6), and the first construction per process
+    emits the one-shot transitional RuntimeWarning naming the v0.9.0 change.
     """
     # Reset the module-level emit-once flag so this test sees the warning
-    # regardless of test ordering. (The TestCrashRecoveryDeprecationWarning
-    # class below also resets it; this standalone test predates that class.)
+    # regardless of test ordering.
     from ccs.coordinator import service as _service_mod
-    _service_mod._BARE_CONSTRUCTION_WARNED = False
-    with pytest.warns(DeprecationWarning, match="enabled=True"):
+    _service_mod._V090_FIRST_USE_WARNED = False
+    with pytest.warns(RuntimeWarning, match="default changed in v0.9.0"):
         cfg = CrashRecoveryConfig()
-    assert cfg.enabled is False
-    assert cfg.heartbeat_timeout_ticks == 10
-    assert cfg.max_hold_ticks == 1000
+    assert cfg.enabled is True
+    assert cfg.heartbeat_timeout_ticks == 120
+    assert cfg.max_hold_ticks == 900
 
 
 def testvalidate_crash_recovery_config_disabled_always_accepts() -> None:
@@ -576,12 +574,13 @@ def test_set_agent_state_failed_log_emit_consistent_for_me_exit_too() -> None:
     assert registry.granted_at_tick(agent_id, artifact.id) is None
 
 
-# ---- v0.8.3 C-flip deprecation cycle ----------------------------------------
+# ---- v0.9.0 C-flip: default flip + transitional warning ---------------------
 #
 # See docs/plans/2026-05-28-001-feat-c-flip-crash-recovery-default-on-plan.md
-# Unit 1. The bare CrashRecoveryConfig() construction must emit a one-shot
-# DeprecationWarning naming the v0.9.0 default flip. Tests below assert both
-# the emission behavior and the silence paths.
+# Units 5 + 6. The v0.8.3 sentinel + DeprecationWarning are gone; the default
+# is now enabled=True with retuned 120/900 thresholds. The first
+# CrashRecoveryConfig construction per process emits a one-shot transitional
+# RuntimeWarning. Tests below assert the flip, the retune, and the warning.
 
 
 import warnings as _warnings  # noqa: E402
@@ -590,279 +589,237 @@ from ccs.coordinator import service as _service_module  # noqa: E402
 
 
 @pytest.fixture
-def reset_bare_construction_flag():
+def reset_v090_first_use_flag():
     """Reset the module-level emit-once flag between tests.
 
-    Without this, the first test to construct CrashRecoveryConfig() would
-    set _BARE_CONSTRUCTION_WARNED=True for the entire pytest session and
-    later tests in this class would see zero warnings (false negatives).
+    Without this, the first test to construct CrashRecoveryConfig() would set
+    _V090_FIRST_USE_WARNED=True for the entire pytest session and later tests
+    asserting the transitional warning would see zero warnings (false negatives).
     """
-    _service_module._BARE_CONSTRUCTION_WARNED = False
+    _service_module._V090_FIRST_USE_WARNED = False
     yield
-    _service_module._BARE_CONSTRUCTION_WARNED = False
+    _service_module._V090_FIRST_USE_WARNED = False
 
 
-class TestCrashRecoveryDeprecationWarning:
-    """Unit 1 — bare CrashRecoveryConfig() emits one-shot DeprecationWarning."""
+class TestCrashRecoveryV090TransitionalWarning:
+    """Unit 5 — first CrashRecoveryConfig() per process emits one RuntimeWarning."""
 
-    def test_bare_construction_emits_deprecation_warning(
-        self, reset_bare_construction_flag
+    def test_first_construction_emits_runtime_warning(
+        self, reset_v090_first_use_flag
     ) -> None:
-        """Happy path: bare construction in fresh process emits one warning."""
+        """Happy path: first construction in a fresh process emits one warning."""
         with _warnings.catch_warnings(record=True) as caught:
             _warnings.simplefilter("always")
             CrashRecoveryConfig()
-        deprecation_warnings = [
-            w for w in caught if issubclass(w.category, DeprecationWarning)
+        runtime_warnings = [
+            w for w in caught if issubclass(w.category, RuntimeWarning)
         ]
-        assert len(deprecation_warnings) == 1
+        assert len(runtime_warnings) == 1
+        assert "default changed in v0.9.0" in str(runtime_warnings[0].message)
 
     def test_warning_message_names_both_silence_paths(
-        self, reset_bare_construction_flag
+        self, reset_v090_first_use_flag
     ) -> None:
         """Warning prose must give users BOTH the opt-in and opt-out recipes."""
         with _warnings.catch_warnings(record=True) as caught:
             _warnings.simplefilter("always")
             CrashRecoveryConfig()
-        # Length guard before indexing — without it, a regression that drops
-        # the warning emission entirely surfaces as IndexError instead of an
-        # informative AssertionError, masking the actual failure mode.
-        assert len(caught) >= 1, (
-            "bare CrashRecoveryConfig() must emit a warning; got 0 warnings"
+        # Filter to RuntimeWarning before indexing: an unrelated warning firing
+        # first must not let the message assertions pass on the wrong text. The
+        # length guard also turns a dropped emission into an informative
+        # AssertionError rather than an IndexError.
+        runtime_warnings = [
+            w for w in caught if issubclass(w.category, RuntimeWarning)
+        ]
+        assert len(runtime_warnings) >= 1, (
+            "first CrashRecoveryConfig() must emit a RuntimeWarning; got 0"
         )
-        msg = str(caught[0].message)
+        msg = str(runtime_warnings[0].message)
         assert "enabled=True" in msg, "warning must name the recommended opt-in"
         assert "enabled=False" in msg, "warning must name the explicit opt-out"
-        assert "v0.9.0" in msg, "warning must name the target release"
+        assert "v0.9.0" in msg, "warning must name the release that changed the default"
 
-    def test_bare_construction_preserves_v0_8_x_default(
-        self, reset_bare_construction_flag
-    ) -> None:
-        """After bare construction, enabled is False (v0.8.x behavior preserved)."""
+    def test_default_is_enabled_true(self, reset_v090_first_use_flag) -> None:
+        """The flip: bare construction now yields enabled=True (was False)."""
         with _warnings.catch_warnings():
-            _warnings.simplefilter("ignore", DeprecationWarning)
+            _warnings.simplefilter("ignore", RuntimeWarning)
             cfg = CrashRecoveryConfig()
-        assert cfg.enabled is False
-        assert cfg.heartbeat_timeout_ticks == 10
-        assert cfg.max_hold_ticks == 1000
+        assert cfg.enabled is True
 
-    def test_emit_once_dedupes_consecutive_bare_constructions(
-        self, reset_bare_construction_flag
+    def test_emit_once_dedupes_consecutive_constructions(
+        self, reset_v090_first_use_flag
     ) -> None:
-        """Module-level flag means two bare constructions emit exactly ONE warning."""
+        """Module-level flag means three constructions emit exactly ONE warning."""
         with _warnings.catch_warnings(record=True) as caught:
             _warnings.simplefilter("always")
             CrashRecoveryConfig()
             CrashRecoveryConfig()
             CrashRecoveryConfig()
-        deprecation_warnings = [
-            w for w in caught if issubclass(w.category, DeprecationWarning)
+        runtime_warnings = [
+            w for w in caught if issubclass(w.category, RuntimeWarning)
         ]
-        assert len(deprecation_warnings) == 1, (
-            f"expected 1 warning across three bare constructions, "
-            f"got {len(deprecation_warnings)}"
+        assert len(runtime_warnings) == 1, (
+            f"expected 1 warning across three constructions, "
+            f"got {len(runtime_warnings)}"
         )
 
-    def test_explicit_false_emits_no_warning(
-        self, reset_bare_construction_flag
+    def test_explicit_false_still_warns_on_first_and_opts_out(
+        self, reset_v090_first_use_flag
     ) -> None:
-        """User passes enabled=False explicitly → no warning, enabled stays False."""
+        """Explicit enabled=False opts out of the sweep, but the transitional
+        warning still fires on the first construction — it announces the default
+        change, not the user's choice (per Unit 5 edge case)."""
         with _warnings.catch_warnings(record=True) as caught:
             _warnings.simplefilter("always")
             cfg = CrashRecoveryConfig(enabled=False)
-        deprecation_warnings = [
-            w for w in caught if issubclass(w.category, DeprecationWarning)
+        runtime_warnings = [
+            w for w in caught if issubclass(w.category, RuntimeWarning)
         ]
-        assert deprecation_warnings == []
+        assert len(runtime_warnings) == 1
         assert cfg.enabled is False
 
-    def test_explicit_true_emits_no_warning(
-        self, reset_bare_construction_flag
+    def test_explicit_true_still_warns_on_first(
+        self, reset_v090_first_use_flag
     ) -> None:
-        """User passes enabled=True explicitly → no warning, enabled stays True."""
+        """Symmetric to the explicit-False case: explicit enabled=True as the
+        first construction ALSO fires the transitional warning (it announces the
+        default change regardless of the value passed). Regression-gates the
+        'fires on first construction regardless of how enabled was supplied'
+        contract so a future `if enabled is not True` short-circuit is caught."""
         with _warnings.catch_warnings(record=True) as caught:
             _warnings.simplefilter("always")
             cfg = CrashRecoveryConfig(enabled=True)
-        deprecation_warnings = [
-            w for w in caught if issubclass(w.category, DeprecationWarning)
+        runtime_warnings = [
+            w for w in caught if issubclass(w.category, RuntimeWarning)
         ]
-        assert deprecation_warnings == []
+        assert len(runtime_warnings) == 1
         assert cfg.enabled is True
 
-    def test_composition_validation_unchanged_for_explicit_true(
-        self, reset_bare_construction_flag
+    def test_no_deprecation_warning_remains(
+        self, reset_v090_first_use_flag
     ) -> None:
-        """R11 composition rule still works on explicit-True configs after Unit 1."""
-        cfg = CrashRecoveryConfig(
-            enabled=True, heartbeat_timeout_ticks=10, max_hold_ticks=1000
-        )
-        # Should not raise — 1000 > 300.
-        validate_crash_recovery_config(cfg, LeaseStrategy(ttl_ticks=300))
+        """The v0.8.3 DeprecationWarning is fully removed in v0.9.0."""
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            CrashRecoveryConfig()
+            CrashRecoveryConfig(enabled=True)
+            CrashRecoveryConfig(enabled=False)
+        assert [w for w in caught if issubclass(w.category, DeprecationWarning)] == []
 
-    def test_dataclass_remains_frozen(
-        self, reset_bare_construction_flag
-    ) -> None:
-        """frozen=True invariant — sentinel mechanism must not break immutability."""
+    def test_dataclass_remains_frozen(self, reset_v090_first_use_flag) -> None:
+        """frozen=True invariant preserved through the warning mechanism."""
         with _warnings.catch_warnings():
-            _warnings.simplefilter("ignore", DeprecationWarning)
+            _warnings.simplefilter("ignore", RuntimeWarning)
             cfg = CrashRecoveryConfig()
         # Direct assignment must still raise FrozenInstanceError.
         with pytest.raises(Exception) as exc_info:
-            cfg.enabled = True  # type: ignore[misc]
+            cfg.enabled = False  # type: ignore[misc]
         assert "frozen" in str(exc_info.value).lower() or "FrozenInstanceError" in type(
             exc_info.value
         ).__name__
 
-    # ---- RM-9 Layer 2: logging channel (ce:review AN-1) ---------------------
 
-    def test_bare_construction_logs_warning_on_service_logger(
-        self, reset_bare_construction_flag, caplog
+class TestCrashRecoveryDefaultsComposition:
+    """Unit 6 — retuned defaults (120/900), safety floor, and same-PR tripwire."""
+
+    def _bare(self) -> CrashRecoveryConfig:
+        """Construct a default config with the transitional warning suppressed."""
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("ignore", RuntimeWarning)
+            return CrashRecoveryConfig()
+
+    def test_defaults_are_retuned(self, reset_v090_first_use_flag) -> None:
+        """R6: production-realistic defaults replace the v0.8.x sim-anchors."""
+        cfg = self._bare()
+        assert cfg.heartbeat_timeout_ticks == 120
+        assert cfg.max_hold_ticks == 900
+
+    def test_default_composition_does_not_raise(
+        self, reset_v090_first_use_flag
     ) -> None:
-        """RM-9 Layer 2: bare construction also logs a WARNING on
-        ``ccs.coordinator.service`` so the migration signal survives CPython's
-        default ``DeprecationWarning`` filter (which hides it for non-__main__
-        importers — i.e. virtually every SDK consumer).
-        """
-        import logging
+        """Enabled-by-default config composes with a 300-tick lease (900 > 300)."""
+        validate_crash_recovery_config(self._bare(), LeaseStrategy(ttl_ticks=300))
 
-        with caplog.at_level(logging.WARNING, logger="ccs.coordinator.service"):
-            with _warnings.catch_warnings():
-                _warnings.simplefilter("ignore", DeprecationWarning)
-                CrashRecoveryConfig()
-        records = [
-            r
-            for r in caplog.records
-            if r.name == "ccs.coordinator.service" and r.levelno == logging.WARNING
-        ]
-        assert len(records) == 1, "bare construction must log exactly one WARNING"
-        message = records[0].getMessage()
-        assert "enabled=True" in message, "log must name the recommended opt-in"
-        assert "enabled=False" in message, "log must name the explicit opt-out"
-        assert "v0.9.0" in message, "log must name the target release"
+    def test_safety_floor_regression_gate(self, reset_v090_first_use_flag) -> None:
+        """Hard floor governing all future tuning patches — distinct from the
+        chosen 120/900 calibration: heartbeat_timeout_ticks >= 60 and
+        max_hold_ticks > 300."""
+        cfg = self._bare()
+        assert cfg.heartbeat_timeout_ticks >= 60
+        assert cfg.max_hold_ticks > 300
 
-    def test_logger_channel_honors_emit_once(
-        self, reset_bare_construction_flag, caplog
+    def test_enabled_implies_heartbeat_floor_tripwire(
+        self, reset_v090_first_use_flag
     ) -> None:
-        """The logging channel shares the emit-once gate with warnings.warn:
-        three bare constructions log exactly one WARNING."""
-        import logging
+        """ADV-11 tripwire: a default config that is enabled MUST carry a
+        heartbeat floor >= 60. Surfaces immediately if a future patch flips the
+        default on without the Unit 6 retune (the aggressive-false-reclaim trap
+        the Units 5+6 same-PR constraint guards against)."""
+        cfg = self._bare()
+        # Unconditional: the v0.9.0 default IS enabled, and an enabled default
+        # MUST carry the heartbeat floor. Asserting both (not guarding the floor
+        # behind `if cfg.enabled`) means a future patch that flips the default
+        # back to disabled trips this test instead of passing vacuously.
+        assert cfg.enabled is True
+        assert cfg.heartbeat_timeout_ticks >= 60
 
-        with caplog.at_level(logging.WARNING, logger="ccs.coordinator.service"):
-            with _warnings.catch_warnings():
-                _warnings.simplefilter("ignore", DeprecationWarning)
-                CrashRecoveryConfig()
-                CrashRecoveryConfig()
-                CrashRecoveryConfig()
-        records = [
-            r
-            for r in caplog.records
-            if r.name == "ccs.coordinator.service" and r.levelno == logging.WARNING
-        ]
-        assert len(records) == 1
+    def test_old_v08x_values_still_settable(
+        self, reset_v090_first_use_flag
+    ) -> None:
+        """Users who want the old sim-anchor thresholds can still pass them."""
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("ignore", RuntimeWarning)
+            cfg = CrashRecoveryConfig(heartbeat_timeout_ticks=10, max_hold_ticks=1000)
+        assert cfg.heartbeat_timeout_ticks == 10
+        assert cfg.max_hold_ticks == 1000
 
 
-# ---- ce:review ADV-01 / ADV-03 — skipped-normalization robustness -----------
+# ---- v0.8.3 sentinel robustness (ADV-01 / ADV-03) — removed in v0.9.0 -------
 #
-# The sentinel marking an unspecified ``enabled`` is falsy, so any path that
-# skips __post_init__ normalization (importlib.reload identity mismatch, or a
-# subclass __post_init__ that omits super()) still reads as disabled rather
-# than truthy-enabled. Removed in v0.9.0 with the rest of the sentinel
-# mechanism.
-
-from ccs.coordinator.service import _DefaultEnabledSentinel  # noqa: E402
+# The falsy-sentinel mechanism (and its importlib.reload / subclass-without-
+# super() robustness tests) is gone now that ``enabled`` is a plain bool field
+# defaulting to True. Nothing replaces it: there is no sentinel to misread.
 
 
-class TestSentinelNormalizationRobustness:
-    """ADV-01/ADV-03 — skipped normalization must read as disabled, not enabled."""
-
-    def test_sentinel_is_falsy(self) -> None:
-        """The unset-enabled sentinel evaluates falsy."""
-        assert bool(_service_module._DEFAULT_ENABLED_SENTINEL) is False
-        assert not _service_module._DEFAULT_ENABLED_SENTINEL
-
-    def test_subclass_post_init_override_without_super_reads_disabled(self) -> None:
-        """ADV-03: a frozen subclass overriding __post_init__ without calling
-        super() skips normalization — enabled stays the sentinel, which must be
-        falsy so ``if config.enabled:`` does not misfire the sweep.
-        """
-        from dataclasses import dataclass as _dataclass
-
-        @_dataclass(frozen=True)
-        class _NoSuperConfig(CrashRecoveryConfig):
-            def __post_init__(self) -> None:  # deliberately omits super()
-                pass
-
-        cfg = _NoSuperConfig()
-        # enabled is the un-normalized sentinel object, not a real bool ...
-        assert cfg.enabled is _service_module._DEFAULT_ENABLED_SENTINEL
-        # ... but it reads as disabled, which is what production checks rely on.
-        assert bool(cfg.enabled) is False
-        assert not cfg.enabled
-
-    def test_reload_identity_mismatch_reads_disabled(self) -> None:
-        """ADV-01: simulate importlib.reload rebinding the module sentinel. An
-        instance carrying a *different* (pre-reload) sentinel fails the ``is``
-        check, skips normalization, and must still read as disabled.
-        """
-        stale_sentinel = _DefaultEnabledSentinel()  # distinct identity
-        with _warnings.catch_warnings(record=True) as caught:
-            _warnings.simplefilter("always")
-            cfg = CrashRecoveryConfig(enabled=stale_sentinel)  # type: ignore[arg-type]
-        # Identity check fails → normalization skipped → enabled keeps the stale
-        # sentinel, and no warning fires (the bare path keys on the *current*
-        # module sentinel).
-        assert cfg.enabled is stale_sentinel
-        assert bool(cfg.enabled) is False
-        assert [w for w in caught if issubclass(w.category, DeprecationWarning)] == []
+# ---- v0.9.0 transitional-warning emit-once under contention (ADV-02 lineage) -
 
 
-# ---- ce:review ADV-02 — concurrent emit-once --------------------------------
+class TestConcurrentFirstUseEmitOnce:
+    """The _V090_FIRST_USE_LOCK keeps emit-once intact under thread contention
+    (free-threaded Python 3.13+ removes the GIL that made the naive check safe).
+    """
 
-
-class TestConcurrentEmitOnce:
-    """ADV-02 — the lock keeps emit-once intact under thread contention."""
-
-    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-    def test_concurrent_bare_construction_emits_one_log(
-        self, reset_bare_construction_flag
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
+    def test_concurrent_construction_emits_one_warning(
+        self, reset_v090_first_use_flag
     ) -> None:
-        """Eight threads constructing bare configs simultaneously produce exactly
-        one WARNING log. Asserts via the logging channel (thread-safe by design)
-        rather than warnings.catch_warnings, which mutates global filter state and
-        is itself not thread-safe. The expected DeprecationWarning is filtered at
-        the mark (thread-safe) since this test cannot wrap workers in
-        catch_warnings; the log assertion is the real contract.
+        """Eight threads constructing configs simultaneously emit exactly one
+        transitional RuntimeWarning. ``warnings.catch_warnings`` mutates global
+        filter state and is not thread-safe, so we count via a lock-protected
+        shim installed over ``warnings.warn`` (which the service module calls).
+        The filterwarnings mark — applied before threads start — suppresses the
+        single real emission so it does not escape to stderr.
         """
-        import logging
         import threading
 
-        captured: list[logging.LogRecord] = []
-        capture_lock = threading.Lock()
+        count_lock = threading.Lock()
+        emissions: list[object] = []
+        original_warn = _warnings.warn
 
-        class _CountingHandler(logging.Handler):
-            def emit(self, record: logging.LogRecord) -> None:
-                with capture_lock:
-                    captured.append(record)
-
-        svc_logger = logging.getLogger("ccs.coordinator.service")
-        handler = _CountingHandler()
-        handler.setLevel(logging.WARNING)
-        svc_logger.addHandler(handler)
-        previous_level = svc_logger.level
-        svc_logger.setLevel(logging.WARNING)
+        def _counting_warn(message, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if isinstance(message, str) and "default changed in v0.9.0" in message:
+                with count_lock:
+                    emissions.append(message)
+            return original_warn(message, *args, **kwargs)
 
         thread_count = 8
         barrier = threading.Barrier(thread_count)
 
         def worker() -> None:
             barrier.wait()  # release all threads together to maximize contention
-            try:
-                CrashRecoveryConfig()
-            except DeprecationWarning:
-                # Under -W error the single emitting thread raises *after* the
-                # log record is emitted (logging precedes warnings.warn).
-                pass
+            CrashRecoveryConfig()
 
+        _warnings.warn = _counting_warn  # type: ignore[assignment]
         try:
             threads = [threading.Thread(target=worker) for _ in range(thread_count)]
             for t in threads:
@@ -870,11 +827,9 @@ class TestConcurrentEmitOnce:
             for t in threads:
                 t.join()
         finally:
-            svc_logger.removeHandler(handler)
-            svc_logger.setLevel(previous_level)
+            _warnings.warn = original_warn  # type: ignore[assignment]
 
-        warning_records = [r for r in captured if r.levelno == logging.WARNING]
-        assert len(warning_records) == 1, (
-            f"expected exactly one WARNING across {thread_count} concurrent bare "
-            f"constructions, got {len(warning_records)}"
+        assert len(emissions) == 1, (
+            f"expected exactly one transitional warning across {thread_count} "
+            f"concurrent constructions, got {len(emissions)}"
         )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -145,9 +145,9 @@ from ccs.coordinator.service import CrashRecoveryConfig  # noqa: E402
 
 
 def test_engine_uses_default_crash_recovery_config_when_block_absent() -> None:
-    """R2: omitting the YAML block must produce the v0.8.x default-disabled config
-    WITHOUT emitting the v0.8.3 bare-construction DeprecationWarning from the
-    library's own engine code path.
+    """v0.9.0: omitting the YAML block inherits the flipped library default
+    (enabled=True with retuned 120/900), and engine construction surfaces no
+    DeprecationWarning (the v0.8.3 warning is removed).
     """
     import warnings as _w
     with _w.catch_warnings(record=True) as caught:
@@ -160,10 +160,11 @@ def test_engine_uses_default_crash_recovery_config_when_block_absent() -> None:
         f"engine construction must not emit DeprecationWarning, got: "
         f"{[str(w.message) for w in deprecation_warnings]}"
     )
-    # Compare against explicit-False (not bare CrashRecoveryConfig()) so the
-    # comparison itself does not emit the warning.
-    assert engine._crash_recovery == CrashRecoveryConfig(enabled=False)
-    assert engine._crash_recovery.enabled is False
+    # The engine inherits the flipped default; compare against explicit-True.
+    assert engine._crash_recovery == CrashRecoveryConfig(enabled=True)
+    assert engine._crash_recovery.enabled is True
+    assert engine._crash_recovery.heartbeat_timeout_ticks == 120
+    assert engine._crash_recovery.max_hold_ticks == 900
 
 
 def test_engine_reads_crash_recovery_block_from_scenario() -> None:
@@ -194,52 +195,115 @@ def test_engine_fail_fast_accepts_max_hold_above_ttl() -> None:
     SimulationEngine(scenario, strategy_name="lease", seed=5)
 
 
-def test_engine_flag_off_state_log_is_byte_identical_with_or_without_block() -> None:
-    """R5: the flag-off path must produce a state-log identical to the v0.5 baseline.
+def _capture_normalized_state_log(
+    crash_recovery_block: dict | None, *, seed: int = 42
+) -> list[dict]:
+    """Run ``_scenario()`` under the given crash_recovery block and return the
+    state-log with per-run uuid fields (instance_id, artifact_id) normalized to
+    deterministic placeholders. Shared by the R5 byte-identity tests below."""
+    scenario = _scenario()
+    if crash_recovery_block is not None:
+        scenario["crash_recovery"] = crash_recovery_block
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=seed)
+    log: list[dict] = []
+    engine._registry._state_log = log.append
+    engine.run()
+    artifact_id_map: dict[str, str] = {}
+    for entry in log:
+        entry["instance_id"] = "<inst>"
+        aid = entry.get("artifact_id")
+        if aid is not None:
+            aid_str = str(aid)
+            placeholder = artifact_id_map.setdefault(
+                aid_str, f"<artifact-{len(artifact_id_map)}>"
+            )
+            entry["artifact_id"] = placeholder
+    return log
 
-    We compare two runs of the same scenario+strategy+seed:
-      - Run A: no ``crash_recovery`` block (legacy v0.5 shape).
-      - Run B: explicit ``crash_recovery: { enabled: false, ... }`` block with
-        knobs the sweep would otherwise read.
 
-    Today this is preventive (Unit 4 will add the sweep call site). The
-    contract: when ``enabled=False`` the engine MUST never invoke the sweep
-    or emit heartbeats, so the state-log is identical to a run with the
-    block omitted entirely.
+def test_engine_flag_off_state_log_is_byte_identical_across_explicit_false_variants() -> None:
+    """R5 (off-path): two explicit ``{enabled: false}`` runs that differ only in
+    the (ignored) sweep knobs produce byte-identical state-logs.
+
+    Post-v0.9.0 the omitted-block default is ENABLED, so the off-path
+    byte-identity contract is asserted between two EXPLICIT-false variants:
+    when ``enabled=False`` the engine MUST never invoke the sweep or emit
+    heartbeats, so the knobs are inert and the logs are identical.
     """
-
-    def _run_and_capture(crash_recovery_block: dict | None) -> list[dict]:
-        scenario = _scenario()
-        if crash_recovery_block is not None:
-            scenario["crash_recovery"] = crash_recovery_block
-        engine = SimulationEngine(scenario, strategy_name="lazy", seed=42)
-        # Wire a state_log onto the registry post-construction. Construction
-        # already populated _instance_id, so it's safe to attach the callback.
-        log: list[dict] = []
-        engine._registry._state_log = log.append
-        engine.run()
-        # Normalize per-run uuid4 fields (instance_id, artifact_id) to
-        # deterministic placeholders. artifact_id is fresh on every Artifact
-        # construction; first-seen order maps to a stable placeholder.
-        artifact_id_map: dict[str, str] = {}
-        for entry in log:
-            entry["instance_id"] = "<inst>"
-            aid = entry.get("artifact_id")
-            if aid is not None:
-                aid_str = str(aid)
-                placeholder = artifact_id_map.setdefault(
-                    aid_str, f"<artifact-{len(artifact_id_map)}>"
-                )
-                entry["artifact_id"] = placeholder
-        return log
-
-    log_without_block = _run_and_capture(None)
-    log_with_disabled_block = _run_and_capture(
+    log_a = _capture_normalized_state_log({"enabled": False})
+    log_b = _capture_normalized_state_log(
         {"enabled": False, "heartbeat_timeout_ticks": 5, "max_hold_ticks": 50}
     )
+    assert log_a == log_b
+    assert len(log_a) > 0  # sanity: we actually captured something
 
-    assert log_without_block == log_with_disabled_block
-    assert len(log_without_block) > 0  # sanity: we actually captured something
+
+def test_engine_flag_on_state_log_is_byte_identical_with_yaml_absent_or_explicit_true() -> None:
+    """R5 (on-path — the inverted contract): an OMITTED crash_recovery block now
+    behaves identically to an explicit ``{enabled: true}`` block. The engine
+    inherits the flipped default, so both runs emit the same heartbeats and the
+    state-logs are byte-identical. This is the v0.9.0 R5 preservation proof.
+    """
+    log_absent = _capture_normalized_state_log(None)
+    log_explicit_true = _capture_normalized_state_log({"enabled": True})
+    assert log_absent == log_explicit_true
+    assert len(log_absent) > 0
+
+
+def test_engine_flag_on_diverges_from_explicit_false_via_reclaim() -> None:
+    """R5 (divergence is real, not trivial — ADV-07): an omitted crash_recovery
+    block (enabled-by-default) DIVERGES from explicit ``{enabled: false}``, and
+    the divergence is attributable to a ``reclaim_*`` event in the enabled-side
+    log — proving the sweep mechanism actually ran, not merely that heartbeat
+    entries appeared.
+
+    Fixture preconditions (ADV-07): the workload drives > heartbeat_timeout_ticks
+    (=120, the v0.9.0 default) so a killed grant-holder's heartbeat gaps past the
+    timeout and the sweep reclaims it. No agent is pre-held past max_hold_ticks
+    (=900), so the reclaim is heartbeat-attributable, not max-hold.
+    """
+
+    def _run(crash_recovery_block: dict | None) -> list[dict]:
+        scenario = _failure_scenario(num_agents=2, duration=150)
+        scenario["failure_events"] = [
+            {"tick": 5, "action": "kill", "agent": "agent_0"},
+        ]
+        if crash_recovery_block is not None:
+            scenario["crash_recovery"] = crash_recovery_block
+        engine = SimulationEngine(scenario, strategy_name="lazy", seed=1)
+        log: list[dict] = []
+        engine._registry._state_log = log.append
+        # Pre-grant EXCLUSIVE to the soon-killed agent so the sweep has a stable
+        # grant to reclaim once its heartbeat gaps past the timeout.
+        artifact_id = engine._artifact_ids[0]
+        agent_a = engine._agent_id_by_name["agent_0"]
+        engine._coordinator.fetch(
+            FetchRequest(
+                artifact_id=artifact_id,
+                requesting_agent_id=agent_a,
+                requested_at_tick=0,
+            )
+        )
+        engine.run()
+        return log
+
+    log_enabled = _run(None)  # omitted block -> enabled-by-default
+    log_disabled = _run({"enabled": False})  # explicit opt-out
+
+    assert log_enabled != log_disabled, (
+        "enabled-by-default must diverge from explicit-false"
+    )
+    enabled_reclaims = [
+        e for e in log_enabled if str(e.get("trigger", "")).startswith("reclaim_")
+    ]
+    assert len(enabled_reclaims) >= 1, (
+        "divergence must be attributable to a reclaim_* event in the enabled log "
+        "(fixture must drive > heartbeat_timeout_ticks with a killed grant-holder)"
+    )
+    disabled_reclaims = [
+        e for e in log_disabled if str(e.get("trigger", "")).startswith("reclaim_")
+    ]
+    assert disabled_reclaims == []
 
 
 # ---- Unit 4: failure-event injection + sweep wiring -------------------------
@@ -456,32 +520,16 @@ def test_baseline_state_log_byte_identical_with_disabled_flag_after_unit4() -> N
     the call site MUST keep the heartbeat / sweep entries out of the log.
     """
 
-    def _run_and_capture(crash_recovery_block: dict | None) -> list[dict]:
-        scenario = _scenario()
-        if crash_recovery_block is not None:
-            scenario["crash_recovery"] = crash_recovery_block
-        engine = SimulationEngine(scenario, strategy_name="lazy", seed=42)
-        log: list[dict] = []
-        engine._registry._state_log = log.append
-        engine.run()
-        artifact_id_map: dict[str, str] = {}
-        for entry in log:
-            entry["instance_id"] = "<inst>"
-            aid = entry.get("artifact_id")
-            if aid is not None:
-                aid_str = str(aid)
-                placeholder = artifact_id_map.setdefault(
-                    aid_str, f"<artifact-{len(artifact_id_map)}>"
-                )
-                entry["artifact_id"] = placeholder
-        return log
-
-    log_without_block = _run_and_capture(None)
-    log_with_disabled_block = _run_and_capture(
+    # Post-v0.9.0 the omitted-block default is enabled, so both arms are
+    # explicit-false to assert the off-path byte-identity (the Unit 4 sweep
+    # call site must stay inert under enabled=False). Reuses the shared
+    # _capture_normalized_state_log helper rather than a local duplicate.
+    log_explicit_false = _capture_normalized_state_log({"enabled": False})
+    log_with_disabled_block = _capture_normalized_state_log(
         {"enabled": False, "heartbeat_timeout_ticks": 5, "max_hold_ticks": 50}
     )
-    assert log_without_block == log_with_disabled_block
-    assert len(log_without_block) > 0
+    assert log_explicit_false == log_with_disabled_block
+    assert len(log_explicit_false) > 0
 
 
 def test_failure_event_unknown_agent_name_raises() -> None:


### PR DESCRIPTION
## Summary

- **Flips the crash-recovery default on.** `CrashRecoveryConfig.enabled` now defaults to `True` (was `False`), so a bare `CCSStore()` / `CoherenceAdapterCore()` reclaims stale `MODIFIED`/`EXCLUSIVE` grants automatically. Completes the deprecation cycle started in v0.8.3.
- **Wires a rate-limited, thread-safe reclamation sweep** into `CoherenceAdapterCore.read()` / `write()`; `CCSStore.batch()` inherits once-per-batch semantics from its shared per-batch tick. The first reclamation per adapter instance logs a one-shot structured `WARNING` on the `ccs.adapters.base` logger (`trigger`, `agent_id_short`, `artifact_id_short`, `reclaim_count`). The sweep is best-effort — a failure is logged and never crashes the read/write path.
- **Retunes the defaults** for realistic batch-tick workloads: `heartbeat_timeout_ticks` 10 → 120, `max_hold_ticks` 1000 → 900.
- Adds a one-shot transitional `RuntimeWarning` on the first `CrashRecoveryConfig` construction per process (migration heads-up for anyone upgrading straight from v0.8.2). Removed in v0.10.0.

## Breaking change / migration

- **Keep the previous behaviour:** pass `CrashRecoveryConfig(enabled=False)` explicitly.
- **`lease` strategy + `lease_ttl_ticks >= 900`:** because the default is now enabled, the composition rule (`max_hold_ticks` must exceed the strategy's inspectable lease TTL) runs at construction. A bare adapter with `lease_ttl_ticks >= 900` (the new default `max_hold_ticks`) now raises `ValueError` at startup — set a larger `max_hold_ticks`, or opt out with `enabled=False`.
- **State-log byte-identity inverted (direction only):** an omitted `crash_recovery` block now matches an explicit `{enabled: true}` block and diverges from `{enabled: false}`. To reproduce v0.8.x byte output, set `enabled=False` explicitly.

Full migration notes are in `CHANGELOG.md`.

## Test plan

- [x] Full test suite: **1565 passed**
- [x] `-W error::RuntimeWarning` clean on the crash-recovery test files (warning hygiene under strict escalation)
- [x] `ruff`, architecture check, and `make tla-check` (MESI + CrashRecovery model check) all pass
- [x] Benchmark token reductions unchanged (0.00pp drift); attestation captured under `benchmarks/results/v0.9.0/`
- [x] Concurrency: sweep runs at most once per rate-limit window under contention; failed sweeps are rate-limited, not retried per-call

## Notes

Draft — opening early for CI + review. Holding merge pending release coordination; not ready to merge yet.
