### PR TITLE
feat(simulation): add temporal source-drift cost benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ examples/conversations_stale_read/q6_*.json
 
 # Claude Code coherence plugin local coordinator state (contains hook.secret, state.db)
 .coherence/
+
+# Generated temporal-coherence cost sweep (like results/latest.json)
+benchmarks/results/cost_sweep.json

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ benchmark-check:  ## Check latest.json drift against expected.json (skips benchm
 cost-benchmark:  ## Run the change-rate × answer-sensitivity cost sweep and write cost_sweep.json
 	python tools/run_cost_sweep.py
 
-cost-benchmark-check:  ## Check cost_sweep.json drift against expected_cost.json (skips sweep run)
+cost-benchmark-check: cost-benchmark  ## Re-run the cost sweep, then drift-check it against expected_cost.json
 	python tools/cost_drift_check.py
 
 TLA2TOOLS := formal/tla/lib/tla2tools.jar

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 # Requires: pip install -e ".[langgraph,benchmark]"
 
-.PHONY: benchmark benchmark-check tla-check help
+.PHONY: benchmark benchmark-check cost-benchmark cost-benchmark-check tla-check help
 
 benchmark:  ## Run all three LangGraph benchmarks and write latest.json
 	python tools/run_benchmarks.py
 
 benchmark-check:  ## Check latest.json drift against expected.json (skips benchmark run)
 	python tools/benchmark_drift_check.py
+
+cost-benchmark:  ## Run the change-rate × answer-sensitivity cost sweep and write cost_sweep.json
+	python tools/run_cost_sweep.py
+
+cost-benchmark-check:  ## Check cost_sweep.json drift against expected_cost.json (skips sweep run)
+	python tools/cost_drift_check.py
 
 TLA2TOOLS := formal/tla/lib/tla2tools.jar
 TLC := java -XX:+UseParallelGC -cp $(TLA2TOOLS) tlc2.TLC -workers auto

--- a/benchmarks/cost_preregistration.md
+++ b/benchmarks/cost_preregistration.md
@@ -1,0 +1,92 @@
+# Cost-sweep pre-registration
+
+Falsifiability scaffolding for the change-rate × answer-sensitivity cost sweep
+(`tools/run_cost_sweep.py`, third benchmark lane — temporal simulation). It
+fixes the three verdicts **and their decision rule** before the full sweep is
+run, so the result cannot be reverse-justified after the numbers land.
+
+The sweep emits, per `(change-rate r, answer-sensitivity s)` cell, gating's
+`savings_ratio` (1 − gated_fetches / always_fetches) and `refetches_avoided`
+(always_fetches − gated_fetches), every figure provenance-labeled
+`temporal-sim (third lane)`. Gating buys re-fetch savings; the question this
+pre-registration answers is **whether that saving is worth the coordination
+dependency at realistic change-rates**, or whether it collapses to noise.
+
+> **Threshold VALUES (`X`, `R`, `W`, `S`) are a founder input set _before_ the
+> full sweep run — they are NOT part of this file's acceptance.** This file is
+> complete when the three verdicts, the distinguishers, and the placeholder
+> thresholds are present. The committed CI baseline lives in
+> `benchmarks/expected_cost.json` and the drift gate in
+> `tools/cost_drift_check.py`; those guard reproducibility, not the verdict.
+
+## Metrics under test
+
+| Metric | Source field | Meaning |
+| --- | --- | --- |
+| Savings | `savings_ratio` | Fraction of always-re-fetch cost gating avoids. |
+| Avoided | `refetches_avoided` | Absolute re-fetches gating skips vs. always-read. |
+| Waste | `wasted_refetches` | Gating re-fetches that were answer-irrelevant churn. |
+
+## Verdicts
+
+### PASS — gating's savings are materially worth the dependency
+
+There exists a realistic change-rate regime where gating saves enough re-fetch
+cost, with low enough waste, to justify the coordination layer.
+
+- **Rule (placeholder):** `savings_ratio ≥ X%` **sustained across all rates
+  `r ≤ R`**, with `wasted_refetches ≤ W` in that same regime.
+- Placeholders to be set by founder before the run: `X` (min savings, e.g.
+  `30%`), `R` (the calm-source ceiling savings must hold below, e.g. `0.25`),
+  `W` (max tolerated wasted re-fetches, e.g. `5`).
+- Interpretation: the savings curve is real and lands in the change-rate band
+  real workloads actually occupy — not only at the degenerate `r = 0` endpoint.
+
+### NULL — savings are trivial across realistic change-rates (honest falsification)
+
+Across the realistic-change-rate band, gating's savings never clear the PASS
+bar; the dependency does not pay for itself. This is the honest negative result
+and is reported as such — **not** softened into INCONCLUSIVE.
+
+- **Rule (placeholder):** for every rate `r` in the realistic band
+  (`r_min … R`), `savings_ratio < X%` (or `savings_ratio ≥ X%` only at
+  unrealistic `r ≈ 0`), i.e. savings decay to noise before the realistic band.
+- Declared **only after** every INCONCLUSIVE distinguisher below has been ruled
+  out — otherwise the apparent null may be a measurement artifact.
+
+### INCONCLUSIVE — the run cannot adjudicate PASS vs. NULL yet
+
+The sweep as run does not let us separate "no real effect" from "effect hidden
+by how we measured it". Triage **all** distinguishers below and re-run before
+declaring NULL.
+
+#### Distinguishers (triage each before declaring NULL)
+
+- **gating-dominates-everywhere** — `savings_ratio` high (and `refetches_avoided`
+  large) at *every* rate including `r = 1.0`. A genuine cost floor should let
+  savings fall toward 0 as the source churns constantly; flat-high savings
+  signals the always-read ceiling is mis-instrumented, not that gating wins
+  everywhere.
+- **grid-too-coarse** — savings drop from high→trivial across one rate step
+  (e.g. `0.0 → 0.5`), so the realistic band `R` falls *between* grid points and
+  the crossover is unobserved. Refine the `rates` grid around `R` and re-run.
+- **degenerate-sensitivity-model** — `savings_ratio` is identical across all
+  `answer-sensitivity` values (sensitivity moves only `wasted_refetches`, never
+  savings). If the verdict depends on sensitivity but the model can't express
+  it, the sensitivity axis is degenerate for this question — fix the model
+  before reading savings.
+- **baseline-mis-modeled** — the always-read ceiling or blind floor is wrong
+  (e.g. `always_fetches ≈ gated_fetches`, collapsing `savings_ratio → 0`
+  spuriously, or `blind_fetches > gated_fetches`). The denominator is broken;
+  no savings verdict is valid until the baselines bracket gating correctly.
+
+## Decision flow
+
+```
+run full sweep
+  └─ any INCONCLUSIVE distinguisher fires?
+        ├─ yes → INCONCLUSIVE: fix instrumentation/grid/model, re-run
+        └─ no  → PASS rule satisfied?
+                    ├─ yes → PASS
+                    └─ no  → NULL (honest falsification)
+```

--- a/benchmarks/cost_preregistration.md
+++ b/benchmarks/cost_preregistration.md
@@ -27,6 +27,14 @@ dependency at realistic change-rates**, or whether it collapses to noise.
 | Avoided | `refetches_avoided` | Absolute re-fetches gating skips vs. always-read. |
 | Waste | `wasted_refetches` | Gating re-fetches that were answer-irrelevant churn. |
 
+**Axis note (by design).** `savings_ratio` and `refetches_avoided` are **invariant
+along the answer-sensitivity axis**: gating re-fetches on *every* source change
+regardless of whether the change was answer-relevant, so the fetch counts depend
+only on change-rate. `wasted_refetches` is therefore the only metric that moves
+with answer-sensitivity, and it is drift-gated in `tools/cost_drift_check.py` so
+the second axis is not left unguarded in CI. A savings PASS/NULL verdict must not
+depend on sensitivity (see the `degenerate-sensitivity-model` distinguisher).
+
 ## Verdicts
 
 ### PASS — gating's savings are materially worth the dependency

--- a/benchmarks/expected_cost.json
+++ b/benchmarks/expected_cost.json
@@ -17,62 +17,74 @@
     {
       "cell": "r0.0_s0.0",
       "savings_ratio": 0.7884,
-      "refetches_avoided": 88.3
+      "refetches_avoided": 88.3,
+      "wasted_refetches": 0.0
     },
     {
       "cell": "r0.0_s0.5",
       "savings_ratio": 0.7884,
-      "refetches_avoided": 88.3
+      "refetches_avoided": 88.3,
+      "wasted_refetches": 0.0
     },
     {
       "cell": "r0.0_s1.0",
       "savings_ratio": 0.7884,
-      "refetches_avoided": 88.3
+      "refetches_avoided": 88.3,
+      "wasted_refetches": 0.0
     },
     {
       "cell": "r0.25_s0.0",
       "savings_ratio": 0.3694,
-      "refetches_avoided": 42.0
+      "refetches_avoided": 42.0,
+      "wasted_refetches": 54.6
     },
     {
       "cell": "r0.25_s0.5",
       "savings_ratio": 0.3694,
-      "refetches_avoided": 42.0
+      "refetches_avoided": 42.0,
+      "wasted_refetches": 17.3
     },
     {
       "cell": "r0.25_s1.0",
       "savings_ratio": 0.3694,
-      "refetches_avoided": 42.0
+      "refetches_avoided": 42.0,
+      "wasted_refetches": 0.0
     },
     {
       "cell": "r0.5_s0.0",
       "savings_ratio": 0.1775,
-      "refetches_avoided": 20.4
+      "refetches_avoided": 20.4,
+      "wasted_refetches": 78.3
     },
     {
       "cell": "r0.5_s0.5",
       "savings_ratio": 0.1775,
-      "refetches_avoided": 20.4
+      "refetches_avoided": 20.4,
+      "wasted_refetches": 20.6
     },
     {
       "cell": "r0.5_s1.0",
       "savings_ratio": 0.1775,
-      "refetches_avoided": 20.4
+      "refetches_avoided": 20.4,
+      "wasted_refetches": 0.0
     },
     {
       "cell": "r1.0_s0.0",
       "savings_ratio": 0.0,
-      "refetches_avoided": 0.0
+      "refetches_avoided": 0.0,
+      "wasted_refetches": 99.4
     },
     {
       "cell": "r1.0_s0.5",
       "savings_ratio": 0.0,
-      "refetches_avoided": 0.0
+      "refetches_avoided": 0.0,
+      "wasted_refetches": 22.1
     },
     {
       "cell": "r1.0_s1.0",
       "savings_ratio": 0.0,
-      "refetches_avoided": 0.0
+      "refetches_avoided": 0.0,
+      "wasted_refetches": 0.0
     }
   ]
 }

--- a/benchmarks/expected_cost.json
+++ b/benchmarks/expected_cost.json
@@ -1,0 +1,78 @@
+{
+  "grid": {
+    "rates": [
+      0.0,
+      0.25,
+      0.5,
+      1.0
+    ],
+    "sensitivities": [
+      0.0,
+      0.5,
+      1.0
+    ],
+    "runs_per_point": 10
+  },
+  "cells": [
+    {
+      "cell": "r0.0_s0.0",
+      "savings_ratio": 0.7884,
+      "refetches_avoided": 88.3
+    },
+    {
+      "cell": "r0.0_s0.5",
+      "savings_ratio": 0.7884,
+      "refetches_avoided": 88.3
+    },
+    {
+      "cell": "r0.0_s1.0",
+      "savings_ratio": 0.7884,
+      "refetches_avoided": 88.3
+    },
+    {
+      "cell": "r0.25_s0.0",
+      "savings_ratio": 0.3694,
+      "refetches_avoided": 42.0
+    },
+    {
+      "cell": "r0.25_s0.5",
+      "savings_ratio": 0.3694,
+      "refetches_avoided": 42.0
+    },
+    {
+      "cell": "r0.25_s1.0",
+      "savings_ratio": 0.3694,
+      "refetches_avoided": 42.0
+    },
+    {
+      "cell": "r0.5_s0.0",
+      "savings_ratio": 0.1775,
+      "refetches_avoided": 20.4
+    },
+    {
+      "cell": "r0.5_s0.5",
+      "savings_ratio": 0.1775,
+      "refetches_avoided": 20.4
+    },
+    {
+      "cell": "r0.5_s1.0",
+      "savings_ratio": 0.1775,
+      "refetches_avoided": 20.4
+    },
+    {
+      "cell": "r1.0_s0.0",
+      "savings_ratio": 0.0,
+      "refetches_avoided": 0.0
+    },
+    {
+      "cell": "r1.0_s0.5",
+      "savings_ratio": 0.0,
+      "refetches_avoided": 0.0
+    },
+    {
+      "cell": "r1.0_s1.0",
+      "savings_ratio": 0.0,
+      "refetches_avoided": 0.0
+    }
+  ]
+}

--- a/src/ccs/core/states.py
+++ b/src/ccs/core/states.py
@@ -76,6 +76,10 @@ def can_act_in_transient(
             return lease_valid
         if strategy_name == "access_count":
             return accesses_remaining
+        # Non-enumerated strategies -- ``broadcast`` and the benchmark-internal
+        # ``blind`` cost floor -- intentionally do not act mid-acquisition. For
+        # ``blind`` this is verified not to contaminate the cost-floor measurement:
+        # it still performs exactly num_agents x num_artifacts fetches regardless.
         return False
 
     if transient_state in {TransientState.MWB, TransientState.MSA}:

--- a/src/ccs/simulation/aggregation.py
+++ b/src/ccs/simulation/aggregation.py
@@ -50,6 +50,10 @@ class AggregatedMetrics:
     invalidation_efficiency_std: float
     message_overhead_mean: float
     message_overhead_std: float
+    source_refetches_mean: float
+    source_refetches_std: float
+    wasted_refetches_mean: float
+    wasted_refetches_std: float
 
     def to_dict(self) -> dict[str, Any]:
         """Return JSON-safe dictionary payload."""
@@ -83,6 +87,10 @@ def aggregate_strategy_runs(strategy: str, runs: Sequence[SimulationMetrics]) ->
         invalidation_efficiency_std=_std([m.invalidation_efficiency for m in runs]),
         message_overhead_mean=_mean([float(m.message_overhead) for m in runs]),
         message_overhead_std=_std([float(m.message_overhead) for m in runs]),
+        source_refetches_mean=_mean([float(m.source_refetches) for m in runs]),
+        source_refetches_std=_std([float(m.source_refetches) for m in runs]),
+        wasted_refetches_mean=_mean([float(m.wasted_refetches) for m in runs]),
+        wasted_refetches_std=_std([float(m.wasted_refetches) for m in runs]),
     )
 
 

--- a/src/ccs/simulation/engine.py
+++ b/src/ccs/simulation/engine.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import random
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Literal, Mapping, Sequence
 from uuid import UUID
 
@@ -31,6 +31,11 @@ from .metrics import SimulationMetrics, StrategyComparisonReport
 
 _INVALIDATION_SIGNAL_TOKENS = 12
 _POINTER_UPDATE_TOKENS = 8
+
+# Offset for the dedicated source-mutation RNG. Drawing mutation/relevance from
+# a stream seeded independently of ``self._rng`` keeps the action-selection
+# stream byte-stable, so the flag-off path and same-seed determinism hold.
+_SOURCE_MUTATION_SEED_OFFSET = 100_000
 
 
 @dataclass(frozen=True)
@@ -89,6 +94,24 @@ class SimulationEngine:
         )
         self._crash_recovery = _build_crash_recovery_config(scenario_config)
         validate_crash_recovery_config(self._crash_recovery, self._strategy)
+
+        # Source-mutation step (the change-rate dial). Flag-gated, default OFF.
+        # Draws use a DEDICATED rng seeded independently of self._rng so the
+        # action-selection stream stays byte-stable whether the feature is on
+        # or off (mirrors the crash_recovery.enabled flag-off byte-identity
+        # contract). When disabled, none of this state is consulted in run().
+        source_mutation_cfg = scenario_config.get("source_mutation") or {}
+        self._source_mutation_enabled = bool(source_mutation_cfg.get("enabled", False))
+        self._source_mutation_answer_sensitivity = float(
+            source_mutation_cfg.get("answer_sensitivity", 1.0)
+        )
+        self._mutation_rng = random.Random(self.seed + _SOURCE_MUTATION_SEED_OFFSET)
+        # Per-tick map {artifact_id: relevant} of source mutations applied this
+        # tick. Unit 3 consumes it; here we only populate/clear it correctly.
+        self._pending_source_mutations: dict[UUID, bool] = {}
+        # Test-only running total of source mutations applied across the run.
+        self._source_mutation_count = 0
+
         self._monitor = ConsistencyMonitor(self._strategy)
         self._network = NetworkSimulator(
             latency_ticks=int(scenario_config["network"]["latency_ticks"]),
@@ -144,6 +167,12 @@ class SimulationEngine:
         self._context_injections = 0
         self._transient_state_timeouts = 0
         self._stable_grant_reclamations = 0
+        # Source-mutation cost accounting (Unit 3). source_refetches counts
+        # re-fetches a this-tick source mutation triggered; wasted_refetches is
+        # the answer-irrelevant subset (a re-fetch the agent paid for that did
+        # not change the answer). Pure cost — no correctness oracle.
+        self._source_refetches = 0
+        self._wasted_refetches = 0
 
     def run(self) -> SimulationMetrics:
         """Run one deterministic simulation and return collected metrics."""
@@ -153,6 +182,11 @@ class SimulationEngine:
             now = self._clock.now()
             self._apply_failure_events_for_tick(now)
             self._deliver_messages()
+            if self._source_mutation_enabled:
+                # Flag-off path must be byte-identical to the no-block baseline:
+                # guard at the call site so no version bump or source_mutation
+                # state-log entry lands when the feature is disabled.
+                self._apply_source_mutations_for_tick(now)
             self._execute_actions_for_tick()
             if self._strategy.broadcasts_every_tick():
                 self._broadcast_all_to_all(now_tick=now)
@@ -270,6 +304,69 @@ class SimulationEngine:
         for agent_id in self._alive_agents:
             self._coordinator.record_heartbeat(agent_id=agent_id, now_tick=now_tick)
 
+    # ---- Source-mutation step (the change-rate dial) --------------------
+
+    def _apply_source_mutations_for_tick(self, now: int) -> None:
+        """Bump artifact versions WITHOUT an agent write (external-source churn).
+
+        Only called when ``self._source_mutation_enabled`` is True (guarded at
+        the run() call site). For each mutable artifact, in registration order,
+        draw against its ``volatility``; on a hit, advance the canonical version
+        by one, invalidate every current non-INVALID holder, and tag the
+        mutation answer-relevant or not. ALL draws use ``self._mutation_rng``
+        (never ``self._rng``) so the action-selection stream stays byte-stable.
+
+        Mechanics deliberately bypass the coordinator commit/invalidate paths:
+        - version bump via ``registry.set_artifact_and_content`` (not
+          ``coordinator.commit``, which requires the mutator to hold M/E);
+        - holder invalidation via ``registry.set_agent_state(...,
+          trigger="source_mutation")`` plus the local cache invalidation that
+          ``runtime.handle_invalidation`` performs — but NOT
+          ``coordinator.invalidate`` / ``runtime.handle_invalidation``
+          themselves, which double-invalidate and hardcode trigger="invalidate",
+          masking the distinct "source_mutation" state-log label.
+        """
+        # Per-tick semantics: reset before populating so the dict reflects only
+        # mutations applied on THIS tick (Unit 3 consumes it each tick).
+        self._pending_source_mutations = {}
+        for artifact_id in self._artifact_ids:
+            spec = self._artifact_specs_by_id[artifact_id]
+            if not bool(spec.get("mutable", True)):
+                continue
+            volatility = float(spec.get("volatility", 0.0))
+            if self._mutation_rng.random() >= volatility:
+                continue
+
+            previous = self._registry.get_artifact(artifact_id)
+            assert previous is not None
+            mutated = replace(previous, version=previous.version + 1)
+            self._registry.set_artifact_and_content(
+                artifact_id,
+                mutated,
+                f"{mutated.name}-v{mutated.version}-source",
+            )
+
+            for holder_id in self._registry.valid_holders(artifact_id):
+                self._registry.set_agent_state(
+                    artifact_id,
+                    holder_id,
+                    MESIState.INVALID,
+                    trigger="source_mutation",
+                    tick=now,
+                )
+                # Replicate the cache-invalidation half of handle_invalidation
+                # (without touching the coordinator) so the holder's local view
+                # is INVALID at version (new_version - 1).
+                self._runtime_by_agent[holder_id].cache.invalidate(
+                    artifact_id,
+                    invalidated_version=max(mutated.version - 1, 0),
+                    issued_at_tick=now,
+                )
+
+            relevant = self._mutation_rng.random() < self._source_mutation_answer_sensitivity
+            self._pending_source_mutations[artifact_id] = relevant
+            self._source_mutation_count += 1
+
     def _register_artifacts(self) -> None:
         for artifact_cfg in self._config["artifacts"]:
             artifact = Artifact(
@@ -339,6 +436,24 @@ class SimulationEngine:
             self._fetch_actions += 1
             self._context_injections += 1
             self._tokens_fetch += self._artifact_token_size(artifact_id)
+            # Source-mutation attribution (Unit 3). A re-fetch is attributed to
+            # a source mutation only when BOTH hold:
+            #   (a) the holder already had a cached copy now sitting at INVALID
+            #       — i.e. this is a genuine re-fetch of an invalidated entry,
+            #       NOT an initial empty-cache fill (entry is None), an
+            #       always_read forced re-read, or a lease-expiry refresh; and
+            #   (b) the artifact was source-mutated THIS tick
+            #       (_pending_source_mutations is reset every tick in Unit 2, so
+            #       membership means "the source just churned this artifact").
+            # The pending entry is intentionally NOT cleared: distinct holders
+            # each re-fetching the same this-tick-mutated artifact are separate,
+            # real re-fetches and all count (each agent acts <=1x/tick, so no
+            # single-agent double-count).
+            relevant = self._pending_source_mutations.get(artifact_id)
+            if relevant is not None and entry is not None and entry.state == MESIState.INVALID:
+                self._source_refetches += 1
+                if relevant is False:
+                    self._wasted_refetches += 1
         else:
             self._cache_hits += 1
 
@@ -582,6 +697,8 @@ class SimulationEngine:
             context_injections=self._context_injections,
             transient_state_timeouts=self._transient_state_timeouts,
             stable_grant_reclamations=self._stable_grant_reclamations,
+            source_refetches=self._source_refetches,
+            wasted_refetches=self._wasted_refetches,
         )
 
 

--- a/src/ccs/simulation/engine.py
+++ b/src/ccs/simulation/engine.py
@@ -106,11 +106,14 @@ class SimulationEngine:
             source_mutation_cfg.get("answer_sensitivity", 1.0)
         )
         self._mutation_rng = random.Random(self.seed + _SOURCE_MUTATION_SEED_OFFSET)
-        # Per-tick map {artifact_id: relevant} of source mutations applied this
-        # tick. Unit 3 consumes it; here we only populate/clear it correctly.
-        self._pending_source_mutations: dict[UUID, bool] = {}
-        # Test-only running total of source mutations applied across the run.
-        self._source_mutation_count = 0
+        # Persistent per-(artifact, holder) marker. Presence means the holder has
+        # un-read source churn for that artifact; the value is whether ANY of that
+        # churn was answer-relevant (accumulated by OR). Set when the source
+        # mutates an artifact the agent holds; consumed (deleted) when that holder
+        # re-fetches. Persisting across ticks is what makes attribution correct
+        # when an agent reads only every few ticks (action_probability < 1) under
+        # churn -- a per-tick reset would lose or mis-tag those re-fetches.
+        self._pending_source_mutations: dict[tuple[UUID, UUID], bool] = {}
 
         self._monitor = ConsistencyMonitor(self._strategy)
         self._network = NetworkSimulator(
@@ -326,9 +329,6 @@ class SimulationEngine:
           themselves, which double-invalidate and hardcode trigger="invalidate",
           masking the distinct "source_mutation" state-log label.
         """
-        # Per-tick semantics: reset before populating so the dict reflects only
-        # mutations applied on THIS tick (Unit 3 consumes it each tick).
-        self._pending_source_mutations = {}
         for artifact_id in self._artifact_ids:
             spec = self._artifact_specs_by_id[artifact_id]
             if not bool(spec.get("mutable", True)):
@@ -363,9 +363,19 @@ class SimulationEngine:
                     issued_at_tick=now,
                 )
 
+            # Accumulate per-holder relevance for EVERY agent that currently holds
+            # a cached copy: the holders just invalidated, plus any already-INVALID
+            # from earlier churn they have not re-read yet. A re-fetch is "wasted"
+            # only if NONE of the churn since the holder last fetched was answer-
+            # relevant, so OR the relevance into each holder's marker.
             relevant = self._mutation_rng.random() < self._source_mutation_answer_sensitivity
-            self._pending_source_mutations[artifact_id] = relevant
-            self._source_mutation_count += 1
+            for holder_id, runtime in self._runtime_by_agent.items():
+                if runtime.cache.get(artifact_id) is None:
+                    continue
+                key = (artifact_id, holder_id)
+                self._pending_source_mutations[key] = (
+                    self._pending_source_mutations.get(key, False) or relevant
+                )
 
     def _register_artifacts(self) -> None:
         for artifact_cfg in self._config["artifacts"]:
@@ -436,24 +446,23 @@ class SimulationEngine:
             self._fetch_actions += 1
             self._context_injections += 1
             self._tokens_fetch += self._artifact_token_size(artifact_id)
-            # Source-mutation attribution (Unit 3). A re-fetch is attributed to
-            # a source mutation only when BOTH hold:
-            #   (a) the holder already had a cached copy now sitting at INVALID
-            #       — i.e. this is a genuine re-fetch of an invalidated entry,
-            #       NOT an initial empty-cache fill (entry is None), an
-            #       always_read forced re-read, or a lease-expiry refresh; and
-            #   (b) the artifact was source-mutated THIS tick
-            #       (_pending_source_mutations is reset every tick in Unit 2, so
-            #       membership means "the source just churned this artifact").
-            # The pending entry is intentionally NOT cleared: distinct holders
-            # each re-fetching the same this-tick-mutated artifact are separate,
-            # real re-fetches and all count (each agent acts <=1x/tick, so no
-            # single-agent double-count).
-            relevant = self._pending_source_mutations.get(artifact_id)
+            # Source-mutation attribution. Credit this re-fetch to source churn
+            # only when (a) the holder had a cached copy now sitting at INVALID --
+            # a genuine re-fetch of an invalidated entry, NOT an initial fill
+            # (entry is None), an always_read forced re-read of a still-valid
+            # entry, or a lease-expiry refresh -- and (b) this holder carries an
+            # un-read source-churn marker for the artifact. The marker persists
+            # across ticks (set when the source mutated an artifact this holder
+            # held) and is CONSUMED here, so the holder is credited exactly once
+            # per stretch of un-read churn no matter how many ticks it spanned.
+            # "Wasted" means none of that churn was answer-relevant.
+            key = (artifact_id, agent_id)
+            relevant = self._pending_source_mutations.get(key)
             if relevant is not None and entry is not None and entry.state == MESIState.INVALID:
                 self._source_refetches += 1
                 if relevant is False:
                     self._wasted_refetches += 1
+                del self._pending_source_mutations[key]
         else:
             self._cache_hits += 1
 

--- a/src/ccs/simulation/metrics.py
+++ b/src/ccs/simulation/metrics.py
@@ -41,6 +41,8 @@ class SimulationMetrics:
     context_injections: int
     transient_state_timeouts: int = 0
     stable_grant_reclamations: int = 0
+    source_refetches: int = 0
+    wasted_refetches: int = 0
 
     @property
     def synchronization_tokens(self) -> int:

--- a/src/ccs/simulation/scenarios.py
+++ b/src/ccs/simulation/scenarios.py
@@ -77,6 +77,7 @@ def _normalize_legacy_keys(data: dict[str, Any]) -> dict[str, Any]:
     transient = data.setdefault("transient", {})
     context_semantics = data.setdefault("context_semantics", {})
     data.setdefault("crash_recovery", {})
+    data.setdefault("source_mutation", {})
 
     if "num_agents" not in simulation and "agents" in simulation:
         simulation["num_agents"] = simulation["agents"]
@@ -287,6 +288,26 @@ def _validate_crash_recovery(crash_recovery: dict[str, Any], path: Path) -> None
         )
 
 
+def _validate_source_mutation(source_mutation: dict[str, Any], path: Path) -> None:
+    """Validate optional ``source_mutation`` block; absent or empty ⇒ defaults.
+
+    ``enabled`` (bool, default False) gates the per-tick source-mutation step.
+    ``answer_sensitivity`` (float in [0, 1], default 1.0) is the probability a
+    given source mutation is tagged answer-relevant. Mirrors how
+    ``crash_recovery`` is validated and the ``artifacts[].volatility`` range.
+    """
+    if "enabled" in source_mutation:
+        _require_bool(source_mutation["enabled"], path=path, field="source_mutation.enabled")
+    if "answer_sensitivity" in source_mutation:
+        _require_float(
+            source_mutation["answer_sensitivity"],
+            path=path,
+            field="source_mutation.answer_sensitivity",
+            min_value=0.0,
+            max_value=1.0,
+        )
+
+
 _SUPPORTED_FAILURE_ACTIONS = {"kill", "busy", "restore"}
 
 
@@ -379,6 +400,7 @@ def validate_scenario(data: dict[str, Any], scenario_path: str | Path) -> dict[s
     transient = _require_mapping(normalized, path, "transient")
     context_semantics = _require_mapping(normalized, path, "context_semantics")
     crash_recovery = _require_mapping(normalized, path, "crash_recovery")
+    source_mutation = _require_mapping(normalized, path, "source_mutation")
 
     _validate_simulation(simulation, path)
     _validate_network(network, path)
@@ -388,6 +410,7 @@ def validate_scenario(data: dict[str, Any], scenario_path: str | Path) -> dict[s
     _validate_transient(transient, path)
     _validate_context_semantics(context_semantics, path)
     _validate_crash_recovery(crash_recovery, path)
+    _validate_source_mutation(source_mutation, path)
     _validate_failure_events(normalized.get("failure_events"), path)
 
     return _populate_runtime_aliases(normalized)

--- a/src/ccs/strategies/__init__.py
+++ b/src/ccs/strategies/__init__.py
@@ -5,7 +5,6 @@
 
 from .access_count import AccessCountStrategy
 from .base import SyncStrategy
-from .blind_cache import BlindCacheStrategy
 from .broadcast import BroadcastStrategy
 from .eager import EagerStrategy
 from .lazy import LazyStrategy
@@ -14,7 +13,6 @@ from .selector import build_strategy, select_strategy_name_for_role
 
 __all__ = [
     "SyncStrategy",
-    "BlindCacheStrategy",
     "BroadcastStrategy",
     "EagerStrategy",
     "LazyStrategy",

--- a/src/ccs/strategies/__init__.py
+++ b/src/ccs/strategies/__init__.py
@@ -5,6 +5,7 @@
 
 from .access_count import AccessCountStrategy
 from .base import SyncStrategy
+from .blind_cache import BlindCacheStrategy
 from .broadcast import BroadcastStrategy
 from .eager import EagerStrategy
 from .lazy import LazyStrategy
@@ -13,6 +14,7 @@ from .selector import build_strategy, select_strategy_name_for_role
 
 __all__ = [
     "SyncStrategy",
+    "BlindCacheStrategy",
     "BroadcastStrategy",
     "EagerStrategy",
     "LazyStrategy",

--- a/src/ccs/strategies/blind_cache.py
+++ b/src/ccs/strategies/blind_cache.py
@@ -1,7 +1,15 @@
 # Copyright (c) 2026 Arbiter contributors.
 # The Coherence Protocol for AI Agents
 
-"""Blind cache strategy that never refetches after the first fill."""
+"""Blind cache strategy — BENCHMARK COST-FLOOR ONLY, never for production.
+
+``requires_refresh`` always returns ``False``: it serves the first-fetched copy
+forever and never honors ``MESIState.INVALID``, modelling the exact failure the
+coherence protocol exists to prevent (unbounded staleness). It is intentionally
+NOT part of the public ``ccs.strategies`` API (absent from ``__all__``) and is
+reachable only via ``build_strategy("blind")`` so the temporal cost benchmark can
+resolve it by name.
+"""
 
 from __future__ import annotations
 
@@ -14,12 +22,15 @@ from .base import SyncStrategy
 
 
 class BlindCacheStrategy(SyncStrategy):
-    """Fetch once on first fill, then serve the local copy forever.
+    """BENCHMARK COST-FLOOR — UNBOUNDED STALENESS, NEVER FOR PRODUCTION.
 
-    This is the cost floor for the temporal benchmark: it deliberately ignores
-    ``MESIState.INVALID`` so it never re-fetches a stale entry. Realistic
-    strategies trade tokens for freshness; this one pays the minimum token cost
-    and accepts unbounded staleness as the comparison baseline.
+    Fetches once on first fill, then serves the local copy forever: it
+    deliberately ignores ``MESIState.INVALID`` so it never re-fetches a stale
+    entry. This models the exact failure the coherence protocol exists to
+    prevent, and exists only as the comparison baseline for the temporal cost
+    benchmark. It is intentionally excluded from ``ccs.strategies.__all__`` and
+    reachable only via ``build_strategy("blind")``. Do not use it in production —
+    it has no freshness guarantee whatsoever.
     """
 
     name = "blind"

--- a/src/ccs/strategies/blind_cache.py
+++ b/src/ccs/strategies/blind_cache.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Blind cache strategy that never refetches after the first fill."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ccs.core.states import MESIState
+from ccs.core.types import ArtifactCacheEntry
+
+from .base import SyncStrategy
+
+
+class BlindCacheStrategy(SyncStrategy):
+    """Fetch once on first fill, then serve the local copy forever.
+
+    This is the cost floor for the temporal benchmark: it deliberately ignores
+    ``MESIState.INVALID`` so it never re-fetches a stale entry. Realistic
+    strategies trade tokens for freshness; this one pays the minimum token cost
+    and accepts unbounded staleness as the comparison baseline.
+    """
+
+    name = "blind"
+
+    def requires_refresh(self, entry: ArtifactCacheEntry, *, now_tick: int) -> bool:
+        del entry, now_tick
+        return False
+
+    def on_read(self, entry: ArtifactCacheEntry, *, now_tick: int) -> ArtifactCacheEntry:
+        del now_tick
+        return self._touch(entry)
+
+    def on_fetch(
+        self,
+        *,
+        artifact_id: UUID,
+        version: int,
+        state: MESIState,
+        now_tick: int,
+    ) -> ArtifactCacheEntry:
+        return self._new_entry(artifact_id=artifact_id, version=version, state=state, now_tick=now_tick)

--- a/src/ccs/strategies/selector.py
+++ b/src/ccs/strategies/selector.py
@@ -9,6 +9,7 @@ from typing import Mapping
 
 from .access_count import AccessCountStrategy
 from .base import SyncStrategy
+from .blind_cache import BlindCacheStrategy
 from .broadcast import BroadcastStrategy
 from .eager import EagerStrategy
 from .lazy import LazyStrategy
@@ -35,6 +36,8 @@ def build_strategy(
 ) -> SyncStrategy:
     """Create strategy instance from normalized strategy name."""
     normalized = strategy_name.strip().lower()
+    if normalized == "blind":
+        return BlindCacheStrategy()
     if normalized == "broadcast":
         return BroadcastStrategy()
     if normalized == "eager":

--- a/src/ccs/strategies/selector.py
+++ b/src/ccs/strategies/selector.py
@@ -36,6 +36,9 @@ def build_strategy(
 ) -> SyncStrategy:
     """Create strategy instance from normalized strategy name."""
     normalized = strategy_name.strip().lower()
+    # Benchmark-internal cost floor (unbounded staleness) — intentionally absent
+    # from ``ccs.strategies.__all__``; resolvable here only so the temporal cost
+    # sweep can name it. Not a production strategy.
     if normalized == "blind":
         return BlindCacheStrategy()
     if normalized == "broadcast":

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -9,7 +9,15 @@ from ccs.simulation.aggregation import aggregate_comparison_runs, aggregate_stra
 from ccs.simulation.metrics import SimulationMetrics
 
 
-def _metric(strategy: str, *, fetch: int, broadcast: int, stale_reads: int) -> SimulationMetrics:
+def _metric(
+    strategy: str,
+    *,
+    fetch: int,
+    broadcast: int,
+    stale_reads: int,
+    source_refetches: int = 0,
+    wasted_refetches: int = 0,
+) -> SimulationMetrics:
     return SimulationMetrics(
         scenario="tiny",
         strategy=strategy,
@@ -38,6 +46,8 @@ def _metric(strategy: str, *, fetch: int, broadcast: int, stale_reads: int) -> S
         tokens_invalidation=24,
         context_injections=3,
         transient_state_timeouts=0,
+        source_refetches=source_refetches,
+        wasted_refetches=wasted_refetches,
     )
 
 
@@ -53,6 +63,24 @@ def test_aggregate_strategy_runs() -> None:
     assert agg.fetch_tokens_mean == 200.0
     assert agg.broadcast_tokens_mean == 0.0
     assert agg.stale_reads_mean == 2.0
+
+
+def test_aggregate_reports_source_and_wasted_refetch_means() -> None:
+    runs = [
+        _metric("lazy", fetch=100, broadcast=0, stale_reads=1, source_refetches=4, wasted_refetches=1),
+        _metric("lazy", fetch=300, broadcast=0, stale_reads=3, source_refetches=8, wasted_refetches=3),
+    ]
+    agg = aggregate_strategy_runs("lazy", runs)
+
+    assert agg.source_refetches_mean == 6.0
+    assert agg.wasted_refetches_mean == 2.0
+    # pstdev over [4, 8] is 2.0; over [1, 3] is 1.0.
+    assert agg.source_refetches_std == 2.0
+    assert agg.wasted_refetches_std == 1.0
+    # New fields are part of the JSON-safe payload.
+    payload = agg.to_dict()
+    assert payload["source_refetches_mean"] == 6.0
+    assert payload["wasted_refetches_mean"] == 2.0
 
 
 def test_aggregate_comparison_and_flatten() -> None:

--- a/tests/test_cost_drift_check.py
+++ b/tests/test_cost_drift_check.py
@@ -36,11 +36,17 @@ def _write_json(path: Path, data: dict) -> None:
     path.write_text(json.dumps(data))
 
 
-def _cell(name: str, savings_ratio: float, refetches_avoided: float) -> dict:
+def _cell(
+    name: str,
+    savings_ratio: float,
+    refetches_avoided: float,
+    wasted_refetches: float = 0.0,
+) -> dict:
     return {
         "cell": name,
         "savings_ratio": savings_ratio,
         "refetches_avoided": refetches_avoided,
+        "wasted_refetches": wasted_refetches,
     }
 
 
@@ -227,3 +233,46 @@ def test_cost_preregistration_has_three_verdicts_and_distinguishers():
         "baseline-mis-modeled",
     ):
         assert distinguisher in doc
+
+
+# ---------------------------------------------------------------------------
+# Answer-sensitivity axis is gated (wasted_refetches) + stream routing
+# ---------------------------------------------------------------------------
+
+
+def test_cost_drift_wasted_delta_just_over_threshold_fails(cost_drift_check, tmp_path):
+    """savings/avoided match; only wasted_refetches drifts past its threshold.
+
+    Guards the answer-sensitivity axis -- savings_ratio is sensitivity-invariant
+    by design, so without gating wasted_refetches a sensitivity-axis regression
+    would pass CI silently.
+    """
+    over = cost_drift_check._WASTED_THRESHOLD + 0.01
+    latest = tmp_path / "cost_sweep.json"
+    expected = tmp_path / "expected_cost.json"
+    _write_json(latest, _latest(_cell("r0.5_s0.0", 0.5, 20.0, wasted_refetches=over)))
+    _write_json(expected, _expected(_cell("r0.5_s0.0", 0.5, 20.0, wasted_refetches=0.0)))
+
+    passed, messages = cost_drift_check.check_drift(latest, expected)
+    assert passed is False
+    assert any("wasted_refetches" in m for m in messages)
+
+
+def test_cost_drift_main_routes_report_to_stdout_on_failure(
+    cost_drift_check, tmp_path, monkeypatch, capsys
+):
+    """On failure the drift table goes to stdout (so a CI job capturing stdout
+    sees it), and stderr carries the terminal failure signal."""
+    latest = tmp_path / "cost_sweep.json"
+    expected = tmp_path / "expected_cost.json"
+    _write_json(latest, _latest(_cell("r0.0_s0.0", 0.9000, 87.0)))  # savings drifts
+    _write_json(expected, _expected(_cell("r0.0_s0.0", 0.7952, 87.0)))
+    monkeypatch.setattr(cost_drift_check, "_LATEST_PATH", latest)
+    monkeypatch.setattr(cost_drift_check, "_EXPECTED_PATH", expected)
+
+    with pytest.raises(SystemExit) as exc:
+        cost_drift_check.main()
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "savings_ratio" in captured.out
+    assert "FAILED" in captured.err

--- a/tests/test_cost_drift_check.py
+++ b/tests/test_cost_drift_check.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for tools/cost_drift_check.py — the cost-lane drift gate.
+
+Mirrors the token drift-check tests (``tests/test_benchmark_stage1.py`` § Unit 3):
+``tools/`` is not an importable package, so the module is loaded by file path,
+and each case writes tiny latest/expected JSON files into ``tmp_path``.
+``check_drift`` returns ``(passed, messages)`` here, so the cell-set-mismatch
+cases also assert the offending cell names surface in ``messages``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _import_cost_drift_check():
+    spec = importlib.util.spec_from_file_location(
+        "cost_drift_check", _REPO_ROOT / "tools" / "cost_drift_check.py"
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def _cell(name: str, savings_ratio: float, refetches_avoided: float) -> dict:
+    return {
+        "cell": name,
+        "savings_ratio": savings_ratio,
+        "refetches_avoided": refetches_avoided,
+    }
+
+
+def _latest(*cells: dict) -> dict:
+    """Latest sweep payload: cells live under ``rows`` (keyed by ``cell``)."""
+    return {"sweep": "cost", "provenance": "temporal-sim (third lane)", "rows": list(cells)}
+
+
+def _expected(*cells: dict) -> dict:
+    """Committed baseline: cells live under ``cells`` (keyed by ``cell``)."""
+    return {"grid": {}, "cells": list(cells)}
+
+
+@pytest.fixture()
+def cost_drift_check():
+    return _import_cost_drift_check()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_cost_drift_check_passes_when_latest_equals_expected(cost_drift_check, tmp_path):
+    latest = tmp_path / "cost_sweep.json"
+    expected = tmp_path / "expected_cost.json"
+    _write_json(latest, _latest(_cell("r0.0_s0.0", 0.7952, 87.0)))
+    _write_json(expected, _expected(_cell("r0.0_s0.0", 0.7952, 87.0)))
+
+    passed, _messages = cost_drift_check.check_drift(latest, expected)
+    assert passed is True
+
+
+def test_cost_drift_check_main_exits_zero_on_match(cost_drift_check, tmp_path, monkeypatch):
+    latest = tmp_path / "cost_sweep.json"
+    expected = tmp_path / "expected_cost.json"
+    _write_json(latest, _latest(_cell("r0.0_s0.0", 0.7952, 87.0)))
+    _write_json(expected, _expected(_cell("r0.0_s0.0", 0.7952, 87.0)))
+    monkeypatch.setattr(cost_drift_check, "_LATEST_PATH", latest)
+    monkeypatch.setattr(cost_drift_check, "_EXPECTED_PATH", expected)
+
+    with pytest.raises(SystemExit) as exc:
+        cost_drift_check.main()
+    assert exc.value.code == 0
+
+
+def test_cost_drift_check_main_exits_one_on_drift(cost_drift_check, tmp_path, monkeypatch):
+    latest = tmp_path / "cost_sweep.json"
+    expected = tmp_path / "expected_cost.json"
+    _write_json(latest, _latest(_cell("r0.0_s0.0", 0.9000, 87.0)))
+    _write_json(expected, _expected(_cell("r0.0_s0.0", 0.7952, 87.0)))
+    monkeypatch.setattr(cost_drift_check, "_LATEST_PATH", latest)
+    monkeypatch.setattr(cost_drift_check, "_EXPECTED_PATH", expected)
+
+    with pytest.raises(SystemExit) as exc:
+        cost_drift_check.main()
+    assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Threshold boundary (strict >)
+# ---------------------------------------------------------------------------
+
+
+def test_cost_drift_savings_delta_exactly_at_threshold_passes(cost_drift_check, tmp_path):
+    # delta == _SAVINGS_THRESHOLD should pass (strict >). baseline 0.0 keeps the
+    # boundary delta binary-exact (abs((0.0 + 0.02) - 0.0) == 0.02 exactly).
+    latest = tmp_path / "cost_sweep.json"
+    expected = tmp_path / "expected_cost.json"
+    baseline = 0.0
+    at_threshold = baseline + cost_drift_check._SAVINGS_THRESHOLD
+    _write_json(latest, _latest(_cell("r0.5_s0.0", at_threshold, 20.6)))
+    _write_json(expected, _expected(_cell("r0.5_s0.0", baseline, 20.6)))
+
+    passed, _messages = cost_drift_check.check_drift(latest, expected)
+    assert passed is True
+
+
+def test_cost_drift_savings_delta_just_over_threshold_fails(cost_drift_check, tmp_path):
+    latest = tmp_path / "cost_sweep.json"
+    expected = tmp_path / "expected_cost.json"
+    baseline = 0.0
+    over_threshold = baseline + cost_drift_check._SAVINGS_THRESHOLD + 0.01
+    _write_json(latest, _latest(_cell("r0.5_s0.0", over_threshold, 20.6)))
+    _write_json(expected, _expected(_cell("r0.5_s0.0", baseline, 20.6)))
+
+    passed, _messages = cost_drift_check.check_drift(latest, expected)
+    assert passed is False
+
+
+def test_cost_drift_avoided_delta_exactly_at_threshold_passes(cost_drift_check, tmp_path):
+    latest = tmp_path / "cost_sweep.json"
+    expected = tmp_path / "expected_cost.json"
+    baseline = 20.0
+    at_threshold = baseline + cost_drift_check._AVOIDED_THRESHOLD
+    _write_json(latest, _latest(_cell("r0.5_s0.0", 0.1833, at_threshold)))
+    _write_json(expected, _expected(_cell("r0.5_s0.0", 0.1833, baseline)))
+
+    passed, _messages = cost_drift_check.check_drift(latest, expected)
+    assert passed is True
+
+
+def test_cost_drift_avoided_delta_just_over_threshold_fails(cost_drift_check, tmp_path):
+    latest = tmp_path / "cost_sweep.json"
+    expected = tmp_path / "expected_cost.json"
+    baseline = 20.0
+    over_threshold = baseline + cost_drift_check._AVOIDED_THRESHOLD + 0.5
+    _write_json(latest, _latest(_cell("r0.5_s0.0", 0.1833, over_threshold)))
+    _write_json(expected, _expected(_cell("r0.5_s0.0", 0.1833, baseline)))
+
+    passed, _messages = cost_drift_check.check_drift(latest, expected)
+    assert passed is False
+
+
+# ---------------------------------------------------------------------------
+# Error paths: missing files + cell-set mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_cost_drift_check_fails_on_missing_latest(cost_drift_check, tmp_path):
+    expected = tmp_path / "expected_cost.json"
+    _write_json(expected, _expected(_cell("r0.0_s0.0", 0.7952, 87.0)))
+    latest = tmp_path / "nonexistent.json"
+
+    passed, messages = cost_drift_check.check_drift(latest, expected)
+    assert passed is False
+    assert any("not found" in line for line in messages)
+
+
+def test_cost_drift_check_fails_on_missing_expected(cost_drift_check, tmp_path):
+    latest = tmp_path / "cost_sweep.json"
+    _write_json(latest, _latest(_cell("r0.0_s0.0", 0.7952, 87.0)))
+    expected = tmp_path / "nonexistent.json"
+
+    passed, messages = cost_drift_check.check_drift(latest, expected)
+    assert passed is False
+    assert any("not found" in line for line in messages)
+
+
+def test_cost_drift_check_fails_on_cell_set_mismatch(cost_drift_check, tmp_path):
+    # One cell MISSING from latest, one UNEXPECTED in latest — both names reported.
+    latest = tmp_path / "cost_sweep.json"
+    expected = tmp_path / "expected_cost.json"
+    _write_json(
+        latest,
+        _latest(
+            _cell("r0.0_s0.0", 0.7952, 87.0),
+            _cell("r9.9_s9.9", 0.1, 1.0),  # unexpected
+        ),
+    )
+    _write_json(
+        expected,
+        _expected(
+            _cell("r0.0_s0.0", 0.7952, 87.0),
+            _cell("r1.0_s0.0", 0.0, 0.0),  # missing from latest
+        ),
+    )
+
+    passed, messages = cost_drift_check.check_drift(latest, expected)
+    assert passed is False
+    blob = "\n".join(messages)
+    assert "MISSING" in blob and "r1.0_s0.0" in blob
+    assert "UNEXPECTED" in blob and "r9.9_s9.9" in blob
+
+
+# ---------------------------------------------------------------------------
+# Pre-registration doc structure
+# ---------------------------------------------------------------------------
+
+
+def test_cost_preregistration_has_three_verdicts_and_distinguishers():
+    doc = (_REPO_ROOT / "benchmarks" / "cost_preregistration.md").read_text()
+
+    # The three falsifiability verdicts.
+    assert "PASS" in doc
+    assert "NULL" in doc
+    assert "INCONCLUSIVE" in doc
+
+    # The four INCONCLUSIVE distinguishers to triage before declaring NULL.
+    for distinguisher in (
+        "gating-dominates-everywhere",
+        "grid-too-coarse",
+        "degenerate-sensitivity-model",
+        "baseline-mis-modeled",
+    ):
+        assert distinguisher in doc

--- a/tests/test_cost_drift_check.py
+++ b/tests/test_cost_drift_check.py
@@ -89,7 +89,7 @@ def test_cost_drift_check_main_exits_zero_on_match(cost_drift_check, tmp_path, m
     monkeypatch.setattr(cost_drift_check, "_EXPECTED_PATH", expected)
 
     with pytest.raises(SystemExit) as exc:
-        cost_drift_check.main()
+        cost_drift_check.main([])
     assert exc.value.code == 0
 
 
@@ -102,7 +102,7 @@ def test_cost_drift_check_main_exits_one_on_drift(cost_drift_check, tmp_path, mo
     monkeypatch.setattr(cost_drift_check, "_EXPECTED_PATH", expected)
 
     with pytest.raises(SystemExit) as exc:
-        cost_drift_check.main()
+        cost_drift_check.main([])
     assert exc.value.code == 1
 
 
@@ -271,8 +271,20 @@ def test_cost_drift_main_routes_report_to_stdout_on_failure(
     monkeypatch.setattr(cost_drift_check, "_EXPECTED_PATH", expected)
 
     with pytest.raises(SystemExit) as exc:
-        cost_drift_check.main()
+        cost_drift_check.main([])
     assert exc.value.code == 1
     captured = capsys.readouterr()
     assert "savings_ratio" in captured.out
     assert "FAILED" in captured.err
+
+
+def test_cost_drift_check_flags_override_paths(cost_drift_check, tmp_path):
+    """--latest / --expected route to the given files (no monkeypatching needed)."""
+    latest = tmp_path / "sweep.json"
+    expected = tmp_path / "baseline.json"
+    _write_json(latest, _latest(_cell("r0.0_s0.0", 0.5, 10.0)))
+    _write_json(expected, _expected(_cell("r0.0_s0.0", 0.5, 10.0)))
+
+    with pytest.raises(SystemExit) as exc:
+        cost_drift_check.main(["--latest", str(latest), "--expected", str(expected)])
+    assert exc.value.code == 0

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -244,6 +244,8 @@ def test_engine_flag_off_state_log_is_byte_identical_with_or_without_block() -> 
 
 # ---- Unit 4: failure-event injection + sweep wiring -------------------------
 
+from uuid import UUID  # noqa: E402
+
 from ccs.core.states import MESIState  # noqa: E402
 from ccs.core.types import FetchRequest  # noqa: E402
 
@@ -779,7 +781,6 @@ def test_source_mutation_zero_volatility_never_mutates() -> None:
     engine.run()
 
     assert engine._registry.get_artifact(artifact_id).version == start_version
-    assert engine._source_mutation_count == 0
 
 
 def test_source_mutation_immutable_artifact_never_mutates() -> None:
@@ -794,14 +795,12 @@ def test_source_mutation_immutable_artifact_never_mutates() -> None:
     engine.run()
 
     assert engine._registry.get_artifact(artifact_id).version == start_version
-    assert engine._source_mutation_count == 0
 
 
 def test_source_mutation_full_sensitivity_tags_all_relevant() -> None:
     """answer_sensitivity=1.0 ⇒ every mutation is tagged relevant=True."""
-    scenario = _mutation_scenario(enabled=True, volatility=1.0, answer_sensitivity=1.0)
+    scenario = _refetch_scenario(volatility=1.0, answer_sensitivity=1.0)
     engine = SimulationEngine(scenario, strategy_name="lazy", seed=5)
-    artifact_id = engine._artifact_ids[0]
 
     seen_relevances: list[bool] = []
     original = engine._apply_source_mutations_for_tick
@@ -819,7 +818,7 @@ def test_source_mutation_full_sensitivity_tags_all_relevant() -> None:
 
 def test_source_mutation_zero_sensitivity_tags_all_irrelevant() -> None:
     """answer_sensitivity=0.0 ⇒ every mutation is tagged relevant=False."""
-    scenario = _mutation_scenario(enabled=True, volatility=1.0, answer_sensitivity=0.0)
+    scenario = _refetch_scenario(volatility=1.0, answer_sensitivity=0.0)
     engine = SimulationEngine(scenario, strategy_name="lazy", seed=5)
 
     seen_relevances: list[bool] = []
@@ -836,29 +835,55 @@ def test_source_mutation_zero_sensitivity_tags_all_irrelevant() -> None:
     assert not any(seen_relevances)
 
 
-def test_source_mutation_pending_dict_reflects_only_current_tick() -> None:
-    """`_pending_source_mutations` is per-tick: cleared at the start of each tick.
+def test_source_refetch_attribution_survives_unread_ticks() -> None:
+    """A holder invalidated on an earlier tick is still credited when it finally
+    re-reads (action_probability < 1).
 
-    With volatility=1.0 a single-artifact scenario produces exactly one entry
-    per tick; after the run completes the dict reflects the final tick only.
+    The per-(artifact, holder) marker persists across ticks rather than resetting,
+    so EVERY re-fetch of a source-invalidated entry is counted exactly once --
+    including the ones that lag the invalidating tick (the regime a per-tick reset
+    would mis-count). With no agent writes, INVALID can only come from the source,
+    so ``source_refetches`` must equal the number of reads that found the entry
+    INVALID.
     """
-    scenario = _mutation_scenario(enabled=True, volatility=1.0, duration=4)
-    engine = SimulationEngine(scenario, strategy_name="lazy", seed=5)
-    artifact_id = engine._artifact_ids[0]
+    scenario = _refetch_scenario(volatility=0.5, answer_sensitivity=0.5, duration=60)
+    # Read sparsely so entries stay INVALID across several mutation ticks before a
+    # holder re-reads.
+    scenario["scenario"]["action_probability"] = 0.4
+    scenario["simulation"]["action_probability"] = 0.4
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=7)
 
-    per_tick_sizes: list[int] = []
-    original = engine._apply_source_mutations_for_tick
+    invalid_entry_reads = 0
+    original = engine._perform_read
 
-    def _spy(now: int) -> None:
-        original(now)
-        per_tick_sizes.append(len(engine._pending_source_mutations))
+    def _spy(*, agent_id: UUID, artifact_id: UUID, now_tick: int) -> None:
+        nonlocal invalid_entry_reads
+        entry = engine._runtime_by_agent[agent_id].cache.get(artifact_id)
+        if entry is not None and entry.state == MESIState.INVALID:
+            invalid_entry_reads += 1
+        original(agent_id=agent_id, artifact_id=artifact_id, now_tick=now_tick)
 
-    engine._apply_source_mutations_for_tick = _spy  # type: ignore[assignment]
-    engine.run()
+    engine._perform_read = _spy  # type: ignore[assignment]
+    metrics = engine.run()
 
-    # Exactly one mutable artifact ⇒ at most one entry per tick, never accumulating.
-    assert per_tick_sizes == [1, 1, 1, 1]
-    assert set(engine._pending_source_mutations) == {artifact_id}
+    assert invalid_entry_reads > 0
+    assert metrics.source_refetches == invalid_entry_reads
+    assert metrics.wasted_refetches <= metrics.source_refetches
+
+
+def test_always_read_does_not_overattribute_source_refetches() -> None:
+    """Under context_model=always_read every read forces a fetch, but only the
+    fetches of source-INVALIDATED entries are credited to the source -- forced
+    re-reads of still-valid entries (and initial fills) are not. So
+    source_refetches stays strictly below the total fetch count. (lease-expiry
+    refreshes are excluded by the same entry.state == INVALID gate.)
+    """
+    scenario = _refetch_scenario(volatility=0.5, answer_sensitivity=0.5, duration=40)
+    scenario["context_semantics"] = {"model": "always_read"}
+    metrics = SimulationEngine(scenario, strategy_name="lazy", seed=5).run()
+
+    assert metrics.fetch_actions > 0
+    assert 0 < metrics.source_refetches < metrics.fetch_actions
 
 
 def test_source_mutation_disabled_run_is_byte_identical_to_no_block() -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -631,3 +631,425 @@ def test_restore_after_kill_resumes_heartbeat_emission() -> None:
     assert last_hb is not None
     assert last_hb >= 12, f"heartbeat should have resumed after restore, got {last_hb}"
     assert last_hb <= 19, f"heartbeat must not exceed final tick, got {last_hb}"
+
+
+# ---- Unit 2: source-mutation step (the change-rate dial) --------------------
+
+
+def _mutation_scenario(
+    *,
+    enabled: bool,
+    volatility: float = 1.0,
+    answer_sensitivity: float = 1.0,
+    num_agents: int = 2,
+    duration: int = 10,
+    mutable: bool = True,
+) -> dict:
+    """Scenario whose single artifact's mutation behavior is fully controlled.
+
+    Action knobs are zero so agents take no actions of their own; the only
+    version churn comes from the source-mutation step. The `source_mutation`
+    block is included only when a non-default shape is requested by the caller.
+    """
+    scenario = {
+        "simulation": {
+            "duration_ticks": duration,
+            "num_agents": num_agents,
+            "seed": 7,
+            "action_probability": 0.0,
+            "actions_per_tick": 1,
+        },
+        "network": {"latency_ticks": 0, "message_loss_rate": 0.0},
+        "scenario": {
+            "name": "source-mutation",
+            "workload": "read_heavy",
+            "action_probability": 0.0,
+            "write_probability": 0.0,
+            "agent_velocity": None,
+            "revocation_tick": None,
+        },
+        "artifacts": [
+            {
+                "id": "plan.md",
+                "size_tokens": 100,
+                "volatility": volatility,
+                "initial_version": 1,
+                "mutable": mutable,
+            },
+        ],
+        "strategies": {
+            "eager": {},
+            "lazy": {"check_interval_ticks": 100},
+            "lease": {"default_ttl_ticks": 5},
+            "access_count": {"max_accesses": 4},
+            "exec_count": {"max_operations": 4},
+        },
+        "transient": {"timeout_ticks": 100},
+        "context_semantics": {"model": "conditional_injection"},
+        "source_mutation": {"enabled": enabled, "answer_sensitivity": answer_sensitivity},
+    }
+    return scenario
+
+
+def test_source_mutation_disabled_is_default_when_block_absent() -> None:
+    """No ``source_mutation`` block ⇒ engine treats it as enabled=False."""
+    engine = SimulationEngine(_scenario(), strategy_name="lazy", seed=5)
+    assert engine._source_mutation_enabled is False
+
+
+def test_source_mutation_explicit_disabled_flag() -> None:
+    scenario = _mutation_scenario(enabled=False, volatility=1.0)
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=5)
+    assert engine._source_mutation_enabled is False
+
+
+def test_source_mutation_full_volatility_advances_version_every_tick() -> None:
+    """enabled + volatility=1.0 ⇒ canonical version advances on every tick."""
+    duration = 8
+    scenario = _mutation_scenario(enabled=True, volatility=1.0, duration=duration)
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=5)
+    artifact_id = engine._artifact_ids[0]
+    start_version = engine._registry.get_artifact(artifact_id).version
+
+    engine.run()
+
+    end_version = engine._registry.get_artifact(artifact_id).version
+    # One mutation per tick, no agent writes (action knobs are zero).
+    assert end_version == start_version + duration
+
+
+def test_source_mutation_invalidates_holders_to_invalid() -> None:
+    """A mutation must flip a non-INVALID holder to INVALID in registry + cache."""
+    scenario = _mutation_scenario(enabled=True, volatility=1.0, num_agents=2, duration=5)
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=5)
+    artifact_id = engine._artifact_ids[0]
+    holder = engine._agent_ids[0]
+
+    # Seed a SHARED holder directly: registry state + a live cache entry.
+    engine._registry.set_agent_state(
+        artifact_id, holder, MESIState.SHARED, trigger="seed", tick=0
+    )
+    runtime = engine._runtime_by_agent[holder]
+    from ccs.core.types import ArtifactCacheEntry  # noqa: PLC0415
+
+    runtime.cache.put(
+        artifact_id,
+        ArtifactCacheEntry(
+            artifact_id=artifact_id,
+            state=MESIState.SHARED,
+            local_version=1,
+            acquired_at_tick=0,
+        ),
+    )
+
+    engine._apply_source_mutations_for_tick(0)
+
+    assert engine._registry.get_agent_state(artifact_id, holder) == MESIState.INVALID
+    cache_entry = runtime.cache.get(artifact_id)
+    assert cache_entry is not None
+    assert cache_entry.state == MESIState.INVALID
+
+
+def test_source_mutation_state_log_uses_source_mutation_trigger() -> None:
+    """The invalidation state-log entry must be labelled ``source_mutation``."""
+    scenario = _mutation_scenario(enabled=True, volatility=1.0, num_agents=2, duration=5)
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=5)
+    artifact_id = engine._artifact_ids[0]
+    holder = engine._agent_ids[0]
+    engine._registry.set_agent_state(
+        artifact_id, holder, MESIState.SHARED, trigger="seed", tick=0
+    )
+
+    log = _capture_state_log(engine)
+    engine._apply_source_mutations_for_tick(1)
+
+    triggers = [entry["trigger"] for entry in log]
+    assert "source_mutation" in triggers
+    assert "invalidate" not in triggers
+
+
+def test_source_mutation_zero_volatility_never_mutates() -> None:
+    """volatility=0.0 ⇒ no mutations even with enabled=True."""
+    duration = 10
+    scenario = _mutation_scenario(enabled=True, volatility=0.0, duration=duration)
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=5)
+    artifact_id = engine._artifact_ids[0]
+    start_version = engine._registry.get_artifact(artifact_id).version
+
+    engine.run()
+
+    assert engine._registry.get_artifact(artifact_id).version == start_version
+    assert engine._source_mutation_count == 0
+
+
+def test_source_mutation_immutable_artifact_never_mutates() -> None:
+    """A mutable=False artifact is never source-mutated regardless of volatility."""
+    scenario = _mutation_scenario(
+        enabled=True, volatility=1.0, duration=6, mutable=False
+    )
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=5)
+    artifact_id = engine._artifact_ids[0]
+    start_version = engine._registry.get_artifact(artifact_id).version
+
+    engine.run()
+
+    assert engine._registry.get_artifact(artifact_id).version == start_version
+    assert engine._source_mutation_count == 0
+
+
+def test_source_mutation_full_sensitivity_tags_all_relevant() -> None:
+    """answer_sensitivity=1.0 ⇒ every mutation is tagged relevant=True."""
+    scenario = _mutation_scenario(enabled=True, volatility=1.0, answer_sensitivity=1.0)
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=5)
+    artifact_id = engine._artifact_ids[0]
+
+    seen_relevances: list[bool] = []
+    original = engine._apply_source_mutations_for_tick
+
+    def _spy(now: int) -> None:
+        original(now)
+        seen_relevances.extend(engine._pending_source_mutations.values())
+
+    engine._apply_source_mutations_for_tick = _spy  # type: ignore[assignment]
+    engine.run()
+
+    assert seen_relevances, "expected at least one mutation"
+    assert all(seen_relevances)
+
+
+def test_source_mutation_zero_sensitivity_tags_all_irrelevant() -> None:
+    """answer_sensitivity=0.0 ⇒ every mutation is tagged relevant=False."""
+    scenario = _mutation_scenario(enabled=True, volatility=1.0, answer_sensitivity=0.0)
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=5)
+
+    seen_relevances: list[bool] = []
+    original = engine._apply_source_mutations_for_tick
+
+    def _spy(now: int) -> None:
+        original(now)
+        seen_relevances.extend(engine._pending_source_mutations.values())
+
+    engine._apply_source_mutations_for_tick = _spy  # type: ignore[assignment]
+    engine.run()
+
+    assert seen_relevances, "expected at least one mutation"
+    assert not any(seen_relevances)
+
+
+def test_source_mutation_pending_dict_reflects_only_current_tick() -> None:
+    """`_pending_source_mutations` is per-tick: cleared at the start of each tick.
+
+    With volatility=1.0 a single-artifact scenario produces exactly one entry
+    per tick; after the run completes the dict reflects the final tick only.
+    """
+    scenario = _mutation_scenario(enabled=True, volatility=1.0, duration=4)
+    engine = SimulationEngine(scenario, strategy_name="lazy", seed=5)
+    artifact_id = engine._artifact_ids[0]
+
+    per_tick_sizes: list[int] = []
+    original = engine._apply_source_mutations_for_tick
+
+    def _spy(now: int) -> None:
+        original(now)
+        per_tick_sizes.append(len(engine._pending_source_mutations))
+
+    engine._apply_source_mutations_for_tick = _spy  # type: ignore[assignment]
+    engine.run()
+
+    # Exactly one mutable artifact ⇒ at most one entry per tick, never accumulating.
+    assert per_tick_sizes == [1, 1, 1, 1]
+    assert set(engine._pending_source_mutations) == {artifact_id}
+
+
+def test_source_mutation_disabled_run_is_byte_identical_to_no_block() -> None:
+    """Flag-off guarantee (TEST-FIRST): an ``enabled=False`` run produces a
+    state-log byte-identical to the same scenario with no ``source_mutation``
+    block at all.
+
+    Mirrors ``test_engine_flag_off_state_log_is_byte_identical_with_or_without_block``:
+    when the feature is disabled the engine MUST never bump a version or emit a
+    ``source_mutation`` state entry, so the two logs are indistinguishable.
+    """
+
+    def _run_and_capture(source_mutation_block: dict | None) -> list[dict]:
+        scenario = _scenario()
+        if source_mutation_block is not None:
+            scenario["source_mutation"] = source_mutation_block
+        engine = SimulationEngine(scenario, strategy_name="lazy", seed=42)
+        log: list[dict] = []
+        engine._registry._state_log = log.append
+        engine.run()
+        artifact_id_map: dict[str, str] = {}
+        for entry in log:
+            entry["instance_id"] = "<inst>"
+            aid = entry.get("artifact_id")
+            if aid is not None:
+                aid_str = str(aid)
+                placeholder = artifact_id_map.setdefault(
+                    aid_str, f"<artifact-{len(artifact_id_map)}>"
+                )
+                entry["artifact_id"] = placeholder
+        return log
+
+    log_without_block = _run_and_capture(None)
+    log_with_disabled_block = _run_and_capture(
+        {"enabled": False, "answer_sensitivity": 1.0}
+    )
+
+    assert log_without_block == log_with_disabled_block
+    assert len(log_without_block) > 0
+
+
+def test_source_mutation_enabled_same_seed_runs_are_byte_identical() -> None:
+    """Determinism: two ``enabled=True`` runs at the same seed must produce
+    identical ``to_dict()`` payloads, and the dedicated mutation RNG must not
+    have perturbed the action-selection stream non-deterministically.
+    """
+    scenario = _mutation_scenario(
+        enabled=True, volatility=0.5, answer_sensitivity=0.5, num_agents=4, duration=20
+    )
+    # Give agents some action probability so we also prove the mutation RNG
+    # does not bleed into the action-selection stream across the two runs.
+    scenario["scenario"]["action_probability"] = 0.6
+    scenario["simulation"]["action_probability"] = 0.6
+
+    first = SimulationEngine(scenario, strategy_name="lazy", seed=123).run().to_dict()
+    second = SimulationEngine(scenario, strategy_name="lazy", seed=123).run().to_dict()
+
+    assert first == second
+
+
+def test_source_mutation_does_not_shift_action_stream_when_off() -> None:
+    """A disabled source_mutation block must leave metrics byte-identical to a
+    run with no block — proving the separate RNG seeding never touches the
+    action-selection path when the feature is off.
+    """
+    scenario_off = _mutation_scenario(enabled=False, volatility=1.0, num_agents=4, duration=20)
+    scenario_off["scenario"]["action_probability"] = 0.6
+    scenario_off["simulation"]["action_probability"] = 0.6
+
+    scenario_none = _mutation_scenario(enabled=False, volatility=1.0, num_agents=4, duration=20)
+    scenario_none["scenario"]["action_probability"] = 0.6
+    scenario_none["simulation"]["action_probability"] = 0.6
+    del scenario_none["source_mutation"]
+
+    with_block = SimulationEngine(scenario_off, strategy_name="lazy", seed=77).run().to_dict()
+    without_block = SimulationEngine(scenario_none, strategy_name="lazy", seed=77).run().to_dict()
+
+    assert with_block == without_block
+
+
+# ---- Unit 3: source-triggered & wasted re-fetch cost metrics ----------------
+
+
+def _refetch_scenario(
+    *,
+    volatility: float = 0.5,
+    answer_sensitivity: float = 0.5,
+    num_agents: int = 4,
+    duration: int = 40,
+) -> dict:
+    """Source-mutation scenario with read-only agents that DO act.
+
+    Mutations invalidate holders; on their next read those holders re-fetch,
+    which is what Unit 3 attributes. Agents read every tick (action_probability
+    1.0, write_probability 0.0) so re-fetches actually occur. ``lazy`` is the
+    realistic strategy — it re-fetches exactly on INVALID, the state a source
+    mutation leaves a holder in.
+    """
+    scenario = _mutation_scenario(
+        enabled=True,
+        volatility=volatility,
+        answer_sensitivity=answer_sensitivity,
+        num_agents=num_agents,
+        duration=duration,
+    )
+    scenario["scenario"]["action_probability"] = 1.0
+    scenario["simulation"]["action_probability"] = 1.0
+    scenario["scenario"]["write_probability"] = 0.0
+    return scenario
+
+
+def test_source_refetches_and_wasted_are_counted_for_lazy() -> None:
+    """Happy path: lazy + mid volatility/sensitivity ⇒ some source re-fetches,
+    a strict-positive wasted subset bounded by the total.
+    """
+    metrics = SimulationEngine(
+        _refetch_scenario(volatility=0.5, answer_sensitivity=0.5),
+        strategy_name="lazy",
+        seed=5,
+    ).run()
+
+    assert metrics.source_refetches > 0
+    assert 0 < metrics.wasted_refetches <= metrics.source_refetches
+
+
+def test_full_sensitivity_yields_zero_wasted_refetches() -> None:
+    """answer_sensitivity=1.0 ⇒ every mutation is relevant ⇒ nothing wasted."""
+    metrics = SimulationEngine(
+        _refetch_scenario(volatility=1.0, answer_sensitivity=1.0),
+        strategy_name="lazy",
+        seed=5,
+    ).run()
+
+    assert metrics.source_refetches > 0
+    assert metrics.wasted_refetches == 0
+
+
+def test_zero_sensitivity_makes_every_refetch_wasted() -> None:
+    """answer_sensitivity=0.0 ⇒ every mutation is irrelevant ⇒ all re-fetches wasted."""
+    metrics = SimulationEngine(
+        _refetch_scenario(volatility=1.0, answer_sensitivity=0.0),
+        strategy_name="lazy",
+        seed=5,
+    ).run()
+
+    assert metrics.source_refetches > 0
+    assert metrics.wasted_refetches == metrics.source_refetches
+
+
+def test_blind_strategy_never_attributes_source_refetches() -> None:
+    """blind never re-fetches on INVALID ⇒ source_refetches == 0 even at max
+    volatility. The cost floor pays zero source-triggered re-fetch cost.
+    """
+    metrics = SimulationEngine(
+        _refetch_scenario(volatility=1.0, answer_sensitivity=0.5),
+        strategy_name="blind",
+        seed=5,
+    ).run()
+
+    assert metrics.source_refetches == 0
+    assert metrics.wasted_refetches == 0
+
+
+def test_source_refetch_metrics_appear_in_to_dict() -> None:
+    """Both new fields are part of the JSON-safe payload."""
+    metrics = SimulationEngine(
+        _refetch_scenario(volatility=0.5, answer_sensitivity=0.5),
+        strategy_name="lazy",
+        seed=5,
+    ).run()
+    payload = metrics.to_dict()
+
+    assert "source_refetches" in payload
+    assert "wasted_refetches" in payload
+    assert payload["source_refetches"] == metrics.source_refetches
+    assert payload["wasted_refetches"] == metrics.wasted_refetches
+
+
+def test_source_refetch_metrics_are_deterministic_for_same_seed() -> None:
+    """Same seed ⇒ identical source/wasted re-fetch counts across two runs."""
+    scenario = _refetch_scenario(volatility=0.5, answer_sensitivity=0.5)
+    first = SimulationEngine(scenario, strategy_name="lazy", seed=123).run()
+    second = SimulationEngine(scenario, strategy_name="lazy", seed=123).run()
+
+    assert first.source_refetches == second.source_refetches
+    assert first.wasted_refetches == second.wasted_refetches
+
+
+def test_source_refetch_metrics_default_to_zero_when_mutation_disabled() -> None:
+    """No source mutations ⇒ no attribution: both counters stay 0."""
+    metrics = SimulationEngine(_scenario(), strategy_name="lazy", seed=5).run()
+
+    assert metrics.source_refetches == 0
+    assert metrics.wasted_refetches == 0

--- a/tests/test_run_cost_sweep.py
+++ b/tests/test_run_cost_sweep.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for tools/run_cost_sweep.py — the change-rate × answer-sensitivity sweep.
+
+``tools/`` is not an importable package, so the module is loaded by file path
+(mirrors ``tests/test_benchmark_stage1.py``). Most assertions drive the
+``run_cost_sweep`` callable directly with a tiny grid; the sensitivity-endpoint
+edge case reads the engine aggregates directly, which is cleaner than threading
+those figures through the sweep payload.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SRC_ROOT = _REPO_ROOT / "src"
+if str(_SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SRC_ROOT))
+
+from ccs.simulation.engine import run_strategy_comparison  # noqa: E402
+from ccs.simulation.scenarios import load_scenario  # noqa: E402
+
+_ROW_KEYS = {
+    "cell",
+    "rate",
+    "sensitivity",
+    "blind_fetches",
+    "gated_fetches",
+    "always_fetches",
+    "refetches_avoided",
+    "wasted_refetches",
+    "savings_ratio",
+}
+_PAYLOAD_KEYS = {"sweep", "provenance", "runs_per_point", "rates", "sensitivities", "rows"}
+
+
+def _load_cost_sweep_module():
+    """Import tools/run_cost_sweep.py by file path (tools/ is not a package)."""
+    spec = importlib.util.spec_from_file_location(
+        "run_cost_sweep", _REPO_ROOT / "tools" / "run_cost_sweep.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _row_by_cell(payload: dict, cell: str) -> dict:
+    return next(row for row in payload["rows"] if row["cell"] == cell)
+
+
+def test_run_cost_sweep_happy_returns_full_grid() -> None:
+    module = _load_cost_sweep_module()
+    payload = module.run_cost_sweep([0.0, 1.0], [0.0, 1.0], runs_per_point=2)
+
+    assert _PAYLOAD_KEYS <= set(payload)
+    assert payload["sweep"] == "cost"
+    assert payload["provenance"], "every figure must be provenance-labeled"
+    assert payload["runs_per_point"] == 2
+    assert len(payload["rows"]) == 4
+
+    for row in payload["rows"]:
+        assert _ROW_KEYS == set(row)
+        expected_cell = f"r{row['rate']}_s{row['sensitivity']}"
+        assert row["cell"] == expected_cell
+
+
+def test_run_cost_sweep_rate_endpoints_are_monotonic() -> None:
+    """rate=0.0 → gating barely re-fetches (avoids ≈ all always-re-fetches);
+    rate=1.0 → gating ≈ always (avoids little). Assert avoided(0.0) > avoided(1.0).
+    """
+    module = _load_cost_sweep_module()
+    payload = module.run_cost_sweep([0.0, 1.0], [0.5], runs_per_point=4)
+
+    low = _row_by_cell(payload, "r0.0_s0.5")
+    high = _row_by_cell(payload, "r1.0_s0.5")
+
+    # At rate 0.0 the source never changes: gating's re-fetches avoided ≈ the
+    # full always-re-fetch count, and gated stays near the blind floor.
+    assert low["refetches_avoided"] == pytest.approx(low["always_fetches"], rel=0.25)
+    assert low["gated_fetches"] == pytest.approx(low["blind_fetches"], abs=low["blind_fetches"])
+
+    # At rate 1.0 gating re-fetches on essentially every churned read ⇒ ≈ always.
+    assert high["refetches_avoided"] == pytest.approx(0.0, abs=2.0)
+
+    # Monotonic direction: more avoided when the source is calm than when it churns.
+    assert low["refetches_avoided"] > high["refetches_avoided"]
+
+
+def _gated_scenario(rate: float, sensitivity: float) -> dict:
+    scenario = load_scenario(
+        str(_REPO_ROOT / "benchmarks" / "scenarios" / "planning_canonical.yaml")
+    )
+    for artifact in scenario["artifacts"]:
+        if bool(artifact.get("mutable", True)):
+            artifact["volatility"] = rate
+    scenario["source_mutation"] = {"enabled": True, "answer_sensitivity": sensitivity}
+    scenario["simulation"]["seed"] = 20260318
+    scenario["scenario"]["name"] = f"cost-sens-r{rate}-s{sensitivity}"
+    return scenario
+
+
+def _lazy_aggregate(rate: float, sensitivity: float) -> dict:
+    report = run_strategy_comparison(
+        _gated_scenario(rate, sensitivity),
+        strategies=["lazy"],
+        runs=4,
+        seed_start=20260318,
+    )
+    return {item["strategy"]: item for item in report.aggregated}["lazy"]
+
+
+def test_sensitivity_endpoints_wasted_fraction() -> None:
+    """sensitivity=0.0 ⇒ all churn answer-irrelevant (wasted == source_refetches);
+    sensitivity=1.0 ⇒ none wasted (wasted == 0). Read engine aggregates directly.
+    """
+    # Use a churning rate so there are source re-fetches to classify.
+    irrelevant = _lazy_aggregate(0.5, 0.0)
+    assert irrelevant["source_refetches_mean"] > 0
+    assert irrelevant["wasted_refetches_mean"] == pytest.approx(
+        irrelevant["source_refetches_mean"]
+    )
+
+    relevant = _lazy_aggregate(0.5, 1.0)
+    assert relevant["source_refetches_mean"] > 0
+    assert relevant["wasted_refetches_mean"] == 0.0
+
+
+def test_run_cost_sweep_cli_output_roundtrips(tmp_path: Path) -> None:
+    """Writing via the --output mechanism produces JSON that round-trips."""
+    module = _load_cost_sweep_module()
+    # Shrink the module-level grid so the CLI path runs fast.
+    module.RATES = [0.0, 1.0]
+    module.SENSITIVITIES = [0.0, 1.0]
+    module.RUNS_PER_POINT = 2
+
+    # ``--output`` is joined onto the module's REPO_ROOT, so point REPO_ROOT at
+    # tmp_path and pass a repo-relative output name for this run.
+    module.REPO_ROOT = tmp_path
+    rc = module.main(["--output", "cost_sweep.json"])
+    assert rc == 0
+
+    written = tmp_path / "cost_sweep.json"
+    assert written.exists()
+    payload = json.loads(written.read_text(encoding="utf-8"))
+
+    assert _PAYLOAD_KEYS <= set(payload)
+    assert payload["sweep"] == "cost"
+    assert payload["provenance"]
+    assert len(payload["rows"]) == 4
+    for row in payload["rows"]:
+        assert _ROW_KEYS == set(row)

--- a/tests/test_run_cost_sweep.py
+++ b/tests/test_run_cost_sweep.py
@@ -157,3 +157,16 @@ def test_run_cost_sweep_cli_output_roundtrips(tmp_path: Path) -> None:
     assert len(payload["rows"]) == 4
     for row in payload["rows"]:
         assert _ROW_KEYS == set(row)
+
+
+def test_run_cost_sweep_absolute_output_passes_through(tmp_path: Path) -> None:
+    """An absolute --output path is written as-is, not re-rooted under REPO_ROOT."""
+    module = _load_cost_sweep_module()
+    module.RATES = [0.0]
+    module.SENSITIVITIES = [0.0]
+    module.RUNS_PER_POINT = 2
+
+    out = tmp_path / "abs_sweep.json"
+    rc = module.main(["--output", str(out)])
+    assert rc == 0
+    assert out.exists()

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -247,3 +247,67 @@ def test_load_scenario_rejects_busy_until_tick_not_after_tick(tmp_path: Path) ->
 
     with pytest.raises(ScenarioValidationError, match="until_tick"):
         load_scenario(str(scenario_path))
+
+
+# ---- Unit 2: source_mutation schema ----------------------------------------
+
+
+def test_load_scenario_without_source_mutation_block_uses_defaults(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "no-sm.yaml"
+    payload = _minimal_scenario_payload()
+    _write_yaml(scenario_path, payload)
+
+    config = load_scenario(str(scenario_path))
+    # Block is normalized to an empty mapping; engine reads defaults (disabled).
+    assert config["source_mutation"] == {}
+
+
+def test_load_scenario_with_source_mutation_block_parses(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "with-sm.yaml"
+    payload = _minimal_scenario_payload()
+    payload["source_mutation"] = {"enabled": True, "answer_sensitivity": 0.25}
+    _write_yaml(scenario_path, payload)
+
+    config = load_scenario(str(scenario_path))
+    assert config["source_mutation"]["enabled"] is True
+    assert config["source_mutation"]["answer_sensitivity"] == 0.25
+
+
+def test_load_scenario_rejects_non_bool_source_mutation_enabled(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "bad-sm-enabled.yaml"
+    payload = _minimal_scenario_payload()
+    payload["source_mutation"] = {"enabled": "yes"}
+    _write_yaml(scenario_path, payload)
+
+    with pytest.raises(ScenarioValidationError, match="enabled"):
+        load_scenario(str(scenario_path))
+
+
+def test_load_scenario_rejects_answer_sensitivity_above_one(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "bad-sm-high.yaml"
+    payload = _minimal_scenario_payload()
+    payload["source_mutation"] = {"answer_sensitivity": 1.5}
+    _write_yaml(scenario_path, payload)
+
+    with pytest.raises(ScenarioValidationError, match="answer_sensitivity"):
+        load_scenario(str(scenario_path))
+
+
+def test_load_scenario_rejects_answer_sensitivity_below_zero(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "bad-sm-low.yaml"
+    payload = _minimal_scenario_payload()
+    payload["source_mutation"] = {"answer_sensitivity": -0.1}
+    _write_yaml(scenario_path, payload)
+
+    with pytest.raises(ScenarioValidationError, match="answer_sensitivity"):
+        load_scenario(str(scenario_path))
+
+
+def test_load_scenario_rejects_non_numeric_answer_sensitivity(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "bad-sm-type.yaml"
+    payload = _minimal_scenario_payload()
+    payload["source_mutation"] = {"answer_sensitivity": "high"}
+    _write_yaml(scenario_path, payload)
+
+    with pytest.raises(ScenarioValidationError, match="answer_sensitivity"):
+        load_scenario(str(scenario_path))

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -13,6 +13,7 @@ from ccs.core.states import MESIState
 from ccs.simulation.engine import SimulationEngine
 from ccs.simulation.scenarios import load_scenario
 from ccs.strategies.access_count import AccessCountStrategy
+from ccs.strategies.blind_cache import BlindCacheStrategy
 from ccs.strategies.broadcast import BroadcastStrategy
 from ccs.strategies.eager import EagerStrategy
 from ccs.strategies.lazy import LazyStrategy
@@ -54,6 +55,43 @@ def test_lazy_invalidates_and_fetches_on_demand() -> None:
     assert strategy.requires_refresh(valid_entry, now_tick=3) is False
     assert strategy.requires_refresh(invalid_entry, now_tick=3) is True
     assert strategy.staleness_bound() is None
+
+
+def test_blind_cache_never_refreshes_even_when_invalid() -> None:
+    strategy = BlindCacheStrategy()
+    invalid_entry = strategy.on_fetch(
+        artifact_id=uuid4(),
+        version=4,
+        state=MESIState.INVALID,
+        now_tick=2,
+    )
+
+    # The point of the cost floor: refuse to refetch even a stale/invalid entry.
+    assert strategy.requires_refresh(invalid_entry, now_tick=99) is False
+    assert strategy.broadcasts_content_on_commit() is False
+    assert strategy.staleness_bound() is None
+    assert strategy.on_read(invalid_entry, now_tick=3).access_count == 1
+
+
+def test_build_strategy_constructs_blind_cache() -> None:
+    assert isinstance(build_strategy("blind"), BlindCacheStrategy)
+    with pytest.raises(ValueError):
+        build_strategy("nope")
+
+
+def test_blind_cache_fetches_once_per_agent_artifact_pair() -> None:
+    scenario = load_scenario("benchmarks/scenarios/planning_canonical.yaml")
+    blind = SimulationEngine(scenario, strategy_name="blind", seed=20260305).run()
+    lazy = SimulationEngine(scenario, strategy_name="lazy", seed=20260305).run()
+
+    num_agents = int(scenario["simulation"]["num_agents"])
+    artifact_count = len(scenario["artifacts"])
+    # Cost floor: each (agent, artifact) pair fills its cache at most once, then
+    # every later access is a hit. Never refetching on INVALID keeps blind
+    # strictly below a strategy (lazy) that does refetch stale entries.
+    assert blind.fetch_actions <= num_agents * artifact_count
+    assert blind.cache_misses == blind.fetch_actions
+    assert blind.fetch_actions < lazy.fetch_actions
 
 
 def test_lease_refreshes_after_ttl_expiry() -> None:

--- a/tools/cost_drift_check.py
+++ b/tools/cost_drift_check.py
@@ -24,6 +24,7 @@ Usage:
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -137,8 +138,23 @@ def check_drift(latest_path: Path, expected_path: Path) -> tuple[bool, list[str]
     return True, messages
 
 
-def main() -> None:
-    passed, messages = check_drift(_LATEST_PATH, _EXPECTED_PATH)
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Drift-gate the cost sweep against the committed baseline."
+    )
+    parser.add_argument(
+        "--latest",
+        default=str(_LATEST_PATH),
+        help="Sweep output to check (default: benchmarks/results/cost_sweep.json).",
+    )
+    parser.add_argument(
+        "--expected",
+        default=str(_EXPECTED_PATH),
+        help="Committed baseline (default: benchmarks/expected_cost.json).",
+    )
+    args = parser.parse_args(argv)
+
+    passed, messages = check_drift(Path(args.latest), Path(args.expected))
     # The full report always goes to stdout (so a CI job capturing stdout sees the
     # table on pass AND on fail, mirroring tools/benchmark_drift_check.py); stderr
     # carries only the terminal failure signal alongside the non-zero exit code.

--- a/tools/cost_drift_check.py
+++ b/tools/cost_drift_check.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""CI drift check: compare benchmarks/results/cost_sweep.json against benchmarks/expected_cost.json.
+
+Mirrors the token drift-check contract (tools/benchmark_drift_check.py) for the
+cost lane. Exits 0 if every cell's ``savings_ratio`` and ``refetches_avoided``
+are within their committed-baseline tolerances. Exits 1 on any drift past a
+threshold, a missing file, or a cell-set mismatch.
+
+Two gating metrics, two tolerances (both strict ``>`` — a delta exactly at the
+threshold passes):
+  - ``savings_ratio``     : absolute tolerance ``_SAVINGS_THRESHOLD`` (the ratio
+    is bounded [0, 1] and already rounded to 4 dp, so an absolute band is the
+    natural unit — 0.02 ≈ 2 percentage points of savings).
+  - ``refetches_avoided`` : absolute tolerance ``_AVOIDED_THRESHOLD`` on the
+    mean fetch-action count (run-to-run averaging jitter is the only expected
+    source of drift for a seeded sweep, so a small absolute band suffices).
+
+Usage:
+    python tools/cost_drift_check.py
+    make cost-benchmark-check
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parent.parent
+_LATEST_PATH = _REPO_ROOT / "benchmarks" / "results" / "cost_sweep.json"
+_EXPECTED_PATH = _REPO_ROOT / "benchmarks" / "expected_cost.json"
+
+# Strict >; a delta exactly at the threshold passes (mirrors benchmark_drift_check).
+_SAVINGS_THRESHOLD = 0.02  # absolute, on the [0, 1] savings_ratio
+_AVOIDED_THRESHOLD = 2.0  # absolute, on the mean refetches_avoided count
+
+
+def check_drift(latest_path: Path, expected_path: Path) -> tuple[bool, list[str]]:
+    """Compare latest against expected; return ``(passed, messages)``.
+
+    ``messages`` is the full human-readable report (table rows + any errors), in
+    print order. ``main`` prints it and maps ``passed`` to the exit code.
+    """
+    if not expected_path.exists():
+        return False, [
+            f"ERROR: {expected_path} not found — "
+            "run `make cost-benchmark` to establish a baseline, then commit the file.",
+        ]
+
+    if not latest_path.exists():
+        return False, [
+            f"ERROR: {latest_path} not found — run `make cost-benchmark` first.",
+        ]
+
+    latest_data = json.loads(latest_path.read_text())
+    expected_data = json.loads(expected_path.read_text())
+
+    # Latest is the sweep payload (rows under "rows"); expected is the committed
+    # baseline (cells under "cells"). Both key on "cell".
+    latest_by_cell = {row["cell"]: row for row in latest_data.get("rows", [])}
+    expected_by_cell = {cell["cell"]: cell for cell in expected_data.get("cells", [])}
+
+    errors: list[str] = []
+
+    # Cells in expected but missing from latest
+    for cell in expected_by_cell:
+        if cell not in latest_by_cell:
+            errors.append(f"  MISSING from latest: '{cell}' (present in expected)")
+
+    # Cells in latest but not in expected
+    for cell in latest_by_cell:
+        if cell not in expected_by_cell:
+            errors.append(f"  UNEXPECTED in latest: '{cell}' (not in expected)")
+
+    if errors:
+        messages = ["Cost cell set mismatch:"]
+        messages.extend(errors)
+        messages.append(
+            "\nUpdate benchmarks/expected_cost.json by running `make cost-benchmark` "
+            "and committing the result."
+        )
+        return False, messages
+
+    # Drift check for matched cells.
+    col = 14
+    header = (
+        f"  {'Cell':<{col}} {'metric':<18} {'Expected':>10}  {'Actual':>10}  {'Delta':>9}"
+    )
+    messages = [header, "-" * (col + 55)]
+    drifted: list[str] = []
+
+    for cell, expected_cell in expected_by_cell.items():
+        latest_cell = latest_by_cell[cell]
+        for metric, threshold in (
+            ("savings_ratio", _SAVINGS_THRESHOLD),
+            ("refetches_avoided", _AVOIDED_THRESHOLD),
+        ):
+            exp = float(expected_cell[metric])
+            act = float(latest_cell[metric])
+            delta = abs(act - exp)
+            is_drift = delta > threshold
+            flag = " ← DRIFT" if is_drift else ""
+            messages.append(
+                f"  {cell:<{col}} {metric:<18} {exp:>10.4f}  {act:>10.4f}  {delta:>9.4f}{flag}"
+            )
+            if is_drift:
+                drifted.append(f"{cell}/{metric} (Δ={delta:.4f} > {threshold})")
+
+    if drifted:
+        messages.append("")
+        messages.append(
+            f"Cost benchmark regression check FAILED: {len(drifted)} metric(s) drifted: "
+            + ", ".join(drifted)
+        )
+        messages.append(
+            "Run `make cost-benchmark` and commit the updated benchmarks/expected_cost.json "
+            "if the change is intentional."
+        )
+        return False, messages
+
+    messages.append("")
+    messages.append("Cost benchmark regression check passed.")
+    return True, messages
+
+
+def main() -> None:
+    passed, messages = check_drift(_LATEST_PATH, _EXPECTED_PATH)
+    stream = sys.stdout if passed else sys.stderr
+    for line in messages:
+        print(line, file=stream)
+    sys.exit(0 if passed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/cost_drift_check.py
+++ b/tools/cost_drift_check.py
@@ -35,6 +35,11 @@ _EXPECTED_PATH = _REPO_ROOT / "benchmarks" / "expected_cost.json"
 # Strict >; a delta exactly at the threshold passes (mirrors benchmark_drift_check).
 _SAVINGS_THRESHOLD = 0.02  # absolute, on the [0, 1] savings_ratio
 _AVOIDED_THRESHOLD = 2.0  # absolute, on the mean refetches_avoided count
+# savings_ratio is sensitivity-invariant by design (gating re-fetches on EVERY
+# source change regardless of answer-relevance), so wasted_refetches is the only
+# metric that moves along the answer_sensitivity axis -- gate it or that whole
+# second axis is unguarded in CI.
+_WASTED_THRESHOLD = 2.0  # absolute, on the mean wasted_refetches count
 
 
 def check_drift(latest_path: Path, expected_path: Path) -> tuple[bool, list[str]]:
@@ -61,6 +66,12 @@ def check_drift(latest_path: Path, expected_path: Path) -> tuple[bool, list[str]
     # baseline (cells under "cells"). Both key on "cell".
     latest_by_cell = {row["cell"]: row for row in latest_data.get("rows", [])}
     expected_by_cell = {cell["cell"]: cell for cell in expected_data.get("cells", [])}
+
+    if not expected_by_cell:
+        return False, [
+            f"ERROR: {expected_path} has no cells — regenerate the baseline from a "
+            "`make cost-benchmark` run before gating.",
+        ]
 
     errors: list[str] = []
 
@@ -96,6 +107,7 @@ def check_drift(latest_path: Path, expected_path: Path) -> tuple[bool, list[str]
         for metric, threshold in (
             ("savings_ratio", _SAVINGS_THRESHOLD),
             ("refetches_avoided", _AVOIDED_THRESHOLD),
+            ("wasted_refetches", _WASTED_THRESHOLD),
         ):
             exp = float(expected_cell[metric])
             act = float(latest_cell[metric])
@@ -127,9 +139,13 @@ def check_drift(latest_path: Path, expected_path: Path) -> tuple[bool, list[str]
 
 def main() -> None:
     passed, messages = check_drift(_LATEST_PATH, _EXPECTED_PATH)
-    stream = sys.stdout if passed else sys.stderr
+    # The full report always goes to stdout (so a CI job capturing stdout sees the
+    # table on pass AND on fail, mirroring tools/benchmark_drift_check.py); stderr
+    # carries only the terminal failure signal alongside the non-zero exit code.
     for line in messages:
-        print(line, file=stream)
+        print(line)
+    if not passed:
+        print("cost-benchmark-check FAILED (see report above).", file=sys.stderr)
     sys.exit(0 if passed else 1)
 
 

--- a/tools/run_cost_sweep.py
+++ b/tools/run_cost_sweep.py
@@ -178,7 +178,11 @@ def main(argv: list[str] | None = None) -> int:
             f"savings={row['savings_ratio']:.1%}"
         )
 
-    output_path = REPO_ROOT / args.output
+    # Absolute --output paths pass through; relative ones resolve under REPO_ROOT
+    # (so the default benchmarks/results/... lands in the repo regardless of CWD).
+    output_path = Path(args.output)
+    if not output_path.is_absolute():
+        output_path = REPO_ROOT / output_path
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     print(f"Wrote {output_path}  [provenance: {payload['provenance']}]")

--- a/tools/run_cost_sweep.py
+++ b/tools/run_cost_sweep.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO_ROOT / "src"
@@ -49,23 +50,26 @@ SEED_START = 20260318
 PROVENANCE = "temporal-sim (third lane)"
 
 
-def _make_scenario(rate: float, sensitivity: float) -> dict:
+def _make_scenario(rate: float, sensitivity: float) -> dict[str, Any]:
     """Gated config: source churn ON, ``conditional_injection`` (the default).
 
     Every mutable artifact's ``volatility`` is set to ``rate`` so the change-rate
     axis is a single dial; ``answer_sensitivity`` sets the relevant fraction.
+
+    The seed is supplied per-run via ``run_strategy_comparison(seed_start=...)``,
+    which the engine prefers over any scenario-level seed, so this helper does not
+    set ``scenario["simulation"]["seed"]``.
     """
     scenario = load_scenario(str(BASE_SCENARIO))
     for artifact in scenario["artifacts"]:
         if bool(artifact.get("mutable", True)):
             artifact["volatility"] = rate
     scenario["source_mutation"] = {"enabled": True, "answer_sensitivity": sensitivity}
-    scenario["simulation"]["seed"] = SEED_START
     scenario["scenario"]["name"] = f"cost-sweep-r{rate}-s{sensitivity}"
     return scenario
 
 
-def _make_always_read_variant(rate: float, sensitivity: float) -> dict:
+def _make_always_read_variant(rate: float, sensitivity: float) -> dict[str, Any]:
     """Always-re-fetch ceiling: same churn, but force a re-fetch on every read."""
     scenario = _make_scenario(rate, sensitivity)
     scenario["context_semantics"]["model"] = "always_read"
@@ -80,17 +84,17 @@ def _mean_fetch_actions(report: StrategyComparisonReport, strategy: str) -> floa
     ``*_mean`` in ``report.aggregated``, so we average the per-run values here.
     ``report.runs`` is flattened across all strategies, hence the filter.
     """
-    values = [m.to_dict()["fetch_actions"] for m in report.runs if m.strategy == strategy]
+    values = [m.fetch_actions for m in report.runs if m.strategy == strategy]
     if not values:
         return 0.0
     return sum(values) / len(values)
 
 
-def _aggregated_by_strategy(report: StrategyComparisonReport) -> dict[str, dict]:
+def _aggregated_by_strategy(report: StrategyComparisonReport) -> dict[str, dict[str, Any]]:
     return {item["strategy"]: item for item in report.aggregated}
 
 
-def _build_cell_row(rate: float, sensitivity: float, runs_per_point: int) -> dict:
+def _build_cell_row(rate: float, sensitivity: float, runs_per_point: int) -> dict[str, Any]:
     """Run both configs for one cell and compute the savings-regime row."""
     gated_report = run_strategy_comparison(
         _make_scenario(rate, sensitivity),
@@ -109,9 +113,14 @@ def _build_cell_row(rate: float, sensitivity: float, runs_per_point: int) -> dic
     gated_fetches = _mean_fetch_actions(gated_report, "lazy")
     always_fetches = _mean_fetch_actions(always_report, "lazy")
 
-    refetches_avoided = always_fetches - gated_fetches
+    # gated and always come from two independent runs (different context_model),
+    # so sampling noise can make gated marginally exceed always; clamp the derived
+    # figures to >= 0 rather than report a nonsensical negative "avoided"/"saving".
+    refetches_avoided = max(0.0, always_fetches - gated_fetches)
     wasted_refetches = float(_aggregated_by_strategy(gated_report)["lazy"]["wasted_refetches_mean"])
-    savings_ratio = 0.0 if always_fetches == 0 else 1.0 - gated_fetches / always_fetches
+    savings_ratio = (
+        0.0 if always_fetches == 0 else max(0.0, 1.0 - gated_fetches / always_fetches)
+    )
 
     return {
         "cell": f"r{rate}_s{sensitivity}",
@@ -130,7 +139,7 @@ def run_cost_sweep(
     rates: list[float],
     sensitivities: list[float],
     runs_per_point: int,
-) -> dict:
+) -> dict[str, Any]:
     """Sweep change-rate × answer-sensitivity and return the savings-map payload.
 
     Callable without argparse so tests can drive a tiny grid. The returned dict

--- a/tools/run_cost_sweep.py
+++ b/tools/run_cost_sweep.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Cost sweep: change-rate × answer-sensitivity → provenance-labeled savings map.
+
+Third benchmark lane (temporal simulation). For every (change-rate, answer-
+sensitivity) cell this sweeps THREE re-fetch configs and emits how many
+re-fetches gating avoids versus an always-re-fetch baseline, plus how many of
+gating's re-fetches were wasted (answer-irrelevant churn):
+
+  - blind   : never re-fetches (the cost floor).
+  - gated    : ``lazy`` under ``conditional_injection`` — re-fetches only on the
+               invalidations a this-tick source mutation triggered.
+  - always   : ``lazy`` under ``context_semantics.model = always_read`` — the
+               re-fetch-on-every-read ceiling.
+
+Each cell needs TWO runs because the always-re-fetch config is a different
+``context_semantics.model`` (a scenario-level switch), not a strategy.
+
+EVERY emitted figure is provenance-labeled: the payload carries a top-level
+``provenance`` field and no bare percentage is written without it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from ccs.simulation.engine import run_strategy_comparison  # noqa: E402
+from ccs.simulation.metrics import StrategyComparisonReport  # noqa: E402
+from ccs.simulation.scenarios import load_scenario  # noqa: E402
+
+# Two-axis grid: change-rate (per-artifact volatility) × answer-sensitivity
+# (fraction of source mutations that are answer-relevant). Small defaults so the
+# driver runs fast; override via the callable for tests.
+RATES = [0.0, 0.25, 0.5, 1.0]
+SENSITIVITIES = [0.0, 0.5, 1.0]
+RUNS_PER_POINT = 10
+
+BASE_SCENARIO = REPO_ROOT / "benchmarks" / "scenarios" / "planning_canonical.yaml"
+SEED_START = 20260318
+PROVENANCE = "temporal-sim (third lane)"
+
+
+def _make_scenario(rate: float, sensitivity: float) -> dict:
+    """Gated config: source churn ON, ``conditional_injection`` (the default).
+
+    Every mutable artifact's ``volatility`` is set to ``rate`` so the change-rate
+    axis is a single dial; ``answer_sensitivity`` sets the relevant fraction.
+    """
+    scenario = load_scenario(str(BASE_SCENARIO))
+    for artifact in scenario["artifacts"]:
+        if bool(artifact.get("mutable", True)):
+            artifact["volatility"] = rate
+    scenario["source_mutation"] = {"enabled": True, "answer_sensitivity": sensitivity}
+    scenario["simulation"]["seed"] = SEED_START
+    scenario["scenario"]["name"] = f"cost-sweep-r{rate}-s{sensitivity}"
+    return scenario
+
+
+def _make_always_read_variant(rate: float, sensitivity: float) -> dict:
+    """Always-re-fetch ceiling: same churn, but force a re-fetch on every read."""
+    scenario = _make_scenario(rate, sensitivity)
+    scenario["context_semantics"]["model"] = "always_read"
+    scenario["scenario"]["name"] = f"cost-sweep-r{rate}-s{sensitivity}-always"
+    return scenario
+
+
+def _mean_fetch_actions(report: StrategyComparisonReport, strategy: str) -> float:
+    """Average per-run ``fetch_actions`` for one strategy.
+
+    ``fetch_actions`` lives only on per-run dicts (``report.runs``); it has no
+    ``*_mean`` in ``report.aggregated``, so we average the per-run values here.
+    ``report.runs`` is flattened across all strategies, hence the filter.
+    """
+    values = [m.to_dict()["fetch_actions"] for m in report.runs if m.strategy == strategy]
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def _aggregated_by_strategy(report: StrategyComparisonReport) -> dict[str, dict]:
+    return {item["strategy"]: item for item in report.aggregated}
+
+
+def _build_cell_row(rate: float, sensitivity: float, runs_per_point: int) -> dict:
+    """Run both configs for one cell and compute the savings-regime row."""
+    gated_report = run_strategy_comparison(
+        _make_scenario(rate, sensitivity),
+        strategies=["blind", "lazy"],
+        runs=runs_per_point,
+        seed_start=SEED_START,
+    )
+    always_report = run_strategy_comparison(
+        _make_always_read_variant(rate, sensitivity),
+        strategies=["lazy"],
+        runs=runs_per_point,
+        seed_start=SEED_START,
+    )
+
+    blind_fetches = _mean_fetch_actions(gated_report, "blind")
+    gated_fetches = _mean_fetch_actions(gated_report, "lazy")
+    always_fetches = _mean_fetch_actions(always_report, "lazy")
+
+    refetches_avoided = always_fetches - gated_fetches
+    wasted_refetches = float(_aggregated_by_strategy(gated_report)["lazy"]["wasted_refetches_mean"])
+    savings_ratio = 0.0 if always_fetches == 0 else 1.0 - gated_fetches / always_fetches
+
+    return {
+        "cell": f"r{rate}_s{sensitivity}",
+        "rate": rate,
+        "sensitivity": sensitivity,
+        "blind_fetches": blind_fetches,
+        "gated_fetches": gated_fetches,
+        "always_fetches": always_fetches,
+        "refetches_avoided": refetches_avoided,
+        "wasted_refetches": wasted_refetches,
+        "savings_ratio": round(savings_ratio, 4),
+    }
+
+
+def run_cost_sweep(
+    rates: list[float],
+    sensitivities: list[float],
+    runs_per_point: int,
+) -> dict:
+    """Sweep change-rate × answer-sensitivity and return the savings-map payload.
+
+    Callable without argparse so tests can drive a tiny grid. The returned dict
+    is the exact JSON payload the CLI writes.
+    """
+    rows = [
+        _build_cell_row(rate, sensitivity, runs_per_point)
+        for rate in rates
+        for sensitivity in sensitivities
+    ]
+    return {
+        "sweep": "cost",
+        "provenance": PROVENANCE,
+        "runs_per_point": runs_per_point,
+        "rates": list(rates),
+        "sensitivities": list(sensitivities),
+        "rows": rows,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Cost sweep (change-rate × answer-sensitivity) savings-regime map."
+    )
+    parser.add_argument("--output", default="benchmarks/results/cost_sweep.json")
+    args = parser.parse_args(argv)
+
+    payload = run_cost_sweep(RATES, SENSITIVITIES, RUNS_PER_POINT)
+    for row in payload["rows"]:
+        # Provenance-labeled: the savings_ratio percentage is always reported
+        # alongside the payload's top-level ``provenance`` field.
+        print(
+            f"  {row['cell']:>12}: blind={row['blind_fetches']:>8.1f} "
+            f"gated={row['gated_fetches']:>8.1f} always={row['always_fetches']:>8.1f} "
+            f"avoided={row['refetches_avoided']:>8.1f} wasted={row['wasted_refetches']:>8.1f} "
+            f"savings={row['savings_ratio']:.1%}"
+        )
+
+    output_path = REPO_ROOT / args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"Wrote {output_path}  [provenance: {payload['provenance']}]")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds a simulation-based **cost benchmark** for temporal (source-drift) coherence: how many re-fetches/re-embeds coherence-gating avoids when an external source changes between a single agent's turns, measured over a **change-rate × answer-sensitivity** sweep.
- **Cost-only** measurement — no correctness oracle, no LLM. Runs natively on the existing `SimulationEngine`, wiring the previously-unused per-artifact `volatility` knob as the change-rate dial.
- Adds a CI drift gate (`make cost-benchmark-check`) and a pre-registration doc with PASS / NULL / INCONCLUSIVE verdicts.

## What's new

- `BlindCacheStrategy` — never-refresh config (the cost floor).
- **Source-mutation step** in `SimulationEngine` — flag-gated (`source_mutation.enabled`, default **off**; byte-identical to today when off), dedicated RNG (action stream unchanged), holders invalidated directly via `set_agent_state(trigger="source_mutation")` + cache invalidation (no coordinator round-trip).
- `source_refetches` / `wasted_refetches` metrics (defaulted) + aggregation.
- `tools/run_cost_sweep.py` — 2-D sweep → savings regime map (provenance-labeled JSON).
- `tools/cost_drift_check.py` + `benchmarks/expected_cost.json` — drift gate mirroring `benchmark_drift_check.py`.
- `benchmarks/cost_preregistration.md` — falsifiability verdicts + distinguishers.

Example regime map (default grid): at change-rate 0 gating avoids ~79% of re-fetches; at change-rate 1 it converges to always-refetch (0% savings); the `wasted` column tracks re-fetches on answer-irrelevant changes.

## Test Plan

- [x] Unit tests for each new surface (strategy, source-mutation, metrics, sweep, drift-check) — 97 feature tests
- [x] Byte-identity: `source_mutation.enabled=False` produces output identical to today
- [x] Determinism: same-seed runs are byte-identical (dedicated mutation RNG)
- [x] Full suite green (1042 passed, 29 skipped); `ruff` clean
- [x] End-to-end: `make cost-benchmark` → `make cost-benchmark-check` exits 0

## Notes

- Synthetic source for v1; a small-real-corpus variant (which would make answer-sensitivity a measured property) is a follow-up.
- Pre-registered threshold *values* are a follow-up; placeholders are in `cost_preregistration.md`.
- No changes to the real-path invalidation gating; the source-mutation is a sim-internal registry operation.
