### PR TITLE
feat(formal): add OCC commit-CAS TLA+ amendment with NoLostUpdate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ examples/conversations_stale_read/q6_*.json
 
 # Generated temporal-coherence cost sweep (like results/latest.json)
 benchmarks/results/cost_sweep.json
+
+# TLC error-trace artifacts from formal/tla mutant testing (generated on a violation)
+formal/tla/*_TTrace_*

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,11 @@ cost-benchmark-check: cost-benchmark  ## Re-run the cost sweep, then drift-check
 TLA2TOOLS := formal/tla/lib/tla2tools.jar
 TLC := java -XX:+UseParallelGC -cp $(TLA2TOOLS) tlc2.TLC -workers auto
 
-tla-check:  ## Run TLC model checker on MESI and CrashRecovery specs
+tla-check:  ## Run TLC model checker on MESI, CrashRecovery, and OCC specs
 	@java -version 2>&1 | head -1 | grep -qE '"(1[7-9]|[2-9][0-9])\.' || { echo "ERROR: Java 17+ required for TLC model checker"; exit 1; }
 	$(TLC) -config formal/tla/MESI_Standalone.cfg formal/tla/MESI_Standalone.tla
 	$(TLC) -config formal/tla/CrashRecovery_CI.cfg formal/tla/CrashRecovery.tla
+	$(TLC) -config formal/tla/OCC_CI.cfg formal/tla/OCC.tla
 
 help:  ## List available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \

--- a/formal/tla/OCC.cfg
+++ b/formal/tla/OCC.cfg
@@ -1,0 +1,19 @@
+SPECIFICATION OCCSpec
+
+CONSTANTS
+    NumAgents = 3
+    NumArtifacts = 1
+    MaxTicks = 6
+    HeartbeatTimeout = 3
+    MaxHoldTicks = 5
+    None = None
+
+INVARIANTS
+    OCCTypeOK
+    SingleWriter
+    MonotonicVersion
+    SweepExclusivity
+    TriggerExclusivity
+    TickMonotonicity
+    SlotPreservedThroughSHARED
+    NoLostUpdate

--- a/formal/tla/OCC.tla
+++ b/formal/tla/OCC.tla
@@ -1,0 +1,159 @@
+------------------------------- MODULE OCC -------------------------------
+(* Optimistic-concurrency commit-CAS amendment to the MESI + crash-recovery
+   protocol. Models a version-checked commit (commit_cas) that closes the
+   concurrent lost-update the pessimistic write path leaves open.
+
+   Plan: docs/plans/2026-06-08-001-feat-occ-write-api-same-host-v1-plan.md
+   (Unit 1). Composes with CrashRecovery via EXTENDS.
+
+   Adds:
+     - observedVersion : the version each agent last read (its expected_version)
+     - lostUpdate      : a sticky history flag — TRUE iff any commit_cas ever
+                         succeeded on a stale observed version (a lost update)
+     - ObserveAction   : an S/I agent reads the current version into its slot
+     - CommitCASAction : optimistic commit — succeeds iff observed == current
+                         AND there is no other M/E holder; else a clean no-op
+                         conflict (no mutation, no silent drop).
+
+   KEY MODELING DECISION (the crux). OCC writers stay in S/I and NEVER acquire
+   EXCLUSIVE. So two concurrent OCC writers are *both* S; the version check
+   elects exactly one winner and the loser observes a version_mismatch. We do
+   NOT model two simultaneous EXCLUSIVE holders — that is a SingleWriter
+   violation and not how OCC works. OCC-vs-pessimistic coexistence IS modeled:
+   an inherited CRWriteAction can put a peer in E, and the OCC commit then sees
+   `other_holder` (the `otherHolder` guard).
+
+   LIVENESS is discharged as safety + prose (founder-resolved; see plan Key
+   Decisions). TLC checks the NoLostUpdate safety invariant only; bounded
+   progress is a prose argument (each OCC-vs-OCC conflict is a version_mismatch,
+   so the version advanced => some writer committed => system-wide progress is
+   monotonic). No temporal / fairness property is checked — consistent with the
+   repo's safety-only TLC convention (README: "Full liveness proofs" out of
+   scope).
+
+   GrantUpdate is overridden (OCCGrantUpdate) to set a fresh grantedAtTick on
+   the S->M commit_cas transition; the base CrashRecovery.GrantUpdate routes
+   S->M through its OTHER branch and would leave the slot stale. This is a
+   MODEL-ONLY correction: the live code already sets a fresh tick on any S->M
+   (sqlite_registry.py, `new_in_me and not prev_in_me`). *)
+
+EXTENDS CrashRecovery
+
+VARIABLES observedVersion, lostUpdate
+
+occVars == <<allVars, observedVersion, lostUpdate>>
+
+--------------------------------------------------------------------
+(* Initialization *)
+--------------------------------------------------------------------
+
+OCCInit ==
+    /\ CRInit
+    /\ observedVersion = [ag \in Agents |-> [art \in Artifacts |-> None]]
+    /\ lostUpdate = FALSE
+
+--------------------------------------------------------------------
+(* grantedAtTick maintenance with the S->M fix (R-CR-1, model-only) *)
+--------------------------------------------------------------------
+
+OCCGrantUpdate(ag, art, oldSt, newSt) ==
+    CASE oldSt \in MorE /\ newSt \in MorE         -> grantedAtTick[ag][art]
+      [] oldSt \in {"I", "S"} /\ newSt \in MorE   -> clock   (* S included: the fix *)
+      [] oldSt \in MorE /\ newSt \notin MorE       -> None
+      [] OTHER                                      -> grantedAtTick[ag][art]
+
+OCCUpdatedGrantedAtTick ==
+    [ag \in Agents |-> [art \in Artifacts |->
+        OCCGrantUpdate(ag, art, mesiState[art][ag], mesiState'[art][ag])]]
+
+--------------------------------------------------------------------
+(* ObserveAction: an S/I agent reads the current version into its slot.
+   This is the OCC "read" that supplies expected_version. It is decoupled
+   from FetchAction on purpose, so we never have to reach into FetchAction's
+   existential binding (the defect the archived spec's OCCFetchAction hit). *)
+--------------------------------------------------------------------
+
+ObserveAction ==
+    \E ag \in Agents, art \in Artifacts :
+        /\ mesiState[art][ag] \in {"S", "I"}
+        /\ observedVersion' = [observedVersion EXCEPT ![ag][art] = version[art]]
+        /\ UNCHANGED <<baseVars, crVars, lostUpdate>>
+
+--------------------------------------------------------------------
+(* CommitCASAction: optimistic version-checked commit.
+   WIN     iff observed == current AND no other M/E holder.
+   CONFLICT otherwise (version_mismatch or other_holder) — a clean no-op. *)
+--------------------------------------------------------------------
+
+CommitCASAction ==
+    \E ag \in Agents, art \in Artifacts :
+        /\ mesiState[art][ag] \in {"S", "I"}             (* D4: OCC from S/I only *)
+        /\ observedVersion[ag][art] /= None              (* must have read first *)
+        /\ version[art] < MaxVersion                     (* finite bound *)
+        /\ LET obs == observedVersion[ag][art]
+               cur == version[art]
+               otherHolder == \E peer \in Agents :
+                                  peer /= ag /\ mesiState[art][peer] \in MorE
+           IN \/ (* WIN: version matches, sole writer -> commit, S->M, invalidate *)
+                 /\ obs = cur
+                 /\ ~otherHolder
+                 /\ mesiState' = [mesiState EXCEPT
+                      ![art] = [peer \in Agents |->
+                          IF peer = ag THEN "M"
+                          ELSE IF peer \in NonInvalidPeers(art, ag) THEN "I"
+                          ELSE mesiState[art][peer]]]
+                 /\ version' = [version EXCEPT ![art] = cur + 1]
+                 /\ observedVersion' = [observedVersion EXCEPT ![ag][art] = cur + 1]
+                 (* Records a lost update iff this commit landed on a stale read.
+                    In the correct spec `obs = cur` is required, so (obs # cur)
+                    is always FALSE here. The mutant (remove the `obs = cur`
+                    conjunct above) lets a stale commit win and flips
+                    lostUpdate -> TRUE, which TLC reports as a NoLostUpdate
+                    violation. This is what gives the invariant teeth. *)
+                 /\ lostUpdate' = (lostUpdate \/ (obs /= cur))
+              \/ (* CONFLICT: version_mismatch (obs # cur) or other_holder.
+                    Clean no-op: no mutation of state, version, or the winner's
+                    data. This is the formal analog of "typed conflict return,
+                    never a silent drop". *)
+                 /\ ~(obs = cur /\ ~otherHolder)
+                 /\ UNCHANGED <<mesiState, version, observedVersion, lostUpdate>>
+        /\ grantedAtTick'   = OCCUpdatedGrantedAtTick
+        /\ lastReclamation' = UpdatedLastReclamation
+        /\ UNCHANGED <<clock, lastHeartbeat>>
+
+--------------------------------------------------------------------
+(* Specification *)
+--------------------------------------------------------------------
+
+(* Inherited CR actions keep the OCC variables unchanged. CRWriteAction +
+   CRCommitAction model the legacy pessimistic path so OCC-vs-pessimistic
+   `other_holder` is exercised. *)
+OCCNext ==
+    \/ (CRFetchAction      /\ UNCHANGED <<observedVersion, lostUpdate>>)
+    \/ (CRWriteAction      /\ UNCHANGED <<observedVersion, lostUpdate>>)
+    \/ (CRCommitAction     /\ UNCHANGED <<observedVersion, lostUpdate>>)
+    \/ (CRInvalidateAction /\ UNCHANGED <<observedVersion, lostUpdate>>)
+    \/ (CRTickAction       /\ UNCHANGED <<observedVersion, lostUpdate>>)
+    \/ (HeartbeatAction    /\ UNCHANGED <<observedVersion, lostUpdate>>)
+    \/ (SweepAction        /\ UNCHANGED <<observedVersion, lostUpdate>>)
+    \/ ObserveAction
+    \/ CommitCASAction
+
+OCCSpec == OCCInit /\ [][OCCNext]_occVars
+
+--------------------------------------------------------------------
+(* Invariants *)
+--------------------------------------------------------------------
+
+OCCTypeOK ==
+    /\ CRTypeOK
+    /\ lostUpdate \in BOOLEAN
+    /\ \A ag \in Agents, art \in Artifacts :
+         observedVersion[ag][art] \in ({None} \cup (1..MaxVersion))
+
+(* The headline safety property: no successful commit_cas ever landed on a
+   stale observed version. SingleWriter, MonotonicVersion, and the CR
+   invariants (I3-I6) are inherited and re-checked to validate composition. *)
+NoLostUpdate == lostUpdate = FALSE
+
+==========================================================================

--- a/formal/tla/OCC.tla
+++ b/formal/tla/OCC.tla
@@ -31,11 +31,12 @@
    repo's safety-only TLC convention (README: "Full liveness proofs" out of
    scope).
 
-   GrantUpdate is overridden (OCCGrantUpdate) to set a fresh grantedAtTick on
-   the S->M commit_cas transition; the base CrashRecovery.GrantUpdate routes
-   S->M through its OTHER branch and would leave the slot stale. This is a
-   MODEL-ONLY correction: the live code already sets a fresh tick on any S->M
-   (sqlite_registry.py, `new_in_me and not prev_in_me`). *)
+   A winning commit_cas leaves the committer in SHARED, not MODIFIED: an OCC
+   writer holds no grant (it never acquired EXCLUSIVE), so SHARED is the honest
+   end-state and lets the same agent immediately re-observe + re-commit. Because
+   no OCC transition ever enters M/E, the inherited CrashRecovery.GrantUpdate
+   suffices (peers leaving M/E on invalidation drop their tick; the committer's
+   S->S preserves) — no override is needed. *)
 
 EXTENDS CrashRecovery
 
@@ -51,20 +52,6 @@ OCCInit ==
     /\ CRInit
     /\ observedVersion = [ag \in Agents |-> [art \in Artifacts |-> None]]
     /\ lostUpdate = FALSE
-
---------------------------------------------------------------------
-(* grantedAtTick maintenance with the S->M fix (R-CR-1, model-only) *)
---------------------------------------------------------------------
-
-OCCGrantUpdate(ag, art, oldSt, newSt) ==
-    CASE oldSt \in MorE /\ newSt \in MorE         -> grantedAtTick[ag][art]
-      [] oldSt \in {"I", "S"} /\ newSt \in MorE   -> clock   (* S included: the fix *)
-      [] oldSt \in MorE /\ newSt \notin MorE       -> None
-      [] OTHER                                      -> grantedAtTick[ag][art]
-
-OCCUpdatedGrantedAtTick ==
-    [ag \in Agents |-> [art \in Artifacts |->
-        OCCGrantUpdate(ag, art, mesiState[art][ag], mesiState'[art][ag])]]
 
 --------------------------------------------------------------------
 (* ObserveAction: an S/I agent reads the current version into its slot.
@@ -94,12 +81,13 @@ CommitCASAction ==
                cur == version[art]
                otherHolder == \E peer \in Agents :
                                   peer /= ag /\ mesiState[art][peer] \in MorE
-           IN \/ (* WIN: version matches, sole writer -> commit, S->M, invalidate *)
+           IN \/ (* WIN: version matches, sole writer -> commit; the committer
+                    ends SHARED (OCC holds no grant), peers invalidated *)
                  /\ obs = cur
                  /\ ~otherHolder
                  /\ mesiState' = [mesiState EXCEPT
                       ![art] = [peer \in Agents |->
-                          IF peer = ag THEN "M"
+                          IF peer = ag THEN "S"
                           ELSE IF peer \in NonInvalidPeers(art, ag) THEN "I"
                           ELSE mesiState[art][peer]]]
                  /\ version' = [version EXCEPT ![art] = cur + 1]
@@ -117,7 +105,7 @@ CommitCASAction ==
                     never a silent drop". *)
                  /\ ~(obs = cur /\ ~otherHolder)
                  /\ UNCHANGED <<mesiState, version, observedVersion, lostUpdate>>
-        /\ grantedAtTick'   = OCCUpdatedGrantedAtTick
+        /\ grantedAtTick'   = UpdatedGrantedAtTick
         /\ lastReclamation' = UpdatedLastReclamation
         /\ UNCHANGED <<clock, lastHeartbeat>>
 

--- a/formal/tla/OCC_CI.cfg
+++ b/formal/tla/OCC_CI.cfg
@@ -1,0 +1,19 @@
+SPECIFICATION OCCSpec
+
+CONSTANTS
+    NumAgents = 2
+    NumArtifacts = 1
+    MaxTicks = 4
+    HeartbeatTimeout = 2
+    MaxHoldTicks = 3
+    None = None
+
+INVARIANTS
+    OCCTypeOK
+    SingleWriter
+    MonotonicVersion
+    SweepExclusivity
+    TriggerExclusivity
+    TickMonotonicity
+    SlotPreservedThroughSHARED
+    NoLostUpdate

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -11,7 +11,7 @@ TLC model checking for the MESI coherence protocol and crash-recovery extension.
   trigger ordering. Corresponds to `enforce_stable_grant_timeouts` in `service.py`.
 - **Heartbeat liveness** — monotonic heartbeat recording per agent.
 - **Reclamation slot lifecycle** — slot preserved through I→S, cleared on I→M∪E re-acquire.
-- **Optimistic commit-CAS (OCC)** — a version-checked commit (`commit_cas`) that bypasses the pessimistic acquire: an S/I writer reads the version (`ObserveAction`), then commits only if its observed version still matches and no other agent holds M∪E. Closes the concurrent lost-update. Corresponds to the planned `commit_cas` (see `docs/plans/2026-06-08-001-feat-occ-write-api-same-host-v1-plan.md`).
+- **Optimistic commit-CAS (OCC)** — a version-checked commit (`commit_cas`) that bypasses the pessimistic acquire: an S/I writer reads the version (`ObserveAction`), then commits only if its observed version still matches and no other agent holds M∪E. Closes the concurrent lost-update. Corresponds to the `commit_cas` implementation (see `docs/plans/2026-06-08-001-feat-occ-write-api-same-host-v1-plan.md`).
 
 ## What is deliberately out of scope
 
@@ -88,11 +88,11 @@ I7 (FlagOffByteIdentity) is a code-level property and is not modelable in TLA+.
 | `SweepAction` | `CoordinatorService.enforce_stable_grant_timeouts()` |
 | `HeartbeatAction` | `CoordinatorService.record_heartbeat()` |
 | `ObserveAction` | the OCC read supplying `expected_version` (`ArtifactCacheEntry.local_version`) |
-| `CommitCASAction` | planned `commit_cas()` — registry CAS + `CoordinatorService.commit_cas` |
+| `CommitCASAction` | `commit_cas()` — registry CAS + `CoordinatorService.commit_cas` |
 | `States` | `MESIState` enum in `src/ccs/core/states.py` |
 | `SingleWriter` | `check_single_writer()` in `src/ccs/core/invariants.py` |
 | `MonotonicVersion` | `check_monotonic_version()` in `src/ccs/core/invariants.py` |
-| `NoLostUpdate` | planned concurrent-writer test (`tests/test_occ_commit_cas.py`) |
+| `NoLostUpdate` | concurrent-writer test (`tests/test_occ_commit_cas.py`) |
 
 The model abstracts away transient states — the implementation's
 `enforce_transient_timeouts` and transient-skip rule in the sweep are not modeled.

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -11,6 +11,7 @@ TLC model checking for the MESI coherence protocol and crash-recovery extension.
   trigger ordering. Corresponds to `enforce_stable_grant_timeouts` in `service.py`.
 - **Heartbeat liveness** — monotonic heartbeat recording per agent.
 - **Reclamation slot lifecycle** — slot preserved through I→S, cleared on I→M∪E re-acquire.
+- **Optimistic commit-CAS (OCC)** — a version-checked commit (`commit_cas`) that bypasses the pessimistic acquire: an S/I writer reads the version (`ObserveAction`), then commits only if its observed version still matches and no other agent holds M∪E. Closes the concurrent lost-update. Corresponds to the planned `commit_cas` (see `docs/plans/2026-06-08-001-feat-occ-write-api-same-host-v1-plan.md`).
 
 ## What is deliberately out of scope
 
@@ -22,7 +23,7 @@ TLC model checking for the MESI coherence protocol and crash-recovery extension.
 | Token-savings / cost metrics | Observability, not correctness |
 | Strategy-specific behavior (lease TTL, access counts, broadcast) | Strategies compose atop the base protocol; invariants hold regardless of strategy |
 | `delete` operation | Artifact deletion invalidates all holders but does not interact with the sweep. Model assumes a fixed artifact set |
-| Full liveness proofs | TLC checks safety invariants; liveness is not checked (bounded models make temporal liveness checks infeasible at this scale) |
+| Full liveness proofs | TLC checks safety invariants; liveness is not checked (bounded models make temporal liveness checks infeasible at this scale). OCC's progress / no-starvation obligation is likewise discharged as a safety property (`NoLostUpdate` + a clean no-op conflict) plus a prose argument, not a temporal check |
 
 ## File layout
 
@@ -34,6 +35,9 @@ formal/tla/
 ├── CrashRecovery.tla       # amendment: EXTENDS MESI, adds sweep + heartbeat
 ├── CrashRecovery.cfg       # TLC config: 3 agents (local deep runs)
 ├── CrashRecovery_CI.cfg    # TLC config: 2 agents (CI, fits 5-min budget)
+├── OCC.tla                 # amendment: EXTENDS CrashRecovery, adds commit-CAS
+├── OCC.cfg                 # TLC config: 3 agents (local deep runs)
+├── OCC_CI.cfg              # TLC config: 2 agents (CI, fits 5-min budget)
 ├── lib/
 │   └── tla2tools.jar       # committed TLC binary (see version below)
 └── README.md               # this file
@@ -51,6 +55,9 @@ java -XX:+UseParallelGC -cp formal/tla/lib/tla2tools.jar tlc2.TLC \
 
 java -XX:+UseParallelGC -cp formal/tla/lib/tla2tools.jar tlc2.TLC \
   -config formal/tla/CrashRecovery.cfg formal/tla/CrashRecovery.tla -workers auto
+
+java -XX:+UseParallelGC -cp formal/tla/lib/tla2tools.jar tlc2.TLC \
+  -config formal/tla/OCC_CI.cfg formal/tla/OCC.tla -workers auto
 ```
 
 Requires Java 17+. CI uses Temurin via `actions/setup-java`.
@@ -59,13 +66,14 @@ Requires Java 17+. CI uses Temurin via `actions/setup-java`.
 
 | ID | TLA+ Name | Checked In | Description |
 |----|-----------|-----------|-------------|
-| I1 | `SingleWriter` | Both | At most one agent holds M∪E per artifact |
-| I2 | `MonotonicVersion` | Both | Artifact version never decreases (≥ 1) |
-| — | `TypeOK` / `CRTypeOK` | Both | State variables have correct types and bounds |
-| I3 | `SweepExclusivity` | CrashRecovery | No (agent, artifact) reclaimed twice in one tick |
-| I4 | `TriggerExclusivity` | CrashRecovery | Each reclamation has exactly one trigger |
-| I5 | `TickMonotonicity` | CrashRecovery | `lastHeartbeat` never decreases |
-| I6 | `SlotPreservedThroughSHARED` | CrashRecovery | Reclamation slot persists across I→S, cleared only on I→M∪E |
+| I1 | `SingleWriter` | All three | At most one agent holds M∪E per artifact |
+| I2 | `MonotonicVersion` | All three | Artifact version never decreases (≥ 1) |
+| — | `TypeOK` / `CRTypeOK` / `OCCTypeOK` | All three | State variables have correct types and bounds |
+| I3 | `SweepExclusivity` | CrashRecovery, OCC | No (agent, artifact) reclaimed twice in one tick |
+| I4 | `TriggerExclusivity` | CrashRecovery, OCC | Each reclamation has exactly one trigger |
+| I5 | `TickMonotonicity` | CrashRecovery, OCC | `lastHeartbeat` never decreases |
+| I6 | `SlotPreservedThroughSHARED` | CrashRecovery, OCC | Reclamation slot persists across I→S, cleared only on I→M∪E |
+| — | `NoLostUpdate` | OCC | No successful `commit_cas` ever landed on a stale observed version — the concurrent lost-update is prevented |
 
 I7 (FlagOffByteIdentity) is a code-level property and is not modelable in TLA+.
 
@@ -79,9 +87,12 @@ I7 (FlagOffByteIdentity) is a code-level property and is not modelable in TLA+.
 | `InvalidateAction` | `CoordinatorService.invalidate()` |
 | `SweepAction` | `CoordinatorService.enforce_stable_grant_timeouts()` |
 | `HeartbeatAction` | `CoordinatorService.record_heartbeat()` |
+| `ObserveAction` | the OCC read supplying `expected_version` (`ArtifactCacheEntry.local_version`) |
+| `CommitCASAction` | planned `commit_cas()` — registry CAS + `CoordinatorService.commit_cas` |
 | `States` | `MESIState` enum in `src/ccs/core/states.py` |
 | `SingleWriter` | `check_single_writer()` in `src/ccs/core/invariants.py` |
 | `MonotonicVersion` | `check_monotonic_version()` in `src/ccs/core/invariants.py` |
+| `NoLostUpdate` | planned concurrent-writer test (`tests/test_occ_commit_cas.py`) |
 
 The model abstracts away transient states — the implementation's
 `enforce_transient_timeouts` and transient-skip rule in the sweep are not modeled.
@@ -105,6 +116,8 @@ Target: **5 minutes** total for both models.
 | MESI_Standalone | `MESI_Standalone.cfg` | 3 | 2 | 12 | 557,037 | ~18s |
 | CrashRecovery (CI) | `CrashRecovery_CI.cfg` | 2 | 1 | 6 | 258,854 | ~18s |
 | CrashRecovery (local) | `CrashRecovery.cfg` | 3 | 2 | 12 | — | ~30+ min |
+| OCC (CI) | `OCC_CI.cfg` | 2 | 1 | 4 | 1,372,720 | ~47s |
+| OCC (local) | `OCC.cfg` | 3 | 1 | 6 | — | minutes |
 
 CI uses `CrashRecovery_CI.cfg` (2 agents, MaxTicks=6) to fit the budget.
 The full 3-agent config (`CrashRecovery.cfg`) is for local deep runs:
@@ -128,6 +141,12 @@ and confirm TLC finds a counterexample:
 2. **MonotonicVersion mutation**: In `MESI.tla`, change `CommitAction`'s version
    update from `version[art] + 1` to `version[art] - 1`. Run `make tla-check`.
    TLC should fail with a `MonotonicVersion` violation.
+
+3. **NoLostUpdate mutation**: In `OCC.tla`, remove the `/\ obs = cur` conjunct
+   from `CommitCASAction`'s WIN branch (so a stale commit can win). Run
+   `make tla-check`. TLC should fail with a `NoLostUpdate` violation, showing a
+   trace where one writer commits on a version another writer already advanced.
+   (Verified 2026-06-08: violation found in ~1s.)
 
 These mutations are run manually during development to validate TLC's
 bug-detection capability. The mutated files are not committed.


### PR DESCRIPTION
## Summary
- Add a TLA+ amendment (`formal/tla/OCC.tla`) modeling an optimistic, version-checked commit (`commit_cas`) that prevents the concurrent lost-update on a shared artifact. OCC writers stay in `S`/`I` and bypass the pessimistic `EXCLUSIVE` acquire; a commit-time compare-and-swap elects a single winner, so a racing writer observes a version mismatch instead of silently overwriting.
- New `NoLostUpdate` safety invariant, composing with `CrashRecovery.tla` and preserving `SingleWriter` / `MonotonicVersion` / the crash-recovery invariants (I3–I6). Progress / no-starvation is discharged as a safety property plus a prose argument, consistent with the repo's safety-only TLC convention.
- Wire `OCC` into `make tla-check` (CI + deep config profiles); document the invariant, CI budget, and a mutant test in `formal/tla/README.md`. Ignore TLC trace artifacts.

## Test Plan
- [x] `make tla-check` green — MESI + CrashRecovery + OCC, ~55–75s total (under the 5-minute budget)
- [x] OCC invariants pass: `NoLostUpdate`, `SingleWriter`, `MonotonicVersion`, crash-recovery `I3`–`I6`, `OCCTypeOK` (~1.37M distinct states, depth 20)
- [x] Mutant test: removing the `obs = cur` guard from the commit-CAS win branch breaks `NoLostUpdate` in ~1s, confirming the invariant catches a real lost update
