### PR TITLE
chore(release): v0.8.4.1 — ccs-diagnose heatmap share fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -39,9 +39,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -64,9 +64,9 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -80,7 +80,7 @@ jobs:
       # this, _has_tsc() in tests/test_refactor_demo.py is False and all real
       # tsc end-to-end tests silently skip, leaving the demo's central
       # correctness claim unverified in CI.
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"
 
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: test-results-py${{ matrix.python-version }}
           path: test-results.xml
@@ -105,9 +105,9 @@ jobs:
     needs: [architecture]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -125,9 +125,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
           cache: pip
@@ -148,9 +148,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
         with:
           distribution: temurin
           java-version: "17"
@@ -164,14 +164,14 @@ jobs:
     needs: [architecture]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"
 
@@ -185,7 +185,7 @@ jobs:
       # harness's resolve_node_dist_path() picks up the explicit env var below
       # rather than the sibling-fallback path.
       - name: Check out agent-coherence-plugin
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           repository: hipvlady/agent-coherence-plugin
           ref: main
@@ -208,9 +208,9 @@ jobs:
     needs: [lint, architecture, test, benchmark-smoke, benchmark-regression, tla-check]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -227,7 +227,7 @@ jobs:
         run: python -m twine check dist/*
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: python-package
           path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -58,9 +58,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -107,14 +107,14 @@ jobs:
           cyclonedx-py environment > sbom.cyclonedx.json
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: python-package
           path: dist/
           retention-days: 30
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: sbom
           path: sbom.cyclonedx.json
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: python-package
           path: dist/
@@ -155,19 +155,19 @@ jobs:
 
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: python-package
           path: dist/
 
       - name: Download SBOM
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: sbom
           path: sbom/
 
       - name: Create GitHub release with wheel, sdist, and SBOM
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           files: |
             dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ Alpha — APIs may change before `v1.0`.
 
 (Nothing yet.)
 
+## [0.8.4.1] — 2026-06-05
+
+A patch release fixing a display bug in the `ccs-diagnose` HTML report. No
+API, core-protocol, or adapter changes.
+
+### Fixed
+
+- **`ccs-diagnose` Per-Artifact Heatmap `share` could exceed 100%.** The
+  heatmap counted headline divergence *events* — which are ordered read
+  *pairs* (`O(n²)`) — against the read *count*, so an artifact written late
+  and read by many downstream nodes rendered shares like 600%, overflowing
+  the CSS bar. `HeatmapRow.divergent_reads` now counts the distinct reads
+  handed a divergent version (the `later_read` of ≥1 headline event), which
+  is a subset of `total_reads`, so `share` is bounded to `[0, 100%]`. The
+  report template also clamps the bar width and labels the column's
+  witness-quality meaning. The headline-event count is unchanged and still
+  drives the Reader-Pair Matrix.
+
 ## [0.8.4] — 2026-06-02
 
 A patch release that adds the experimental OpenAI Agents SDK integration and

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Protocol safety properties (single-writer, monotonic versioning, crash-recovery 
 
 ## Status
 
-**`v0.8.4` released — experimental OpenAI Agents SDK adapter + packaging fixes.** Adds an experimental (0.x) adapter that brings coherence to the OpenAI Agents SDK `Session` cache (`wrap_session` + optional `RunHooks`); install with `pip install "agent-coherence[openai-agents]"`. New `openai` / `openai-agents` / `mistral` extras and an offline Conversations stale-read example. Fixes: the `otel` extra now pulls `opentelemetry-sdk` so metrics actually export, and `agent-coherence-status` keeps the version column inline. No core-protocol changes; the v0.8.3 crash-recovery deprecation cycle and the upcoming v0.9.0 default flip are unaffected.
+**`v0.8.4.1` released — `ccs-diagnose` heatmap fix.** A patch over `v0.8.4`: the diagnose report's Per-Artifact Heatmap `share` column counted divergent read-*pairs* against the read *count*, so it could exceed 100% (observed 600%); it now reports the share of distinct reads handed a divergent version, bounded to `[0, 100%]`. No API or core-protocol changes. `v0.8.4` added the experimental (0.x) OpenAI Agents SDK adapter that brings coherence to the SDK `Session` cache (`wrap_session` + optional `RunHooks`; `pip install "agent-coherence[openai-agents]"`), the `openai` / `openai-agents` / `mistral` extras, and an offline Conversations stale-read example — see [CHANGELOG.md](CHANGELOG.md). The v0.8.3 crash-recovery deprecation cycle and the upcoming v0.9.0 default flip are unaffected.
 
 See [CHANGELOG.md](CHANGELOG.md) for the full version history and [releases](https://github.com/hipvlady/agent-coherence/releases) for tagged artifacts. Alpha — APIs may change before `v1.0`.
 

--- a/src/ccs/__init__.py
+++ b/src/ccs/__init__.py
@@ -3,4 +3,4 @@
 
 """agent-coherence core package."""
 
-__version__ = "0.8.4"
+__version__ = "0.8.4.1"

--- a/src/ccs/diagnose/detection.py
+++ b/src/ccs/diagnose/detection.py
@@ -156,7 +156,16 @@ class DivergenceEvent:
 
 @dataclass(frozen=True)
 class HeatmapRow:
-    """Per-artifact divergent vs total read counts (for the heatmap panel)."""
+    """Per-artifact divergent vs total read counts (for the heatmap panel).
+
+    ``divergent_reads`` is the number of *distinct read observations* handed
+    a divergent version — i.e. the ``later_read`` of at least one headline
+    divergence event. It is a subset of ``total_reads`` (the count of read
+    observations for the artifact), so ``divergent_reads <= total_reads``
+    always holds and the rendered ``share`` is bounded to ``[0, 100%]``. It
+    is deliberately *not* the headline-event count: events are ordered read
+    *pairs* (``O(n^2)``), which can far exceed the read count.
+    """
 
     artifact_key: str
     artifact_id: uuid.UUID
@@ -691,14 +700,20 @@ def _build_heatmap(
     headline_events: Sequence[DivergenceEvent],
     inverse: Mapping[uuid.UUID, str],
 ) -> tuple[HeatmapRow, ...]:
-    divergent_per_artifact: dict[uuid.UUID, int] = {}
+    # Count DISTINCT reads handed a divergent version (the ``later_read`` of
+    # ≥1 headline event), NOT the number of headline events. Events are
+    # ordered read pairs (O(n^2)); counting them would let ``divergent_reads``
+    # exceed ``total_reads`` and overflow the report's "share" bar past 100%.
+    # Key on object identity, not value: every ``later_read`` instance
+    # originates from ``reads_per_artifact`` and is alive for this call, so
+    # ``id()`` shares the positional basis of ``total_reads = len(reads)`` and
+    # guarantees ``divergent_reads <= total_reads``.
+    divergent_read_ids: dict[uuid.UUID, set[int]] = {}
     for ev in headline_events:
-        divergent_per_artifact[ev.artifact_id] = (
-            divergent_per_artifact.get(ev.artifact_id, 0) + 1
-        )
+        divergent_read_ids.setdefault(ev.artifact_id, set()).add(id(ev.later_read))
 
     rows: list[HeatmapRow] = []
-    for aid, count in divergent_per_artifact.items():
+    for aid, read_ids in divergent_read_ids.items():
         key = inverse.get(aid)
         if key is None:
             continue
@@ -706,7 +721,7 @@ def _build_heatmap(
             HeatmapRow(
                 artifact_key=key,
                 artifact_id=aid,
-                divergent_reads=count,
+                divergent_reads=len(read_ids),
                 total_reads=len(reads_per_artifact.get(aid, [])),
             )
         )

--- a/src/ccs/diagnose/templates/diagnose_report.html
+++ b/src/ccs/diagnose/templates/diagnose_report.html
@@ -154,6 +154,7 @@ th {
 .bar {
   display: inline-block;
   height: 8px;
+  max-width: 100%;
   background: var(--accent);
   border-radius: 2px;
   vertical-align: middle;
@@ -340,6 +341,12 @@ details[open] summary { margin-bottom: 8px; }
 {# ============================================================ #}
 {% if show_heatmap %}
 <h2>Per-Artifact Heatmap</h2>
+<p class="note">
+  <code>divergent_reads</code> is the count of distinct reads handed a version
+  that diverged from another read of the same artifact; <code>share</code> is
+  that count over <code>total_reads</code>. Witness-quality &mdash; a divergent
+  handing is observed; whether the node acted on the value is unobservable.
+</p>
 <table>
   <thead>
     <tr>
@@ -357,7 +364,8 @@ details[open] summary { margin-bottom: 8px; }
         <td data-label="total_reads">{{ row.total_reads }}</td>
         <td data-label="share">
           {% set pct = (row.divergent_reads * 100 / row.total_reads) if row.total_reads > 0 else 0 %}
-          <span class="bar" style="width: {{ pct|round(0, 'floor')|int }}%"></span>
+          {% set bar_pct = 100 if pct > 100 else pct %}
+          <span class="bar" style="width: {{ bar_pct|round(0, 'floor')|int }}%"></span>
           {{ pct|round(1) }}%
         </td>
       </tr>

--- a/tests/test_diagnose_detection.py
+++ b/tests/test_diagnose_detection.py
@@ -389,6 +389,61 @@ def test_single_writer_verdict_with_zero_divergence_events():
     assert report.agent_pain_count == 0
 
 
+def test_heatmap_divergent_reads_bounded_by_total_reads():
+    """Regression: heatmap ``share`` must stay within [0, 100%].
+
+    ``divergent_reads`` counts distinct reads handed a divergent version
+    (the ``later_read`` of a headline event), NOT headline events. Events
+    are ordered read *pairs* (O(n^2)), so an event-count numerator could
+    far exceed ``total_reads`` and overflow the report's "share" bar past
+    100% (observed 600% in the field).
+
+    Shape: one write of the current version, three fresh readers, then
+    three later readers handed the stale prior version. That yields
+    3 x 3 = 9 headline divergence events but only 3 distinct stale reads
+    out of 6 total reads -> share 50%, never 150%.
+    """
+    key_index = _ids_for(["A"])
+    events: list[DiagnoseEvent] = []
+    seq = 0
+
+    def add(tick: int, node: str, evtype: str, state: dict) -> None:
+        nonlocal seq
+        seq += 1
+        events.append(
+            _make_event(sequence=seq, tick=tick, node=node, event_type=evtype, state=state)
+        )
+
+    add(1, "W", "node_end", {"A": "a-v2"})  # single write: current version
+    add(2, "fresh1", "node_start", {"A": "a-v2"})
+    add(3, "fresh2", "node_start", {"A": "a-v2"})
+    add(4, "fresh3", "node_start", {"A": "a-v2"})
+    add(5, "stale1", "node_start", {"A": "a-v1"})  # handed the prior version
+    add(6, "stale2", "node_start", {"A": "a-v1"})
+    add(7, "stale3", "node_start", {"A": "a-v1"})
+
+    report = detect(
+        events,
+        verdict=_verdict(tracked_keys=("A",)),
+        key_index=key_index,
+    )
+
+    # The raw pair-count exceeds the read count — this is the condition that
+    # made the old event-count numerator overflow the share bar.
+    assert len(report.headline_divergence_events) == 9
+    assert len(report.heatmap) == 1
+    row = report.heatmap[0]
+    assert row.artifact_key == "A"
+    assert row.total_reads == 6
+    # Distinct stale (later) reads, not the 9 events.
+    assert row.divergent_reads == 3
+
+    # The invariant the renderer relies on: share is bounded to [0, 100%].
+    for r in report.heatmap:
+        assert 0 <= r.divergent_reads <= r.total_reads
+        assert 0.0 <= (r.divergent_reads * 100.0 / r.total_reads) <= 100.0
+
+
 # -------------------------------------------------------------------- #
 # Cost extrapolation paths
 # -------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Patch release **v0.8.4.1** over `v0.8.4`. Fixes a display bug in the `ccs-diagnose` HTML report's **Per-Artifact Heatmap**: the `share` column counted divergent read-*pairs* against the read *count*, so it could exceed 100% (observed 600%), overflowing the CSS bar. No API, core-protocol, or adapter changes.

## What changed

- **`fix(diagnose)`** — `HeatmapRow.divergent_reads` now counts the distinct reads handed a divergent version (the `later_read` of ≥1 headline event), a subset of `total_reads`, so `share` is bounded to `[0, 100%]`. The report template clamps the bar width defensively (`.bar { max-width: 100% }`) and adds a witness-quality note for the column. The headline-event count is unchanged and still drives the Reader-Pair Matrix. New detection test asserts `divergent_reads <= total_reads`.
- **`chore(release)`** — bump `__version__` to `0.8.4.1`, CHANGELOG entry, README Status.
- Also carries `chore(ci)` #89 (GitHub Actions Node 24 runtime pins) already on `dev`.

## Test plan

- Full suite green under Python 3.11 (1515 passed; the 2 `test_claude_code_e2e.py` failures are pre-existing and environmental — they need the installed `agent-coherence-coordinator` console script, absent under a `PYTHONPATH=src` run, and pass in CI).
- All 320 `diagnose` tests pass; end-to-end render confirms `share` ≤ 100% on the real detect path and the template clamps a forced-overflow row.
- `tools/check_release_readiness.py` — all three gh-side gates PASS (pypi env, `main` branch protection, `v*` tag ruleset).
- `release.yml` version/tag gate simulated: `__version__ == "0.8.4.1"` matches tag `v0.8.4.1`.

## Release mechanics

Merging this makes `main` the publish point. After merge + green CI, pushing the annotated tag `v0.8.4.1` to `main` triggers `release.yml` (preflight → build + CycloneDX SBOM → PyPI publish via Trusted Publishers OIDC + PEP 740 attestations → GitHub Release). Pre-tag-push prerequisite (PyPI Trusted Publisher for `release.yml` / `pypi` environment) is unchanged from `v0.8.4` and #89 did not rename the workflow or alter the environment. Post-merge: tag, watch the workflow, then sync `main` back into `dev`.
