### PR TITLE
fix(diagnose): rank multi-writer artifacts above single-writer pipeline ordering in the heatmap

### DIFF
--- a/src/ccs/diagnose/render.py
+++ b/src/ccs/diagnose/render.py
@@ -273,7 +273,7 @@ class _ReportContext(TypedDict):
     top_event_writes: Any
     ownership: tuple[OwnershipRow, ...]
     # Section 3 data
-    heatmap_rows: tuple[Any, ...]
+    heatmap_rows: tuple[_HeatmapDisplayRow, ...]
     # Section 4 data
     reader_pairs: Any
     # Section 5 data
@@ -437,7 +437,7 @@ def _build_heatmap_display_rows(
     count unknown) fall back to the existing divergent-reads order.
     """
     writers_by_id = {row.artifact_id: len(row.writers) for row in ownership}
-    rows = [
+    rows = (
         _HeatmapDisplayRow(
             artifact_key=row.artifact_key,
             divergent_reads=row.divergent_reads,
@@ -446,15 +446,19 @@ def _build_heatmap_display_rows(
         )
         for row in report.heatmap
         if row.divergent_reads > 0
-    ]
-    rows.sort(
-        key=lambda r: (
-            0 if r.writer_count >= 2 else 1,
-            -r.divergent_reads,
-            r.artifact_key,
+    )
+    # Stable sort: multi-writer first, then by divergent reads, then key. The
+    # multi-writer threshold lives only in ``_HeatmapDisplayRow.is_multi_writer``.
+    return tuple(
+        sorted(
+            rows,
+            key=lambda r: (
+                0 if r.is_multi_writer else 1,
+                -r.divergent_reads,
+                r.artifact_key,
+            ),
         )
     )
-    return tuple(rows)
 
 
 def _build_section_data(

--- a/src/ccs/diagnose/render.py
+++ b/src/ccs/diagnose/render.py
@@ -401,6 +401,62 @@ def _build_section_toggles(
     }
 
 
+@dataclass(frozen=True)
+class _HeatmapDisplayRow:
+    """A heatmap row enriched with its writer count for display.
+
+    The detection-layer :class:`~ccs.diagnose.detection.HeatmapRow` ranks
+    purely by ``divergent_reads``, which over-surfaces single-writer artifacts
+    whose high ``share`` is expected pipeline ordering (readers handed the
+    pre-write value). For the report we re-rank genuine *multi-writer*
+    artifacts — the coordination signal — first.
+    """
+
+    artifact_key: str
+    divergent_reads: int
+    total_reads: int
+    writer_count: int
+
+    @property
+    def is_multi_writer(self) -> bool:
+        return self.writer_count >= 2
+
+
+def _build_heatmap_display_rows(
+    *,
+    report: DetectionReport,
+    ownership: tuple[OwnershipRow, ...],
+) -> tuple[_HeatmapDisplayRow, ...]:
+    """Heatmap rows for the report: joined with writer counts and re-ranked so
+    genuine multi-writer artifacts sort above single-writer pipeline ordering.
+
+    Mirrors the Ownership Map's multi-writer-first sort
+    (:func:`ccs.diagnose.ownership._row_sort_key`). Detection's ``HeatmapRow``
+    order — which feeds :func:`_pick_top_event` — is left unchanged; this is a
+    presentation-only re-rank. Artifacts absent from ``ownership`` (writer
+    count unknown) fall back to the existing divergent-reads order.
+    """
+    writers_by_id = {row.artifact_id: len(row.writers) for row in ownership}
+    rows = [
+        _HeatmapDisplayRow(
+            artifact_key=row.artifact_key,
+            divergent_reads=row.divergent_reads,
+            total_reads=row.total_reads,
+            writer_count=writers_by_id.get(row.artifact_id, 0),
+        )
+        for row in report.heatmap
+        if row.divergent_reads > 0
+    ]
+    rows.sort(
+        key=lambda r: (
+            0 if r.writer_count >= 2 else 1,
+            -r.divergent_reads,
+            r.artifact_key,
+        )
+    )
+    return tuple(rows)
+
+
 def _build_section_data(
     *,
     verdict: ClassifierVerdict,
@@ -412,8 +468,8 @@ def _build_section_data(
         "top_event": report.top_event,
         "top_event_writes": _top_event_writes(report),
         "ownership": ownership,
-        "heatmap_rows": tuple(
-            row for row in report.heatmap if row.divergent_reads > 0
+        "heatmap_rows": _build_heatmap_display_rows(
+            report=report, ownership=ownership
         ),
         "reader_pairs": report.reader_pair_matrix,
         "exclusion_panel": report.exclusion_panel,

--- a/src/ccs/diagnose/templates/diagnose_report.html
+++ b/src/ccs/diagnose/templates/diagnose_report.html
@@ -363,7 +363,7 @@ details[open] summary { margin-bottom: 8px; }
   </thead>
   <tbody>
     {% for row in heatmap_rows %}
-      <tr>
+      <tr class="{% if row.is_multi_writer %}multi-writer{% endif %}">
         <td data-label="artifact_key"><code>{{ row.artifact_key }}</code></td>
         <td data-label="writers">
           {% if row.writer_count >= 1 %}{{ row.writer_count }}{% else %}&mdash;{% endif %}

--- a/src/ccs/diagnose/templates/diagnose_report.html
+++ b/src/ccs/diagnose/templates/diagnose_report.html
@@ -346,11 +346,16 @@ details[open] summary { margin-bottom: 8px; }
   that diverged from another read of the same artifact; <code>share</code> is
   that count over <code>total_reads</code>. Witness-quality &mdash; a divergent
   handing is observed; whether the node acted on the value is unobservable.
+  Rows are ordered with genuine <strong>multi-writer</strong> artifacts first
+  &mdash; those are the coordination signal. A high share on a single-writer
+  artifact is usually expected pipeline ordering (readers handed the pre-write
+  value), not a coordination gap.
 </p>
 <table>
   <thead>
     <tr>
       <th>artifact_key</th>
+      <th>writers</th>
       <th>divergent_reads</th>
       <th>total_reads</th>
       <th>share</th>
@@ -360,6 +365,10 @@ details[open] summary { margin-bottom: 8px; }
     {% for row in heatmap_rows %}
       <tr>
         <td data-label="artifact_key"><code>{{ row.artifact_key }}</code></td>
+        <td data-label="writers">
+          {% if row.writer_count >= 1 %}{{ row.writer_count }}{% else %}&mdash;{% endif %}
+          {% if row.is_multi_writer %}<strong>multi-writer</strong>{% elif row.writer_count == 1 %}<span style="opacity:0.6">pipeline ordering</span>{% endif %}
+        </td>
         <td data-label="divergent_reads">{{ row.divergent_reads }}</td>
         <td data-label="total_reads">{{ row.total_reads }}</td>
         <td data-label="share">

--- a/tests/test_diagnose_render.py
+++ b/tests/test_diagnose_render.py
@@ -44,6 +44,7 @@ from ccs.diagnose.ownership import OwnershipRow
 from ccs.diagnose.render import (
     DEFAULT_BOOK_A_CALL_URL,
     RenderOptions,
+    _build_heatmap_display_rows,
     build_environment,
     render_html,
     render_to_string,
@@ -995,6 +996,78 @@ def test_heatmap_omits_rows_with_zero_divergent_reads():
     heatmap_section = html[heatmap_section_idx:next_section_idx]
     assert "A" in heatmap_section
     assert ">B<" not in heatmap_section  # filtered out
+
+
+def test_heatmap_ranks_multi_writer_above_higher_share_single_writer():
+    """A single-writer artifact's high divergent-read share is expected
+    pipeline ordering; a genuine multi-writer artifact is the coordination
+    signal and must surface first even with a lower share (mirrors Run 001:
+    single-writer sentiment_report ~79% vs the multi-writer debate dicts)."""
+    sw = _aid(21)  # single-writer, HIGH share
+    mw = _aid(22)  # multi-writer, LOWER share
+    events = (
+        _make_divergence_event(artifact_key="sentiment_report", artifact_id=sw),
+        _make_divergence_event(artifact_key="risk_debate_state", artifact_id=mw),
+    )
+    heatmap = (
+        HeatmapRow("sentiment_report", sw, 27, 34),
+        HeatmapRow("risk_debate_state", mw, 6, 34),
+    )
+    ownership = (
+        OwnershipRow(
+            artifact_key="sentiment_report",
+            artifact_id=sw,
+            writers=(("Sentiment Analyst", 1),),
+            readers=(("Trader", 5),),
+            version_range="v1 -> v5",
+            append_only=False,
+        ),
+        OwnershipRow(
+            artifact_key="risk_debate_state",
+            artifact_id=mw,
+            writers=(
+                ("Aggressive", 1),
+                ("Conservative", 1),
+                ("Neutral", 1),
+                ("Portfolio Manager", 1),
+            ),
+            readers=(("Portfolio Manager", 4),),
+            version_range="va6 -> v55",
+            append_only=False,
+        ),
+    )
+    report = DetectionReport(
+        headline_divergence_events=events,
+        excluded_events=(),
+        heatmap=heatmap,
+        reader_pair_matrix=(),
+        top_event=events[0],
+        exclusion_panel=ExclusionPanel(0, 0, 0),
+        agent_pain_count=2,
+        rework_tokens_this_run=0,
+        rework_cost_this_run=0.0,
+        rework_cost_annualized=None,
+        cost_unmeasurable_reason=None,
+        strict_mode=False,
+        schema_version=CCS_DIAGNOSE_LOG_SCHEMA_VERSION,
+    )
+
+    # Helper: multi-writer ranks first despite the LOWER divergent-read share.
+    rows = _build_heatmap_display_rows(report=report, ownership=ownership)
+    assert [r.artifact_key for r in rows] == [
+        "risk_debate_state",
+        "sentiment_report",
+    ]
+    assert rows[0].writer_count == 4 and rows[0].is_multi_writer
+    assert rows[1].writer_count == 1 and not rows[1].is_multi_writer
+
+    # Rendered report surfaces the multi-writer artifact first + labels it.
+    html = render_to_string(verdict=_verdict(), report=report, ownership=ownership)
+    start = html.find("Per-Artifact Heatmap")
+    end = html.find("Reader-Pair Matrix", start)
+    section = html[start : end if end != -1 else len(html)]
+    assert section.find("risk_debate_state") < section.find("sentiment_report")
+    assert "multi-writer" in section
 
 
 # -------------------------------------------------------------------- #

--- a/tests/test_diagnose_render.py
+++ b/tests/test_diagnose_render.py
@@ -1068,6 +1068,68 @@ def test_heatmap_ranks_multi_writer_above_higher_share_single_writer():
     section = html[start : end if end != -1 else len(html)]
     assert section.find("risk_debate_state") < section.find("sentiment_report")
     assert "multi-writer" in section
+    # The single-writer row carries the "pipeline ordering" label.
+    assert "pipeline ordering" in section
+
+
+def test_heatmap_artifact_absent_from_ownership_falls_back_to_unknown_bucket():
+    """An artifact present in the heatmap but ABSENT from the ownership map has
+    an unknown writer count (``writer_count == 0``): it must not be treated as
+    multi-writer, and a genuine multi-writer artifact still outranks it even
+    when the unknown artifact has a much higher divergent-read share."""
+    mw = _aid(31)  # multi-writer, LOWER share
+    unknown = _aid(32)  # absent from ownership, HIGHER share
+    events = (
+        _make_divergence_event(artifact_key="risk_debate_state", artifact_id=mw),
+        _make_divergence_event(artifact_key="orphan_artifact", artifact_id=unknown),
+    )
+    heatmap = (
+        HeatmapRow("risk_debate_state", mw, 5, 34),
+        HeatmapRow("orphan_artifact", unknown, 30, 34),
+    )
+    # Ownership covers ONLY the multi-writer artifact; orphan_artifact is absent.
+    ownership = (
+        OwnershipRow(
+            artifact_key="risk_debate_state",
+            artifact_id=mw,
+            writers=(
+                ("Aggressive", 1),
+                ("Conservative", 1),
+                ("Neutral", 1),
+            ),
+            readers=(("Portfolio Manager", 4),),
+            version_range="va6 -> v55",
+            append_only=False,
+        ),
+    )
+    report = DetectionReport(
+        headline_divergence_events=events,
+        excluded_events=(),
+        heatmap=heatmap,
+        reader_pair_matrix=(),
+        top_event=events[0],
+        exclusion_panel=ExclusionPanel(0, 0, 0),
+        agent_pain_count=2,
+        rework_tokens_this_run=0,
+        rework_cost_this_run=0.0,
+        rework_cost_annualized=None,
+        cost_unmeasurable_reason=None,
+        strict_mode=False,
+        schema_version=CCS_DIAGNOSE_LOG_SCHEMA_VERSION,
+    )
+
+    rows = _build_heatmap_display_rows(report=report, ownership=ownership)
+    assert [r.artifact_key for r in rows] == ["risk_debate_state", "orphan_artifact"]
+    orphan = rows[1]
+    assert orphan.writer_count == 0 and not orphan.is_multi_writer
+
+    # The re-rank propagates to the rendered report: the multi-writer artifact
+    # surfaces above the higher-share artifact whose ownership is unknown.
+    html = render_to_string(verdict=_verdict(), report=report, ownership=ownership)
+    start = html.find("Per-Artifact Heatmap")
+    end = html.find("Reader-Pair Matrix", start)
+    section = html[start : end if end != -1 else len(html)]
+    assert section.find("risk_debate_state") < section.find("orphan_artifact")
 
 
 # -------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

The per-artifact heatmap ranked purely by `divergent_reads` (descending), which surfaces single-writer artifacts — whose high `share` is expected pipeline ordering (readers handed the pre-write value) — *above* genuine multi-writer artifacts, the actual coordination signal. This re-ranks the heatmap so multi-writer artifacts appear first, mirroring the Ownership Map's existing multi-writer-first sort.

Presentation-only: the change lives at the render layer (`_build_heatmap_display_rows`). The detection-layer `HeatmapRow` order — which feeds `_pick_top_event` — is unchanged.

- Re-rank heatmap rows multi-writer-first (writer count joined from the ownership map; falls back to the existing divergent-reads order when writers are unknown)
- Add a `writers` column + a `multi-writer` / `pipeline ordering` flag
- Add a one-line decomposition note to the heatmap panel

Follows up #93 (which fixed the `share` count); this fixes the row *ordering*.

## Test Plan

- New `test_heatmap_ranks_multi_writer_above_higher_share_single_writer`: a single-writer artifact with a *higher* share ranks below a multi-writer artifact, and the rendered report surfaces + labels the multi-writer row.
- Full diagnose suite green (`158 passed`), `ruff` clean.
- Detection / `_pick_top_event` behavior unchanged (detection + ownership tests untouched and green).