### PR TITLE
fix(replay): create recorder session dir with mode 0o700

### DIFF
--- a/src/ccs/replay/recorder.py
+++ b/src/ccs/replay/recorder.py
@@ -291,7 +291,15 @@ class RecordingSession:
     _writers: dict[str, _StreamWriter] = field(default_factory=dict, init=False)
 
     def __enter__(self) -> "RecordingSession":
-        self.session_dir.mkdir(parents=True, exist_ok=True)
+        # Owner-only (0o700) to match the 0o600 stream-file mode in
+        # _open_stream: traces carry artifact UUIDs + content hashes, so the
+        # directory is default-deny too — without it, group/other could
+        # enumerate stream filenames and sizes even though the files
+        # themselves stay unreadable. umask only narrows this mode (0o700
+        # has no group/other bits to clear); a pre-existing dir keeps its
+        # mode (exist_ok does not re-chmod), matching the diagnose/* and
+        # adapters/* mkdir convention.
+        self.session_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         # Refuse-if-exists (Gated #2): a prior capture's manifest at this
         # path means a second record_to would silently interleave JSONL
         # entries from two coordinator instances; replay would later

--- a/tests/test_replay_recorder.py
+++ b/tests/test_replay_recorder.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -604,3 +605,43 @@ class TestCCSStoreRecordTo:
         assert on_disk, "file writer did not produce on-disk entries"
         # Both saw the same entries (composition, not override).
         assert len(captured) == len(on_disk)
+
+
+# ---------------------------------------------------------------------------
+# Session-directory permissions
+# ---------------------------------------------------------------------------
+
+
+class TestSessionDirPermissions:
+    """The session directory is created owner-only (0o700) to match the
+    0o600 stream-file mode in _open_stream. A world-traversable trace
+    directory would let other local users enumerate stream filenames and
+    sizes even though the JSONL contents stay unreadable."""
+
+    def test_session_dir_created_owner_only(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "session"
+        assert not session_dir.exists()
+        with record_callbacks(session_dir, accept_unverified=True):
+            pass
+        dir_mode = stat.S_IMODE(session_dir.stat().st_mode)
+        # 0o700 is requested at creation; umask can only narrow it (0o700
+        # has no group/other bits to clear), so assert no group/other
+        # access rather than an exact mode that could vary by platform.
+        assert dir_mode & 0o077 == 0, f"session dir too permissive: {oct(dir_mode)}"
+
+    def test_session_dir_and_stream_file_both_default_deny(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression guard for the dir/file mode pair: the directory
+        (0o700) and the stream JSONL it contains (0o600) are both
+        owner-only — neither leaks group/other access."""
+        session_dir = tmp_path / "session"
+        with record_callbacks(
+            session_dir, accept_unverified=True
+        ) as (state_cb, _audit_cb):
+            state_cb(_state_log_entry())
+
+        dir_mode = stat.S_IMODE(session_dir.stat().st_mode)
+        file_mode = stat.S_IMODE((session_dir / "state_log.jsonl").stat().st_mode)
+        assert dir_mode & 0o077 == 0, f"session dir too permissive: {oct(dir_mode)}"
+        assert file_mode & 0o077 == 0, f"stream file too permissive: {oct(file_mode)}"


### PR DESCRIPTION
## Summary
- `RecordingSession.__enter__` created the trace/session directory with `mkdir(parents=True, exist_ok=True)` and no `mode`, so it inherited default umask permissions (typically world-traversable `0o755`).
- The stream files inside are already `0o600` (`_open_stream`) — traces carry artifact UUIDs and content hashes — but a world-readable directory still lets other local users enumerate stream filenames and sizes, weakening the default-deny intent.
- Add `mode=0o700` to match the file mode and the existing `diagnose/*` / `adapters/*` mkdir convention. `umask` only narrows `0o700` (no group/other bits to clear); a pre-existing directory keeps its mode (`exist_ok` does not re-chmod).

## Test Plan
- [x] Added `TestSessionDirPermissions` asserting the session dir and its stream JSONL are both owner-only (`mode & 0o077 == 0`)
- [x] `pytest tests/test_replay_recorder.py` — 27 passed (25 + 2 new)
- [x] Adjacent suites green: loader + replay CLI + e2e (53 passed)
- [x] `ruff check` clean