### PR TITLE
chore(release): v0.8.4.3 — ccs-diagnose heatmap report clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ Alpha — APIs may change before `v1.0`.
 
 (Nothing yet.)
 
+## [0.8.4.3] — 2026-06-06
+
+A patch release completing the `ccs-diagnose` heatmap report improvements
+started in v0.8.4.2. No API, core-protocol, or adapter changes.
+
+### Changed
+
+- **`ccs-diagnose` Per-Artifact Heatmap note now bridges the two ranking
+  criteria.** When the highest-rework artifact (Section 2, "The Event That
+  Matters Most") differs from the highest-coordination-signal artifact
+  (Section 3, heatmap row-1), a new sentence in the heatmap note explains
+  that Section 2 ranks by rework impact (`divergent_reads`) while Section 3
+  ranks by multi-writer coordination signal. Prevents reader confusion when
+  comparing the two panels in a shared report.
+- **Sort-key secondary difference documented.** `_build_heatmap_display_rows`
+  and `ownership._row_sort_key` share the multi-writer-first top bucket; the
+  secondary sort keys differ intentionally (`-divergent_reads` vs
+  `-total_reads`). The docstring now calls this out explicitly, and a new
+  machine-checked regression test pins the shared invariant.
+- **Minor template cleanup.** The writer-count display cell's redundant
+  `>= 1` outer guard simplified to `> 0`.
+
 ## [0.8.4.2] — 2026-06-06
 
 A patch release improving the `ccs-diagnose` HTML report's Per-Artifact

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Protocol safety properties (single-writer, monotonic versioning, crash-recovery 
 
 ## Status
 
-**`v0.8.4.2` released — `ccs-diagnose` heatmap multi-writer ranking.** A patch over `v0.8.4.1`: the diagnose report's Per-Artifact Heatmap now ranks genuine *multi-writer* artifacts — the real coordination signal — above single-writer artifacts whose high `share` is expected pipeline ordering, adds a `writers` column and a multi-writer row highlight, and leaves the detection-layer ordering (which drives the top-event callout) unchanged. Presentation-only; no API or core-protocol changes. `v0.8.4.1` bounded that same heatmap's `share` column to `[0, 100%]` (it previously counted divergent read-*pairs* against the read *count* and could exceed 100%). See [CHANGELOG.md](CHANGELOG.md). The v0.8.3 crash-recovery deprecation cycle and the upcoming v0.9.0 default flip are unaffected.
+**`v0.8.4.3` released — `ccs-diagnose` heatmap report clarity.** A patch over `v0.8.4.2`: the Per-Artifact Heatmap note now explains why the "Event That Matters Most" panel (ranked by rework impact) and the heatmap row-1 (ranked by multi-writer coordination signal) can name different artifacts, preventing reader confusion in shared reports. Also closes test-coverage and documentation residuals from the v0.8.4.2 heatmap re-rank. No API or core-protocol changes. See [CHANGELOG.md](CHANGELOG.md). The v0.8.3 crash-recovery deprecation cycle and the upcoming v0.9.0 default flip are unaffected.
 
 See [CHANGELOG.md](CHANGELOG.md) for the full version history and [releases](https://github.com/hipvlady/agent-coherence/releases) for tagged artifacts. Alpha — APIs may change before `v1.0`.
 

--- a/src/ccs/__init__.py
+++ b/src/ccs/__init__.py
@@ -3,4 +3,4 @@
 
 """agent-coherence core package."""
 
-__version__ = "0.8.4.2"
+__version__ = "0.8.4.3"

--- a/src/ccs/diagnose/render.py
+++ b/src/ccs/diagnose/render.py
@@ -437,6 +437,12 @@ def _build_heatmap_display_rows(
     count unknown) fall back to the existing divergent-reads order.
     """
     writers_by_id = {row.artifact_id: len(row.writers) for row in ownership}
+    # CLI invariant: both ``report`` and ``ownership`` are built from the same
+    # ``key_index``, so every heatmap artifact_id has a matching ownership row
+    # and ``writers_by_id.get(aid, 0)`` always returns the real writer count.
+    # The fallback to 0 handles callers that pass ownership built from a
+    # different key_index snapshot (e.g. test fixtures); those rows sort into
+    # the single-writer display bucket by ``is_multi_writer == False``.
     rows = (
         _HeatmapDisplayRow(
             artifact_key=row.artifact_key,

--- a/src/ccs/diagnose/render.py
+++ b/src/ccs/diagnose/render.py
@@ -427,14 +427,16 @@ def _build_heatmap_display_rows(
     report: DetectionReport,
     ownership: tuple[OwnershipRow, ...],
 ) -> tuple[_HeatmapDisplayRow, ...]:
-    """Heatmap rows for the report: joined with writer counts and re-ranked so
-    genuine multi-writer artifacts sort above single-writer pipeline ordering.
+    """Return heatmap display rows joined with writer counts and re-ranked multi-writer-first.
 
     Mirrors the Ownership Map's multi-writer-first sort
-    (:func:`ccs.diagnose.ownership._row_sort_key`). Detection's ``HeatmapRow``
-    order — which feeds :func:`_pick_top_event` — is left unchanged; this is a
-    presentation-only re-rank. Artifacts absent from ``ownership`` (writer
-    count unknown) fall back to the existing divergent-reads order.
+    (:func:`ccs.diagnose.ownership._row_sort_key`) at the top bucket; the
+    secondary sort key differs intentionally — this function sorts within each
+    bucket by ``-divergent_reads`` (detection signal), while ``_row_sort_key``
+    sorts by ``-total_reads`` (reader-traffic signal). Detection's
+    ``HeatmapRow`` order — which feeds :func:`_pick_top_event` — is left
+    unchanged; this is a presentation-only re-rank. Artifacts absent from
+    ``ownership`` (writer count unknown) fall back to the divergent-reads order.
     """
     writers_by_id = {row.artifact_id: len(row.writers) for row in ownership}
     # CLI invariant: both ``report`` and ``ownership`` are built from the same
@@ -443,6 +445,10 @@ def _build_heatmap_display_rows(
     # The fallback to 0 handles callers that pass ownership built from a
     # different key_index snapshot (e.g. test fixtures); those rows sort into
     # the single-writer display bucket by ``is_multi_writer == False``.
+    # Known ambiguity: ``writer_count == 0`` means both "artifact absent from
+    # ownership" (unknown) and "OwnershipRow.writers == () i.e. zero observed
+    # writers". Both are correctly treated as non-multi-writer; the distinction
+    # is not surfaced in the display because neither is a coordination signal.
     rows = (
         _HeatmapDisplayRow(
             artifact_key=row.artifact_key,

--- a/src/ccs/diagnose/templates/diagnose_report.html
+++ b/src/ccs/diagnose/templates/diagnose_report.html
@@ -369,7 +369,7 @@ details[open] summary { margin-bottom: 8px; }
       <tr class="{% if row.is_multi_writer %}multi-writer{% endif %}">
         <td data-label="artifact_key"><code>{{ row.artifact_key }}</code></td>
         <td data-label="writers">
-          {% if row.writer_count >= 1 %}{{ row.writer_count }}{% else %}&mdash;{% endif %}
+          {% if row.writer_count > 0 %}{{ row.writer_count }}{% else %}&mdash;{% endif %}
           {% if row.is_multi_writer %}<strong>multi-writer</strong>{% elif row.writer_count == 1 %}<span style="opacity:0.6">pipeline ordering</span>{% endif %}
         </td>
         <td data-label="divergent_reads">{{ row.divergent_reads }}</td>

--- a/src/ccs/diagnose/templates/diagnose_report.html
+++ b/src/ccs/diagnose/templates/diagnose_report.html
@@ -349,7 +349,10 @@ details[open] summary { margin-bottom: 8px; }
   Rows are ordered with genuine <strong>multi-writer</strong> artifacts first
   &mdash; those are the coordination signal. A high share on a single-writer
   artifact is usually expected pipeline ordering (readers handed the pre-write
-  value), not a coordination gap.
+  value), not a coordination gap. The <em>Event That Matters Most</em> panel above
+  ranks by rework impact (highest <code>divergent_reads</code>); this table ranks
+  by coordination signal (multi-writer first), so the two panels may highlight
+  different artifacts.
 </p>
 <table>
   <thead>

--- a/tests/test_diagnose_render.py
+++ b/tests/test_diagnose_render.py
@@ -1132,6 +1132,154 @@ def test_heatmap_artifact_absent_from_ownership_falls_back_to_unknown_bucket():
     assert section.find("risk_debate_state") < section.find("orphan_artifact")
 
 
+def test_heatmap_note_explains_ranking_difference_from_top_event():
+    """When top_event.artifact_key (detection order, max divergent_reads) differs
+    from heatmap_rows[0].artifact_key (display order, multi-writer first), the
+    heatmap section note must contain a bridging sentence so a reader understands
+    why Section 2 and Section 3 name different artifacts."""
+    sw = _aid(41)  # single-writer, HIGHEST divergent_reads — wins top_event
+    mw = _aid(42)  # multi-writer, fewer reads — wins heatmap row-1
+    events = (
+        _make_divergence_event(artifact_key="sentiment_report", artifact_id=sw),
+        _make_divergence_event(artifact_key="risk_debate_state", artifact_id=mw),
+    )
+    # Detection heatmap: sentiment_report ranks first (27 > 6 divergent_reads).
+    # _pick_top_event therefore selects events[0] = sentiment_report.
+    heatmap = (
+        HeatmapRow("sentiment_report", sw, 27, 34),
+        HeatmapRow("risk_debate_state", mw, 6, 34),
+    )
+    ownership = (
+        OwnershipRow(
+            artifact_key="sentiment_report",
+            artifact_id=sw,
+            writers=(("Sentiment Analyst", 1),),
+            readers=(("Trader", 5),),
+            version_range="v1 -> v5",
+            append_only=False,
+        ),
+        OwnershipRow(
+            artifact_key="risk_debate_state",
+            artifact_id=mw,
+            writers=(("Aggressive", 1), ("Conservative", 1), ("Neutral", 1)),
+            readers=(("Portfolio Manager", 3),),
+            version_range="va6 -> v55",
+            append_only=False,
+        ),
+    )
+    report = DetectionReport(
+        headline_divergence_events=events,
+        excluded_events=(),
+        heatmap=heatmap,
+        reader_pair_matrix=(),
+        top_event=events[0],  # sentiment_report (detection order winner)
+        exclusion_panel=ExclusionPanel(0, 0, 0),
+        agent_pain_count=2,
+        rework_tokens_this_run=0,
+        rework_cost_this_run=0.0,
+        rework_cost_annualized=None,
+        cost_unmeasurable_reason=None,
+        strict_mode=False,
+        schema_version=CCS_DIAGNOSE_LOG_SCHEMA_VERSION,
+    )
+
+    html = render_to_string(verdict=_verdict(), report=report, ownership=ownership)
+
+    # Section 2 names the detection-order winner.
+    s2_start = html.find("The Event That Matters Most")
+    s2_end = html.find("Per-Artifact Heatmap", s2_start)
+    s2 = html[s2_start:s2_end]
+    assert "sentiment_report" in s2
+
+    # Section 3 heatmap row-1 names the multi-writer winner.
+    start = html.find("Per-Artifact Heatmap")
+    end = html.find("Reader-Pair Matrix", start)
+    section = html[start : end if end != -1 else len(html)]
+    assert section.find("risk_debate_state") < section.find("sentiment_report")
+
+    # The heatmap note must contain a bridging sentence so a reader understands
+    # why "The Event That Matters Most" (Section 2, ranked by divergent_reads /
+    # rework) can name a different artifact than heatmap row-1 (ranked by
+    # multi-writer coordination signal). The note must cross-reference the
+    # Section 2 callout or explicitly mention the two different criteria.
+    note_start = section.find("<p class=\"note\">")
+    note_end = section.find("</p>", note_start)
+    note = section[note_start:note_end]
+    note_lower = note.lower()
+    has_cross_reference = (
+        "section 2" in note_lower
+        or "above" in note_lower
+        or "event that matters" in note_lower
+        or "top event" in note_lower
+    )
+    assert has_cross_reference, (
+        "heatmap note must cross-reference Section 2 to bridge the two ranking criteria"
+    )
+
+
+def test_heatmap_display_rows_join_invariant_holds_for_all_tracked_artifacts():
+    """Smoke-test the CLI-level invariant: when both ``report`` and ``ownership``
+    are built from the same key_index (as the CLI always does), every heatmap
+    artifact has a non-zero writer_count — the writer_count==0 fallback should
+    NOT fire under normal production conditions.
+
+    This does not use the CLI end-to-end; it verifies that a report+ownership
+    pair constructed consistently (matching artifact_ids) gives no writer_count==0
+    rows for tracked multi-writer artifacts."""
+    mw1 = _aid(51)
+    mw2 = _aid(52)
+    events = (
+        _make_divergence_event(artifact_key="debate_state", artifact_id=mw1),
+        _make_divergence_event(artifact_key="risk_state", artifact_id=mw2),
+    )
+    heatmap = (
+        HeatmapRow("debate_state", mw1, 10, 20),
+        HeatmapRow("risk_state", mw2, 5, 20),
+    )
+    ownership = (
+        OwnershipRow(
+            artifact_key="debate_state",
+            artifact_id=mw1,  # same id as heatmap row
+            writers=(("A", 1), ("B", 1)),
+            readers=(("C", 2),),
+            version_range="v1 -> v5",
+            append_only=False,
+        ),
+        OwnershipRow(
+            artifact_key="risk_state",
+            artifact_id=mw2,  # same id as heatmap row
+            writers=(("X", 1), ("Y", 1)),
+            readers=(("Z", 2),),
+            version_range="v1 -> v5",
+            append_only=False,
+        ),
+    )
+    report = DetectionReport(
+        headline_divergence_events=events,
+        excluded_events=(),
+        heatmap=heatmap,
+        reader_pair_matrix=(),
+        top_event=events[0],
+        exclusion_panel=ExclusionPanel(0, 0, 0),
+        agent_pain_count=2,
+        rework_tokens_this_run=0,
+        rework_cost_this_run=0.0,
+        rework_cost_annualized=None,
+        cost_unmeasurable_reason=None,
+        strict_mode=False,
+        schema_version=CCS_DIAGNOSE_LOG_SCHEMA_VERSION,
+    )
+
+    rows = _build_heatmap_display_rows(report=report, ownership=ownership)
+    # When artifact_ids are consistent (as the CLI guarantees), every row has a
+    # real writer_count and no row silently falls back to the unknown (0) bucket.
+    assert all(r.writer_count > 0 for r in rows), (
+        "CLI-invariant violation: heatmap row with writer_count==0 despite "
+        "consistent artifact_ids — the join likely used different key_indexes."
+    )
+    assert all(r.is_multi_writer for r in rows)
+
+
 # -------------------------------------------------------------------- #
 # RenderOptions URL / email scheme allowlist (XSS prevention)
 # -------------------------------------------------------------------- #

--- a/tests/test_diagnose_render.py
+++ b/tests/test_diagnose_render.py
@@ -1281,6 +1281,211 @@ def test_heatmap_display_rows_join_invariant_holds_for_all_tracked_artifacts():
 
 
 # -------------------------------------------------------------------- #
+# Sort-key coverage (#6, #7, #8)
+# -------------------------------------------------------------------- #
+
+
+def test_heatmap_sort_mirrors_ownership_multi_writer_first_bucket():
+    """#6 — machine-checked 'mirrors' regression.
+
+    Both ``_build_heatmap_display_rows`` and ``ownership._row_sort_key`` share
+    the same top-bucket rule: multi-writer artifacts first.  The secondary sort
+    keys differ intentionally (``-divergent_reads`` vs ``-total_reads``), so we
+    only pin the shared invariant: given the same multi-writer / single-writer
+    split, both orderings agree on which group comes first."""
+    from ccs.diagnose.ownership import _row_sort_key
+
+    mw = _aid(61)
+    sw = _aid(62)
+
+    # Heatmap side.
+    heatmap = (
+        HeatmapRow("single_writer_artifact", sw, 50, 60),  # high reads but single-writer
+        HeatmapRow("multi_writer_artifact", mw, 3, 60),   # low reads but multi-writer
+    )
+    ownership = (
+        OwnershipRow(
+            artifact_key="single_writer_artifact",
+            artifact_id=sw,
+            writers=(("Agent A", 1),),
+            readers=(("Agent B", 10),),
+            version_range="v1 -> v5",
+            append_only=False,
+        ),
+        OwnershipRow(
+            artifact_key="multi_writer_artifact",
+            artifact_id=mw,
+            writers=(("Agent X", 1), ("Agent Y", 1)),
+            readers=(("Agent Z", 1),),
+            version_range="v1 -> v5",
+            append_only=False,
+        ),
+    )
+    report = DetectionReport(
+        headline_divergence_events=(),
+        excluded_events=(),
+        heatmap=heatmap,
+        reader_pair_matrix=(),
+        top_event=None,
+        exclusion_panel=ExclusionPanel(0, 0, 0),
+        agent_pain_count=0,
+        rework_tokens_this_run=0,
+        rework_cost_this_run=0.0,
+        rework_cost_annualized=None,
+        cost_unmeasurable_reason=None,
+        strict_mode=False,
+        schema_version=CCS_DIAGNOSE_LOG_SCHEMA_VERSION,
+    )
+
+    display_rows = _build_heatmap_display_rows(report=report, ownership=ownership)
+    ownership_sorted = sorted(ownership, key=_row_sort_key)
+
+    # Both orderings agree on multi-writer first: top bucket is the shared invariant.
+    assert display_rows[0].artifact_key == "multi_writer_artifact"
+    assert ownership_sorted[0].artifact_key == "multi_writer_artifact"
+    assert display_rows[1].artifact_key == "single_writer_artifact"
+    assert ownership_sorted[1].artifact_key == "single_writer_artifact"
+
+
+def test_heatmap_intra_group_tiebreak_by_divergent_reads_then_key():
+    """#7 — intra-bucket tie-break: within each bucket, higher divergent_reads
+    first; when divergent_reads are equal, artifact_key lexicographic order."""
+    mw_high = _aid(71)
+    mw_low = _aid(72)
+    sw_aardvark = _aid(73)
+    sw_zebra = _aid(74)
+
+    heatmap = (
+        HeatmapRow("mw_low_reads", mw_low, 4, 20),
+        HeatmapRow("mw_high_reads", mw_high, 12, 20),
+        HeatmapRow("zebra_artifact", sw_zebra, 8, 20),
+        HeatmapRow("aardvark_artifact", sw_aardvark, 8, 20),  # same reads, sorts first by key
+    )
+    ownership = (
+        OwnershipRow(
+            artifact_key="mw_high_reads",
+            artifact_id=mw_high,
+            writers=(("A", 1), ("B", 1)),
+            readers=(("C", 2),),
+            version_range="v1",
+            append_only=False,
+        ),
+        OwnershipRow(
+            artifact_key="mw_low_reads",
+            artifact_id=mw_low,
+            writers=(("D", 1), ("E", 1)),
+            readers=(("F", 2),),
+            version_range="v1",
+            append_only=False,
+        ),
+        OwnershipRow(
+            artifact_key="aardvark_artifact",
+            artifact_id=sw_aardvark,
+            writers=(("G", 1),),
+            readers=(("H", 2),),
+            version_range="v1",
+            append_only=False,
+        ),
+        OwnershipRow(
+            artifact_key="zebra_artifact",
+            artifact_id=sw_zebra,
+            writers=(("I", 1),),
+            readers=(("J", 2),),
+            version_range="v1",
+            append_only=False,
+        ),
+    )
+    report = DetectionReport(
+        headline_divergence_events=(),
+        excluded_events=(),
+        heatmap=heatmap,
+        reader_pair_matrix=(),
+        top_event=None,
+        exclusion_panel=ExclusionPanel(0, 0, 0),
+        agent_pain_count=0,
+        rework_tokens_this_run=0,
+        rework_cost_this_run=0.0,
+        rework_cost_annualized=None,
+        cost_unmeasurable_reason=None,
+        strict_mode=False,
+        schema_version=CCS_DIAGNOSE_LOG_SCHEMA_VERSION,
+    )
+
+    rows = _build_heatmap_display_rows(report=report, ownership=ownership)
+    keys = [r.artifact_key for r in rows]
+
+    # Multi-writer group: higher divergent_reads first.
+    assert keys[0] == "mw_high_reads"
+    assert keys[1] == "mw_low_reads"
+    # Single-writer group: equal divergent_reads → lexicographic key order.
+    assert keys[2] == "aardvark_artifact"
+    assert keys[3] == "zebra_artifact"
+
+
+def test_detection_heatmap_order_unchanged_after_display_rerank():
+    """#8 — detection-layer invariant: ``_build_heatmap_display_rows`` must not
+    mutate or re-sort ``report.heatmap``, and ``top_event`` must still reflect
+    the detection winner (highest divergent_reads) even when the display rerank
+    promotes a different artifact to heatmap row-1."""
+    sw = _aid(81)  # detection winner: highest divergent_reads
+    mw = _aid(82)  # display winner: multi-writer
+
+    events = (
+        _make_divergence_event(artifact_key="detection_winner", artifact_id=sw),
+        _make_divergence_event(artifact_key="display_winner", artifact_id=mw),
+    )
+    # Detection heatmap: detection_winner first (30 > 5).
+    heatmap = (
+        HeatmapRow("detection_winner", sw, 30, 40),
+        HeatmapRow("display_winner", mw, 5, 40),
+    )
+    ownership = (
+        OwnershipRow(
+            artifact_key="detection_winner",
+            artifact_id=sw,
+            writers=(("Solo", 1),),
+            readers=(("Reader", 5),),
+            version_range="v1",
+            append_only=False,
+        ),
+        OwnershipRow(
+            artifact_key="display_winner",
+            artifact_id=mw,
+            writers=(("Alpha", 1), ("Beta", 1)),
+            readers=(("Gamma", 3),),
+            version_range="v1",
+            append_only=False,
+        ),
+    )
+    report = DetectionReport(
+        headline_divergence_events=events,
+        excluded_events=(),
+        heatmap=heatmap,
+        reader_pair_matrix=(),
+        top_event=events[0],  # detection_winner selected by _pick_top_event
+        exclusion_panel=ExclusionPanel(0, 0, 0),
+        agent_pain_count=2,
+        rework_tokens_this_run=0,
+        rework_cost_this_run=0.0,
+        rework_cost_annualized=None,
+        cost_unmeasurable_reason=None,
+        strict_mode=False,
+        schema_version=CCS_DIAGNOSE_LOG_SCHEMA_VERSION,
+    )
+
+    display_rows = _build_heatmap_display_rows(report=report, ownership=ownership)
+
+    # Display re-rank promotes multi-writer to row-1 …
+    assert display_rows[0].artifact_key == "display_winner"
+    # … but the detection heatmap order is UNCHANGED.
+    assert report.heatmap[0].artifact_key == "detection_winner"
+    assert report.heatmap[1].artifact_key == "display_winner"
+    # And top_event still reflects the detection-layer winner.
+    assert report.top_event is not None
+    assert report.top_event.artifact_key == "detection_winner"
+
+
+# -------------------------------------------------------------------- #
 # RenderOptions URL / email scheme allowlist (XSS prevention)
 # -------------------------------------------------------------------- #
 


### PR DESCRIPTION
## Release v0.8.4.3

Patch over v0.8.4.2. Closes all deferred heatmap ce-review residuals (#6–8, #9–11, #13–14). No API, core-protocol, or adapter changes.

### Delta since v0.8.4.2

**PR #96** — bridging note + join-invariant comment
- Heatmap Section 3 note explains why the top-event callout (Section 2, ranked by rework impact) and heatmap row-1 (ranked by multi-writer coordination signal) can name different artifacts.
- `_build_heatmap_display_rows` join invariant documented with CLI-level guarantee and fallback scope.

**PR #97** — sort-key, tie-break, and documentation residuals
- Machine-checked regression test that both sort keys share multi-writer-first top bucket; intentional secondary-key difference (`-divergent_reads` vs `-total_reads`) documented.
- Tests for intra-bucket tie-break (`-divergent_reads` then `artifact_key`) and the detection-layer order invariant (`report.heatmap` unchanged by display re-rank; `top_event` reflects detection winner).
- `writer_count=0` ambiguity documented. Template `>= 1` guard simplified to `> 0`. Docstring summary one-lined.

**Release prep** — `__version__` → 0.8.4.3, README Status, CHANGELOG.

### Verification
- Full offline suite: **1524 passed, 15 skipped** (total, all Python 3.13).
- `ruff check src/ tests/`: clean.
- `check_release_readiness.py`: 3/3 PASS.
- PRs #96 and #97 CI green on Python 3.11 + 3.12.