### PR TITLE
feat(occ): commit-CAS write API — concurrent lost-update prevention

### DIFF
--- a/src/ccs/adapters/base.py
+++ b/src/ccs/adapters/base.py
@@ -309,6 +309,55 @@ class CoherenceAdapterCore:
 
         return updated
 
+    def write_cas(
+        self,
+        *,
+        agent_name: str,
+        artifact_id: UUID,
+        make_content: Callable[[Any], "tuple[str, str | None]"],
+        now_tick: int,
+    ) -> Artifact:
+        """Optimistic-concurrency write through one runtime (plan Unit 5).
+
+        The OCC sibling of :meth:`write`: same adapter envelope (heartbeat
+        piggyback gated on ``crash_recovery.enabled`` at THIS layer per R9,
+        ``_maybe_sweep``, peer event-bus publish on success), but it drives
+        ``runtime.write_cas`` — which bypasses the pessimistic acquire and runs
+        the strategy-bounded retry loop. On retry exhaustion the runtime raises
+        ``CasRetriesExhausted`` (a ``CoherenceError`` subclass), propagated here
+        unchanged — never a silent dropped write.
+
+        ``make_content`` re-applies the caller's intent against the freshly-read
+        cache entry on each attempt (see ``AgentRuntime.write_cas``).
+        """
+        writer = self._binding(agent_name)
+        if self._crash_recovery.enabled:
+            self.coordinator.record_heartbeat(agent_id=writer.agent_id, now_tick=now_tick)
+        self._maybe_sweep(now_tick)
+        updated, invalidation_signals = writer.runtime.write_cas(
+            artifact_id=artifact_id,
+            make_content=make_content,
+            now_tick=now_tick,
+        )
+        peers = [binding.agent_id for binding in self._agents_by_name.values() if binding.agent_id != writer.agent_id]
+
+        for signal in invalidation_signals:
+            self.event_bus.publish_invalidation(signal, recipients=peers)
+
+        if self.strategy.broadcasts_content_on_commit():
+            self.event_bus.publish_update(
+                ArtifactUpdateEvent(
+                    artifact_id=artifact_id,
+                    version=updated.version,
+                    content=self.content(agent_name=agent_name, artifact_id=artifact_id) or "",
+                    issued_at_tick=now_tick,
+                    issuer_agent_id=writer.agent_id,
+                ),
+                recipients=peers,
+            )
+
+        return updated
+
     def content(self, *, agent_name: str, artifact_id: UUID) -> str | None:
         """Return local content cached by one agent runtime."""
         return self._binding(agent_name).runtime.content(artifact_id)

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1800,10 +1800,11 @@ def _handle_post_edit_cas(req: _RequestProtocol, coordinator: CoordinatorHTTPSer
             }
 
         updated, _signals = result
-        # WIN: commit_cas already did the peer-invalidation + S/I→MODIFIED
+        # WIN: commit_cas already did the peer-invalidation + S/I→SHARED
         # transition atomically. A successful OCC commit acquired no separate
-        # EXCLUSIVE grant, but it IS a write that bumped the version, so it
-        # exercises fine-grained write protection — mirror post-edit's signal.
+        # EXCLUSIVE grant (it ends SHARED, not MODIFIED), but it IS a write that
+        # bumped the version, so it exercises fine-grained write protection —
+        # mirror post-edit's signal.
         coordinator.increment_intra_task_acquire_release()
         return {"ok": True, "version": updated.version}
 

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -10,6 +10,8 @@ shared-secret Bearer auth + Host-header check (KTD-12):
 - ``POST /hooks/pre-read``      — stale-read check; KTD-9 first-observation
 - ``POST /hooks/pre-edit``      — acquire EXCLUSIVE; KTD-1 single-writer
 - ``POST /hooks/post-edit``     — commit on success, release on failure
+- ``POST /hooks/post-edit-cas`` — OCC commit (Unit 6); version-checked CAS,
+  NO pre-edit acquire (the OCC writer stays S/I); fail-closed degrade
 - ``POST /hooks/session-stop``  — KTD-11 release on end-of-turn
 - ``POST /policy/track``        — Unit 6 CLI hot-add to tracked.yaml
 - ``POST /policy/untrack``      — Unit 6 CLI hot-add to ignored.yaml
@@ -60,6 +62,7 @@ from ccs.coordinator.service import CoordinatorService
 from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
 from ccs.core.exceptions import CoherenceError
 from ccs.core.states import MESIState
+from ccs.core.types import ConflictDetail
 
 logger = logging.getLogger(__name__)
 
@@ -396,6 +399,7 @@ class CoordinatorHTTPServer:
             "pre_read_total": 0,
             "pre_edit_total": 0,
             "post_edit_total": 0,
+            "post_edit_cas_total": 0,
             "session_stop_total": 0,
             "pre_bash_total": 0,
             "pre_grep_total": 0,
@@ -1252,7 +1256,11 @@ def _handle_pre_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
                 artifact_id, agent_id, MESIState.SHARED,
                 trigger="first_read", tick=now, content_hash=seed_hash,
             )
-            return {"status": "fresh"}
+            # Unit 6: surface the version so an OCC writer can source
+            # ``expected_version`` for a later ``post-edit-cas`` (additive —
+            # status-based clients ignore it). First observation seeds v1.
+            seeded = coordinator.registry.get_artifact(artifact_id)
+            return {"status": "fresh", "version": seeded.version if seeded else 1}
 
         # KTD-J (Unit 8): if a prior pre-read on this exact (agent,
         # artifact) pair emitted a stale warning, count THIS call as the
@@ -1265,8 +1273,10 @@ def _handle_pre_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
         agent_state = coordinator.registry.get_agent_state(artifact_id, agent_id)
 
         if agent_state is not None and agent_state != MESIState.INVALID:
-            # Reader has a valid grant on the current version.
-            return {"status": "fresh"}
+            # Reader has a valid grant on the current version. Unit 6:
+            # include the version so an OCC writer can source
+            # ``expected_version`` (additive — status clients ignore it).
+            return {"status": "fresh", "version": artifact.version}
 
         # Stale: either first time this session sees the artifact OR they
         # were invalidated by a peer commit.
@@ -1688,6 +1698,129 @@ def _handle_post_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer)
     # AC-05: post-edit's wire contract is {ok: bool}; ok-shape degraded
     # envelope keeps clients reading result.get("ok") safe on timeout.
     _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE)
+
+
+def _handle_post_edit_cas(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
+    """POST /hooks/post-edit-cas — OCC commit (plan Unit 6, R1–R3 + fail-closed).
+
+    The optimistic-concurrency counterpart to ``/hooks/post-edit``. The hook
+    flow is ``pre-read`` (→ SHARED, returns the artifact ``version``) →
+    [agent edits] → ``post-edit-cas`` carrying that ``expected_version`` —
+    it **never takes the** ``/hooks/pre-edit`` **EXCLUSIVE acquire** (the OCC
+    writer stays S/I; the winner is elected by ``service.commit_cas``'s
+    serialized version check, not a lock on the acquire). The pessimistic
+    ``pre-edit`` → ``post-edit`` flow is untouched for strict-deny callers.
+
+    Three outcomes map to STABLE, byte-consistent bodies (plan R2):
+
+    - WIN → ``{ok: true, version: N+1}``.
+    - :class:`~ccs.core.types.ConflictDetail` → ``{ok: false,
+      reason: "version_mismatch"|"other_holder", current_version: N}`` — a
+      clean typed conflict, NOT a degrade. The client re-reads + retries.
+    - corruption / precondition failure (``CoherenceError`` from
+      ``commit_cas``: ``expected > current``, artifact missing, caller
+      mid-transient, or caller in M/E) → ``{ok: false, reason: <verbatim>}``
+      the client raises on.
+
+    Fail-closed degrade: on a watchdog timeout this endpoint returns the
+    DISTINCT :data:`_OCC_DEGRADED_RESPONSE` (``{ok: false, degraded: true,
+    reason: "commit_unconfirmed"}``), NOT the ``{ok: true, …}``
+    :data:`_OK_DEGRADED_RESPONSE` the pessimistic post-edit uses — a
+    timed-out CAS returning ``ok: true`` would let the client assume its
+    write landed (the load-bearing fix; see :data:`_OCC_DEGRADED_RESPONSE`).
+    """
+    body = req._read_json()
+    if body is None:
+        return
+    session_id = body.get("session_id")
+    path = body.get("path", "")
+    content_hash = body.get("content_hash")  # always required on the OCC commit
+    expected_version = body.get("expected_version")
+    sid_err = validate_session_id(session_id)
+    if sid_err:
+        req._json(400, {"error": sid_err[1]})
+        return
+    path_err = validate_path(path)
+    if path_err:
+        msg = "missing or empty path" if path_err in ("path is empty", "path must be a string") else path_err
+        req._json(400, {"error": msg})
+        return
+    # The OCC commit always carries the bytes it just wrote — there is no
+    # "release on failure" sub-mode here (that lives on the pessimistic
+    # post-edit), so content_hash is unconditionally required.
+    hash_err = validate_content_hash(content_hash, required=True)
+    if hash_err:
+        req._json(400, {"error": hash_err})
+        return
+    # expected_version is the OCC discriminator — a non-negative int the
+    # client read from pre-read. Reject anything else at the boundary so a
+    # malformed client cannot drive the CAS with a garbage comparand.
+    if not isinstance(expected_version, int) or isinstance(expected_version, bool) or expected_version < 0:
+        req._json(400, {"error": "expected_version must be a non-negative integer"})
+        return
+    if not coordinator.policy.is_tracked(path):
+        req._json(200, {"ok": True})
+        return
+
+    agent_id = coordinator.register_session(session_id)
+    now = monotonic_seconds()
+
+    def work() -> dict:
+        coordinator.service.record_heartbeat(agent_id=agent_id, now_tick=now)
+        artifact_id = coordinator.registry.lookup_artifact_id_by_name(path)
+        if artifact_id is None:
+            # No prior pre-read seeded the artifact; nothing to CAS against.
+            # Mirror post-edit's untracked-at-commit fast path.
+            return {"ok": True, "note": "untracked-at-commit"}
+
+        # OCC commit — version-checked CAS. Does NOT take EXCLUSIVE: the
+        # caller is S (from pre-read) or I (preempted); commit_cas rejects an
+        # M/E caller (D4) by raising CoherenceError.
+        try:
+            result = coordinator.service.commit_cas(
+                agent_id=agent_id,
+                artifact_id=artifact_id,
+                expected_version=expected_version,
+                content_hash=content_hash,
+                issued_at_tick=now,
+            )
+        except CoherenceError as exc:
+            # Corruption (expected > current) or a precondition failure
+            # (caller mid-transient / in M/E) — non-retryable; the client
+            # raises on the {ok: false, reason} body.
+            return {"ok": False, "reason": str(exc)}
+
+        if isinstance(result, ConflictDetail):
+            # Retry-eligible typed conflict: NO mutation happened. Byte-stable
+            # body the client maps to reacquire() + retry.
+            return {
+                "ok": False,
+                "reason": result.reason,
+                "current_version": result.current_version,
+            }
+
+        updated, _signals = result
+        # WIN: commit_cas already did the peer-invalidation + S/I→MODIFIED
+        # transition atomically. A successful OCC commit acquired no separate
+        # EXCLUSIVE grant, but it IS a write that bumped the version, so it
+        # exercises fine-grained write protection — mirror post-edit's signal.
+        coordinator.increment_intra_task_acquire_release()
+        return {"ok": True, "version": updated.version}
+
+    # Fail-closed: the OCC commit degrades to a body that reads as FAILURE.
+    # A timed-out commit_cas whose future the watchdog does NOT cancel may
+    # still run to completion later (a pre-existing hazard — detection-only
+    # via watchdog_late_completion_total). For OCC the residual is bounded
+    # and honest: in the contended case the late CAS sees the advanced
+    # version → version_mismatch, no mutation; in the uncontended case it
+    # lands N+1 AFTER the client gave up — a phantom/duplicate version bump
+    # from the SAME edit, NOT a lost write (NoLostUpdate still holds). Full
+    # prevention (a per-attempt fencing/idempotency token) needs surface
+    # beyond v1 (no new reservation / no migration) and is DEFERRED to the
+    # cross-host follow-on. v1's only obligation: the client must never
+    # mistake a degraded CAS for success — hence _OCC_DEGRADED_RESPONSE
+    # ({ok: false, …}), never _OK_DEGRADED_RESPONSE.
+    _run_or_degrade(req, coordinator, work, degraded_response=_OCC_DEGRADED_RESPONSE)
 
 
 def _handle_session_stop(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
@@ -2507,6 +2640,9 @@ _ROUTES: dict[tuple[str, str], Callable] = {
     ("POST", "/hooks/pre-read"): _handle_pre_read,
     ("POST", "/hooks/pre-edit"): _handle_pre_edit,
     ("POST", "/hooks/post-edit"): _handle_post_edit,
+    # Unit 6: OCC commit. Version-checked CAS that bypasses the pre-edit
+    # EXCLUSIVE acquire (the OCC writer stays S/I).
+    ("POST", "/hooks/post-edit-cas"): _handle_post_edit_cas,
     ("POST", "/hooks/session-stop"): _handle_session_stop,
     # v0.1.1 KTD-N — H4 mitigation: catch model routing-around-via-Bash/Grep
     # to bypass the Read-only stale-read warning. Per the v0.2 Phase 0
@@ -2530,6 +2666,12 @@ _ROUTES: dict[tuple[str, str], Callable] = {
 # writes, so they stay out of this set.
 _MIGRATION_REJECTED_ROUTES: set[tuple[str, str]] = {
     ("POST", "/hooks/pre-edit"),
+    # Unit 6: the OCC commit is a self-contained NEW write initiation — it
+    # has no prior pre-edit chain to complete (it bypasses the acquire), so
+    # it belongs here with pre-edit. Letting it through mid-migration would
+    # bump a version the imminent shutdown then strands; the client retries
+    # after the coordinator restarts.
+    ("POST", "/hooks/post-edit-cas"),
 }
 
 
@@ -2541,6 +2683,7 @@ _ENDPOINT_COUNTER_NAMES: dict[tuple[str, str], str] = {
     ("POST", "/hooks/pre-read"): "pre_read_total",
     ("POST", "/hooks/pre-edit"): "pre_edit_total",
     ("POST", "/hooks/post-edit"): "post_edit_total",
+    ("POST", "/hooks/post-edit-cas"): "post_edit_cas_total",
     ("POST", "/hooks/session-stop"): "session_stop_total",
     ("POST", "/hooks/pre-bash"): "pre_bash_total",
     ("POST", "/hooks/pre-grep"): "pre_grep_total",
@@ -2568,6 +2711,22 @@ whose contract is ``{ok: bool}`` (pre-edit, post-edit, session-stop) pass
 _OK_DEGRADED_RESPONSE: dict = {"ok": True, "degraded": True}
 """AC-05: degraded envelope for {ok: bool}-shape endpoints (pre-edit,
 post-edit, session-stop). Pairs with ``_DEFAULT_DEGRADED_RESPONSE``."""
+
+_OCC_DEGRADED_RESPONSE: dict = {
+    "ok": False,
+    "degraded": True,
+    "reason": "commit_unconfirmed",
+}
+"""Plan Unit 6 (the load-bearing fix): degrade envelope for the OCC commit
+endpoint (``/hooks/post-edit-cas``). Unlike the pessimistic endpoints — which
+degrade to ``_OK_DEGRADED_RESPONSE`` (``{ok: true, …}``) so a generic client
+reading ``result.get("ok")`` proceeds — a degraded/timed-out ``commit_cas``
+MUST read as **failure**: returning ``ok: true`` would let the client assume
+its write landed when the CAS never confirmed (and may still be running in the
+watchdog pool — the late-completion residual). ``ok: false`` forces the
+fail-closed client to raise. The residual is a phantom version bump, NOT a
+lost update — full fencing is deferred to the cross-host follow-on (see
+``_handle_post_edit_cas``)."""
 
 
 def _run_or_degrade(

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -60,7 +60,11 @@ from ccs.adapters.claude_code.bash_path_detector import detect_tracked_paths
 from ccs.adapters.claude_code.policy import TrackedArtifactPolicy
 from ccs.coordinator.service import CoordinatorService
 from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
-from ccs.core.exceptions import CoherenceError
+from ccs.core.exceptions import (
+    OCC_CALLER_TRANSIENT_REASON,
+    CoherenceError,
+    OccCallerTransientError,
+)
 from ccs.core.states import MESIState
 from ccs.core.types import ConflictDetail
 
@@ -1717,10 +1721,16 @@ def _handle_post_edit_cas(req: _RequestProtocol, coordinator: CoordinatorHTTPSer
     - :class:`~ccs.core.types.ConflictDetail` → ``{ok: false,
       reason: "version_mismatch"|"other_holder", current_version: N}`` — a
       clean typed conflict, NOT a degrade. The client re-reads + retries.
-    - corruption / precondition failure (``CoherenceError`` from
-      ``commit_cas``: ``expected > current``, artifact missing, caller
-      mid-transient, or caller in M/E) → ``{ok: false, reason: <verbatim>}``
-      the client raises on.
+    - retry-eligible transient precondition
+      (:class:`~ccs.core.exceptions.OccCallerTransientError`: a peer
+      invalidated the caller between its read and this CAS) → ``{ok: false,
+      reason: "caller_in_transient_state", current_version: N}`` carrying the
+      STABLE :data:`~ccs.core.exceptions.OCC_CALLER_TRANSIENT_REASON` so the
+      client (``CoherentVolume._classify_cas_response``) routes it to
+      reacquire + retry independent of the exception's human message (AC2).
+    - corruption / non-retryable precondition failure (``CoherenceError`` from
+      ``commit_cas``: ``expected > current``, artifact missing, or caller in
+      M/E) → ``{ok: false, reason: <verbatim>}`` the client raises on.
 
     Fail-closed degrade: on a watchdog timeout this endpoint returns the
     DISTINCT :data:`_OCC_DEGRADED_RESPONSE` (``{ok: false, degraded: true,
@@ -1784,10 +1794,22 @@ def _handle_post_edit_cas(req: _RequestProtocol, coordinator: CoordinatorHTTPSer
                 content_hash=content_hash,
                 issued_at_tick=now,
             )
+        except OccCallerTransientError:
+            # Retry-eligible (AC2): a peer invalidated the caller between its
+            # read and this CAS. Surface a STABLE machine reason decoupled from
+            # the exception's human message so the client's retry classifier
+            # (CoherentVolume._classify_cas_response) matches exactly. Include
+            # current_version when readily available (the caller is INVALID, so
+            # the artifact still exists) so the client can advance its comparand.
+            current_artifact = coordinator.registry.get_artifact(artifact_id)
+            body: dict = {"ok": False, "reason": OCC_CALLER_TRANSIENT_REASON}
+            if current_artifact is not None:
+                body["current_version"] = current_artifact.version
+            return body
         except CoherenceError as exc:
-            # Corruption (expected > current) or a precondition failure
-            # (caller mid-transient / in M/E) — non-retryable; the client
-            # raises on the {ok: false, reason} body.
+            # Corruption (expected > current) or a non-retryable precondition
+            # (caller in M/E) — the client raises on the {ok: false, reason}
+            # body verbatim.
             return {"ok": False, "reason": str(exc)}
 
         if isinstance(result, ConflictDetail):

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -65,11 +65,25 @@ from ccs.cli._coherence_client import (
 from ccs.cli._coherence_client import (
     post as _coordinator_post,
 )
-from ccs.core.exceptions import CoherenceDegradedWarning, CoherenceError
+from ccs.core.exceptions import (
+    CasRetriesExhausted,
+    CoherenceDegradedWarning,
+    CoherenceError,
+)
 
 logger = logging.getLogger(__name__)
 
 __all__ = ["CoherentVolume", "coherent_workspace", "install", "uninstall"]
+
+# Plan Unit 6 (R6): client-side bound on the OCC reacquire→re-commit loop in
+# :meth:`CoherentVolume.write_cas`. Mirrors ``SyncStrategy.max_cas_retries``
+# (the in-process library knob) — the HTTP path runs its own bounded loop via
+# ``reacquire()`` rather than the ``AgentRuntime``/``SyncStrategy`` loop (which
+# governs only the in-process library path). Total commit attempts is
+# ``MAX_CAS_REACQUIRES + 1`` (initial + retries); on exhaustion ``write_cas``
+# raises :class:`~ccs.core.exceptions.CasRetriesExhausted` (a typed terminal,
+# never a silent drop).
+MAX_CAS_REACQUIRES = 8
 
 
 class CoherentVolume:
@@ -457,6 +471,140 @@ class CoherentVolume:
         # MANDATORY fresh read under the new identity -> SHARED@current.
         return self.read(path)
 
+    def write_cas(
+        self,
+        path: str | os.PathLike[str],
+        make_content: Callable[[bytes], bytes | bytearray],
+    ) -> None:
+        """Optimistically commit a write that BYPASSES the EXCLUSIVE acquire.
+
+        The OCC counterpart to :meth:`write` (plan Unit 6). Unlike ``write`` —
+        which takes EXCLUSIVE via ``pre-edit`` before committing — ``write_cas``
+        **never acquires EXCLUSIVE**: it reads (→ SHARED), derives the bytes via
+        ``make_content(current_bytes)``, and commits through the coordinator's
+        ``/hooks/post-edit-cas`` version-checked CAS. The winner is elected by
+        the coordinator's serialized commit, so two concurrent OCC writers
+        cannot both land the same version — the loser is told ``version_mismatch``
+        and retries. The pessimistic ``write()`` path is untouched.
+
+        Conflict recovery follows the :meth:`reacquire` contract: on a
+        ``version_mismatch`` / ``other_holder`` conflict the loop
+        ``reacquire()``s (re-mint identity + a MANDATORY fresh read), re-derives
+        the bytes from the fresh view via ``make_content``, and retries —
+        bounded by :data:`MAX_CAS_REACQUIRES`. On exhaustion it raises
+        :class:`~ccs.core.exceptions.CasRetriesExhausted` (a typed terminal,
+        NEVER a silent drop).
+
+        ``make_content`` is invoked once per attempt with the freshly-read
+        current bytes and returns the bytes to commit — re-deriving the caller's
+        intent against the latest state is what makes the retry an *update*
+        rather than a stale overwrite. A caller that ignores its ``bytes``
+        argument and returns a buffer computed from older bytes defeats the
+        guard (the one fundamental OCC-proof boundary; same as :meth:`reacquire`).
+
+        **A deny ALWAYS raises, in both ``on_error`` modes** — including the
+        coordinator's fail-closed degrade body
+        (``{ok: false, degraded: true, reason: "commit_unconfirmed"}``): a
+        degraded CAS is unconfirmed, so it must read as failure (the client must
+        never assume the write landed). ``on_error`` governs only
+        coherence-infrastructure failures (unavailable coordinator, transport).
+        """
+        self._ensure_attached()
+        _abs_path, rel = self._to_relative(path)
+
+        if self._endpoint is None:
+            # Unattached / degraded coordinator (strict already raised at
+            # construction). Degrade mode: best-effort write, no enforcement —
+            # there is no version to CAS against, so derive from current bytes.
+            current = self._current_bytes_or_empty(_abs_path)
+            data = bytes(make_content(current))
+            self._atomic_write(_abs_path, data)
+            self._last_committed_hash[rel] = self._sha256_bytes(data)
+            return
+
+        last_current_version = -1
+        max_attempts = MAX_CAS_REACQUIRES + 1
+        for attempt in range(max_attempts):
+            # Fresh read each attempt. _read_with_version returns the bytes, the
+            # coordinator's authoritative version (the OCC comparand), and
+            # whether the read was a sticky strict-deny — i.e. this instance is
+            # INVALID and the pre-read did NOT re-grant SHARED (KTD-T). An
+            # INVALID writer cannot CAS (the coordinator's invalidation left a
+            # transient that commit_cas rejects as a precondition), so recovery
+            # is the reacquire() contract: re-mint identity (no INVALID /
+            # transient) + a MANDATORY fresh read → clean SHARED@current.
+            current_bytes, expected_version, stale_denied = self._read_with_version(rel)
+            if stale_denied:
+                # This instance is INVALID (sticky strict-deny) → it cannot CAS
+                # until it reacquires (re-mint identity clears INVALID + the
+                # invalidation transient). reacquire() returns the fresh bytes;
+                # _read_with_version then re-resolves the version under the fresh
+                # identity. A warn-mode stale read here is fine — the fresh
+                # identity has no transient, so it can CAS.
+                if attempt >= max_attempts - 1:
+                    last_current_version = max(last_current_version, expected_version)
+                    break
+                current_bytes = self.reacquire(rel)
+                _aid, expected_version, refused_again = self._read_with_version(rel)
+                if refused_again:
+                    # A fresh-minted identity is brand new (no prior INVALID), so
+                    # a strict-deny here is impossible in normal operation — it
+                    # means the coordinator is wedged. Fail closed, do not spin.
+                    raise CoherenceError(
+                        f"OCC reacquire did not clear INVALID for {rel}; "
+                        "coordinator may be wedged"
+                    )
+
+            data = bytes(make_content(current_bytes))
+            new_hash = self._sha256_bytes(data)
+
+            # CAS FIRST, write to disk only on WIN. An OCC writer is S/I — it
+            # holds no EXCLUSIVE grant, so unconfirmed bytes must NEVER touch
+            # disk (a denied/degraded CAS landing on disk would be the very
+            # lost-update this guards). Contrast the pessimistic write(), which
+            # writes between pre-edit (EXCLUSIVE held) and post-edit.
+            resp = self._post(
+                "/hooks/post-edit-cas",
+                {
+                    "session_id": self._session_id,
+                    "path": rel,
+                    "success": True,
+                    "content_hash": new_hash,
+                    "expected_version": expected_version,
+                },
+            )
+            if resp is None:
+                # Degrade mode swallowed a transport/infra failure in _post and
+                # returned None; best-effort write so the bytes are not lost.
+                self._atomic_write(_abs_path, data)
+                self._last_committed_hash[rel] = new_hash
+                return
+
+            outcome = self._classify_cas_response(resp)
+            if outcome == "win":
+                self._atomic_write(_abs_path, data)  # confirmed → persist
+                self._last_committed_hash[rel] = new_hash
+                return
+            if outcome == "conflict":
+                last_current_version = self._cas_current_version(resp, last_current_version)
+                # Recover via the reacquire() contract before the next attempt so
+                # expected_version + make_content() see the winner's state.
+                if attempt < max_attempts - 1:
+                    self.reacquire(rel)
+                continue
+            # outcome == "raise": a deny, corruption, or the fail-closed
+            # commit_unconfirmed degrade body — ALWAYS raises in both modes.
+            # Nothing was written to disk (the CAS did not win).
+            raise CoherenceError(self._deny_reason(resp))
+
+        # Every allowed attempt lost the race — typed terminal, never a silent
+        # drop. (last_current_version is the latest version the loser observed.)
+        raise CasRetriesExhausted(
+            artifact_id=rel,
+            attempts=max_attempts,
+            last_current_version=last_current_version,
+        )
+
     # --- coordinator I/O helpers --------------------------------------------
 
     def _to_relative(self, path: str | os.PathLike[str]) -> tuple[Path, str]:
@@ -532,6 +680,120 @@ class CoherentVolume:
                 f"coordinator request to {endpoint_path} failed: {exc}"
             )
             return None  # reached only in degrade mode
+
+    def _read_with_version(self, rel: str) -> tuple[bytes, int, bool]:
+        """OCC helper: register a SHARED view and return
+        ``(bytes, version, stale_denied)``.
+
+        Mirrors :meth:`read` (same pre-read call + same fail-closed degrade
+        handling) but also surfaces the coordinator's authoritative ``version``
+        — the comparand ``write_cas`` passes as ``expected_version`` — and
+        whether this instance is INVALID (a sticky strict-deny: the pre-read
+        returned a ``stale`` response and did NOT re-grant SHARED, KTD-T).
+        ``read`` itself stays ``bytes``-returning (a public contract); this is
+        the internal version-aware variant ``write_cas`` drives.
+
+        A fresh pre-read carries ``{"status": "fresh", "version": N}``; a
+        warn-mode stale read and a strict-deny both carry ``status == "stale"``
+        with the version under ``summary.current_version``. ``stale_denied`` is
+        True on the strict-deny case — an INVALID writer cannot CAS until it
+        :meth:`reacquire`s. If the version cannot be resolved (older coordinator
+        / degraded status surface) ``0`` is used — a CAS against
+        ``expected_version=0`` on a non-empty artifact loses cleanly
+        (``version_mismatch``), so the fallback never causes a silent overwrite.
+        """
+        abs_path, _rel = self._to_relative(rel)
+        if not abs_path.is_file():
+            raise FileNotFoundError(f"no such file in workspace: {_rel}")
+        data = self._read_file_bytes(abs_path)
+        version = 0
+        stale_denied = False
+        if self._endpoint is not None:
+            resp = self._post(
+                "/hooks/pre-read",
+                {
+                    "session_id": self._session_id,
+                    "path": _rel,
+                    "content_hash": self._sha256_bytes(data),
+                },
+            )
+            if isinstance(resp, dict):
+                if resp.get("degraded"):
+                    self._fail_closed_or_degrade(
+                        f"coordinator watchdog timeout during read of {_rel}"
+                    )
+                version = self._pre_read_version(resp)
+                # A strict-deny (INVALID, NOT re-granted — KTD-T) is the only
+                # pre-read outcome that leaves this instance unable to CAS: it
+                # stays INVALID AND keeps the invalidation transient the peer
+                # commit set, which commit_cas rejects as a precondition. A
+                # warn-mode stale read (permissionDecision == "allow") re-grants
+                # SHARED, so it is NOT treated as denied here. The distinguisher
+                # is permissionDecision == "deny" (set only by emit_strict_deny).
+                hook_output = resp.get("hookSpecificOutput")
+                if isinstance(hook_output, dict):
+                    stale_denied = hook_output.get("permissionDecision") == "deny"
+        return data, version, stale_denied
+
+    @staticmethod
+    def _pre_read_version(resp: dict) -> int:
+        """Extract the coordinator version from a pre-read response (fresh or
+        stale shape). Returns 0 when absent (older coordinator / degraded)."""
+        v = resp.get("version")
+        if isinstance(v, int) and not isinstance(v, bool):
+            return v
+        summary = resp.get("summary")
+        if isinstance(summary, dict):
+            cv = summary.get("current_version")
+            if isinstance(cv, int) and not isinstance(cv, bool):
+                return cv
+        return 0
+
+    def _current_bytes_or_empty(self, abs_path: Path) -> bytes:
+        """Degrade-path read of the on-disk bytes (b\"\" if the file is absent),
+        so ``make_content`` always gets a defined current view."""
+        if not abs_path.is_file():
+            return b""
+        return self._read_file_bytes(abs_path)
+
+    # Retry-eligible OCC conflict reasons (typed ConflictDetail.reason values).
+    _CAS_RETRY_REASONS: frozenset[str] = frozenset({"version_mismatch", "other_holder"})
+
+    def _classify_cas_response(self, resp: dict) -> Literal["win", "conflict", "raise"]:
+        """Map a ``/hooks/post-edit-cas`` 200 body to an OCC outcome.
+
+        - ``ok: true``  → ``"win"`` (the CAS committed; version bumped).
+        - ``ok: false`` with a retry-eligible reason → ``"conflict"`` (reacquire
+          + retry). Two cases: the typed ``ConflictDetail`` reasons
+          (``version_mismatch`` / ``other_holder``), AND
+          ``caller_in_transient_state`` — when a peer invalidates this instance
+          in the window BETWEEN its fresh read and its CAS, the coordinator
+          leaves an invalidation transient that ``commit_cas`` rejects as a
+          precondition; that is a lost race, not corruption, so reacquire +
+          retry (a fresh identity has no transient).
+        - ``ok: false`` otherwise — true corruption (``commit_cas_corruption``,
+          ``expected > current``) OR the fail-closed ``{degraded: true,
+          reason: "commit_unconfirmed"}`` body → ``"raise"``. The degrade body
+          deliberately reads as failure so the client never mistakes an
+          unconfirmed CAS for a landed write.
+        """
+        if resp.get("ok") is True:
+            return "win"
+        reason = resp.get("reason")
+        if reason in self._CAS_RETRY_REASONS:
+            return "conflict"
+        # A precondition rejection from a peer invalidating us mid-window is a
+        # lost race (retry-eligible via reacquire), NOT terminal corruption.
+        if isinstance(reason, str) and "caller_in_transient_state" in reason:
+            return "conflict"
+        return "raise"
+
+    @staticmethod
+    def _cas_current_version(resp: dict, fallback: int) -> int:
+        cv = resp.get("current_version")
+        if isinstance(cv, int) and not isinstance(cv, bool):
+            return cv
+        return fallback
 
     def _check_grant(self, resp: dict, rel: str, *, phase: str) -> None:
         """Map a coordinator pre-/post-edit response to the fail-closed contract.

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -506,8 +506,15 @@ class CoherentVolume:
         coordinator's fail-closed degrade body
         (``{ok: false, degraded: true, reason: "commit_unconfirmed"}``): a
         degraded CAS is unconfirmed, so it must read as failure (the client must
-        never assume the write landed). ``on_error`` governs only
-        coherence-infrastructure failures (unavailable coordinator, transport).
+        never assume the write landed). The SAME fail-closed rule covers a
+        mid-commit transport failure that ``degrade`` mode swallowed (``_post``
+        returned ``None`` after a version was read): an unconfirmed CAS must
+        never write its bytes to disk, so it raises in both modes rather than
+        best-effort writing (unconfirmed bytes on disk would re-open the
+        lost-update). ``on_error`` still governs whether an infra failure raises
+        vs. warns *inside* ``_post`` and the genuinely-unattached
+        (``_endpoint is None``) degrade branch above — but never lets an
+        unconfirmed OCC commit silently land.
         """
         self._ensure_attached()
         _abs_path, rel = self._to_relative(path)
@@ -574,11 +581,20 @@ class CoherentVolume:
                 },
             )
             if resp is None:
-                # Degrade mode swallowed a transport/infra failure in _post and
-                # returned None; best-effort write so the bytes are not lost.
-                self._atomic_write(_abs_path, data)
-                self._last_committed_hash[rel] = new_hash
-                return
+                # Degrade mode swallowed a mid-operation transport/infra failure
+                # in _post and returned None — the CAS was NOT confirmed. An OCC
+                # writer holds NO grant (S/I), so unconfirmed bytes must NEVER
+                # touch disk: writing them would re-open the very lost-update this
+                # guards. Fail closed in BOTH on_error modes — identical to how
+                # the {ok:false, degraded:true, commit_unconfirmed} degrade BODY
+                # is handled below ("raise"). on_error governs only whether the
+                # infra failure already warned (degrade) or raised (strict) inside
+                # _post; either way an unconfirmed CAS must read as failure.
+                raise CoherenceError(
+                    f"OCC commit of {rel} could not be confirmed (coordinator "
+                    "transport failed mid-commit); the write did not land. "
+                    "reacquire() and retry from the fresh bytes."
+                )
 
             outcome = self._classify_cas_response(resp)
             if outcome == "win":

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -66,6 +66,7 @@ from ccs.cli._coherence_client import (
     post as _coordinator_post,
 )
 from ccs.core.exceptions import (
+    OCC_CALLER_TRANSIENT_REASON,
     CasRetriesExhausted,
     CoherenceDegradedWarning,
     CoherenceError,
@@ -88,6 +89,20 @@ MAX_CAS_REACQUIRES = 8
 
 class CoherentVolume:
     """Coherent shared workspace for a single-host agent fleet (v1).
+
+    .. warning::
+
+       **An instance is NOT thread-safe — one operation at a time, one instance
+       per thread (A5).** ``read``/``write``/``write_cas`` read ``_session_id``
+       lock-free while ``reacquire``/``_after_fork`` re-mint it, so overlapping
+       calls on a SINGLE instance from different threads could split an in-flight
+       CAS across identities. This is misuse, and it is made LOUD: a public op
+       that detects another op already in flight on the same instance raises
+       :class:`~ccs.core.exceptions.CoherenceError` rather than corrupting
+       silently. Each thread (and each forked child) must own its OWN instance —
+       per-instance identity is exactly what makes distinct writers distinct. The
+       guard is re-entrant for the same thread, so the internal
+       ``write_cas`` → ``reacquire`` → ``read`` nesting is unaffected.
 
     The appliance **spawns** the coordinator for ``root`` and enables strict
     mode on the ``managed`` globs (by writing ``.coherence/tracked.yaml`` and
@@ -137,6 +152,16 @@ class CoherentVolume:
         self._bind_host = bind_host
 
         self._lock = threading.Lock()
+        # A5: single-instance concurrency guard, SEPARATE from self._lock (which
+        # protects identity mutation in reacquire/_after_fork). A non-reentrant
+        # threading.Lock here would deadlock with the reacquire-within-write_cas
+        # path; instead we track the owning thread + a re-entry depth so the SAME
+        # thread's nested internal calls (write_cas → reacquire → read) pass while
+        # an OVERLAPPING call from a DIFFERENT thread raises. _guard_meta_lock is
+        # held only for the microsecond check-then-set, never across an operation.
+        self._guard_meta_lock = threading.Lock()
+        self._guard_owner_ident: int | None = None
+        self._guard_depth = 0
         self._degradation_count = 0
         self._endpoint: CoordinatorEndpoint | None = None
         # Set by the fork child-handler so the next read/write re-attaches (the
@@ -194,6 +219,48 @@ class CoherentVolume:
     def is_attached(self) -> bool:
         """True if a coordinator endpoint was resolved (strict-mode owner)."""
         return self._endpoint is not None
+
+    # --- single-instance concurrency guard (A5) -----------------------------
+
+    @contextlib.contextmanager
+    def _single_op_guard(self) -> Iterator[None]:
+        """Reject overlapping use of ONE instance across threads (A5).
+
+        A :class:`CoherentVolume` instance is single-threaded by contract: one
+        operation at a time. Concurrent ``read``/``write``/``write_cas`` on the
+        same instance from different threads could split an in-flight CAS across
+        identities (``reacquire``/``_after_fork`` re-mint ``_session_id`` while
+        the lock-free op path reads it). This guard makes that misuse LOUD rather
+        than silently corrupting: a second thread entering while another holds the
+        guard raises ``CoherenceError``.
+
+        Re-entrant for the SAME thread so internal nesting works (``write_cas``
+        calls :meth:`reacquire`, which calls :meth:`read`): the owning thread
+        bumps a depth counter instead of self-deadlocking. A separate
+        non-reentrant ``threading.Lock`` would deadlock that path, and silently
+        serializing instead of raising would hide the misuse + risk deadlock with
+        ``self._lock`` — so we detect-and-raise, never block.
+        """
+        ident = threading.get_ident()
+        with self._guard_meta_lock:
+            if self._guard_owner_ident is not None and self._guard_owner_ident != ident:
+                raise CoherenceError(
+                    "CoherentVolume is single-threaded; concurrent use detected. "
+                    "One operation at a time per instance — use one instance per "
+                    "thread (an in-flight read/write/write_cas can re-mint identity "
+                    "via reacquire, so overlapping ops on one instance could split a "
+                    "CAS across identities)."
+                )
+            self._guard_owner_ident = ident
+            self._guard_depth += 1
+        try:
+            yield
+        finally:
+            with self._guard_meta_lock:
+                self._guard_depth -= 1
+                if self._guard_depth <= 0:
+                    self._guard_depth = 0
+                    self._guard_owner_ident = None
 
     # --- spawn-with-strict --------------------------------------------------
 
@@ -348,7 +415,15 @@ class CoherentVolume:
         failure (unavailable coordinator, watchdog timeout) raises
         ``CoherenceError`` — a read whose coherence cannot be registered fails
         closed.
+
+        **Not thread-safe (A5).** Overlapping use of this instance from another
+        thread raises ``CoherenceError`` (the single-op guard) — one instance per
+        thread.
         """
+        with self._single_op_guard():
+            return self._read_impl(path)
+
+    def _read_impl(self, path: str | os.PathLike[str]) -> bytes:
         self._ensure_attached()
         abs_path, rel = self._to_relative(path)
         # Stat before registering so a missing file raises rather than seeding a
@@ -391,7 +466,15 @@ class CoherentVolume:
         :meth:`reacquire`'s fresh bytes. ``on_error`` governs only
         coherence-infrastructure failures (unavailable coordinator, watchdog
         timeout): strict raises, degrade warns once and writes best-effort.
+
+        **Not thread-safe (A5).** Overlapping use of this instance from another
+        thread raises ``CoherenceError`` (the single-op guard) — one instance per
+        thread.
         """
+        with self._single_op_guard():
+            self._write_impl(path, data)
+
+    def _write_impl(self, path: str | os.PathLike[str], data: bytes | bytearray) -> None:
         if not isinstance(data, (bytes, bytearray)):
             raise TypeError("CoherentVolume.write expects bytes")
         data = bytes(data)
@@ -515,7 +598,20 @@ class CoherentVolume:
         vs. warns *inside* ``_post`` and the genuinely-unattached
         (``_endpoint is None``) degrade branch above — but never lets an
         unconfirmed OCC commit silently land.
+
+        **Not thread-safe (A5).** Overlapping use of this instance from another
+        thread raises ``CoherenceError`` (the single-op guard). The internal
+        :meth:`reacquire` retries run on the SAME thread, so they re-enter the
+        guard rather than tripping it — one instance per thread.
         """
+        with self._single_op_guard():
+            self._write_cas_impl(path, make_content)
+
+    def _write_cas_impl(
+        self,
+        path: str | os.PathLike[str],
+        make_content: Callable[[bytes], bytes | bytearray],
+    ) -> None:
         self._ensure_attached()
         _abs_path, rel = self._to_relative(path)
 
@@ -772,21 +868,30 @@ class CoherentVolume:
             return b""
         return self._read_file_bytes(abs_path)
 
-    # Retry-eligible OCC conflict reasons (typed ConflictDetail.reason values).
-    _CAS_RETRY_REASONS: frozenset[str] = frozenset({"version_mismatch", "other_holder"})
+    # Retry-eligible OCC conflict reasons matched EXACTLY against the wire
+    # ``reason``: the typed ``ConflictDetail`` reasons plus
+    # ``caller_in_transient_state`` (AC2 — a peer invalidated us mid-window).
+    # The transient literal is the SHARED constant the coordinator server emits,
+    # so a reword on either side can't drift the retry classification.
+    _CAS_RETRY_REASONS: frozenset[str] = frozenset(
+        {"version_mismatch", "other_holder", OCC_CALLER_TRANSIENT_REASON}
+    )
 
     def _classify_cas_response(self, resp: dict) -> Literal["win", "conflict", "raise"]:
         """Map a ``/hooks/post-edit-cas`` 200 body to an OCC outcome.
 
         - ``ok: true``  → ``"win"`` (the CAS committed; version bumped).
         - ``ok: false`` with a retry-eligible reason → ``"conflict"`` (reacquire
-          + retry). Two cases: the typed ``ConflictDetail`` reasons
-          (``version_mismatch`` / ``other_holder``), AND
-          ``caller_in_transient_state`` — when a peer invalidates this instance
-          in the window BETWEEN its fresh read and its CAS, the coordinator
-          leaves an invalidation transient that ``commit_cas`` rejects as a
-          precondition; that is a lost race, not corruption, so reacquire +
-          retry (a fresh identity has no transient).
+          + retry). Matched EXACTLY against :attr:`_CAS_RETRY_REASONS`: the
+          typed ``ConflictDetail`` reasons (``version_mismatch`` /
+          ``other_holder``) AND ``caller_in_transient_state`` — when a peer
+          invalidates this instance in the window BETWEEN its fresh read and its
+          CAS, the coordinator leaves an invalidation transient that
+          ``commit_cas`` rejects as a precondition; that is a lost race, not
+          corruption, so reacquire + retry (a fresh identity has no transient).
+          The transient reason is the shared
+          :data:`~ccs.core.exceptions.OCC_CALLER_TRANSIENT_REASON` the server
+          emits, so the match is exact (no brittle substring) and cannot drift.
         - ``ok: false`` otherwise — true corruption (``commit_cas_corruption``,
           ``expected > current``) OR the fail-closed ``{degraded: true,
           reason: "commit_unconfirmed"}`` body → ``"raise"``. The degrade body
@@ -797,10 +902,6 @@ class CoherentVolume:
             return "win"
         reason = resp.get("reason")
         if reason in self._CAS_RETRY_REASONS:
-            return "conflict"
-        # A precondition rejection from a peer invalidating us mid-window is a
-        # lost race (retry-eligible via reacquire), NOT terminal corruption.
-        if isinstance(reason, str) and "caller_in_transient_state" in reason:
             return "conflict"
         return "raise"
 

--- a/src/ccs/agent/runtime.py
+++ b/src/ccs/agent/runtime.py
@@ -211,6 +211,7 @@ class AgentRuntime:
                 expected_version=expected_version,
                 content_hash=content_hash,
                 issued_at_tick=now_tick,
+                content=content,
             )
 
             if isinstance(result, ConflictDetail):
@@ -228,12 +229,18 @@ class AgentRuntime:
                 continue
 
             updated, signals = result
+            # An OCC win ends the committer SHARED on the coordinator (it holds no
+            # grant — see commit_cas). The local cache must mirror that: a
+            # coherence layer cannot leave the agent's local view (MODIFIED) more
+            # privileged than the coordinator's now-SHARED end-state. Contrast the
+            # pessimistic write() above, which legitimately caches MODIFIED because
+            # it acquired EXCLUSIVE.
             self.cache.put(
                 artifact_id,
                 self.strategy.on_fetch(
                     artifact_id=artifact_id,
                     version=updated.version,
-                    state=MESIState.MODIFIED,
+                    state=MESIState.SHARED,
                     now_tick=now_tick,
                 ),
             )

--- a/src/ccs/agent/runtime.py
+++ b/src/ccs/agent/runtime.py
@@ -9,12 +9,27 @@ from typing import Any, Callable, Optional
 from uuid import UUID
 
 from ccs.coordinator.service import CoordinatorService
+from ccs.core.exceptions import CasRetriesExhausted
 from ccs.core.hashing import compute_content_hash
 from ccs.core.states import MESIState
-from ccs.core.types import Artifact, FetchRequest, FetchResponse, InvalidationSignal
+from ccs.core.types import (
+    Artifact,
+    ArtifactCacheEntry,
+    ConflictDetail,
+    FetchRequest,
+    FetchResponse,
+    InvalidationSignal,
+)
 from ccs.strategies.base import SyncStrategy
 
 from .cache import ArtifactCache
+
+# A content producer for the OCC write path. Called once per attempt with the
+# freshly-read cache entry (SHARED, carrying the winner's local_version) so the
+# caller re-derives content against current state on every retry. Returns the
+# content body and an OPTIONAL precomputed content_hash (None → the runtime
+# computes it via compute_content_hash, matching how `write` derives the hash).
+MakeContent = Callable[[ArtifactCacheEntry], "tuple[str, str | None]"]
 
 CCS_CONTENT_AUDIT_LOG_SCHEMA_VERSION = "ccs.content_audit.v1"
 
@@ -119,6 +134,137 @@ class AgentRuntime:
             now_tick=now_tick,
         )
         return updated, [*write_signals, *commit_signals]
+
+    def write_cas(
+        self,
+        artifact_id: UUID,
+        *,
+        make_content: MakeContent,
+        now_tick: int,
+    ) -> tuple[Artifact, list[InvalidationSignal]]:
+        """Optimistic-concurrency write that BYPASSES the pessimistic acquire.
+
+        The OCC counterpart to :meth:`write` (plan Unit 5, R6/R8). Unlike
+        ``write`` — which calls ``coordinator.write()`` to take EXCLUSIVE before
+        ``coordinator.commit()`` — ``write_cas`` **never acquires EXCLUSIVE**. The
+        writer reads (→ SHARED), computes locally (stays SHARED/INVALID), and
+        commits via ``coordinator.commit_cas``; the commit-time version CAS (not a
+        lock on the acquire) elects the winner. ``coordinator.write()`` is never
+        called on this path.
+
+        Retry: policy lives in the strategy (``max_cas_retries`` /
+        ``cas_backoff_ticks``), the loop lives HERE (the actor) — strategies are
+        policy, not actors. ``expected_version`` is sourced from the cache entry's
+        ``local_version`` each attempt; on a :class:`ConflictDetail` the loop
+        re-reads (re-fetch → refreshes ``local_version`` to the winner's new
+        version) and recomputes content via ``make_content`` against that fresh
+        state, then retries. There is NO auto-escalation to EXCLUSIVE (D5).
+
+        ``make_content`` is invoked once per attempt with the freshly-read cache
+        entry and returns ``(content, content_hash | None)``; a ``None`` hash is
+        computed via :func:`compute_content_hash` (mirroring ``write``).
+
+        Args:
+            artifact_id: The shared artifact to commit to.
+            make_content: Producer re-applying the caller's intent against the
+                freshly-read state for THIS attempt (see :data:`MakeContent`).
+            now_tick: Logical tick for the attempt(s).
+
+        Returns:
+            ``(updated_artifact, signals)`` on the winning commit. ``signals``
+            mirrors ``write``'s shape so the adapter publishes them unchanged.
+
+        Raises:
+            CasRetriesExhausted: every allowed attempt lost the race — a typed
+                terminal, NEVER a silent drop. The cache is left at the latest
+                refreshed version (no unconfirmed write cached).
+            CoherenceError: the coordinator reported corruption
+                (``expected_version > current``) or a precondition failure
+                (caller mid-transient / in M/E) — non-retryable, propagated.
+            ValueError: ``make_content`` returned a content_hash that does not
+                match the content (same guard as ``write``).
+        """
+        # Ensure a fresh read first so the cache entry exists and SHARED with a
+        # populated local_version (the OCC writer is now S, never E).
+        entry = self.cache.get(artifact_id)
+        if entry is None or self.strategy.requires_refresh(entry, now_tick=now_tick):
+            self._fetch(artifact_id, now_tick=now_tick)
+
+        last_current_version = -1
+        max_attempts = self.strategy.max_cas_retries() + 1
+        for attempt in range(max_attempts):
+            entry = self.cache.get(artifact_id)
+            if entry is None:
+                # A peer invalidation can drop the placeholder; re-fetch to land
+                # a fresh SHARED entry before reading expected_version.
+                self._fetch(artifact_id, now_tick=now_tick)
+                entry = self.cache.get(artifact_id)
+                assert entry is not None  # _fetch always populates the cache
+
+            expected_version = entry.local_version
+            content, provided_hash = make_content(entry)
+            content_hash = self._resolve_content_hash(content, provided_hash)
+
+            result = self.coordinator.commit_cas(
+                agent_id=self.agent_id,
+                artifact_id=artifact_id,
+                expected_version=expected_version,
+                content_hash=content_hash,
+                issued_at_tick=now_tick,
+            )
+
+            if isinstance(result, ConflictDetail):
+                last_current_version = result.current_version
+                # Re-read: re-fetch refreshes the cache entry to the winner's new
+                # version (SHARED, fresh local_version) so the next attempt's
+                # expected_version + make_content() see current state.
+                self._fetch(artifact_id, now_tick=now_tick)
+                # Consult the strategy's backoff schedule (policy seam, D1). In
+                # this synchronous logical-tick model there is no wall clock to
+                # sleep against, so the deterministic value documents the bound a
+                # tick-driven scheduler would honor; the loop itself does not block.
+                if attempt < max_attempts - 1:
+                    _ = self.strategy.cas_backoff_ticks(attempt)
+                continue
+
+            updated, signals = result
+            self.cache.put(
+                artifact_id,
+                self.strategy.on_fetch(
+                    artifact_id=artifact_id,
+                    version=updated.version,
+                    state=MESIState.MODIFIED,
+                    now_tick=now_tick,
+                ),
+            )
+            self._record_content_view(
+                artifact_id=artifact_id,
+                version=updated.version,
+                content=content,
+                source="write_cas",
+                now_tick=now_tick,
+            )
+            return updated, signals
+
+        raise CasRetriesExhausted(
+            artifact_id=artifact_id,
+            attempts=max_attempts,
+            last_current_version=last_current_version,
+        )
+
+    def _resolve_content_hash(self, content: str, provided_hash: str | None) -> str:
+        """Return the content_hash for content, validating a caller-provided one.
+
+        Mirrors ``write``'s hash handling: a provided hash must match the
+        computed one (fail fast on mismatch), else compute it.
+        """
+        computed = compute_content_hash(content)
+        if provided_hash is not None and provided_hash != computed:
+            raise ValueError(
+                f"content_hash mismatch: caller provided {provided_hash!r}, "
+                f"computed {computed!r}"
+            )
+        return computed
 
     def invalidate_all_cache(
         self,

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -10,12 +10,17 @@ from typing import Any, Callable, Optional, TypeAlias
 from uuid import UUID, uuid4
 
 from ccs.core.states import MESIState, TransientState
-from ccs.core.types import Artifact
+from ccs.core.types import Artifact, CasCorruption, ConflictDetail
 
 CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
 
 ReclamationSlot: TypeAlias = tuple[str, int]  # (trigger, tick)
 _M_OR_E_STATES: frozenset[MESIState] = frozenset({MESIState.MODIFIED, MESIState.EXCLUSIVE})
+
+# OCC commit-CAS result (plan Unit 2) — parity with SqliteArtifactRegistry.
+# WIN = (updated_artifact, invalidated_agent_ids); loss = ConflictDetail;
+# impossible state = CasCorruption. None is raised by the registry.
+CasResult: TypeAlias = "tuple[Artifact, list[UUID]] | ConflictDetail | CasCorruption"
 
 
 @dataclass
@@ -171,6 +176,166 @@ class ArtifactRegistry:
                 # Roll back so the next successful emission does not create a phantom gap.
                 self._seq -= 1
                 raise
+
+    def commit_cas(
+        self,
+        artifact_id: UUID,
+        agent_id: UUID,
+        *,
+        expected_version: int,
+        content_hash: str,
+        size_tokens: int | None = None,
+        tick: int = 0,
+        trigger: str = "commit_cas",
+    ) -> CasResult:
+        """In-memory optimistic-concurrency compare-and-swap (plan Unit 2,
+        parity with :meth:`SqliteArtifactRegistry.commit_cas`). Written fresh
+        from the contract — there is no ``resolve_or_register`` precedent here
+        and the two registries share no base class. Plain GIL-atomic dict
+        mutation; no ``BEGIN IMMEDIATE`` (single-process library callers).
+
+        Same 3-outcome discrimination, version check BEFORE the holder check:
+
+        - ``expected_version > current`` → :class:`CasCorruption` (no mutation).
+        - ``expected_version < current`` → ``ConflictDetail("version_mismatch")``
+          (no mutation).
+        - version matches but another agent holds M/E → ``ConflictDetail(
+          "other_holder")`` (no mutation).
+        - else → WIN: version → ``current + 1``, committer S/I → MODIFIED,
+          peers → INVALID; returns ``(updated_artifact, invalidated_agent_ids)``.
+
+        The state-log emit follows the same mutation-then-log + ``_seq``-rollback
+        invariant as :meth:`set_agent_state`. To keep that invariant under a
+        callback raise during peer/committer logging, the in-memory mutations
+        are computed into a staging plan and applied only after all log entries
+        emit successfully — so a raise leaves ``state_by_agent`` /
+        ``granted_at_tick`` untouched (matching the sqlite ROLLBACK).
+        """
+        record = self._records.get(artifact_id)
+        if record is None:
+            raise KeyError(f"artifact {artifact_id} not in registry")
+        current = record.artifact.version
+
+        if expected_version > current:
+            return CasCorruption(current_version=current)
+        if expected_version < current:
+            return ConflictDetail("version_mismatch", current)
+        other_holder = any(
+            peer_id != agent_id and state in _M_OR_E_STATES
+            for peer_id, state in record.state_by_agent.items()
+        )
+        if other_holder:
+            return ConflictDetail("other_holder", current)
+
+        # ---- WIN ----
+        next_version = current + 1
+        committer_from = record.state_by_agent.get(agent_id, MESIState.INVALID)
+        peers = [
+            (peer_id, state)
+            for peer_id, state in record.state_by_agent.items()
+            if peer_id != agent_id and state != MESIState.INVALID
+        ]
+
+        # Emit all state_log entries FIRST (peers then committer), reserving
+        # _seq per emission. If any raises, _emit_state_log has already
+        # decremented its own reservation; we decrement the ones that already
+        # succeeded in this call and re-raise — nothing has mutated yet, so the
+        # registry stays consistent (mutation-then-log parity).
+        emitted_here = 0
+        try:
+            for peer_id, peer_from in peers:
+                emitted_here += self._emit_state_log(
+                    artifact_id=artifact_id,
+                    agent_id=peer_id,
+                    from_state=peer_from,
+                    to_state=MESIState.INVALID,
+                    trigger=trigger,
+                    tick=tick,
+                    version=next_version,
+                    content_hash=None,
+                )
+            emitted_here += self._emit_state_log(
+                artifact_id=artifact_id,
+                agent_id=agent_id,
+                from_state=committer_from,
+                to_state=MESIState.MODIFIED,
+                trigger=trigger,
+                tick=tick,
+                version=next_version,
+                content_hash=content_hash,
+            )
+        except Exception:
+            self._seq -= emitted_here
+            raise
+
+        # All logs emitted — now apply the mutations (cannot fail).
+        updated = Artifact(
+            id=artifact_id,
+            name=record.artifact.name,
+            version=next_version,
+            content_hash=content_hash,
+            size_tokens=size_tokens if size_tokens is not None else record.artifact.size_tokens,
+            depends_on=record.artifact.depends_on,
+        )
+        if self._retain_versions:
+            record.version_history[next_version] = record.content
+        record.artifact = updated
+        record.last_writer = agent_id
+
+        invalidated: list[UUID] = []
+        for peer_id, peer_from in peers:
+            record.state_by_agent[peer_id] = MESIState.INVALID
+            if peer_from in _M_OR_E_STATES:
+                record.granted_at_tick_by_agent.pop(peer_id, None)
+            invalidated.append(peer_id)
+
+        # Committer S/I → MODIFIED is an M∪E acquire: set granted_at_tick,
+        # clear the reclaim slot (set_agent_state's acquire branch).
+        record.state_by_agent[agent_id] = MESIState.MODIFIED
+        record.granted_at_tick_by_agent[agent_id] = tick
+        record.last_reclamation_by_agent.pop(agent_id, None)
+
+        return updated, invalidated
+
+    def _emit_state_log(
+        self,
+        *,
+        artifact_id: UUID,
+        agent_id: UUID,
+        from_state: MESIState,
+        to_state: MESIState,
+        trigger: str,
+        tick: int,
+        version: int,
+        content_hash: str | None,
+    ) -> int:
+        """Emit one ``state_log`` entry for the inlined CAS region. Returns 1 if
+        ``_seq`` was bumped (0 if no state_log configured). On callback raise,
+        decrements its own reservation and re-raises (mutation-then-log parity
+        with :meth:`set_agent_state`)."""
+        if self._state_log is None:
+            return 0
+        self._seq += 1
+        entry = {
+            "tick": tick,
+            "artifact_id": str(artifact_id),
+            "agent_id": str(agent_id),
+            "agent_name": self._agent_names.get(agent_id) if self._agent_names is not None else None,
+            "from_state": from_state.name,
+            "to_state": to_state.name,
+            "trigger": trigger,
+            "version": version,
+            "content_hash": content_hash,
+            "sequence_number": self._seq,
+            "instance_id": self._instance_id,
+            "schema_version": CCS_STATE_LOG_SCHEMA_VERSION,
+        }
+        try:
+            self._state_log(entry)
+        except Exception:
+            self._seq -= 1
+            raise
+        return 1
 
     def record_heartbeat(self, agent_id: UUID, now_tick: int) -> None:
         """Record an agent's heartbeat tick using max(prev, incoming) (R12 monotonicity)."""

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -185,6 +185,7 @@ class ArtifactRegistry:
         expected_version: int,
         content_hash: str,
         size_tokens: int | None = None,
+        content: bytes | str | None = None,
         tick: int = 0,
         trigger: str = "commit_cas",
     ) -> CasResult:
@@ -201,8 +202,10 @@ class ArtifactRegistry:
           (no mutation).
         - version matches but another agent holds M/E → ``ConflictDetail(
           "other_holder")`` (no mutation).
-        - else → WIN: version → ``current + 1``, committer S/I → MODIFIED,
-          peers → INVALID; returns ``(updated_artifact, invalidated_agent_ids)``.
+        - else → WIN: version → ``current + 1``, committer S/I → SHARED (an OCC
+          writer holds no grant — SHARED keeps its next commit_cas repeatable;
+          MODIFIED would trip the service D4 precondition), peers → INVALID;
+          returns ``(updated_artifact, invalidated_agent_ids)``.
 
         The state-log emit follows the same mutation-then-log + ``_seq``-rollback
         invariant as :meth:`set_agent_state`. To keep that invariant under a
@@ -210,6 +213,14 @@ class ArtifactRegistry:
         are computed into a staging plan and applied only after all log entries
         emit successfully — so a raise leaves ``state_by_agent`` /
         ``granted_at_tick`` untouched (matching the sqlite ROLLBACK).
+
+        ``content`` is the winning body. When provided (the in-process library
+        path threads it from ``AgentRuntime.write_cas``) the WIN updates
+        ``record.content`` (and ``version_history[next_version]`` when versions
+        are retained) to the NEW body, so a peer re-fetching after the win reads
+        the winner's content at the new version — not the stale pre-CAS body.
+        ``None`` (the cross-process / sqlite path, which stores no content)
+        leaves the prior content-coherence behaviour unchanged.
         """
         record = self._records.get(artifact_id)
         if record is None:
@@ -258,7 +269,7 @@ class ArtifactRegistry:
                 artifact_id=artifact_id,
                 agent_id=agent_id,
                 from_state=committer_from,
-                to_state=MESIState.MODIFIED,
+                to_state=MESIState.SHARED,
                 trigger=trigger,
                 tick=tick,
                 version=next_version,
@@ -277,6 +288,14 @@ class ArtifactRegistry:
             size_tokens=size_tokens if size_tokens is not None else record.artifact.size_tokens,
             depends_on=record.artifact.depends_on,
         )
+        # Content coherence: when the caller threaded the winning body, advance
+        # record.content to it so a peer re-fetch reads the NEW content at the new
+        # version (without this, version + content_hash bump but the body stays
+        # stale). The retained version snapshot stores the SAME new body. content
+        # is None on the cross-process / sqlite path (no content stored) — keep
+        # the prior body unchanged there.
+        if content is not None:
+            record.content = content  # type: ignore[assignment]
         if self._retain_versions:
             record.version_history[next_version] = record.content
         record.artifact = updated
@@ -289,11 +308,14 @@ class ArtifactRegistry:
                 record.granted_at_tick_by_agent.pop(peer_id, None)
             invalidated.append(peer_id)
 
-        # Committer S/I → MODIFIED is an M∪E acquire: set granted_at_tick,
-        # clear the reclaim slot (set_agent_state's acquire branch).
-        record.state_by_agent[agent_id] = MESIState.MODIFIED
-        record.granted_at_tick_by_agent[agent_id] = tick
-        record.last_reclamation_by_agent.pop(agent_id, None)
+        # Committer S/I → SHARED, NOT MODIFIED: an OCC writer is optimistic and
+        # holds no grant, so SHARED is the honest end-state and keeps the same
+        # agent's next commit_cas repeatable (a sticky MODIFIED would trip the
+        # service D4 "M/E callers use commit()" precondition). SHARED is not in
+        # M∪E, so this is not an acquire — do NOT set granted_at_tick and do NOT
+        # clear the reclaim slot (mirror set_agent_state's non-M/E-from-non-M/E
+        # path, which leaves both untouched).
+        record.state_by_agent[agent_id] = MESIState.SHARED
 
         return updated, invalidated
 

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -12,7 +12,11 @@ from dataclasses import dataclass
 from typing import Callable, Optional
 from uuid import UUID
 
-from ccs.core.exceptions import CoherenceError
+from ccs.core.exceptions import (
+    OCC_CALLER_TRANSIENT_REASON,
+    CoherenceError,
+    OccCallerTransientError,
+)
 from ccs.core.hashing import compute_content_hash
 from ccs.core.invariants import check_monotonic_version, check_single_writer
 from ccs.core.states import MESIState, TransientState
@@ -425,15 +429,22 @@ class CoordinatorService:
             :class:`ConflictDetail` on a retry-eligible conflict.
 
         Raises:
-            CoherenceError: artifact missing, caller mid-transient, caller in
-                M/E (use ``commit``), or the registry reported corruption.
+            OccCallerTransientError: the caller is mid-transient (a peer
+                invalidated it between read and CAS) — a retry-eligible subclass
+                of ``CoherenceError`` carrying the stable wire reason
+                :data:`~ccs.core.exceptions.OCC_CALLER_TRANSIENT_REASON`.
+            CoherenceError: artifact missing, caller in M/E (use ``commit``), or
+                the registry reported corruption (all non-retryable).
         """
         artifact = self._require_artifact(artifact_id)
 
         if self.registry.get_agent_transient(artifact_id, agent_id) is not None:
-            raise CoherenceError(
+            # Retry-eligible: a peer invalidated the caller between its read and
+            # this CAS, leaving an invalidation transient. Typed so the wire
+            # reason stays stable independent of this human message (AC2).
+            raise OccCallerTransientError(
                 f"commit_cas_not_allowed agent={agent_id} artifact={artifact_id} "
-                f"reason=caller_in_transient_state"
+                f"reason={OCC_CALLER_TRANSIENT_REASON}"
             )
 
         agent_state = self.registry.get_agent_state(artifact_id, agent_id)

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -376,6 +376,7 @@ class CoordinatorService:
         content_hash: str,
         issued_at_tick: int = 0,
         size_tokens: int | None = None,
+        content: bytes | str | None = None,
     ) -> tuple[Artifact, list[InvalidationSignal]] | ConflictDetail:
         """Optimistic-concurrency commit via an atomic version-checked CAS.
 
@@ -407,10 +408,17 @@ class CoordinatorService:
           returned UNCHANGED, with **no mutation and no invalidation signals**
           (it is a typed return, never an exception).
         - WIN ``(updated_artifact, invalidated_ids)`` → the registry has already
-          done the peer-invalidation + committer S/I→MODIFIED transition
-          atomically; this method only builds the matching
+          done the peer-invalidation + committer S/I→SHARED transition
+          atomically (the OCC writer holds no grant, so it ends SHARED — which
+          keeps a subsequent commit_cas by the same caller eligible past the D4
+          precondition below); this method only builds the matching
           :class:`InvalidationSignal` list (mirroring ``commit``'s shape),
           re-validates single-writer, and returns ``(updated, signals)``.
+
+        ``content`` is the winning body, threaded to the registry so the
+        in-memory (library) path advances ``record.content`` on a WIN — a peer
+        re-fetch then reads the winner's NEW content, not the stale pre-CAS body.
+        The cross-process / sqlite path passes ``None`` (it stores no content).
 
         Returns:
             ``(updated_artifact, signals)`` on a winning commit, or a
@@ -442,6 +450,7 @@ class CoordinatorService:
             expected_version=expected_version,
             content_hash=content_hash,
             size_tokens=size_tokens,
+            content=content,
             tick=issued_at_tick,
         )
 

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -16,7 +16,14 @@ from ccs.core.exceptions import CoherenceError
 from ccs.core.hashing import compute_content_hash
 from ccs.core.invariants import check_monotonic_version, check_single_writer
 from ccs.core.states import MESIState, TransientState
-from ccs.core.types import Artifact, FetchRequest, FetchResponse, InvalidationSignal
+from ccs.core.types import (
+    Artifact,
+    CasCorruption,
+    ConflictDetail,
+    FetchRequest,
+    FetchResponse,
+    InvalidationSignal,
+)
 
 from .registry import ArtifactRegistry
 
@@ -357,6 +364,112 @@ class CoordinatorService:
             trigger="commit", tick=issued_at_tick, content_hash=commit_hash,
         )
         self.registry.clear_agent_transient(artifact_id, agent_id)
+        self._validate_single_writer(artifact_id)
+        return updated, signals
+
+    def commit_cas(
+        self,
+        *,
+        agent_id: UUID,
+        artifact_id: UUID,
+        expected_version: int,
+        content_hash: str,
+        issued_at_tick: int = 0,
+        size_tokens: int | None = None,
+    ) -> tuple[Artifact, list[InvalidationSignal]] | ConflictDetail:
+        """Optimistic-concurrency commit via an atomic version-checked CAS.
+
+        The OCC counterpart to :meth:`commit` (plan Unit 3, R1–R4/R6). Unlike
+        ``commit`` — which requires the caller to already hold EXCLUSIVE/MODIFIED
+        from a pessimistic ``write()`` acquire — ``commit_cas`` lets a SHARED (or
+        INVALID) caller commit *only if* ``expected_version`` still matches the
+        registry's current version and no *pessimistic* peer holds M/E. The
+        winner is elected by the registry's serialized ``BEGIN IMMEDIATE``, not a
+        lock on the acquire, so two concurrent OCC writers cannot both land the
+        same version.
+
+        This method owns the **D4 precondition layer** the registry deliberately
+        omits (the registry only does the version/holder CAS):
+
+        - artifact must exist (``_require_artifact`` → ``CoherenceError``);
+        - the caller must NOT be mid-transient (``get_agent_transient`` is
+          ``None``, else ``CoherenceError``);
+        - the caller's MESI state must be SHARED or INVALID — a MODIFIED/EXCLUSIVE
+          holder is an *acquired* pessimistic writer and must use plain
+          :meth:`commit` (rejected with a ``CoherenceError`` pointing there).
+
+        Three-outcome discrimination of the registry result (plan R2):
+
+        - :class:`CasCorruption` (``expected_version > current``) → raise
+          ``CoherenceError`` — corruption / a second coordinator on the store,
+          non-retryable.
+        - :class:`ConflictDetail` (``version_mismatch`` / ``other_holder``) →
+          returned UNCHANGED, with **no mutation and no invalidation signals**
+          (it is a typed return, never an exception).
+        - WIN ``(updated_artifact, invalidated_ids)`` → the registry has already
+          done the peer-invalidation + committer S/I→MODIFIED transition
+          atomically; this method only builds the matching
+          :class:`InvalidationSignal` list (mirroring ``commit``'s shape),
+          re-validates single-writer, and returns ``(updated, signals)``.
+
+        Returns:
+            ``(updated_artifact, signals)`` on a winning commit, or a
+            :class:`ConflictDetail` on a retry-eligible conflict.
+
+        Raises:
+            CoherenceError: artifact missing, caller mid-transient, caller in
+                M/E (use ``commit``), or the registry reported corruption.
+        """
+        artifact = self._require_artifact(artifact_id)
+
+        if self.registry.get_agent_transient(artifact_id, agent_id) is not None:
+            raise CoherenceError(
+                f"commit_cas_not_allowed agent={agent_id} artifact={artifact_id} "
+                f"reason=caller_in_transient_state"
+            )
+
+        agent_state = self.registry.get_agent_state(artifact_id, agent_id)
+        if agent_state in {MESIState.EXCLUSIVE, MESIState.MODIFIED}:
+            raise CoherenceError(
+                f"commit_cas_not_allowed agent={agent_id} artifact={artifact_id} "
+                f"state={agent_state} reason=occ_is_shared_or_invalid_only "
+                f"(use commit() for an EXCLUSIVE/MODIFIED holder)"
+            )
+
+        result = self.registry.commit_cas(
+            artifact_id,
+            agent_id,
+            expected_version=expected_version,
+            content_hash=content_hash,
+            size_tokens=size_tokens,
+            tick=issued_at_tick,
+        )
+
+        if isinstance(result, CasCorruption):
+            raise CoherenceError(
+                f"commit_cas_corruption agent={agent_id} artifact={artifact_id} "
+                f"expected_version={expected_version} "
+                f"current_version={result.current_version} "
+                f"(expected > current — corruption or multi-coordinator violation)"
+            )
+        if isinstance(result, ConflictDetail):
+            # Typed retry-eligible conflict: no mutation happened in the
+            # registry, so emit no invalidation signals and surface it as-is.
+            return result
+
+        updated, invalidated_ids = result
+        # Defense-in-depth: the CAS computed N+1 atomically; assert it did not
+        # regress (NOT the concurrency guard — that was the version check).
+        check_monotonic_version(artifact.version, updated.version)
+        signals = [
+            InvalidationSignal(
+                artifact_id=artifact_id,
+                new_version=updated.version,
+                issued_at_tick=issued_at_tick,
+                issuer_agent_id=agent_id,
+            )
+            for _ in invalidated_ids
+        ]
         self._validate_single_writer(artifact_id)
         return updated, signals
 

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -979,6 +979,7 @@ class SqliteArtifactRegistry:
         expected_version: int,
         content_hash: str,
         size_tokens: int | None = None,
+        content: bytes | str | None = None,
         tick: int = 0,
         trigger: str = "commit_cas",
     ) -> CasResult:
@@ -1002,18 +1003,32 @@ class SqliteArtifactRegistry:
           ``ConflictDetail("other_holder")``. No mutation.
         - else (version matches, no other M/E holder) → **WIN**: bump version
           to ``current + 1``, write ``content_hash`` + ``last_writer_id``,
-          transition the committer S/I → MODIFIED, invalidate every non-INVALID
+          transition the committer S/I → SHARED, invalidate every non-INVALID
           peer to INVALID. Returns ``(updated_artifact, invalidated_agent_ids)``.
 
-        The committer's MODIFIED bookkeeping and the per-peer invalidation are
-        INLINED as raw SQL — :meth:`set_agent_state` opens its own
-        ``BEGIN IMMEDIATE`` and cannot be called nested. This reproduces
-        ``set_agent_state``'s contract for the participants it touches:
-        ``granted_at_tick`` (set on the S/I→MODIFIED M∪E acquire; reclaim slot
-        cleared), the mutation-then-log + ``_seq`` rollback invariant, and the
-        ``state_log`` emit per transition (KTD-13: compare on version, never
-        content bytes).
+        The committer ends **SHARED, not MODIFIED**: an OCC writer is optimistic
+        and never acquired EXCLUSIVE, so it holds no grant — SHARED is the honest
+        end-state, and it keeps the same agent's subsequent commit_cas repeatable
+        (a sticky MODIFIED would trip the service's D4 "M/E callers use commit()"
+        precondition). ``size_tokens=None`` PRESERVES the persisted value (the
+        cross-process path always passes None), matching the in-memory registry.
+
+        The committer's bookkeeping and the per-peer invalidation are INLINED as
+        raw SQL — :meth:`set_agent_state` opens its own ``BEGIN IMMEDIATE`` and
+        cannot be called nested. This reproduces ``set_agent_state``'s contract
+        for the participants it touches: SHARED is not in M∪E, so the committer's
+        ``granted_at_tick`` is left untouched (preserved; no acquire) and its
+        reclaim slot is NOT cleared, while a peer leaving M∪E drops its
+        ``granted_at_tick`` slot; plus the mutation-then-log + ``_seq`` rollback
+        invariant and the ``state_log`` emit per transition (KTD-13: compare on
+        version, never content bytes).
+
+        ``content`` is accepted for signature parity with the in-memory registry
+        but IGNORED (KTD-13: this registry persists no content body —
+        :meth:`get_content` returns ``b""``). The content-hash on the artifact is
+        the source of truth for staleness comparison.
         """
+        del content  # KTD-13: not persisted (signature parity only)
         with self._lock:
             # Track every _seq increment in this call so the outer
             # BaseException handler can roll them ALL back if COMMIT (or any
@@ -1023,11 +1038,13 @@ class SqliteArtifactRegistry:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
                 version_row = self._conn.execute(
-                    "SELECT version FROM artifacts WHERE id = ?", (artifact_id.hex,)
+                    "SELECT version, size_tokens FROM artifacts WHERE id = ?",
+                    (artifact_id.hex,),
                 ).fetchone()
                 if version_row is None:
                     raise KeyError(f"artifact {artifact_id} not in registry")
                 current = version_row[0]
+                current_size_tokens = version_row[1]
 
                 # 3-outcome discrimination. Each non-win branch COMMITs the
                 # (read-only) transaction and returns a typed result; nothing
@@ -1059,6 +1076,14 @@ class SqliteArtifactRegistry:
 
                 # ---- WIN: mutate atomically ----
                 next_version = current + 1
+                # Preserve the persisted size_tokens when the caller passes None
+                # (the cross-process / coordinator-server path always does) —
+                # matches the in-memory registry, where a None arg keeps the
+                # prior value rather than NULLing it. Without this, every
+                # cross-process OCC commit would silently zero size_tokens.
+                resolved_size_tokens = (
+                    current_size_tokens if size_tokens is None else size_tokens
+                )
                 self._conn.execute(
                     """
                     UPDATE artifacts
@@ -1069,7 +1094,7 @@ class SqliteArtifactRegistry:
                     (
                         next_version,
                         content_hash,
-                        size_tokens,
+                        resolved_size_tokens,
                         agent_id.hex,
                         time.time(),
                         artifact_id.hex,
@@ -1119,12 +1144,20 @@ class SqliteArtifactRegistry:
                     )
                     invalidated.append(UUID(hex=peer_hex))
 
-                # Transition the committer S/I → MODIFIED. MODIFIED is in M∪E
-                # and the prior S/I is not, so this is an M∪E *acquire*:
-                # granted_at_tick = tick, reclaim slot cleared (mirrors
-                # set_agent_state's "new_in_me and not prev_in_me" branch).
+                # Transition the committer S/I → SHARED. An OCC writer holds NO
+                # grant (it is optimistic — it never acquired EXCLUSIVE), so the
+                # honest end-state is SHARED, NOT MODIFIED. A sticky MODIFIED
+                # grant would make the SAME agent's next commit_cas/write_cas hit
+                # the service D4 precondition (which rejects M/E callers) and hard-
+                # fail; ending SHARED keeps OCC writes repeatable. SHARED is not
+                # in M∪E, so this is NOT an acquire: do NOT set granted_at_tick to
+                # ``tick`` and do NOT clear the reclaim slot (mirror
+                # set_agent_state's non-M/E branch — preserve prior granted_at,
+                # leave reclaim columns untouched). A fresh S/I committer holds no
+                # grant slot, so the preserved value is None either way.
                 committer_row = self._conn.execute(
-                    "SELECT state FROM agent_states WHERE artifact_id = ? AND agent_id = ?",
+                    "SELECT state, granted_at_tick FROM agent_states "
+                    "WHERE artifact_id = ? AND agent_id = ?",
                     (artifact_id.hex, agent_id.hex),
                 ).fetchone()
                 committer_from = (
@@ -1135,25 +1168,28 @@ class SqliteArtifactRegistry:
                         """
                         INSERT INTO agent_states (artifact_id, agent_id, state, granted_at_tick,
                                                   last_reclaim_trigger, last_reclaim_tick)
-                        VALUES (?, ?, ?, ?, NULL, NULL)
+                        VALUES (?, ?, ?, NULL, NULL, NULL)
                         """,
-                        (artifact_id.hex, agent_id.hex, MESIState.MODIFIED.name, tick),
+                        (artifact_id.hex, agent_id.hex, MESIState.SHARED.name),
                     )
                 else:
+                    # Preserve granted_at_tick (None for an S/I committer); the
+                    # reclaim columns are NOT touched — exactly set_agent_state's
+                    # "neither new nor prev in M∪E" path.
+                    prior_granted_at = committer_row[1]
                     self._conn.execute(
                         """
                         UPDATE agent_states
-                        SET state = ?, granted_at_tick = ?, last_reclaim_trigger = NULL,
-                            last_reclaim_tick = NULL
+                        SET state = ?, granted_at_tick = ?
                         WHERE artifact_id = ? AND agent_id = ?
                         """,
-                        (MESIState.MODIFIED.name, tick, artifact_id.hex, agent_id.hex),
+                        (MESIState.SHARED.name, prior_granted_at, artifact_id.hex, agent_id.hex),
                     )
                 seq_incremented_count += self._emit_state_log(
                     artifact_id=artifact_id,
                     agent_id=agent_id,
                     from_state=committer_from,
-                    to_state=MESIState.MODIFIED,
+                    to_state=MESIState.SHARED,
                     trigger=trigger,
                     tick=tick,
                     version=next_version,
@@ -1179,7 +1215,7 @@ class SqliteArtifactRegistry:
                 name=self._artifact_name(artifact_id),
                 version=next_version,
                 content_hash=content_hash,
-                size_tokens=size_tokens,
+                size_tokens=resolved_size_tokens,
             )
             return updated, invalidated
 

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -74,7 +74,7 @@ from typing import Any, Callable, Iterable, Optional, TypeAlias
 from uuid import UUID, uuid4
 
 from ccs.core.states import MESIState, TransientState
-from ccs.core.types import Artifact
+from ccs.core.types import Artifact, CasCorruption, ConflictDetail
 
 CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
 """Reuses the same schema version as in-memory registry (state_log emissions
@@ -86,6 +86,13 @@ v0.1 raises on mismatch; v0.2 will add real migration dispatch when needed."""
 
 ReclamationSlot: TypeAlias = tuple[str, int]
 _M_OR_E_STATES: frozenset[MESIState] = frozenset({MESIState.MODIFIED, MESIState.EXCLUSIVE})
+
+# OCC commit-CAS result (plan Unit 2). A WIN is ``(updated_artifact,
+# invalidated_agent_ids)`` — the service layer turns the id list into
+# ``InvalidationSignal``s. A loss is a typed ``ConflictDetail`` (retry-eligible,
+# no mutation). ``CasCorruption`` is the impossible-state sentinel the service
+# maps to ``CoherenceError``. None of these is raised by the registry.
+CasResult: TypeAlias = "tuple[Artifact, list[UUID]] | ConflictDetail | CasCorruption"
 
 
 class SchemaVersionError(RuntimeError):
@@ -963,6 +970,277 @@ class SqliteArtifactRegistry:
                 # uncommitted transaction that the next BEGIN IMMEDIATE sees.
                 self._conn.execute("ROLLBACK")
                 raise
+
+    def commit_cas(
+        self,
+        artifact_id: UUID,
+        agent_id: UUID,
+        *,
+        expected_version: int,
+        content_hash: str,
+        size_tokens: int | None = None,
+        tick: int = 0,
+        trigger: str = "commit_cas",
+    ) -> CasResult:
+        """Atomic optimistic-concurrency compare-and-swap commit (plan Unit 2,
+        R1/R2/R4/R5/R8). Models :meth:`resolve_or_register`: one
+        ``BEGIN IMMEDIATE`` under one lock acquisition does the entire
+        version-check → discriminate → conditional-mutate sequence, so two
+        cross-process OCC writers cannot both win the same version.
+
+        Three-outcome discrimination (the version check PRECEDES the holder
+        check so a just-committed winner's MODIFIED state never mis-fires
+        ``other_holder`` for the loser):
+
+        - ``expected_version > current`` → :class:`CasCorruption` (impossible
+          from an honest single coordinator; service raises ``CoherenceError``).
+          No mutation.
+        - ``expected_version < current`` → ``ConflictDetail("version_mismatch")``.
+          No mutation. (Two OCC writers — both SHARED — are arbitrated here.)
+        - version matches **and** another agent holds M/E (a *pessimistic*
+          peer; the OCC writer itself is S/I and does not count) →
+          ``ConflictDetail("other_holder")``. No mutation.
+        - else (version matches, no other M/E holder) → **WIN**: bump version
+          to ``current + 1``, write ``content_hash`` + ``last_writer_id``,
+          transition the committer S/I → MODIFIED, invalidate every non-INVALID
+          peer to INVALID. Returns ``(updated_artifact, invalidated_agent_ids)``.
+
+        The committer's MODIFIED bookkeeping and the per-peer invalidation are
+        INLINED as raw SQL — :meth:`set_agent_state` opens its own
+        ``BEGIN IMMEDIATE`` and cannot be called nested. This reproduces
+        ``set_agent_state``'s contract for the participants it touches:
+        ``granted_at_tick`` (set on the S/I→MODIFIED M∪E acquire; reclaim slot
+        cleared), the mutation-then-log + ``_seq`` rollback invariant, and the
+        ``state_log`` emit per transition (KTD-13: compare on version, never
+        content bytes).
+        """
+        with self._lock:
+            # Track every _seq increment in this call so the outer
+            # BaseException handler can roll them ALL back if COMMIT (or any
+            # later step) fails — mirrors set_agent_state's COR-02 contract,
+            # generalized to the multiple emissions one CAS can produce.
+            seq_incremented_count = 0
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                version_row = self._conn.execute(
+                    "SELECT version FROM artifacts WHERE id = ?", (artifact_id.hex,)
+                ).fetchone()
+                if version_row is None:
+                    raise KeyError(f"artifact {artifact_id} not in registry")
+                current = version_row[0]
+
+                # 3-outcome discrimination. Each non-win branch COMMITs the
+                # (read-only) transaction and returns a typed result; nothing
+                # was mutated, so the COMMIT just releases the lock cleanly.
+                if expected_version > current:
+                    self._conn.execute("COMMIT")
+                    return CasCorruption(current_version=current)
+                if expected_version < current:
+                    self._conn.execute("COMMIT")
+                    return ConflictDetail("version_mismatch", current)
+                # Version matches. Holder check is the OCC-vs-pessimistic guard;
+                # exclude the committer itself (it is S/I, but be defensive).
+                other_holder = self._conn.execute(
+                    """
+                    SELECT 1 FROM agent_states
+                    WHERE artifact_id = ? AND agent_id != ? AND state IN (?, ?)
+                    LIMIT 1
+                    """,
+                    (
+                        artifact_id.hex,
+                        agent_id.hex,
+                        MESIState.MODIFIED.name,
+                        MESIState.EXCLUSIVE.name,
+                    ),
+                ).fetchone()
+                if other_holder is not None:
+                    self._conn.execute("COMMIT")
+                    return ConflictDetail("other_holder", current)
+
+                # ---- WIN: mutate atomically ----
+                next_version = current + 1
+                self._conn.execute(
+                    """
+                    UPDATE artifacts
+                    SET version = ?, content_hash = ?, size_tokens = ?,
+                        last_writer_id = ?, updated_at = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        next_version,
+                        content_hash,
+                        size_tokens,
+                        agent_id.hex,
+                        time.time(),
+                        artifact_id.hex,
+                    ),
+                )
+
+                # Invalidate every non-INVALID peer (inlined; cannot call
+                # set_agent_state). Read the peers first so we can both emit a
+                # per-peer state_log entry and return the id list for the
+                # service's InvalidationSignal construction.
+                peer_rows = self._conn.execute(
+                    """
+                    SELECT agent_id, state, granted_at_tick FROM agent_states
+                    WHERE artifact_id = ? AND agent_id != ? AND state != ?
+                    """,
+                    (artifact_id.hex, agent_id.hex, MESIState.INVALID.name),
+                ).fetchall()
+                invalidated: list[UUID] = []
+                for peer_hex, peer_state_name, peer_granted in peer_rows:
+                    peer_from = MESIState[peer_state_name]
+                    # A peer leaving M∪E drops its granted_at_tick slot
+                    # (set_agent_state's "prev_in_me and not new_in_me" branch).
+                    peer_in_me = peer_from in _M_OR_E_STATES
+                    new_granted = None if peer_in_me else peer_granted
+                    self._conn.execute(
+                        """
+                        UPDATE agent_states
+                        SET state = ?, granted_at_tick = ?
+                        WHERE artifact_id = ? AND agent_id = ?
+                        """,
+                        (
+                            MESIState.INVALID.name,
+                            new_granted,
+                            artifact_id.hex,
+                            peer_hex,
+                        ),
+                    )
+                    seq_incremented_count += self._emit_state_log(
+                        artifact_id=artifact_id,
+                        agent_id=UUID(hex=peer_hex),
+                        from_state=peer_from,
+                        to_state=MESIState.INVALID,
+                        trigger=trigger,
+                        tick=tick,
+                        version=next_version,
+                        content_hash=None,
+                    )
+                    invalidated.append(UUID(hex=peer_hex))
+
+                # Transition the committer S/I → MODIFIED. MODIFIED is in M∪E
+                # and the prior S/I is not, so this is an M∪E *acquire*:
+                # granted_at_tick = tick, reclaim slot cleared (mirrors
+                # set_agent_state's "new_in_me and not prev_in_me" branch).
+                committer_row = self._conn.execute(
+                    "SELECT state FROM agent_states WHERE artifact_id = ? AND agent_id = ?",
+                    (artifact_id.hex, agent_id.hex),
+                ).fetchone()
+                committer_from = (
+                    MESIState[committer_row[0]] if committer_row else MESIState.INVALID
+                )
+                if committer_row is None:
+                    self._conn.execute(
+                        """
+                        INSERT INTO agent_states (artifact_id, agent_id, state, granted_at_tick,
+                                                  last_reclaim_trigger, last_reclaim_tick)
+                        VALUES (?, ?, ?, ?, NULL, NULL)
+                        """,
+                        (artifact_id.hex, agent_id.hex, MESIState.MODIFIED.name, tick),
+                    )
+                else:
+                    self._conn.execute(
+                        """
+                        UPDATE agent_states
+                        SET state = ?, granted_at_tick = ?, last_reclaim_trigger = NULL,
+                            last_reclaim_tick = NULL
+                        WHERE artifact_id = ? AND agent_id = ?
+                        """,
+                        (MESIState.MODIFIED.name, tick, artifact_id.hex, agent_id.hex),
+                    )
+                seq_incremented_count += self._emit_state_log(
+                    artifact_id=artifact_id,
+                    agent_id=agent_id,
+                    from_state=committer_from,
+                    to_state=MESIState.MODIFIED,
+                    trigger=trigger,
+                    tick=tick,
+                    version=next_version,
+                    content_hash=content_hash,
+                )
+
+                self._conn.execute("COMMIT")
+                # COMMIT succeeded — _seq durably persisted; suppress rollback.
+                seq_incremented_count = 0
+            except BaseException:
+                # BaseException (not Exception) so KeyboardInterrupt/SystemExit
+                # mid-transaction still ROLLBACK before propagating — the same
+                # idiom every mutating method here uses.
+                self._conn.execute("ROLLBACK")
+                # Roll the in-memory _seq back to match the rolled-back DB so
+                # the next successful emission does not leave a phantom gap.
+                if seq_incremented_count:
+                    self._seq -= seq_incremented_count
+                raise
+
+            updated = Artifact(
+                id=artifact_id,
+                name=self._artifact_name(artifact_id),
+                version=next_version,
+                content_hash=content_hash,
+                size_tokens=size_tokens,
+            )
+            return updated, invalidated
+
+    def _emit_state_log(
+        self,
+        *,
+        artifact_id: UUID,
+        agent_id: UUID,
+        from_state: MESIState,
+        to_state: MESIState,
+        trigger: str,
+        tick: int,
+        version: int,
+        content_hash: str | None,
+    ) -> int:
+        """Emit one ``state_log`` entry for a transition that already happened
+        inside the CALLER's open ``BEGIN IMMEDIATE``. Returns 1 if ``_seq`` was
+        bumped (so the caller can roll it back on a later failure), 0 otherwise.
+
+        Reproduces the mutation-then-log + ``_seq`` rollback invariant from
+        :meth:`set_agent_state` for the inlined CAS region: ``_seq`` is reserved
+        on success, and if the callback raises we decrement and re-raise so the
+        caller's ``ROLLBACK`` leaves no phantom gap. Caller holds the lock and
+        an open transaction.
+        """
+        if self._state_log is None:
+            return 0
+        self._seq += 1
+        entry = {
+            "tick": tick,
+            "artifact_id": str(artifact_id),
+            "agent_id": str(agent_id),
+            "agent_name": self._agent_names.get(agent_id) if self._agent_names is not None else None,
+            "from_state": from_state.name,
+            "to_state": to_state.name,
+            "trigger": trigger,
+            "version": version,
+            "content_hash": content_hash,
+            "sequence_number": self._seq,
+            "instance_id": self._instance_id,
+            "schema_version": CCS_STATE_LOG_SCHEMA_VERSION,
+        }
+        try:
+            self._state_log(entry)
+        except Exception:
+            self._seq -= 1
+            raise
+        self._conn.execute(
+            "UPDATE registry_meta SET value = ? WHERE key = 'sequence_number'",
+            (str(self._seq),),
+        )
+        return 1
+
+    def _artifact_name(self, artifact_id: UUID) -> str:
+        """Read the artifact's name inside the caller's open transaction."""
+        row = self._conn.execute(
+            "SELECT name FROM artifacts WHERE id = ?", (artifact_id.hex,)
+        ).fetchone()
+        if row is None:  # pragma: no cover - guarded by caller's earlier SELECT
+            raise KeyError(f"artifact {artifact_id} not in registry")
+        return row[0]
 
     def artifacts_held_by_agent(
         self, agent_id: UUID, states: Iterable[MESIState]

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -42,6 +42,32 @@ class InvariantViolationError(CoherenceError):
     """Raised when a runtime invariant check fails."""
 
 
+class CasRetriesExhausted(CoherenceError):
+    """Raised when an optimistic-concurrency commit-CAS retry loop is exhausted.
+
+    The typed terminal failure for the OCC write path (plan Unit 5, R6 /
+    R-OCC-6). When ``AgentRuntime.write_cas`` has retried ``commit_cas`` the
+    strategy-allowed number of times and every attempt lost the race
+    (``ConflictDetail``), the loop surfaces THIS rather than silently dropping
+    the write. A ``CasRetriesExhausted`` therefore means *no mutation landed for
+    this caller* — the cache is left at the latest observed (refreshed) version,
+    never corrupted with an unconfirmed write.
+
+    A subclass of :class:`CoherenceError` so the deny-always-raises consumers
+    (CoherentVolume / CCSStore strict mode) already treat it as a hard failure.
+    """
+
+    def __init__(self, artifact_id: object, attempts: int, last_current_version: int) -> None:
+        super().__init__(
+            f"cas_retries_exhausted artifact={artifact_id} attempts={attempts} "
+            f"last_current_version={last_current_version} "
+            f"(no write landed — every commit_cas attempt lost the race)"
+        )
+        self.artifact_id = artifact_id
+        self.attempts = attempts
+        self.last_current_version = last_current_version
+
+
 class ScenarioValidationError(CoherenceError):
     """Raised when scenario configuration does not match schema expectations."""
 

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -5,9 +5,35 @@
 
 from __future__ import annotations
 
+# Wire-stable reason string for the retry-eligible OCC precondition where a peer
+# invalidated the caller in the window BETWEEN its fresh read and its CAS. Defined
+# ONCE here so the coordinator server's response mapping
+# (``_handle_post_edit_cas``) and the CoherentVolume client matcher
+# (``_classify_cas_response``) reference the SAME literal and cannot drift — a
+# reword on one side would otherwise silently break the other's retry routing.
+OCC_CALLER_TRANSIENT_REASON = "caller_in_transient_state"
+
 
 class CoherenceError(Exception):
     """Base error for coherence domain failures."""
+
+
+class OccCallerTransientError(CoherenceError):
+    """Retry-eligible OCC precondition: the caller is mid-transient at CAS time.
+
+    Raised by ``CoordinatorService.commit_cas`` when a peer invalidated the
+    caller between its fresh read and its commit-CAS — the registry left an
+    invalidation transient that ``commit_cas`` rejects as a precondition. This
+    is a LOST RACE, not corruption: a fresh identity (via ``reacquire()``) has
+    no transient, so the client may retry.
+
+    A dedicated type so the wire reason (:data:`OCC_CALLER_TRANSIENT_REASON`,
+    surfaced by the coordinator server) is decoupled from the human-readable
+    message — a reword of the message can no longer break the client's
+    substring-free retry classification. The M/E-rejection and
+    artifact-not-found branches of ``commit_cas`` stay plain
+    :class:`CoherenceError`; only the transient precondition is retry-eligible.
+    """
 
 
 class CoherenceDegradedWarning(UserWarning):

--- a/src/ccs/core/types.py
+++ b/src/ccs/core/types.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Literal, Optional
 from uuid import UUID, uuid4
 
 from .states import MESIState, TransientState
@@ -36,6 +36,50 @@ class ArtifactCacheEntry:
     expires_at_tick: Optional[int] = None
     transient_state: Optional[TransientState] = None
     transient_entered_tick: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class ConflictDetail:
+    """Typed result of an optimistic-concurrency commit that did NOT mutate.
+
+    Returned (never raised) by the registry ``commit_cas`` primitive and the
+    service ``commit_cas`` orchestration when a compare-and-swap loses the
+    race (OCC write API, plan R2 / R-OCC-2). The two retry-eligible reasons:
+
+    - ``"version_mismatch"`` — the caller's ``expected_version`` is *behind*
+      the registry's current version (another writer committed first). Two
+      concurrent OCC writers (both SHARED) are arbitrated here: the serialized
+      transaction lets the first win and the second observes this.
+    - ``"other_holder"`` — the version matched, but a *pessimistic* peer holds
+      MODIFIED or EXCLUSIVE during the OCC compute window (OCC-vs-pessimistic
+      coexistence guard). Not how two OCC writers are arbitrated.
+
+    Both are retry-eligible (re-read → recompute → retry). ``current_version``
+    is the registry's authoritative version at the point the conflict was
+    detected, so the caller can re-seed its retry. Corruption
+    (``expected_version > current``) is signalled separately (it is never a
+    ``ConflictDetail``) and the service layer raises ``CoherenceError`` for it.
+    """
+
+    reason: Literal["version_mismatch", "other_holder"]
+    current_version: int
+
+
+@dataclass(frozen=True)
+class CasCorruption:
+    """Typed registry signal that an OCC compare-and-swap saw an impossible
+    state: ``expected_version > current_version``.
+
+    A correct single-coordinator system cannot produce this — an honest writer
+    only ever observes a version ≤ the current one. It indicates corruption or
+    a second coordinator writing the same store. Kept DISTINCT from
+    ``ConflictDetail`` (a retry-eligible conflict) so the service layer can map
+    it to a non-retryable ``CoherenceError`` (plan R2). The registry returns
+    this sentinel rather than raising so all in-transaction outcomes are typed
+    returns and the ``BEGIN IMMEDIATE`` region stays a single clean commit path.
+    """
+
+    current_version: int
 
 
 @dataclass(frozen=True)

--- a/src/ccs/strategies/base.py
+++ b/src/ccs/strategies/base.py
@@ -22,6 +22,32 @@ class SyncStrategy(ABC):
         """Whether peers should receive invalidation when writer commits."""
         return True
 
+    def max_cas_retries(self) -> int:
+        """Max retry attempts the OCC caller may make after a commit-CAS conflict.
+
+        Policy knob only: the retry *loop* (re-read -> recompute -> commit_cas)
+        lives in the caller/``AgentRuntime`` (the actor), never in the strategy
+        (D1 "retry is policy, strategy-layer"; strategies are policy, not actors).
+        Total commit_cas attempts is ``max_cas_retries() + 1`` (initial + retries).
+        Conservative default; a strategy MAY override (e.g. to tune retries vs a
+        lease TTL). There is deliberately NO auto-escalation to EXCLUSIVE (D5).
+        """
+        return 3
+
+    def cas_backoff_ticks(self, attempt: int) -> int:
+        """Deterministic, non-negative backoff (in ticks) before retry ``attempt``.
+
+        ``attempt`` is 0-based (0 == the first retry after the initial attempt).
+        Default is a capped exponential schedule (0, 1, 2, 4, 8, ... up to 16):
+        the first retry is immediate so a single transient conflict re-reads with
+        no delay, then growth bounds livelock under sustained contention. Pure
+        function of ``attempt`` (no wall clock, no RNG) so behavior is testable
+        and reproducible. Negative ``attempt`` clamps to no delay.
+        """
+        if attempt <= 0:
+            return 0
+        return min(1 << (attempt - 1), 16)
+
     def broadcasts_content_on_commit(self) -> bool:
         """Whether the strategy pushes full content on commit."""
         return False

--- a/tests/adapters/test_ccsstore.py
+++ b/tests/adapters/test_ccsstore.py
@@ -1194,3 +1194,43 @@ def test_ccsstore_default_thresholds_no_false_reclaim_then_reclaims() -> None:
     store._tick = 120
     _put(store, ("other", "shared"), "scratch", {"v": 2})  # tick 121: sweep fires, holder gap 120 >= 120
     assert store.core.registry.get_agent_state(artifact_id, holder_id) == MESIState.INVALID
+
+
+# ---------------------------------------------------------------------------
+# Unit 5 — OCC write_cas reachability through CCSStore
+#
+# CCSStore inherits write_cas via CoherenceAdapterCore (store.core). This is a
+# reachability smoke test confirming the OCC path is wired through the verified
+# representative adapter; the other four framework adapters inherit the same
+# write_cas via CoherenceAdapterCore with no per-adapter change (verified by the
+# CoherenceAdapterCore tests in tests/test_adapters.py).
+# ---------------------------------------------------------------------------
+
+
+def test_ccsstore_occ_write_cas_path_is_reachable() -> None:
+    store = _store()
+    _put(store, ("writer", "shared"), "doc", {"v": 1})
+    artifact_id = store._artifact_map[(("shared",), "doc")]
+
+    # Land two SHARED holders at the coordinator (the S/I OCC starting point).
+    store.core.register_agent("writer")
+    store.core.register_agent("peer")
+    store.core.read(agent_name="writer", artifact_id=artifact_id, now_tick=10)
+    store.core.read(agent_name="peer", artifact_id=artifact_id, now_tick=10)
+    assert (
+        store.core.registry.get_agent_state(artifact_id, store.core.agent_id_for("writer"))
+        == MESIState.SHARED
+    )
+
+    # The inherited OCC path commits and invalidates the peer.
+    updated = store.core.write_cas(
+        agent_name="writer",
+        artifact_id=artifact_id,
+        make_content=lambda entry: (json.dumps({"v": entry.local_version + 1}), None),
+        now_tick=11,
+    )
+
+    assert updated.version > 1
+    assert (
+        store.core.runtime("peer").cache.get(artifact_id).state == MESIState.INVALID
+    )

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -30,7 +30,11 @@ from ccs.adapters.coherent_volume import (
     install,
     uninstall,
 )
-from ccs.core.exceptions import CoherenceDegradedWarning, CoherenceError
+from ccs.core.exceptions import (
+    CasRetriesExhausted,
+    CoherenceDegradedWarning,
+    CoherenceError,
+)
 
 
 @pytest.fixture
@@ -403,6 +407,193 @@ def test_deny_raises_even_in_degrade_mode(
             vol_b.write("data/shared.txt", b"stale")  # deny still raises in degrade mode
         assert not vol_b.is_degraded  # the deny did not register as infra degradation
         assert target.read_bytes() == b"v2-from-A"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Unit 6 — CoherentVolume.write_cas (OCC write path, bypasses the acquire).
+#
+# write_cas reads (→ SHARED) → derives bytes via make_content(current) →
+# commits through /hooks/post-edit-cas. On a version conflict it reacquire()s
+# (re-mint + fresh read) and retries, bounded by MAX_CAS_REACQUIRES; on
+# exhaustion it raises CasRetriesExhausted. Deny — including the fail-closed
+# {ok:false, degraded:true, commit_unconfirmed} body — ALWAYS raises.
+# ---------------------------------------------------------------------------
+
+
+def test_write_cas_first_writer_commits(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    """A single OCC writer reads then write_cas-commits cleanly (version bumps
+    on the coordinator; bytes land on disk)."""
+    target = _seed(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.write_cas("data/shared.txt", lambda cur: cur + b"\nappended")
+        assert target.read_bytes() == b"v1\nappended"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_cas_conflict_reacquires_and_converges(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """THE OCC RECOVERY: A reads v1, B reads v1, A commits v2 (B → INVALID).
+    A's turn then ends (session-stop releases A's grant — the realistic
+    "the other agent finished" case). B.write_cas finds itself INVALID,
+    reacquire()s (re-mint + fresh read of A's v2 bytes), re-derives via
+    make_content against the fresh view, and commits → converges. No lost
+    update: B's commit is an UPDATE rebased on A's v2, not a stale clobber.
+
+    (A's grant must clear before B's OCC commit can land: an OCC writer is S/I
+    and never invalidates a peer's MODIFIED grant, so a lingering pessimistic
+    holder yields ``other_holder`` until the grant is released or times out —
+    the OCC-vs-pessimistic coexistence bound. Here A releases via session-stop.)
+    """
+    from ccs.cli._coherence_client import post as _cpost
+
+    target = _seed(tmp_path, content=b"v1")
+    vol_a, vol_b = _pair(tmp_path, fast_cfg)
+    try:
+        vol_a.read("data/shared.txt")
+        vol_b.read("data/shared.txt")  # B is SHARED@v1
+
+        vol_a.write("data/shared.txt", b"v2-from-A")  # B → INVALID, version → 2
+        assert target.read_bytes() == b"v2-from-A"
+        # A's turn ends — release its grant so the OCC writer is not blocked by
+        # other_holder against A's lingering MODIFIED.
+        _cpost(vol_a._endpoint, "/hooks/session-stop", {"session_id": vol_a.session_id})
+
+        seen: list[bytes] = []
+
+        def make(current: bytes) -> bytes:
+            # Records the bytes each attempt derives from — proves the retry
+            # re-reads A's v2 (not B's stale v1 buffer).
+            seen.append(current)
+            return current + b"\nrebased-by-B"
+
+        vol_b.write_cas("data/shared.txt", make)
+        # Converged on top of A's bytes — the lost update did NOT happen.
+        assert target.read_bytes() == b"v2-from-A\nrebased-by-B"
+        # The winning attempt derived from A's v2 bytes (re-read via reacquire),
+        # never from the original stale v1.
+        assert b"v2-from-A" in seen[-1]
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_cas_exhaustion_raises_typed_terminal(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """Bounded progress (R6): if every attempt loses the race, write_cas raises
+    CasRetriesExhausted (a typed terminal) rather than silently dropping the
+    write. Simulated by a peer that commits a fresh version on EVERY attempt, so
+    B's expected_version is always stale by commit time."""
+    import ccs.adapters.coherent_volume as cv_mod
+
+    target = _seed(tmp_path, content=b"v1")
+    vol_a, vol_b = _pair(tmp_path, fast_cfg)
+    # Shrink the bound so the test is fast + deterministic.
+    original_max = cv_mod.MAX_CAS_REACQUIRES
+    cv_mod.MAX_CAS_REACQUIRES = 2
+    try:
+        vol_a.read("data/shared.txt")
+        counter = {"n": 1}
+
+        def make(current: bytes) -> bytes:
+            # On every B attempt, A commits a NEW version first → B's read is
+            # immediately stale → guaranteed version_mismatch each attempt.
+            counter["n"] += 1
+            vol_a.reacquire("data/shared.txt")
+            vol_a.write("data/shared.txt", f"vA-{counter['n']}".encode())
+            return current + b"\nB-attempt"
+
+        with pytest.raises(CasRetriesExhausted) as exc:
+            vol_b.write_cas("data/shared.txt", make)
+        # The terminal records the artifact + that no write landed for B.
+        assert exc.value.attempts == cv_mod.MAX_CAS_REACQUIRES + 1
+        # B's stale buffer never clobbered A's latest.
+        assert b"B-attempt" not in target.read_bytes()
+    finally:
+        cv_mod.MAX_CAS_REACQUIRES = original_max
+        stop_coordinator(tmp_path)
+
+
+def test_write_cas_deny_raises_in_both_on_error_modes(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """A non-retry-eligible deny (e.g. corruption: expected_version > current)
+    ALWAYS raises CoherenceError — in BOTH strict and degrade on_error modes —
+    and never silently succeeds. write_cas sources expected_version from its own
+    read, so we force corruption by stubbing _read_with_version to over-report
+    the version (expected > current → the coordinator returns an error body)."""
+    for mode in ("strict", "degrade"):
+        target = _seed(tmp_path, content=b"v1")
+        vol = CoherentVolume(
+            tmp_path, managed=("data/**",), on_error=mode, config=fast_cfg
+        )
+        try:
+            # Seed the artifact on the coordinator (v1 + SHARED) via a real read
+            # so the CAS has a real version to compare against.
+            assert vol.read("data/shared.txt") == b"v1"
+            # Force expected_version far above current → corruption body
+            # ({ok:false, reason:commit_cas_corruption...}) which must raise.
+            # (bytes, version, stale_denied) — not stale, so no reacquire.
+            vol._read_with_version = lambda rel: (b"v1", 999, False)  # type: ignore[assignment]
+            with pytest.raises(CoherenceError):
+                vol.write_cas("data/shared.txt", lambda cur: b"should-not-land")
+            assert not vol.is_degraded, (
+                "a deny is enforcement working, not infra degradation"
+            )
+            # The unconfirmed write never landed.
+            assert target.read_bytes() == b"v1"
+        finally:
+            stop_coordinator(tmp_path)
+
+
+def test_write_cas_degrade_body_raises_in_both_modes(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """The fail-closed degrade body ({ok:false, degraded:true,
+    reason:'commit_unconfirmed'}) must raise in BOTH on_error modes — a degraded
+    CAS is unconfirmed, so the client must never assume the write landed.
+    Simulated by stubbing the coordinator POST to return that body."""
+    for mode in ("strict", "degrade"):
+        target = _seed(tmp_path, content=b"v1")
+        vol = CoherentVolume(
+            tmp_path, managed=("data/**",), on_error=mode, config=fast_cfg
+        )
+        try:
+            real_post = vol._post
+
+            def fake_post(endpoint_path: str, payload: dict, _real=real_post):
+                if endpoint_path == "/hooks/post-edit-cas":
+                    return {"ok": False, "degraded": True, "reason": "commit_unconfirmed"}
+                return _real(endpoint_path, payload)
+
+            vol._post = fake_post  # type: ignore[assignment]
+            with pytest.raises(CoherenceError):
+                vol.write_cas("data/shared.txt", lambda cur: b"unconfirmed")
+            # commit_unconfirmed is a hard failure, not infra degradation, so the
+            # deny path does NOT bump the degradation counter.
+            assert not vol.is_degraded
+            assert target.read_bytes() == b"v1"
+        finally:
+            stop_coordinator(tmp_path)
+
+
+def test_write_cas_make_content_sees_current_bytes(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """make_content is invoked with the freshly-read current bytes so the
+    caller re-derives intent against the latest state (the OCC update contract,
+    same boundary as reacquire())."""
+    _seed(tmp_path, content=b"hello")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        captured: list[bytes] = []
+        vol.write_cas("data/shared.txt", lambda cur: captured.append(cur) or (cur + b"!"))
+        assert captured == [b"hello"]
+        assert (tmp_path / "data/shared.txt").read_bytes() == b"hello!"
     finally:
         stop_coordinator(tmp_path)
 

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -598,6 +598,61 @@ def test_write_cas_make_content_sees_current_bytes(
         stop_coordinator(tmp_path)
 
 
+def test_write_cas_degrade_none_response_fails_closed_no_disk_write(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """FIX 1: in degrade mode, a mid-commit transport failure that ``_post``
+    swallowed (returns None for /hooks/post-edit-cas AFTER a version was read)
+    must FAIL CLOSED — raise CoherenceError and NOT write the unconfirmed bytes
+    to disk. An OCC writer holds no grant, so unconfirmed bytes touching disk
+    would re-open the lost update the feature prevents. Before the fix this path
+    best-effort _atomic_write'd and returned success."""
+    target = _seed(tmp_path, content=b"v1")
+    vol = CoherentVolume(
+        tmp_path, managed=("data/**",), on_error="degrade", config=fast_cfg
+    )
+    try:
+        # Seed a real read so the CAS has a real version comparand (pre-read must
+        # succeed; only the commit POST is forced to None).
+        assert vol.read("data/shared.txt") == b"v1"
+        real_post = vol._post
+
+        def fake_post(endpoint_path: str, payload: dict, _real=real_post):
+            # Simulate a degrade-swallowed transport failure on the OCC commit
+            # only — every other call (pre-read) behaves normally.
+            if endpoint_path == "/hooks/post-edit-cas":
+                return None
+            return _real(endpoint_path, payload)
+
+        vol._post = fake_post  # type: ignore[assignment]
+        with pytest.raises(CoherenceError):
+            vol.write_cas("data/shared.txt", lambda cur: b"unconfirmed-bytes")
+        # The unconfirmed bytes NEVER touched disk (the whole point of the fix).
+        assert target.read_bytes() == b"v1"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_cas_repeatable_for_same_volume(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """FIX 3 (cross-process): the same volume can write_cas the same path TWICE
+    back-to-back — both win (version bumps each time) with no D4 'use commit()'
+    rejection, because a winning commit_cas ends the committer SHARED on the
+    coordinator (an OCC writer holds no grant). Before the fix the first win left
+    the agent MODIFIED and the second write_cas hard-failed the D4 precondition."""
+    target = _seed(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.write_cas("data/shared.txt", lambda cur: cur + b"\nfirst")
+        assert target.read_bytes() == b"v1\nfirst"
+        # Second OCC write by the SAME volume must also land (no D4 rejection).
+        vol.write_cas("data/shared.txt", lambda cur: cur + b"\nsecond")
+        assert target.read_bytes() == b"v1\nfirst\nsecond"
+    finally:
+        stop_coordinator(tmp_path)
+
+
 # ---------------------------------------------------------------------------
 # Unit 3 — install() builtins.open / io.open shim (opt-in, demo-grade).
 #

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -15,6 +15,7 @@ import builtins
 import io
 import os
 import subprocess
+import threading
 from pathlib import Path
 
 import pytest
@@ -649,6 +650,241 @@ def test_write_cas_repeatable_for_same_volume(
         # Second OCC write by the SAME volume must also land (no D4 rejection).
         vol.write_cas("data/shared.txt", lambda cur: cur + b"\nsecond")
         assert target.read_bytes() == b"v1\nfirst\nsecond"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_classify_cas_response_transient_is_conflict(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """AC2 (unit): the stable wire reason 'caller_in_transient_state' classifies
+    as a retry-eligible 'conflict' via an EXACT match (no brittle substring) so a
+    reword of the coordinator's human message can't break retry routing."""
+    _seed(tmp_path)
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        assert vol._classify_cas_response(
+            {"ok": False, "reason": "caller_in_transient_state"}
+        ) == "conflict"
+        # The legacy human message ("commit_cas_not_allowed ... reason=...") is
+        # no longer matched — only the exact stable reason routes to conflict.
+        assert vol._classify_cas_response(
+            {"ok": False, "reason": "commit_cas_not_allowed agent=x reason=caller_in_transient_state"}
+        ) == "raise"
+        # Sanity: the typed ConflictDetail reasons still classify as conflict.
+        assert vol._classify_cas_response(
+            {"ok": False, "reason": "version_mismatch", "current_version": 2}
+        ) == "conflict"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_cas_transient_reason_reacquires_and_converges(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """AC2 (end-to-end client): a CAS that comes back with the stable transient
+    reason 'caller_in_transient_state' is treated as a CONFLICT — write_cas
+    reacquires (re-mint + fresh read) and retries to convergence, NOT raise.
+    Stubbed so the FIRST OCC commit returns the transient body and the next
+    passes through to the real coordinator (which wins)."""
+    target = _seed(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        # A real read so the artifact + version exist for the eventual real CAS.
+        assert vol.read("data/shared.txt") == b"v1"
+        real_post = vol._post
+        cas_calls = {"n": 0}
+
+        def fake_post(endpoint_path: str, payload: dict, _real=real_post):
+            if endpoint_path == "/hooks/post-edit-cas":
+                cas_calls["n"] += 1
+                if cas_calls["n"] == 1:
+                    # First attempt: a peer invalidated us mid-window. Stable
+                    # retry-eligible reason — the client must reacquire + retry.
+                    return {
+                        "ok": False,
+                        "reason": "caller_in_transient_state",
+                        "current_version": 1,
+                    }
+            return _real(endpoint_path, payload)
+
+        vol._post = fake_post  # type: ignore[assignment]
+        vol.write_cas("data/shared.txt", lambda cur: cur + b"\nrebased")
+        # Converged (did NOT raise): the retry landed the rebased bytes.
+        assert target.read_bytes() == b"v1\nrebased"
+        assert cas_calls["n"] >= 2  # first transient-conflict, then a real win
+        # A retry-eligible conflict is not infra degradation.
+        assert not vol.is_degraded
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# A5 — single-instance concurrency guard. One instance is single-threaded by
+# contract; overlapping use across threads raises (loud misuse) rather than
+# splitting an in-flight CAS across re-minted identities. The guard is re-entrant
+# for the same thread so the internal write_cas → reacquire → read nesting works.
+# ---------------------------------------------------------------------------
+
+
+def test_overlapping_use_from_another_thread_raises(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """A5: while one thread holds an op in flight on an instance, a second
+    thread calling a public op on the SAME instance raises CoherenceError —
+    concurrent use is detected, not silently allowed."""
+    _seed(tmp_path)
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    held = threading.Event()
+    release = threading.Event()
+
+    def holder() -> None:
+        # Hold the guard the way an in-flight op does (same mechanism the public
+        # ops use), then block so the main thread's op truly overlaps.
+        with vol._single_op_guard():
+            held.set()
+            release.wait(timeout=5)
+
+    t = threading.Thread(target=holder)
+    t.start()
+    try:
+        assert held.wait(timeout=5), "holder thread never acquired the guard"
+        # A different thread (this one) calling a public op while the guard is
+        # held elsewhere must raise — overlapping single-instance use.
+        with pytest.raises(CoherenceError, match="single-threaded"):
+            vol.read("data/shared.txt")
+        with pytest.raises(CoherenceError, match="single-threaded"):
+            vol.write("data/shared.txt", b"nope")
+        with pytest.raises(CoherenceError, match="single-threaded"):
+            vol.write_cas("data/shared.txt", lambda cur: b"nope")
+    finally:
+        release.set()
+        t.join(timeout=5)
+        stop_coordinator(tmp_path)
+
+
+def test_guard_released_after_op_allows_subsequent_ops(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """A5: the guard is released in a finally, so normal SEQUENTIAL use is
+    unaffected — back-to-back read/write/write_cas (and the internal
+    reacquire-within-write_cas path) all succeed. Also asserts the guard owner is
+    cleared after each op so the instance is reusable."""
+    from ccs.cli._coherence_client import post as _cpost
+
+    target = _seed(tmp_path, content=b"v1")
+    vol_a, vol_b = _pair(tmp_path, fast_cfg)
+    try:
+        # Sequential reads + write on one instance: guard taken + released each
+        # time, never tripping itself.
+        assert vol_a.read("data/shared.txt") == b"v1"
+        assert vol_b.read("data/shared.txt") == b"v1"
+        vol_a.write("data/shared.txt", b"v2-from-A")  # B -> INVALID
+        assert vol_a._guard_owner_ident is None  # released after the op
+        # A's turn ends — release its MODIFIED grant so B's OCC commit is not
+        # blocked by other_holder (the OCC-vs-pessimistic coexistence bound).
+        _cpost(vol_a._endpoint, "/hooks/session-stop", {"session_id": vol_a.session_id})
+
+        # The internal reacquire-within-write_cas path: B is INVALID, so
+        # write_cas must reacquire() (which calls read()) on the SAME thread —
+        # re-entering the guard, not deadlocking or tripping it — and converge.
+        vol_b.write_cas("data/shared.txt", lambda cur: cur + b"\nrebased-by-B")
+        assert target.read_bytes() == b"v2-from-A\nrebased-by-B"
+        assert vol_b._guard_owner_ident is None  # released after write_cas too
+
+        # And a plain direct reacquire() still works (its internal read()
+        # re-enters the guard fresh on this thread).
+        fresh = vol_b.reacquire("data/shared.txt")
+        assert fresh == b"v2-from-A\nrebased-by-B"
+        assert vol_b._guard_owner_ident is None  # released after reacquire too
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# T2 — write_cas recovery from a STICKY strict-deny (KTD-T), plus the
+# coordinator-wedged guard. Distinct from the conflict-classify convergence
+# above: here B is INVALID at CAS time, so the stale-deny branch (NOT a
+# version_mismatch conflict) drives the reacquire.
+# ---------------------------------------------------------------------------
+
+
+def test_write_cas_recovers_from_sticky_strict_deny_and_converges(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """T2: a peer commit leaves THIS volume INVALID (sticky strict-deny). The
+    very first OCC read inside write_cas is a strict-deny (stale_denied), so
+    write_cas must reacquire() (re-mint identity → clears INVALID + the
+    invalidation transient) and commit the rebased bytes — converge, NOT raise.
+    No lost update: B's commit is rebased on A's v2."""
+    from ccs.cli._coherence_client import post as _cpost
+
+    target = _seed(tmp_path, content=b"v1")
+    vol_a, vol_b = _pair(tmp_path, fast_cfg)
+    try:
+        vol_a.read("data/shared.txt")
+        vol_b.read("data/shared.txt")  # B SHARED@v1
+        vol_a.write("data/shared.txt", b"v2-from-A")  # B -> INVALID (sticky deny)
+        # A's turn ends — release its grant so B's OCC commit is not blocked by
+        # other_holder against A's lingering MODIFIED.
+        _cpost(vol_a._endpoint, "/hooks/session-stop", {"session_id": vol_a.session_id})
+
+        # Confirm B really is in the sticky-deny state BEFORE write_cas: a bare
+        # version-aware read reports stale_denied=True (INVALID, not re-granted).
+        _bytes, _ver, stale_denied = vol_b._read_with_version("data/shared.txt")
+        assert stale_denied is True, "precondition: B must be a sticky strict-deny"
+
+        seen: list[bytes] = []
+
+        def make(current: bytes) -> bytes:
+            seen.append(current)
+            return current + b"\nrebased-by-B"
+
+        # write_cas drives the stale-deny branch → reacquire → fresh read → CAS.
+        vol_b.write_cas("data/shared.txt", make)
+        assert target.read_bytes() == b"v2-from-A\nrebased-by-B"
+        # The winning attempt derived from A's v2 (re-read via reacquire), never
+        # the stale v1 buffer.
+        assert b"v2-from-A" in seen[-1]
+        assert not vol_b.is_degraded  # a deny/recovery is enforcement, not infra
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_cas_raises_when_reacquire_cannot_clear_invalid(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """T2: the coordinator-wedged guard. If a fresh-minted identity STILL reads
+    as a strict-deny (impossible in normal operation — a brand-new identity has
+    no prior INVALID), write_cas must fail closed with a clear CoherenceError and
+    NOT spin forever. Simulated by stubbing _read_with_version to report
+    stale_denied on both the fresh read AND the post-reacquire re-read."""
+    _seed(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        assert vol.read("data/shared.txt") == b"v1"
+        calls = {"n": 0}
+
+        def always_denied(rel: str):
+            # (bytes, version, stale_denied) — always denied → the fresh read is
+            # denied AND the re-read after reacquire is denied (refused_again).
+            calls["n"] += 1
+            return (b"v1", 1, True)
+
+        vol._read_with_version = always_denied  # type: ignore[assignment]
+
+        made = {"called": False}
+
+        def make(_cur: bytes) -> bytes:
+            made["called"] = True
+            return b"should-not-commit"
+
+        with pytest.raises(CoherenceError, match="wedged"):
+            vol.write_cas("data/shared.txt", make)
+        # No spin: fresh read (1) + post-reacquire re-read (2) = exactly 2 calls,
+        # then it raises before ever deriving/committing bytes.
+        assert calls["n"] == 2
+        assert made["called"] is False
     finally:
         stop_coordinator(tmp_path)
 

--- a/tests/integration/test_strict_mode.py
+++ b/tests/integration/test_strict_mode.py
@@ -245,7 +245,8 @@ def test_pre_read_strict_tracked_fresh_allows(strict_client: _Client) -> None:
     )
     assert status == 200
     # First observation seeds SHARED → fresh response, no hookSpecificOutput.
-    assert body == {"status": "fresh"}
+    # Unit 6: the fresh response additively carries the seeded version.
+    assert body == {"status": "fresh", "version": 1}
 
 
 def test_pre_read_tracked_not_strict_stale_returns_warn(strict_client: _Client) -> None:

--- a/tests/protocol_corpus/fixtures/strict_mode/02-pre-read-strict-tracked-fresh-allows.json
+++ b/tests/protocol_corpus/fixtures/strict_mode/02-pre-read-strict-tracked-fresh-allows.json
@@ -15,6 +15,7 @@
       "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"
     }
   },
+  "optional_keys": ["version"],
   "expected": {
     "status": 200,
     "body": {"status": "fresh"}

--- a/tests/protocol_corpus/fixtures/warn_mode/02-pre-read-tracked-first-observation.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/02-pre-read-tracked-first-observation.json
@@ -16,13 +16,12 @@
       "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"
     }
   },
-  "ignore_keys": ["version"],
+  "optional_keys": ["version"],
   "expected": {
     "status": 200,
     "body": {
-      "status": "fresh",
-      "version": "<IGNORED>"
+      "status": "fresh"
     }
   },
-  "_comment": "Unit 6: the Python coordinator's fresh pre-read additively carries the artifact version (so OCC writers can source expected_version). The contract this fixture pins is status:fresh; version is ignore_keyed so it stays backend-agnostic (the Node coordinator does not implement it in this version) and value-agnostic."
+  "_comment": "Unit 6: the Python coordinator's fresh pre-read additively carries the artifact version (so OCC writers can source expected_version). version is in optional_keys, so it is DROPPED from both actual and expected before comparison — the shared baseline {status:fresh} stays parity-checked while the Python-only OCC extension field is tolerated (the Node coordinator does not emit it)."
 }

--- a/tests/protocol_corpus/fixtures/warn_mode/02-pre-read-tracked-first-observation.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/02-pre-read-tracked-first-observation.json
@@ -16,10 +16,13 @@
       "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"
     }
   },
+  "ignore_keys": ["version"],
   "expected": {
     "status": 200,
     "body": {
-      "status": "fresh"
+      "status": "fresh",
+      "version": "<IGNORED>"
     }
-  }
+  },
+  "_comment": "Unit 6: the Python coordinator's fresh pre-read additively carries the artifact version (so OCC writers can source expected_version). The contract this fixture pins is status:fresh; version is ignore_keyed so it stays backend-agnostic (the Node coordinator does not implement it in this version) and value-agnostic."
 }

--- a/tests/protocol_corpus/harness.py
+++ b/tests/protocol_corpus/harness.py
@@ -155,6 +155,7 @@ def normalize_response(
     value: Any,
     *,
     ignore_keys: Optional[frozenset[str]] = None,
+    optional_keys: Optional[frozenset[str]] = None,
 ) -> Any:
     """Replace non-deterministic field values with stable sentinels.
 
@@ -163,12 +164,23 @@ def normalize_response(
 
     ``ignore_keys`` — per-fixture opt-in set of additional key names whose
     values should be replaced with ``"<IGNORED>"``. Use sparingly; each entry
-    is a hole in the catch surface."""
+    is a hole in the catch surface.
+
+    ``optional_keys`` — per-fixture opt-in set of key names DROPPED entirely
+    from the normalized dict (on both actual and expected), for backend-specific
+    optional extension fields whose shared baseline both backends must still
+    match (e.g. a Python-only OCC ``version`` field on a pre-read response that
+    the Node coordinator does not emit)."""
     ignore_keys = ignore_keys or frozenset()
+    optional_keys = optional_keys or frozenset()
 
     def _walk(v: Any, parent_key: Optional[str]) -> Any:
         if isinstance(v, dict):
-            return {k: _walk_keyed(v[k], k) for k in sorted(v.keys())}
+            return {
+                k: _walk_keyed(v[k], k)
+                for k in sorted(v.keys())
+                if k not in optional_keys
+            }
         if isinstance(v, list):
             return [_walk(item, None) for item in v]
         if isinstance(v, str):
@@ -229,6 +241,7 @@ class Fixture:
     expected: dict[str, Any]
     backends: tuple[str, ...]
     ignore_keys: frozenset[str]
+    optional_keys: frozenset[str]
 
 
 def load_fixtures(mode: str = "warn_mode") -> list[Fixture]:
@@ -256,6 +269,7 @@ def load_fixtures(mode: str = "warn_mode") -> list[Fixture]:
                 expected=data["expected"],
                 backends=tuple(backends_raw),
                 ignore_keys=frozenset(data.get("ignore_keys", [])),
+                optional_keys=frozenset(data.get("optional_keys", [])),
             )
         )
     return fixtures
@@ -614,4 +628,6 @@ def run_scenario(
         if preflight:
             apply_preflight_requests(backend, preflight)
         status, body = execute_request(backend, fixture.request)
-    return status, normalize_response(body, ignore_keys=fixture.ignore_keys)
+    return status, normalize_response(
+        body, ignore_keys=fixture.ignore_keys, optional_keys=fixture.optional_keys
+    )

--- a/tests/protocol_corpus/harness.py
+++ b/tests/protocol_corpus/harness.py
@@ -170,19 +170,26 @@ def normalize_response(
     from the normalized dict (on both actual and expected), for backend-specific
     optional extension fields whose shared baseline both backends must still
     match (e.g. a Python-only OCC ``version`` field on a pre-read response that
-    the Node coordinator does not emit)."""
+    the Node coordinator does not emit). **Scoped to the TOP-LEVEL response body
+    only** (AC3) — a nested key that happens to share a name with an optional_key
+    is still compared, so a real nested divergence is never masked."""
     ignore_keys = ignore_keys or frozenset()
     optional_keys = optional_keys or frozenset()
 
-    def _walk(v: Any, parent_key: Optional[str]) -> Any:
+    def _walk(v: Any, *, depth: int) -> Any:
         if isinstance(v, dict):
+            # optional_keys are dropped at the ROOT dict only (depth == 0): they
+            # describe top-level backend-specific extension fields, not arbitrary
+            # nested occurrences. A nested same-named key (depth > 0) is kept and
+            # compared so a nested divergence still fails the diff.
+            drop = optional_keys if depth == 0 else frozenset()
             return {
-                k: _walk_keyed(v[k], k)
+                k: _walk_keyed(v[k], k, depth=depth)
                 for k in sorted(v.keys())
-                if k not in optional_keys
+                if k not in drop
             }
         if isinstance(v, list):
-            return [_walk(item, None) for item in v]
+            return [_walk(item, depth=depth + 1) for item in v]
         if isinstance(v, str):
             # String-position scrubbing: UUID and ISO-8601 substrings in
             # error messages / log fragments.
@@ -191,7 +198,7 @@ def normalize_response(
             return scrubbed
         return v
 
-    def _walk_keyed(v: Any, key: str) -> Any:
+    def _walk_keyed(v: Any, key: str, *, depth: int) -> Any:
         # Per-fixture ignore set wins over everything else.
         if key in ignore_keys:
             return "<IGNORED>"
@@ -209,9 +216,11 @@ def normalize_response(
             return _UUID_SENTINEL
         if key in _HASH_KEYS:
             return _HASH_SENTINEL
-        return _walk(v, key)
+        # Descend into the value; nested dicts are depth + 1 (so optional_keys no
+        # longer apply below the root).
+        return _walk(v, depth=depth + 1)
 
-    return _walk(value, None)
+    return _walk(value, depth=0)
 
 
 # ----------------------------------------------------------------------

--- a/tests/protocol_corpus/test_strict_mode_corpus.py
+++ b/tests/protocol_corpus/test_strict_mode_corpus.py
@@ -70,7 +70,9 @@ def test_strict_mode_fixture_response_matches_expected(
 
     expected_status = fixture.expected["status"]
     expected_body = normalize_response(
-        fixture.expected["body"], ignore_keys=fixture.ignore_keys
+        fixture.expected["body"],
+        ignore_keys=fixture.ignore_keys,
+        optional_keys=fixture.optional_keys,
     )
 
     assert actual_status == expected_status, (

--- a/tests/protocol_corpus/test_warn_mode_corpus.py
+++ b/tests/protocol_corpus/test_warn_mode_corpus.py
@@ -152,3 +152,40 @@ def test_normalizer_handles_nested_uuid_and_timestamp() -> None:
     assert "<UUID>" in session["message"]
     assert "<TS>" in session["message"]
     assert out["coordinator_uptime_seconds"] == "<UPTIME>"
+
+
+def test_optional_keys_dropped_only_at_top_level() -> None:
+    """AC3 harness self-test: ``optional_keys`` drops a key at the TOP-LEVEL
+    response body only. A nested occurrence of the SAME key name is kept and
+    compared, so a nested divergence still fails the diff (the bug was the drop
+    firing at every dict depth, masking nested drift)."""
+    optional = frozenset({"version"})
+
+    # Top-level: dropped on both sides → the version difference is tolerated.
+    top_a = {"status": "fresh", "version": 1}
+    top_b = {"status": "fresh", "version": 99}
+    assert normalize_response(top_a, optional_keys=optional) == normalize_response(
+        top_b, optional_keys=optional
+    )
+    # And the top-level key is actually gone after normalization.
+    assert "version" not in normalize_response(top_a, optional_keys=optional)
+
+    # Nested: a same-named key one level deep is NOT dropped, so a real nested
+    # divergence in that key still makes the two bodies compare UNEQUAL.
+    nested_a = {"status": "fresh", "payload": {"version": 1}}
+    nested_b = {"status": "fresh", "payload": {"version": 2}}
+    norm_nested_a = normalize_response(nested_a, optional_keys=optional)
+    norm_nested_b = normalize_response(nested_b, optional_keys=optional)
+    assert "version" in norm_nested_a["payload"], (
+        "nested optional-named key must be preserved, not dropped"
+    )
+    assert norm_nested_a != norm_nested_b, (
+        "a nested divergence in an optional-named key must still fail the diff"
+    )
+
+    # A same-named key nested inside a LIST element is also preserved/compared.
+    list_a = {"items": [{"version": 1}]}
+    list_b = {"items": [{"version": 7}]}
+    assert normalize_response(list_a, optional_keys=optional) != normalize_response(
+        list_b, optional_keys=optional
+    )

--- a/tests/protocol_corpus/test_warn_mode_corpus.py
+++ b/tests/protocol_corpus/test_warn_mode_corpus.py
@@ -78,7 +78,9 @@ def test_warn_mode_fixture_response_matches_expected(
     # normalizer so author choice doesn't affect equality.
     expected_status = fixture.expected["status"]
     expected_body = normalize_response(
-        fixture.expected["body"], ignore_keys=fixture.ignore_keys
+        fixture.expected["body"],
+        ignore_keys=fixture.ignore_keys,
+        optional_keys=fixture.optional_keys,
     )
 
     assert actual_status == expected_status, (

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -490,3 +490,124 @@ def test_explicit_crash_recovery_kwarg_emits_no_deprecation_warning() -> None:
     ]
     assert deprecation_warnings == []
     assert core._crash_recovery.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Unit 5 — CoherenceAdapterCore.write_cas (OCC path through the adapter envelope).
+#
+# The adapter exposes the OCC write while preserving the same envelope as
+# write(): heartbeat piggyback (ONLY when crash_recovery.enabled, at THIS layer
+# per R9), _maybe_sweep, and event-bus publish of invalidation signals on
+# success. The five framework adapters inherit write_cas via CoherenceAdapterCore.
+# ---------------------------------------------------------------------------
+
+
+def _two_shared_agents(core: CoherenceAdapterCore, *, name_a: str, name_b: str, artifact_id):
+    """Register two agents and read from both so each ends SHARED at the
+    coordinator (the S/I starting point an OCC commit_cas requires)."""
+    core.register_agent(name_a)
+    core.register_agent(name_b)
+    core.read(agent_name=name_a, artifact_id=artifact_id, now_tick=1)
+    core.read(agent_name=name_b, artifact_id=artifact_id, now_tick=1)
+    assert core.coordinator.registry.get_agent_state(artifact_id, core.agent_id_for(name_a)) == MESIState.SHARED
+    assert core.coordinator.registry.get_agent_state(artifact_id, core.agent_id_for(name_b)) == MESIState.SHARED
+
+
+def test_adapter_write_cas_commits_and_publishes_invalidation_to_peers() -> None:
+    """Integration (R8/R3): a winning OCC commit publishes the same invalidation
+    signals to the bus as write() — peers see INVALID."""
+    core = CoherenceAdapterCore(strategy_name="lazy", crash_recovery=CrashRecoveryConfig(enabled=False))
+    artifact = core.register_artifact(name="plan.md", content="v1")
+    _two_shared_agents(core, name_a="writer", name_b="peer", artifact_id=artifact.id)
+
+    updated = core.write_cas(
+        agent_name="writer",
+        artifact_id=artifact.id,
+        make_content=lambda entry: (f"writer-v{entry.local_version + 1}", None),
+        now_tick=2,
+    )
+
+    assert updated.version == 2
+    # The peer's cached copy was invalidated via the published signal (bus path).
+    peer_entry = core.runtime("peer").cache.get(artifact.id)
+    assert peer_entry is not None
+    assert peer_entry.state == MESIState.INVALID
+    # The writer holds MODIFIED locally.
+    assert core.runtime("writer").cache.get(artifact.id).state == MESIState.MODIFIED
+
+
+def test_adapter_write_cas_records_heartbeat_only_when_crash_recovery_enabled() -> None:
+    """Edge (R9): heartbeat is piggybacked at the ADAPTER layer on the OCC path
+    exactly as on write(), and ONLY when crash_recovery.enabled."""
+    # --- enabled: heartbeat recorded on write_cas ---
+    core = CoherenceAdapterCore(
+        strategy_name="lazy",
+        crash_recovery=CrashRecoveryConfig(enabled=True, heartbeat_timeout_ticks=10, max_hold_ticks=1000),
+    )
+    artifact = core.register_artifact(name="plan.md", content="v1")
+    _two_shared_agents(core, name_a="writer", name_b="peer", artifact_id=artifact.id)
+
+    hb_calls: list[int] = []
+    orig = core.coordinator.record_heartbeat
+
+    def spy(**kwargs):  # type: ignore[no-untyped-def]
+        hb_calls.append(kwargs.get("now_tick"))
+        return orig(**kwargs)
+
+    core.coordinator.record_heartbeat = spy  # type: ignore[assignment]
+    core.write_cas(
+        agent_name="writer",
+        artifact_id=artifact.id,
+        make_content=lambda entry: ("writer-v2", None),
+        now_tick=5,
+    )
+    core.coordinator.record_heartbeat = orig  # type: ignore[assignment]
+    assert 5 in hb_calls  # heartbeat piggybacked for tick 5 on the OCC path
+
+    # --- disabled: NO heartbeat recorded on write_cas ---
+    core2 = CoherenceAdapterCore(strategy_name="lazy", crash_recovery=CrashRecoveryConfig(enabled=False))
+    artifact2 = core2.register_artifact(name="plan.md", content="v1")
+    _two_shared_agents(core2, name_a="writer", name_b="peer", artifact_id=artifact2.id)
+
+    hb_calls2: list[int] = []
+    orig2 = core2.coordinator.record_heartbeat
+
+    def spy2(**kwargs):  # type: ignore[no-untyped-def]
+        hb_calls2.append(kwargs.get("now_tick"))
+        return orig2(**kwargs)
+
+    core2.coordinator.record_heartbeat = spy2  # type: ignore[assignment]
+    core2.write_cas(
+        agent_name="writer",
+        artifact_id=artifact2.id,
+        make_content=lambda entry: ("writer-v2", None),
+        now_tick=5,
+    )
+    core2.coordinator.record_heartbeat = orig2  # type: ignore[assignment]
+    assert hb_calls2 == []  # crash recovery off -> no heartbeat on the OCC path
+
+
+def test_adapter_write_cas_propagates_exhaustion_terminal() -> None:
+    """Retry exhaustion surfaces as the typed CasRetriesExhausted through the
+    adapter (a CoherenceError subclass) — never a silent dropped write."""
+    from ccs.core.exceptions import CasRetriesExhausted
+    from ccs.core.types import ConflictDetail
+
+    core = CoherenceAdapterCore(strategy_name="lazy", crash_recovery=CrashRecoveryConfig(enabled=False))
+    artifact = core.register_artifact(name="plan.md", content="v1")
+    _two_shared_agents(core, name_a="writer", name_b="peer", artifact_id=artifact.id)
+
+    def always_conflict(**kwargs):  # type: ignore[no-untyped-def]
+        return ConflictDetail(reason="version_mismatch", current_version=1)
+
+    core.coordinator.commit_cas = always_conflict  # type: ignore[assignment]
+
+    with pytest.raises(CasRetriesExhausted):
+        core.write_cas(
+            agent_name="writer",
+            artifact_id=artifact.id,
+            make_content=lambda entry: ("never-lands", None),
+            now_tick=2,
+        )
+    # No silent drop: version never advanced.
+    assert core.coordinator.registry.get_artifact(artifact.id).version == 1

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -532,8 +532,9 @@ def test_adapter_write_cas_commits_and_publishes_invalidation_to_peers() -> None
     peer_entry = core.runtime("peer").cache.get(artifact.id)
     assert peer_entry is not None
     assert peer_entry.state == MESIState.INVALID
-    # The writer holds MODIFIED locally.
-    assert core.runtime("writer").cache.get(artifact.id).state == MESIState.MODIFIED
+    # The OCC writer ends SHARED locally (an OCC win holds no grant) — the cache
+    # mirrors the coordinator's now-SHARED committer end-state, not MODIFIED.
+    assert core.runtime("writer").cache.get(artifact.id).state == MESIState.SHARED
 
 
 def test_adapter_write_cas_records_heartbeat_only_when_crash_recovery_enabled() -> None:

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -7,11 +7,15 @@ from __future__ import annotations
 
 from uuid import uuid4
 
+import pytest
+
 from ccs.agent.runtime import AgentRuntime
 from ccs.coordinator.registry import ArtifactRegistry
 from ccs.coordinator.service import CoordinatorService
+from ccs.core.exceptions import CasRetriesExhausted
+from ccs.core.hashing import compute_content_hash
 from ccs.core.states import MESIState
-from ccs.core.types import InvalidationSignal
+from ccs.core.types import ConflictDetail, FetchRequest, InvalidationSignal
 from ccs.strategies.lazy import LazyStrategy
 
 
@@ -121,3 +125,210 @@ def test_invalidate_all_cache_clears_entries_without_coordinator_call() -> None:
     assert runtime.cache.get(a1.id).state == MESIState.INVALID
     assert runtime.cache.get(a2.id).state == MESIState.INVALID
     assert call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit 5 — AgentRuntime.write_cas (the OCC library write path).
+#
+# write_cas BYPASSES the pessimistic acquire: it never calls coordinator.write()
+# / never takes EXCLUSIVE. The writer stays SHARED/INVALID and the commit-time
+# version CAS elects the winner. The retry loop lives here (the actor); the
+# strategy only supplies the knob (max_cas_retries / cas_backoff_ticks).
+# ---------------------------------------------------------------------------
+
+
+def _shared_occ_writer(coordinator: CoordinatorService, artifact_id, *, version: int) -> AgentRuntime:
+    """Return a runtime whose cache holds the artifact SHARED at ``version`` and
+    is SHARED (not EXCLUSIVE) at the coordinator too.
+
+    A lone fetch grants the *first* reader EXCLUSIVE; an OCC ``commit_cas`` needs
+    the caller in S/I (D4). So we register a throwaway co-reader, which downgrades
+    this writer to SHARED coordinator-side. The local cache entry is then seeded
+    SHARED at ``version`` so ``write_cas``'s pre-loop ``requires_refresh`` is
+    False and the first attempt submits ``expected_version=version``.
+    """
+    runtime = _runtime(coordinator)
+    coordinator.fetch(
+        FetchRequest(artifact_id=artifact_id, requesting_agent_id=runtime.agent_id, requested_at_tick=1)
+    )
+    # Co-reader downgrades `runtime` from EXCLUSIVE to SHARED at the coordinator.
+    coordinator.fetch(
+        FetchRequest(artifact_id=artifact_id, requesting_agent_id=uuid4(), requested_at_tick=1)
+    )
+    assert coordinator.registry.get_agent_state(artifact_id, runtime.agent_id) == MESIState.SHARED
+    runtime.cache.put(
+        artifact_id,
+        runtime.strategy.on_fetch(
+            artifact_id=artifact_id, version=version, state=MESIState.SHARED, now_tick=1
+        ),
+    )
+    return runtime
+
+
+def test_write_cas_never_calls_coordinator_write() -> None:
+    """The crux (R4): the OCC path must not take the pessimistic EXCLUSIVE acquire."""
+    coordinator = CoordinatorService(ArtifactRegistry())
+    artifact = coordinator.register_artifact(name="plan.md", content="v1")
+    writer = _shared_occ_writer(coordinator, artifact.id, version=artifact.version)
+
+    write_calls = 0
+    orig_write = coordinator.write
+
+    def spy_write(**kwargs):  # type: ignore[no-untyped-def]
+        nonlocal write_calls
+        write_calls += 1
+        return orig_write(**kwargs)
+
+    coordinator.write = spy_write  # type: ignore[assignment]
+
+    updated, _ = writer.write_cas(
+        artifact.id,
+        make_content=lambda entry: (f"occ-v{entry.local_version + 1}", None),
+        now_tick=2,
+    )
+
+    assert updated.version == 2
+    assert write_calls == 0  # never acquired EXCLUSIVE via coordinator.write()
+    assert writer.cache.get(artifact.id).state == MESIState.MODIFIED
+
+
+def test_write_cas_conflict_then_reread_then_commits_at_fresh_version() -> None:
+    """Happy path with a concurrent peer: first attempt hits version_mismatch,
+    the loop re-reads to the winner's version and commits there (R6/R8)."""
+    coordinator = CoordinatorService(ArtifactRegistry())
+    artifact = coordinator.register_artifact(name="plan.md", content="v1")
+    writer = _shared_occ_writer(coordinator, artifact.id, version=artifact.version)
+
+    # A concurrent OCC peer (also SHARED) commits first, bumping version 1 -> 2.
+    # `writer`'s LOCAL cache still says SHARED v1, so its first attempt is stale.
+    peer = _shared_occ_writer(coordinator, artifact.id, version=artifact.version)
+    peer_updated = coordinator.commit_cas(
+        agent_id=peer.agent_id,
+        artifact_id=artifact.id,
+        expected_version=artifact.version,
+        content_hash=compute_content_hash("peer-v2"),
+    )
+    assert peer_updated[0].version == 2  # the peer won the race
+
+    seen_expected: list[int] = []
+
+    def make_content(entry):  # type: ignore[no-untyped-def]
+        seen_expected.append(entry.local_version)
+        return (f"occ-v{entry.local_version + 1}", None)
+
+    updated, signals = writer.write_cas(artifact.id, make_content=make_content, now_tick=3)
+
+    # First attempt saw stale v1 (mismatch) -> re-read -> second attempt saw v2 (win).
+    assert seen_expected == [1, 2]
+    assert updated.version == 3
+    # Cache reflects the committed version; content recomputed against fresh state.
+    entry = writer.cache.get(artifact.id)
+    assert entry is not None
+    assert entry.state == MESIState.MODIFIED
+    assert entry.local_version == 3
+    assert writer.content(artifact.id) == "occ-v3"
+    assert len(signals) >= 0  # signals mirror commit_cas (peers already INVALID here)
+
+
+def test_write_cas_exhaustion_raises_typed_terminal_no_silent_drop() -> None:
+    """Perpetual conflict (stubbed) -> CasRetriesExhausted after exactly N+1
+    attempts; the committed version is NOT the loser's and the cache is intact."""
+    coordinator = CoordinatorService(ArtifactRegistry())
+    artifact = coordinator.register_artifact(name="plan.md", content="v1")
+    writer = _shared_occ_writer(coordinator, artifact.id, version=artifact.version)
+
+    attempts = 0
+    real_commit_cas = coordinator.commit_cas
+
+    def always_conflict(**kwargs):  # type: ignore[no-untyped-def]
+        nonlocal attempts
+        attempts += 1
+        # The registry version is still 1 (no real winner) — assert no silent drop.
+        return ConflictDetail(reason="version_mismatch", current_version=1)
+
+    coordinator.commit_cas = always_conflict  # type: ignore[assignment]
+
+    with pytest.raises(CasRetriesExhausted) as excinfo:
+        writer.write_cas(
+            artifact.id,
+            make_content=lambda entry: ("never-lands", None),
+            now_tick=2,
+        )
+
+    coordinator.commit_cas = real_commit_cas  # type: ignore[assignment]
+
+    assert attempts == writer.strategy.max_cas_retries() + 1
+    assert excinfo.value.attempts == writer.strategy.max_cas_retries() + 1
+    # No silent drop: the artifact's committed version did not advance to the
+    # loser's content, and the registry was never mutated.
+    assert coordinator.registry.get_artifact(artifact.id).version == 1
+    # Cache not corrupted with the unconfirmed write — it is not MODIFIED.
+    entry = writer.cache.get(artifact.id)
+    assert entry is not None
+    assert entry.state != MESIState.MODIFIED
+    assert writer.content(artifact.id) != "never-lands"
+
+
+def test_write_cas_loop_obeys_strategy_max_retries_knob() -> None:
+    """Unit 4 integration: a strategy with max_cas_retries()=N yields exactly
+    N+1 commit_cas attempts before CasRetriesExhausted (loop honors the knob)."""
+
+    class _TwoRetryStrategy(LazyStrategy):
+        def max_cas_retries(self) -> int:
+            return 2
+
+    coordinator = CoordinatorService(ArtifactRegistry())
+    artifact = coordinator.register_artifact(name="plan.md", content="v1")
+    runtime = AgentRuntime(
+        agent_id=uuid4(), coordinator=coordinator, strategy=_TwoRetryStrategy()
+    )
+    coordinator.fetch(
+        FetchRequest(artifact_id=artifact.id, requesting_agent_id=runtime.agent_id, requested_at_tick=1)
+    )
+    runtime.cache.put(
+        artifact.id,
+        runtime.strategy.on_fetch(
+            artifact_id=artifact.id, version=1, state=MESIState.SHARED, now_tick=1
+        ),
+    )
+
+    attempts = 0
+
+    def always_conflict(**kwargs):  # type: ignore[no-untyped-def]
+        nonlocal attempts
+        attempts += 1
+        return ConflictDetail(reason="other_holder", current_version=1)
+
+    coordinator.commit_cas = always_conflict  # type: ignore[assignment]
+
+    with pytest.raises(CasRetriesExhausted):
+        runtime.write_cas(
+            artifact.id, make_content=lambda entry: ("x", None), now_tick=2
+        )
+
+    assert attempts == 3  # max_cas_retries()=2 -> 2 + 1 attempts
+
+
+def test_write_cas_validates_provided_content_hash() -> None:
+    """A make_content-provided hash that does not match the content fails fast,
+    mirroring write()'s content_hash guard."""
+    coordinator = CoordinatorService(ArtifactRegistry())
+    artifact = coordinator.register_artifact(name="plan.md", content="v1")
+    writer = _shared_occ_writer(coordinator, artifact.id, version=artifact.version)
+
+    with pytest.raises(ValueError, match="content_hash mismatch"):
+        writer.write_cas(
+            artifact.id,
+            make_content=lambda entry: ("real-content", "deadbeef-not-the-hash"),
+            now_tick=2,
+        )
+
+    # A correct provided hash is accepted (parity with write()).
+    correct = compute_content_hash("good-content")
+    writer2 = _shared_occ_writer(coordinator, artifact.id, version=artifact.version)
+    updated, _ = writer2.write_cas(
+        artifact.id,
+        make_content=lambda entry: ("good-content", correct),
+        now_tick=3,
+    )
+    assert updated.version == 2

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -336,3 +336,113 @@ def test_write_cas_validates_provided_content_hash() -> None:
         now_tick=3,
     )
     assert updated.version == 2
+
+
+def test_write_cas_refetches_when_cache_entry_evicted_mid_loop() -> None:
+    """T5: a peer invalidation can evict the cache placeholder BETWEEN attempts.
+    write_cas must re-fetch a fresh SHARED entry before reading
+    ``entry.local_version`` (the ``entry is None`` guard) — never raise
+    AttributeError. Here attempt 0 conflicts (a peer won v2), then the
+    top-of-attempt-1 cache.get is forced to None; write_cas re-fetches and the
+    second attempt commits at the fresh version (converges)."""
+    coordinator = CoordinatorService(ArtifactRegistry())
+    artifact = coordinator.register_artifact(name="plan.md", content="v1")
+    writer = _shared_occ_writer(coordinator, artifact.id, version=artifact.version)
+
+    # A concurrent OCC peer commits first (v1 -> v2), so the writer's first
+    # attempt is stale → version_mismatch → the loop iterates to attempt 1.
+    peer = _shared_occ_writer(coordinator, artifact.id, version=artifact.version)
+    coordinator.commit_cas(
+        agent_id=peer.agent_id,
+        artifact_id=artifact.id,
+        expected_version=artifact.version,
+        content_hash=compute_content_hash("peer-v2"),
+    )
+
+    # Evict the placeholder exactly once, at the top of the SECOND attempt
+    # (the 3rd cache.get overall: pre-loop, attempt-0 top, attempt-1 top←evict).
+    real_get = writer.cache.get
+    calls = {"n": 0}
+
+    def evicting_get(aid):  # type: ignore[no-untyped-def]
+        calls["n"] += 1
+        if calls["n"] == 3:
+            return None  # simulate a peer invalidation dropping the entry
+        return real_get(aid)
+
+    writer.cache.get = evicting_get  # type: ignore[assignment]
+    try:
+        updated, _ = writer.write_cas(
+            artifact.id,
+            make_content=lambda entry: (f"occ-v{entry.local_version + 1}", None),
+            now_tick=3,
+        )
+    finally:
+        writer.cache.get = real_get  # type: ignore[assignment]
+
+    # Converged at the fresh version with no AttributeError on entry.local_version.
+    assert updated.version == 3
+    assert calls["n"] >= 4  # the eviction forced the re-fetch + re-get branch
+    entry = writer.cache.get(artifact.id)
+    assert entry is not None
+    assert entry.local_version == 3
+
+
+def test_write_cas_exhaustion_with_eviction_raises_typed_terminal() -> None:
+    """T5 (terminal path): even when the cache entry is evicted on EVERY attempt,
+    write_cas re-fetches cleanly and surfaces the typed CasRetriesExhausted on a
+    perpetual conflict — never an AttributeError, never a silent drop."""
+
+    class _TwoRetryStrategy(LazyStrategy):
+        def max_cas_retries(self) -> int:
+            return 2
+
+    coordinator = CoordinatorService(ArtifactRegistry())
+    artifact = coordinator.register_artifact(name="plan.md", content="v1")
+    runtime = AgentRuntime(
+        agent_id=uuid4(), coordinator=coordinator, strategy=_TwoRetryStrategy()
+    )
+    coordinator.fetch(
+        FetchRequest(artifact_id=artifact.id, requesting_agent_id=runtime.agent_id, requested_at_tick=1)
+    )
+    runtime.cache.put(
+        artifact.id,
+        runtime.strategy.on_fetch(
+            artifact_id=artifact.id, version=1, state=MESIState.SHARED, now_tick=1
+        ),
+    )
+
+    # Perpetual conflict — no real winner advances the registry.
+    def always_conflict(**kwargs):  # type: ignore[no-untyped-def]
+        return ConflictDetail(reason="version_mismatch", current_version=1)
+
+    coordinator.commit_cas = always_conflict  # type: ignore[assignment]
+
+    # Evict the placeholder once mid-loop (at the top of the second attempt:
+    # the 3rd cache.get — pre-loop, attempt-0 top, attempt-1 top←evict). The
+    # eviction must drive the re-fetch branch and the loop must still reach its
+    # bounded terminal rather than raising AttributeError on entry.local_version.
+    real_get = runtime.cache.get
+    calls = {"n": 0}
+
+    def evicting_get(aid):  # type: ignore[no-untyped-def]
+        calls["n"] += 1
+        if calls["n"] == 3:
+            return None  # peer invalidation drops the entry between attempts
+        return real_get(aid)
+
+    runtime.cache.get = evicting_get  # type: ignore[assignment]
+    try:
+        with pytest.raises(CasRetriesExhausted):
+            runtime.write_cas(
+                artifact.id,
+                make_content=lambda entry: ("never-lands", None),
+                now_tick=2,
+            )
+    finally:
+        runtime.cache.get = real_get  # type: ignore[assignment]
+
+    # The eviction branch was exercised, and the registry never advanced (no
+    # silent drop on the eviction+conflict path).
+    assert calls["n"] >= 4  # re-fetch branch fired after the eviction
+    assert coordinator.registry.get_artifact(artifact.id).version == 1

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -189,7 +189,9 @@ def test_write_cas_never_calls_coordinator_write() -> None:
 
     assert updated.version == 2
     assert write_calls == 0  # never acquired EXCLUSIVE via coordinator.write()
-    assert writer.cache.get(artifact.id).state == MESIState.MODIFIED
+    # An OCC win ends SHARED (no grant) on the coordinator; the local cache
+    # mirrors that — it must not be left more privileged than the registry.
+    assert writer.cache.get(artifact.id).state == MESIState.SHARED
 
 
 def test_write_cas_conflict_then_reread_then_commits_at_fresh_version() -> None:
@@ -222,9 +224,11 @@ def test_write_cas_conflict_then_reread_then_commits_at_fresh_version() -> None:
     assert seen_expected == [1, 2]
     assert updated.version == 3
     # Cache reflects the committed version; content recomputed against fresh state.
+    # An OCC win ends SHARED (no grant), so the local cache mirrors the
+    # coordinator's now-SHARED committer end-state, not MODIFIED.
     entry = writer.cache.get(artifact.id)
     assert entry is not None
-    assert entry.state == MESIState.MODIFIED
+    assert entry.state == MESIState.SHARED
     assert entry.local_version == 3
     assert writer.content(artifact.id) == "occ-v3"
     assert len(signals) >= 0  # signals mirror commit_cas (peers already INVALID here)

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -1744,13 +1744,14 @@ def test_occ_commit_does_not_take_pre_edit_acquire(coordinator, client: _Client)
                             "content_hash": _hash("v2"), "expected_version": v})
         assert s == 200
         assert b == {"ok": True, "version": v + 1}
-        # The OCC writer is never EXCLUSIVE — it is MODIFIED via commit_cas's
-        # S/I→M transition, and the pre-edit counter never moved.
+        # The OCC writer is never EXCLUSIVE — it ends SHARED via commit_cas's
+        # S/I→S transition (an OCC writer holds no grant), and the pre-edit
+        # counter never moved.
         after_pre_edit = coordinator.endpoint_counters_snapshot()["pre_edit_total"]
         assert after_pre_edit == before_pre_edit
         aid = coordinator.registry.lookup_artifact_id_by_name("plan.md")
         state = coordinator.registry.get_agent_state(aid, session_to_agent_id(sid))
-        assert state == MESIState.MODIFIED
+        assert state == MESIState.SHARED
     finally:
         mod._ROUTES[("POST", "/hooks/pre-edit")] = original
 

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -189,21 +189,23 @@ def test_get_on_post_route_returns_404(client: _Client) -> None:
 
 def test_pre_read_first_observation_returns_fresh(client: _Client) -> None:
     """KTD-9: first observation of a tracked artifact seeds v1 + grants
-    SHARED + returns fresh."""
+    SHARED + returns fresh. Unit 6: the fresh response also carries the
+    seeded ``version`` (additive — for OCC writers sourcing expected_version)."""
     status, body = client.post("/hooks/pre-read",
                                 {"session_id": _sid("s1"), "path": "CLAUDE.md",
                                  "content_hash": _hash("abc")})
     assert status == 200
-    assert body == {"status": "fresh"}
+    assert body == {"status": "fresh", "version": 1}
 
 
 def test_pre_read_repeat_from_same_session_stays_fresh(client: _Client) -> None:
-    """A second read from the same session on the same artifact is fresh."""
+    """A second read from the same session on the same artifact is fresh.
+    Unit 6: still carries the artifact version on the fresh response."""
     client.post("/hooks/pre-read", {"session_id": _sid("s1"), "path": "CLAUDE.md", "content_hash": _hash("h1")})
     status, body = client.post("/hooks/pre-read",
                                 {"session_id": _sid("s1"), "path": "CLAUDE.md", "content_hash": _hash("h1")})
     assert status == 200
-    assert body == {"status": "fresh"}
+    assert body == {"status": "fresh", "version": 1}
 
 
 def test_pre_read_after_peer_write_returns_stale(client: _Client) -> None:
@@ -1612,6 +1614,263 @@ def test_a8_failed_post_edit_does_not_increment_acquire_release(
                 {"session_id": sid, "path": "plan.md",
                  "content_hash": _hash("j6"), "success": False})
     assert coordinator._intra_task_acquire_release_total == before
+
+
+# ----------------------------------------------------------------------
+# Unit 6 — OCC commit endpoint (/hooks/post-edit-cas)
+# ----------------------------------------------------------------------
+
+
+def _occ_seed_shared(client: _Client, sid: str, path: str, h: str) -> int:
+    """OCC helper: pre-read a tracked path to register SHARED + seed the
+    artifact, returning the coordinator's version (the OCC comparand).
+
+    A first-observation read returns a fresh response carrying a top-level
+    ``version``; a second session reading an already-seeded artifact (matching
+    hash) falls through to the warn-mode stale response, which carries the
+    version under ``summary.current_version`` (mirrors the production
+    ``CoherentVolume._pre_read_version`` two-shape extraction)."""
+    s, b = client.post("/hooks/pre-read",
+                       {"session_id": sid, "path": path, "content_hash": h})
+    assert s == 200, b
+    if isinstance(b.get("version"), int):
+        return b["version"]
+    summary = b.get("summary")
+    if isinstance(summary, dict) and isinstance(summary.get("current_version"), int):
+        return summary["current_version"]
+    raise AssertionError(f"pre-read surfaced no version for OCC: {b}")
+
+
+def test_occ_commit_happy_path_bumps_version(client: _Client) -> None:
+    """OCC commit (post-edit-cas) with a matching expected_version commits and
+    returns the new version N+1 — WITHOUT a pre-edit EXCLUSIVE acquire."""
+    sid = _sid("occ1")
+    v = _occ_seed_shared(client, sid, "plan.md", _hash("occ1-v1"))  # v1
+    s, b = client.post("/hooks/post-edit-cas",
+                       {"session_id": sid, "path": "plan.md",
+                        "success": True, "content_hash": _hash("occ1-v2"),
+                        "expected_version": v})
+    assert s == 200
+    assert b == {"ok": True, "version": v + 1}
+
+
+def _artifact_version(coordinator, path: str) -> int:
+    """Read the coordinator's authoritative version for a tracked path."""
+    aid = coordinator.registry.lookup_artifact_id_by_name(path)
+    assert aid is not None
+    art = coordinator.registry.get_artifact(aid)
+    assert art is not None
+    return art.version
+
+
+def test_occ_commit_stale_version_conflicts_no_mutation(coordinator, client: _Client) -> None:
+    """A stale expected_version → {ok:false, reason:'version_mismatch',
+    current_version} — a clean typed conflict (NOT a degrade), no mutation."""
+    a, b_sid = _sid("occA"), _sid("occB")
+    v1 = _occ_seed_shared(client, a, "plan.md", _hash("v1"))      # A reads v1
+    _occ_seed_shared(client, b_sid, "plan.md", _hash("v1"))       # B reads v1
+    # A commits first → v2 (A wins).
+    s, ba = client.post("/hooks/post-edit-cas",
+                        {"session_id": a, "path": "plan.md", "success": True,
+                         "content_hash": _hash("v2-A"), "expected_version": v1})
+    assert ba == {"ok": True, "version": v1 + 1}
+    after_a = _artifact_version(coordinator, "plan.md")
+
+    # B commits with its now-stale expected_version (still v1) → version_mismatch.
+    s, bb = client.post("/hooks/post-edit-cas",
+                        {"session_id": b_sid, "path": "plan.md", "success": True,
+                         "content_hash": _hash("v2-B-stale"), "expected_version": v1})
+    assert s == 200
+    assert bb["ok"] is False
+    assert bb["reason"] == "version_mismatch"
+    assert bb["current_version"] == after_a
+    assert "degraded" not in bb  # a clean typed conflict, NOT a degrade
+    # No mutation: B's stale commit did not bump the version past A's.
+    assert _artifact_version(coordinator, "plan.md") == after_a
+
+
+def test_occ_commit_corruption_expected_gt_current_raises_body(coordinator, client: _Client) -> None:
+    """expected_version > current → corruption: commit_cas raises CoherenceError,
+    the endpoint returns {ok:false, reason:<verbatim>} the client raises on."""
+    sid = _sid("occCorrupt")
+    _occ_seed_shared(client, sid, "plan.md", _hash("v1"))  # v1
+    s, b = client.post("/hooks/post-edit-cas",
+                       {"session_id": sid, "path": "plan.md", "success": True,
+                        "content_hash": _hash("vN"), "expected_version": 999})
+    assert s == 200
+    assert b["ok"] is False
+    assert "corruption" in b["reason"] or "commit_cas_corruption" in b["reason"]
+    # No mutation on corruption.
+    assert _artifact_version(coordinator, "plan.md") == 1
+
+
+def test_occ_commit_degrade_reads_as_failure(coordinator, client: _Client) -> None:
+    """THE LOAD-BEARING FIX: a timed-out/degraded OCC commit returns
+    {ok:false, degraded:true, reason:'commit_unconfirmed'} — NOT the
+    {ok:true, degraded:true} the pessimistic post-edit uses. A client reading
+    result.get('ok') must see False so it never assumes the write landed."""
+    from concurrent.futures import TimeoutError as FuturesTimeout
+    from unittest.mock import patch
+
+    sid = _sid("occDegrade")
+    v = _occ_seed_shared(client, sid, "plan.md", _hash("v1"))
+    with patch.object(coordinator, "run_with_watchdog", side_effect=FuturesTimeout()):
+        s, b = client.post("/hooks/post-edit-cas",
+                           {"session_id": sid, "path": "plan.md", "success": True,
+                            "content_hash": _hash("v2"), "expected_version": v})
+    assert s == 200
+    assert b.get("ok") is False, "degraded OCC commit must read as FAILURE, not ok:true"
+    assert b.get("degraded") is True
+    assert b.get("reason") == "commit_unconfirmed"
+
+
+def test_occ_commit_does_not_take_pre_edit_acquire(coordinator, client: _Client) -> None:
+    """The OCC path must NOT invoke the pre-edit EXCLUSIVE-acquire handler.
+    Monkeypatch _handle_pre_edit to blow up: a full read→post-edit-cas cycle
+    still succeeds, proving the OCC writer never routes through the acquire."""
+    import ccs.adapters.claude_code.coordinator_server as mod
+    original = mod._ROUTES[("POST", "/hooks/pre-edit")]
+
+    def exploding_pre_edit(req, coord):
+        raise AssertionError("OCC path must NOT call _handle_pre_edit")
+
+    mod._ROUTES[("POST", "/hooks/pre-edit")] = exploding_pre_edit
+    try:
+        sid = _sid("occNoAcq")
+        v = _occ_seed_shared(client, sid, "plan.md", _hash("v1"))
+        before_pre_edit = coordinator.endpoint_counters_snapshot()["pre_edit_total"]
+        s, b = client.post("/hooks/post-edit-cas",
+                           {"session_id": sid, "path": "plan.md", "success": True,
+                            "content_hash": _hash("v2"), "expected_version": v})
+        assert s == 200
+        assert b == {"ok": True, "version": v + 1}
+        # The OCC writer is never EXCLUSIVE — it is MODIFIED via commit_cas's
+        # S/I→M transition, and the pre-edit counter never moved.
+        after_pre_edit = coordinator.endpoint_counters_snapshot()["pre_edit_total"]
+        assert after_pre_edit == before_pre_edit
+        aid = coordinator.registry.lookup_artifact_id_by_name("plan.md")
+        state = coordinator.registry.get_agent_state(aid, session_to_agent_id(sid))
+        assert state == MESIState.MODIFIED
+    finally:
+        mod._ROUTES[("POST", "/hooks/pre-edit")] = original
+
+
+def test_occ_commit_untracked_path_fastpath(client: _Client) -> None:
+    """An untracked path fast-paths to {ok:true} without a CAS (mirrors
+    post-edit's is_tracked early return)."""
+    s, b = client.post("/hooks/post-edit-cas",
+                       {"session_id": _sid("occU"), "path": "src/random.py",
+                        "success": True, "content_hash": _hash("h"),
+                        "expected_version": 0})
+    assert s == 200
+    assert b == {"ok": True}
+
+
+def test_occ_commit_rejects_non_int_expected_version(client: _Client) -> None:
+    """expected_version is the OCC discriminator — a malformed (non-int)
+    value is rejected at the boundary with 400, never driven into the CAS."""
+    sid = _sid("occBad")
+    _occ_seed_shared(client, sid, "plan.md", _hash("v1"))
+    s, b = client.post("/hooks/post-edit-cas",
+                       {"session_id": sid, "path": "plan.md", "success": True,
+                        "content_hash": _hash("v2"), "expected_version": "1"})
+    assert s == 400
+    assert "expected_version" in b["error"]
+
+
+def test_occ_commit_missing_content_hash_400(client: _Client) -> None:
+    """The OCC commit always carries the bytes it wrote → content_hash required."""
+    sid = _sid("occNoHash")
+    v = _occ_seed_shared(client, sid, "plan.md", _hash("v1"))
+    s, b = client.post("/hooks/post-edit-cas",
+                       {"session_id": sid, "path": "plan.md", "success": True,
+                        "expected_version": v})
+    assert s == 400
+
+
+def test_occ_commit_increments_endpoint_counter(coordinator, client: _Client) -> None:
+    """KTD-J: the OCC endpoint has its own per-endpoint counter."""
+    sid = _sid("occCount")
+    v = _occ_seed_shared(client, sid, "plan.md", _hash("v1"))
+    before = coordinator.endpoint_counters_snapshot()["post_edit_cas_total"]
+    client.post("/hooks/post-edit-cas",
+                {"session_id": sid, "path": "plan.md", "success": True,
+                 "content_hash": _hash("v2"), "expected_version": v})
+    after = coordinator.endpoint_counters_snapshot()["post_edit_cas_total"]
+    assert after == before + 1
+
+
+def test_occ_commit_concurrent_winner_election_no_lost_update(coordinator, client: _Client) -> None:
+    """R11-flavored funnel through the HTTP path: two OCC clients both read v1
+    (fixed stale buffers, NOT a counter increment), barrier-synced, both POST
+    post-edit-cas with expected_version=v1. Exactly one wins (v2), the loser
+    gets a typed version_mismatch, final version is v2 (no lost update)."""
+    n_writers = 2
+    a, b_sid = _sid("raceA"), _sid("raceB")
+    v1 = _occ_seed_shared(client, a, "plan.md", _hash("v1"))
+    assert _occ_seed_shared(client, b_sid, "plan.md", _hash("v1")) == v1
+
+    barrier = threading.Barrier(n_writers)
+    results: dict[str, tuple[int, dict]] = {}
+
+    def commit(sid: str, label: str) -> None:
+        barrier.wait()
+        results[label] = client.post(
+            "/hooks/post-edit-cas",
+            {"session_id": sid, "path": "plan.md", "success": True,
+             "content_hash": _hash(f"v2-{label}"), "expected_version": v1},
+        )
+
+    threads = [
+        threading.Thread(target=commit, args=(a, "A")),
+        threading.Thread(target=commit, args=(b_sid, "B")),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    wins = [lbl for lbl, (_, body) in results.items() if body.get("ok") is True]
+    losers = [lbl for lbl, (_, body) in results.items() if body.get("ok") is False]
+    assert len(wins) == 1, f"exactly one OCC writer must win: {results}"
+    assert len(losers) == 1
+    loser_body = results[losers[0]][1]
+    assert loser_body["reason"] == "version_mismatch"
+    # Final version is exactly v1+1 — the loser's stale buffer did NOT clobber.
+    assert _artifact_version(coordinator, "plan.md") == v1 + 1
+
+
+def test_occ_late_completion_residual_contended_is_noop_not_lost_update(
+    coordinator, client: _Client,
+) -> None:
+    """Late-completion residual (plan Unit 6 / Key Decision). The watchdog does
+    not cancel a timed-out future, so a late commit_cas may run after the client
+    gave up. This asserts the SAFE half of that residual deterministically: a
+    late CAS in the CONTENDED case (the version already advanced) sees the
+    advanced version → version_mismatch, NO mutation — it cannot drop an
+    acknowledged write. (The uncontended case lands a phantom/duplicate N+1 from
+    the same edit — a duplicate version bump, NOT a lost write; NoLostUpdate
+    still holds. Full fencing is deferred to the cross-host follow-on.)"""
+    a, late = _sid("liveWinner"), _sid("lateGaveUp")
+    v1 = _occ_seed_shared(client, a, "plan.md", _hash("v1"))
+    _occ_seed_shared(client, late, "plan.md", _hash("v1"))  # the "late" writer also read v1
+    # The live winner commits → v2 (this models the contention the late writer
+    # raced against).
+    s, ba = client.post("/hooks/post-edit-cas",
+                        {"session_id": a, "path": "plan.md", "success": True,
+                         "content_hash": _hash("v2-winner"), "expected_version": v1})
+    assert ba == {"ok": True, "version": v1 + 1}
+    v2 = _artifact_version(coordinator, "plan.md")
+    # The late writer's CAS finally runs with its now-stale expected_version
+    # (==v1): it observes the advanced version → version_mismatch, no mutation.
+    s, bl = client.post("/hooks/post-edit-cas",
+                        {"session_id": late, "path": "plan.md", "success": True,
+                         "content_hash": _hash("v2-late"), "expected_version": v1})
+    assert bl["ok"] is False
+    assert bl["reason"] == "version_mismatch"
+    # No acknowledged write was dropped — the version is the winner's v2, and the
+    # late writer's stale bytes were NOT committed over it.
+    assert _artifact_version(coordinator, "plan.md") == v2
 
 
 def test_a8_status_exposes_coordinator_backend_and_version(client: _Client) -> None:

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -1704,6 +1704,41 @@ def test_occ_commit_corruption_expected_gt_current_raises_body(coordinator, clie
     assert _artifact_version(coordinator, "plan.md") == 1
 
 
+def test_occ_commit_caller_in_transient_returns_stable_reason(
+    coordinator, client: _Client
+) -> None:
+    """AC2: a caller left mid-transient (a peer invalidated it between its read
+    and its CAS) → {ok:false, reason:'caller_in_transient_state'} — a STABLE
+    machine reason (NOT the exception's human message), so the client's retry
+    classifier matches it exactly. The body also carries current_version so the
+    client can advance its comparand. No mutation: this is a lost race."""
+    from ccs.core.states import TransientState
+
+    sid = _sid("occTransient")
+    v = _occ_seed_shared(client, sid, "plan.md", _hash("v1"))  # caller SHARED@v1
+    # Force the caller mid-transient on the coordinator (the registry shape a
+    # peer's invalidating write leaves on a SHARED holder: SIA). commit_cas
+    # rejects this as a retry-eligible precondition.
+    aid = coordinator.registry.lookup_artifact_id_by_name("plan.md")
+    agent_id = session_to_agent_id(sid)
+    coordinator.registry.set_agent_transient(
+        aid, agent_id, TransientState.SIA, entered_tick=v
+    )
+
+    s, b = client.post(
+        "/hooks/post-edit-cas",
+        {"session_id": sid, "path": "plan.md", "success": True,
+         "content_hash": _hash("v2"), "expected_version": v},
+    )
+    assert s == 200
+    # The STABLE wire reason — exactly the literal the client matcher keys on,
+    # decoupled from commit_cas's "commit_cas_not_allowed ..." human message.
+    assert b == {"ok": False, "reason": "caller_in_transient_state", "current_version": v}
+    assert "degraded" not in b  # a clean retry-eligible conflict, not a degrade
+    # No mutation: the version did not advance.
+    assert _artifact_version(coordinator, "plan.md") == v
+
+
 def test_occ_commit_degrade_reads_as_failure(coordinator, client: _Client) -> None:
     """THE LOAD-BEARING FIX: a timed-out/degraded OCC commit returns
     {ok:false, degraded:true, reason:'commit_unconfirmed'} — NOT the

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -878,8 +878,9 @@ def test_commit_cas_happy_path_commits_and_invalidates_peers() -> None:
 
     # Version advanced N -> N+1.
     assert updated.version == artifact.version + 1
-    # Committer is now MODIFIED; the SHARED peer was invalidated.
-    assert svc.registry.get_agent_state(artifact.id, writer) == MESIState.MODIFIED
+    # Committer ends SHARED (an OCC writer holds no grant); the SHARED peer was
+    # invalidated.
+    assert svc.registry.get_agent_state(artifact.id, writer) == MESIState.SHARED
     assert svc.registry.get_agent_state(artifact.id, peer) == MESIState.INVALID
     # Signal shape mirrors commit(): one signal per invalidated peer, carrying
     # the new version, issued tick, and the committer as issuer.
@@ -888,6 +889,41 @@ def test_commit_cas_happy_path_commits_and_invalidates_peers() -> None:
     assert signals[0].new_version == updated.version
     assert signals[0].issued_at_tick == 7
     assert signals[0].issuer_agent_id == writer
+
+
+def test_commit_cas_is_repeatable_for_same_agent_no_d4_rejection() -> None:
+    """FIX 3: a winning commit_cas ends the committer SHARED (not MODIFIED), so
+    the SAME agent can commit_cas AGAIN on the same artifact without tripping the
+    D4 precondition (which rejects M/E callers). Two back-to-back wins by one
+    agent: version 1→2→3, no CoherenceError. Before the fix the sticky MODIFIED
+    grant made the second call hard-fail with 'use commit()'.
+    """
+    svc = _service()
+    artifact, writer, _peer = _two_shared_holders(svc)
+    assert artifact.version == 1
+
+    # First OCC win → version 2, committer ends SHARED (the fix).
+    first, _ = svc.commit_cas(
+        agent_id=writer,
+        artifact_id=artifact.id,
+        expected_version=1,
+        content_hash=compute_content_hash("v2"),
+        issued_at_tick=5,
+    )
+    assert first.version == 2
+    assert svc.registry.get_agent_state(artifact.id, writer) == MESIState.SHARED
+
+    # Second OCC win by the SAME agent at the new version — must NOT be rejected
+    # by D4 (SHARED is OCC-eligible) and must win again.
+    second, _ = svc.commit_cas(
+        agent_id=writer,
+        artifact_id=artifact.id,
+        expected_version=2,
+        content_hash=compute_content_hash("v3"),
+        issued_at_tick=6,
+    )
+    assert second.version == 3
+    assert svc.registry.get_agent_state(artifact.id, writer) == MESIState.SHARED
 
 
 def test_commit_cas_version_mismatch_returns_conflict_no_mutation() -> None:
@@ -913,9 +949,10 @@ def test_commit_cas_version_mismatch_returns_conflict_no_mutation() -> None:
     assert isinstance(result, ConflictDetail)
     assert result.reason == "version_mismatch"
     assert result.current_version == 2
-    # No mutation: version unchanged, winner still MODIFIED, loser still INVALID.
+    # No mutation: version unchanged, winner still SHARED (OCC writer holds no
+    # grant), loser still INVALID.
     assert svc.registry.get_artifact(artifact.id).version == 2
-    assert svc.registry.get_agent_state(artifact.id, first) == MESIState.MODIFIED
+    assert svc.registry.get_agent_state(artifact.id, first) == MESIState.SHARED
     assert svc.registry.get_agent_state(artifact.id, second) == MESIState.INVALID
 
 
@@ -1057,7 +1094,8 @@ def test_commit_cas_win_actually_invalidates_peers_in_registry() -> None:
     state_map = svc.registry.get_state_map(artifact.id)
     assert state_map[peer_b] == MESIState.INVALID
     assert state_map[peer_c] == MESIState.INVALID
-    assert state_map[writer] == MESIState.MODIFIED
+    # The OCC committer ends SHARED (it holds no grant).
+    assert state_map[writer] == MESIState.SHARED
     # And the signal list covers exactly the invalidated peers.
     assert len(signals) == 2
     assert {s.issuer_agent_id for s in signals} == {writer}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -12,8 +12,9 @@ import pytest
 from ccs.coordinator.registry import ArtifactRegistry
 from ccs.coordinator.service import CoordinatorService
 from ccs.core.exceptions import CoherenceError
+from ccs.core.hashing import compute_content_hash
 from ccs.core.states import MESIState, TransientState
-from ccs.core.types import FetchRequest
+from ccs.core.types import ConflictDetail, FetchRequest
 
 
 def _service() -> CoordinatorService:
@@ -833,3 +834,233 @@ class TestConcurrentFirstUseEmitOnce:
             f"expected exactly one transitional warning across {thread_count} "
             f"concurrent constructions, got {len(emissions)}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Unit 3 — CoordinatorService.commit_cas (OCC service-level orchestration).
+#
+# The OCC writer reads (→ SHARED) → computes → commit_cas from S/I; it never
+# takes EXCLUSIVE via write(). Two SHARED peers are the canonical setup: a
+# matching version + no *pessimistic* M/E holder → WIN; a stale version →
+# version_mismatch; a concurrent pessimistic E/M holder → other_holder; an
+# over-shot version → CoherenceError (corruption).
+# ---------------------------------------------------------------------------
+
+
+def _two_shared_holders(svc: CoordinatorService):
+    """Register an artifact and fetch it from two agents so both end SHARED.
+
+    Returns ``(artifact, agent_a, agent_b)``. Both agents are SHARED at the
+    artifact's current version — the eligible (S/I) starting point for an OCC
+    ``commit_cas`` where the *other* holder is not a pessimistic M/E writer.
+    """
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    agent_a = uuid4()
+    agent_b = uuid4()
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=agent_a, requested_at_tick=1))
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=agent_b, requested_at_tick=2))
+    assert svc.registry.get_agent_state(artifact.id, agent_a) == MESIState.SHARED
+    assert svc.registry.get_agent_state(artifact.id, agent_b) == MESIState.SHARED
+    return artifact, agent_a, agent_b
+
+
+def test_commit_cas_happy_path_commits_and_invalidates_peers() -> None:
+    svc = _service()
+    artifact, writer, peer = _two_shared_holders(svc)
+
+    updated, signals = svc.commit_cas(
+        agent_id=writer,
+        artifact_id=artifact.id,
+        expected_version=artifact.version,
+        content_hash=compute_content_hash("v2"),
+        issued_at_tick=7,
+    )
+
+    # Version advanced N -> N+1.
+    assert updated.version == artifact.version + 1
+    # Committer is now MODIFIED; the SHARED peer was invalidated.
+    assert svc.registry.get_agent_state(artifact.id, writer) == MESIState.MODIFIED
+    assert svc.registry.get_agent_state(artifact.id, peer) == MESIState.INVALID
+    # Signal shape mirrors commit(): one signal per invalidated peer, carrying
+    # the new version, issued tick, and the committer as issuer.
+    assert len(signals) == 1
+    assert signals[0].artifact_id == artifact.id
+    assert signals[0].new_version == updated.version
+    assert signals[0].issued_at_tick == 7
+    assert signals[0].issuer_agent_id == writer
+
+
+def test_commit_cas_version_mismatch_returns_conflict_no_mutation() -> None:
+    svc = _service()
+    artifact, first, second = _two_shared_holders(svc)
+
+    # First OCC writer wins → version bumps to 2, `second` invalidated.
+    updated, _ = svc.commit_cas(
+        agent_id=first,
+        artifact_id=artifact.id,
+        expected_version=artifact.version,
+        content_hash=compute_content_hash("v2"),
+    )
+    assert updated.version == 2
+
+    # `second` still holds the stale expected_version (1) → version_mismatch.
+    result = svc.commit_cas(
+        agent_id=second,
+        artifact_id=artifact.id,
+        expected_version=artifact.version,  # stale (==1, current is 2)
+        content_hash=compute_content_hash("v2-stale"),
+    )
+    assert isinstance(result, ConflictDetail)
+    assert result.reason == "version_mismatch"
+    assert result.current_version == 2
+    # No mutation: version unchanged, winner still MODIFIED, loser still INVALID.
+    assert svc.registry.get_artifact(artifact.id).version == 2
+    assert svc.registry.get_agent_state(artifact.id, first) == MESIState.MODIFIED
+    assert svc.registry.get_agent_state(artifact.id, second) == MESIState.INVALID
+
+
+def test_commit_cas_other_holder_returns_conflict_no_mutation() -> None:
+    svc = _service()
+    artifact, occ_writer, pessimist = _two_shared_holders(svc)
+
+    # A pessimistic peer acquires EXCLUSIVE via write() (version unchanged at 1);
+    # this also invalidates the OCC writer. write() leaves the invalidated peer
+    # mid-transient until it ACKs, so apply the invalidation ACK to land the OCC
+    # writer cleanly INVALID (S/I-eligible, no transient) — the realistic state
+    # of a writer that observed the invalidation.
+    svc.write(agent_id=pessimist, artifact_id=artifact.id)
+    svc.invalidate(
+        agent_id=occ_writer,
+        artifact_id=artifact.id,
+        new_version=artifact.version,
+        issuer_agent_id=pessimist,
+        issued_at_tick=4,
+    )
+    assert svc.registry.get_agent_state(artifact.id, pessimist) == MESIState.EXCLUSIVE
+    assert svc.registry.get_agent_state(artifact.id, occ_writer) == MESIState.INVALID
+    assert svc.registry.get_agent_transient(artifact.id, occ_writer) is None
+
+    # Version still matches (write does not bump), but a pessimistic E holder is
+    # present → other_holder (distinct from version_mismatch).
+    result = svc.commit_cas(
+        agent_id=occ_writer,
+        artifact_id=artifact.id,
+        expected_version=artifact.version,  # ==1, current is still 1
+        content_hash=compute_content_hash("v2"),
+    )
+    assert isinstance(result, ConflictDetail)
+    assert result.reason == "other_holder"
+    assert result.current_version == 1
+    # No mutation: version unchanged, pessimist keeps EXCLUSIVE.
+    assert svc.registry.get_artifact(artifact.id).version == 1
+    assert svc.registry.get_agent_state(artifact.id, pessimist) == MESIState.EXCLUSIVE
+
+
+def test_commit_cas_expected_greater_than_current_raises_coherence_error() -> None:
+    svc = _service()
+    artifact, writer, _peer = _two_shared_holders(svc)
+
+    # expected_version > current → corruption / multi-coordinator violation.
+    with pytest.raises(CoherenceError, match="corruption"):
+        svc.commit_cas(
+            agent_id=writer,
+            artifact_id=artifact.id,
+            expected_version=artifact.version + 5,
+            content_hash=compute_content_hash("v2"),
+        )
+    # No mutation.
+    assert svc.registry.get_artifact(artifact.id).version == 1
+
+
+def test_commit_cas_rejects_modified_or_exclusive_caller_pointing_to_commit() -> None:
+    svc = _service()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    owner = uuid4()
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=owner, requested_at_tick=1))
+    # Pessimistic acquire → EXCLUSIVE.
+    svc.write(agent_id=owner, artifact_id=artifact.id)
+    assert svc.registry.get_agent_state(artifact.id, owner) == MESIState.EXCLUSIVE
+
+    # EXCLUSIVE holder must use plain commit() (D4) — error points there.
+    with pytest.raises(CoherenceError, match="commit"):
+        svc.commit_cas(
+            agent_id=owner,
+            artifact_id=artifact.id,
+            expected_version=artifact.version,
+            content_hash=compute_content_hash("v2"),
+        )
+    # And the MODIFIED case rejects identically.
+    svc.commit(agent_id=owner, artifact_id=artifact.id, content="v2")
+    assert svc.registry.get_agent_state(artifact.id, owner) == MESIState.MODIFIED
+    with pytest.raises(CoherenceError, match="commit"):
+        svc.commit_cas(
+            agent_id=owner,
+            artifact_id=artifact.id,
+            expected_version=2,
+            content_hash=compute_content_hash("v3"),
+        )
+
+
+def test_commit_cas_rejects_caller_in_transient_state() -> None:
+    svc = _service()
+    artifact, writer, _peer = _two_shared_holders(svc)
+    # Force the OCC writer mid-transient (e.g. ISG) — not eligible to commit.
+    svc.registry.set_agent_transient(
+        artifact.id, writer, TransientState.ISG, entered_tick=3
+    )
+
+    with pytest.raises(CoherenceError, match="transient"):
+        svc.commit_cas(
+            agent_id=writer,
+            artifact_id=artifact.id,
+            expected_version=artifact.version,
+            content_hash=compute_content_hash("v2"),
+        )
+    # No mutation.
+    assert svc.registry.get_artifact(artifact.id).version == 1
+
+
+def test_commit_cas_artifact_not_found_raises_coherence_error() -> None:
+    svc = _service()
+    missing = uuid4()
+
+    with pytest.raises(CoherenceError, match="artifact_not_found"):
+        svc.commit_cas(
+            agent_id=uuid4(),
+            artifact_id=missing,
+            expected_version=1,
+            content_hash=compute_content_hash("v2"),
+        )
+
+
+def test_commit_cas_win_actually_invalidates_peers_in_registry() -> None:
+    """Integration: on a winning CAS, peers are INVALID in the registry itself,
+    not merely named in the returned signal list."""
+    svc = _service()
+    artifact = svc.register_artifact(name="plan.md", content="v1")
+    writer = uuid4()
+    peer_b = uuid4()
+    peer_c = uuid4()
+    for tick, agent in enumerate((writer, peer_b, peer_c), start=1):
+        svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=agent, requested_at_tick=tick))
+    # Three SHARED holders.
+    assert svc.registry.get_agent_state(artifact.id, writer) == MESIState.SHARED
+
+    updated, signals = svc.commit_cas(
+        agent_id=writer,
+        artifact_id=artifact.id,
+        expected_version=artifact.version,
+        content_hash=compute_content_hash("v2"),
+    )
+
+    # Both peers are actually INVALID in the registry's state map.
+    state_map = svc.registry.get_state_map(artifact.id)
+    assert state_map[peer_b] == MESIState.INVALID
+    assert state_map[peer_c] == MESIState.INVALID
+    assert state_map[writer] == MESIState.MODIFIED
+    # And the signal list covers exactly the invalidated peers.
+    assert len(signals) == 2
+    assert {s.issuer_agent_id for s in signals} == {writer}
+    assert all(s.new_version == updated.version for s in signals)
+    # Single-writer invariant holds afterward (no exception from the service).
+    svc._validate_single_writer(artifact.id)

--- a/tests/test_occ_commit_cas.py
+++ b/tests/test_occ_commit_cas.py
@@ -200,8 +200,9 @@ def test_r11_two_concurrent_writers_exactly_one_wins_no_clobber(db_path: Path) -
         assert persisted.content_hash == expected_winner_hash
         assert winner_artifact.content_hash == expected_winner_hash
         assert winner_artifact.version == 2
-        # The winner transitioned S → MODIFIED; the loser was invalidated.
-        assert reg.get_agent_state(art.id, winner_id) == MESIState.MODIFIED
+        # The winner ends SHARED (an OCC writer holds no grant); the loser was
+        # invalidated.
+        assert reg.get_agent_state(art.id, winner_id) == MESIState.SHARED
         loser_id = next(w for w, r in results.items() if isinstance(r, ConflictDetail))
         assert loser_id in invalidated
         assert reg.get_agent_state(art.id, loser_id) == MESIState.INVALID
@@ -275,9 +276,10 @@ def test_r12_sustained_contention_version_strictly_advances(db_path: Path) -> No
             assert isinstance(peer_result, tuple)
             # Peer winning re-invalidated the peer's peers, including the
             # protagonist; re-grant SHARED so it is OCC-eligible again (a re-read
-            # in production lands it back in S). The peer is now MODIFIED, so to
-            # keep the round OCC-vs-OCC (version-elected, not other_holder) drop
-            # the peer back to SHARED too.
+            # in production lands it back in S). The peer itself already ends
+            # SHARED (an OCC writer holds no grant), so the round stays OCC-vs-OCC
+            # (version-elected, not other_holder); the explicit re-grant below is
+            # defensive and keeps the protagonist SHARED.
             reg.set_agent_state(art.id, protagonist, MESIState.SHARED, tick=round_idx)
             reg.set_agent_state(art.id, peer, MESIState.SHARED, tick=round_idx)
 
@@ -301,8 +303,9 @@ def test_r12_sustained_contention_version_strictly_advances(db_path: Path) -> No
                     continue
                 landed = True
                 observed_versions.append(result[0].version)
-                # The protagonist is now MODIFIED at this version; its next-round
-                # comparand is this version, and it drops back to SHARED.
+                # The protagonist now ends SHARED at this version (OCC writer
+                # holds no grant); its next-round comparand is this version. The
+                # explicit set_agent_state is defensive (it is already SHARED).
                 protagonist_expected = result[0].version
                 reg.set_agent_state(art.id, protagonist, MESIState.SHARED, tick=round_idx)
                 break

--- a/tests/test_occ_commit_cas.py
+++ b/tests/test_occ_commit_cas.py
@@ -1,0 +1,542 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Concurrent-writer + bounded-progress proof suite for the OCC commit-CAS
+(plan Unit 7, R11/R12/R6).
+
+This is the cross-cutting *empirical* proof that the atomic version-checked
+compare-and-swap closes the concurrent lost-update across the real stack — the
+runtime counterpart to ``formal/tla/OCC.tla``'s ``NoLostUpdate`` safety proof.
+Default-suite: fast, offline, no pytest marker.
+
+The load-bearing test-design rule (from
+``docs/solutions/best-practices/coordinator-invalidation-not-mutex-honest-coherence-claims-2026-06-04.md``
+Fact 4): every concurrent arm holds a **fixed stale buffer** — both writers read
+version ``N`` and each computes *distinct* content from that *same* ``N``. A
+"read counter → +1 → write" arm is refetch-safe by construction and **passes
+even if enforcement is broken**, so it would not stress the CAS at all. The
+``content_hash`` here is therefore derived from the *writer identity*, never from
+a re-fetched version.
+
+Concurrency-realism caveat (from
+``docs/solutions/test-failures/mp-pool-pid-distinctness-flaky-on-constrained-ci-2026-05-18.md``):
+a constrained runner may serialize threads. So the *only* hard assertion is the
+correctness property (exactly one win, every loser typed-conflicted, version
+advanced by exactly one, no silent clobber). Any "did the interleave actually
+overlap" check is a :class:`RuntimeWarning`, never an assertion. A
+``threading.Barrier`` forces the race window so the CAS is genuinely exercised
+when the runner does run the threads in parallel.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import time
+import uuid
+import warnings
+from pathlib import Path
+from urllib import error as urlerror
+from urllib import request as urlrequest
+from uuid import UUID, uuid4
+
+import pytest
+
+from ccs.adapters.claude_code.auth import load_secret
+from ccs.adapters.claude_code.coordinator_server import CoordinatorHTTPServer
+from ccs.agent.runtime import AgentRuntime
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.service import CoordinatorService
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.exceptions import CasRetriesExhausted
+from ccs.core.hashing import compute_content_hash
+from ccs.core.states import MESIState
+from ccs.core.types import Artifact, ConflictDetail, FetchRequest
+from ccs.strategies.lazy import LazyStrategy
+
+# ----------------------------------------------------------------------
+# Fixtures + helpers
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "state.db"
+
+
+def _make_artifact(name: str = "plan.md", version: int = 1, content_hash: str = "h1") -> Artifact:
+    return Artifact(id=uuid4(), name=name, version=version, content_hash=content_hash)
+
+
+def _seed_shared_writers(
+    reg: SqliteArtifactRegistry, n: int, *, version: int = 1
+) -> tuple[Artifact, list[UUID]]:
+    """Register one artifact at ``version`` and seed ``n`` SHARED writers on it.
+
+    OCC writers are S/I by construction (they bypass the pessimistic acquire),
+    so the winner is elected by the version check, never ``other_holder``.
+    """
+    art = _make_artifact(version=version, content_hash="h-init")
+    reg.register_artifact(art, content="")
+    writers = [uuid4() for _ in range(n)]
+    for w in writers:
+        reg.set_agent_state(art.id, w, MESIState.SHARED, tick=1)
+    return art, writers
+
+
+def _run_barrier_cas_round(
+    reg: SqliteArtifactRegistry,
+    artifact_id: UUID,
+    writers: list[UUID],
+    expected_version: int,
+    *,
+    tick: int = 5,
+) -> dict[UUID, object]:
+    """Fire every writer at ``commit_cas`` from a shared barrier, each carrying a
+    FIXED stale buffer (content derived from the writer id, NOT a re-fetch).
+
+    Returns ``{writer_id: commit_cas_result}``. ``results`` is written from
+    distinct keys per thread, so the plain dict is safe without a lock.
+    """
+    results: dict[UUID, object] = {}
+    barrier = threading.Barrier(len(writers))
+    overlap_seen = threading.Event()
+    in_flight = {"n": 0}
+    in_flight_lock = threading.Lock()
+
+    def attempt(writer_id: UUID) -> None:
+        # FIXED stale buffer: content is a function of the writer identity, not
+        # of any re-read version. Both writers commit DISTINCT content computed
+        # from the SAME expected_version — the shape that actually stresses CAS.
+        content_hash = hashlib.sha256(writer_id.bytes).hexdigest()
+        barrier.wait()
+        with in_flight_lock:
+            in_flight["n"] += 1
+            if in_flight["n"] > 1:
+                overlap_seen.set()
+        try:
+            results[writer_id] = reg.commit_cas(
+                artifact_id,
+                writer_id,
+                expected_version=expected_version,
+                content_hash=content_hash,
+                tick=tick,
+            )
+        finally:
+            with in_flight_lock:
+                in_flight["n"] -= 1
+
+    threads = [threading.Thread(target=attempt, args=(w,)) for w in writers]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Concurrency-realism probe: NOT an assertion (a constrained runner may
+    # serialize the threads). Only the correctness property below is asserted.
+    if not overlap_seen.is_set():
+        warnings.warn(
+            "barrier CAS round did not observe overlapping in-flight writers; "
+            "the runner may have serialized threads. The correctness property is "
+            "still asserted, but the race window was not stressed this run.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    return results
+
+
+def _assert_exactly_one_win_rest_conflict(
+    results: dict[UUID, object],
+    *,
+    n_writers: int,
+    expected_current: int,
+) -> tuple[Artifact, list[UUID]]:
+    """Assert the no-lost-update correctness property over one CAS round and
+    return the winner's ``(Artifact, invalidated_ids)``."""
+    wins = [r for r in results.values() if isinstance(r, tuple)]
+    conflicts = [r for r in results.values() if isinstance(r, ConflictDetail)]
+    assert len(wins) == 1, f"expected exactly one win, got {len(wins)}: {results}"
+    assert len(conflicts) == n_writers - 1, (
+        f"every non-winner must get a typed ConflictDetail; "
+        f"got {len(conflicts)} of {n_writers - 1}"
+    )
+    # Two OCC writers are both SHARED → the loser is elected by the version
+    # check, so the reason is ALWAYS version_mismatch (never other_holder).
+    assert all(c.reason == "version_mismatch" for c in conflicts), [
+        c.reason for c in conflicts
+    ]
+    assert all(c.current_version == expected_current for c in conflicts)
+    return wins[0]
+
+
+# ----------------------------------------------------------------------
+# R11 — the headline test: two concurrent writers, fixed stale buffers
+# ----------------------------------------------------------------------
+
+
+def test_r11_two_concurrent_writers_exactly_one_wins_no_clobber(db_path: Path) -> None:
+    """R11 (headline). Two ``threading.Barrier``-synced writers, each holding a
+    FIXED stale buffer at the SAME version N, both call ``commit_cas`` against
+    ONE registry. Exactly one wins, the other gets a ``ConflictDetail``, the
+    final version is N+1 (NOT N+2), and the WINNER's content is what persisted
+    (no silent clobber)."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        art, writers = _seed_shared_writers(reg, 2, version=1)
+
+        results = _run_barrier_cas_round(reg, art.id, writers, expected_version=1)
+
+        winner_artifact, invalidated = _assert_exactly_one_win_rest_conflict(
+            results, n_writers=2, expected_current=2
+        )
+        # Final version advanced by EXACTLY one — the loser's stale buffer did
+        # not produce a second bump (N+1, not N+2).
+        persisted = reg.get_artifact(art.id)
+        assert persisted.version == 2
+        # The persisted content_hash is the WINNER's — no silent clobber by the
+        # loser. The winner is the only writer whose result is a (Artifact, ...).
+        winner_id = next(w for w, r in results.items() if isinstance(r, tuple))
+        expected_winner_hash = hashlib.sha256(winner_id.bytes).hexdigest()
+        assert persisted.content_hash == expected_winner_hash
+        assert winner_artifact.content_hash == expected_winner_hash
+        assert winner_artifact.version == 2
+        # The winner transitioned S → MODIFIED; the loser was invalidated.
+        assert reg.get_agent_state(art.id, winner_id) == MESIState.MODIFIED
+        loser_id = next(w for w, r in results.items() if isinstance(r, ConflictDetail))
+        assert loser_id in invalidated
+        assert reg.get_agent_state(art.id, loser_id) == MESIState.INVALID
+
+
+# ----------------------------------------------------------------------
+# N-writer (N >= 3) variant — one winner per round, no dropped write
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_writers", [3, 5, 8])
+def test_n_writers_fixed_stale_buffers_exactly_one_wins(
+    db_path: Path, n_writers: int
+) -> None:
+    """N (>=3) barrier-synced writers, all with fixed stale buffers at the same
+    N → exactly one wins that round; every loser gets a ``ConflictDetail``; the
+    final version is N+1; no acknowledged write was dropped (the persisted hash
+    is the single winner's)."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        art, writers = _seed_shared_writers(reg, n_writers, version=1)
+
+        results = _run_barrier_cas_round(reg, art.id, writers, expected_version=1)
+
+        _assert_exactly_one_win_rest_conflict(
+            results, n_writers=n_writers, expected_current=2
+        )
+        persisted = reg.get_artifact(art.id)
+        assert persisted.version == 2  # exactly one bump across N racers
+        winner_id = next(w for w, r in results.items() if isinstance(r, tuple))
+        assert persisted.content_hash == hashlib.sha256(winner_id.bytes).hexdigest()
+
+
+# ----------------------------------------------------------------------
+# R12 — bounded progress under sustained contention
+# ----------------------------------------------------------------------
+
+
+def test_r12_sustained_contention_version_strictly_advances(db_path: Path) -> None:
+    """R12 bounded progress. Under sustained contention a writer retries
+    (re-read → recompute → ``commit_cas``) and commits keep LANDING: the version
+    strictly advances every round, no permanent livelock. Models the caller-side
+    retry loop directly against the registry (the cross-process path runs the
+    same loop via ``reacquire()``).
+
+    The protagonist carries its OWN last-known expected_version (a fixed stale
+    buffer between re-reads). A contending peer bumps the version at the top of
+    each round, so the protagonist's first attempt is guaranteed stale → it must
+    re-read (mirroring ``reacquire()``) and retry, and the retry lands."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        art = _make_artifact(version=1, content_hash="h-init")
+        reg.register_artifact(art, content="")
+        protagonist = uuid4()
+        peer = uuid4()
+        reg.set_agent_state(art.id, protagonist, MESIState.SHARED, tick=1)
+        reg.set_agent_state(art.id, peer, MESIState.SHARED, tick=1)
+
+        observed_versions: list[int] = []
+        rounds = 6
+        # The protagonist's last-read version (its expected_version comparand).
+        # Seeded stale on purpose so round 0's first attempt also has to retry.
+        protagonist_expected = reg.get_artifact(art.id).version
+        for round_idx in range(rounds):
+            # A contending peer commits FIRST, bumping the version so the
+            # protagonist's held expected_version goes stale.
+            peer_now = reg.get_artifact(art.id).version
+            peer_result = reg.commit_cas(
+                art.id, peer, expected_version=peer_now,
+                content_hash=hashlib.sha256(f"peer-{round_idx}".encode()).hexdigest(),
+                tick=round_idx,
+            )
+            assert isinstance(peer_result, tuple)
+            # Peer winning re-invalidated the peer's peers, including the
+            # protagonist; re-grant SHARED so it is OCC-eligible again (a re-read
+            # in production lands it back in S). The peer is now MODIFIED, so to
+            # keep the round OCC-vs-OCC (version-elected, not other_holder) drop
+            # the peer back to SHARED too.
+            reg.set_agent_state(art.id, protagonist, MESIState.SHARED, tick=round_idx)
+            reg.set_agent_state(art.id, peer, MESIState.SHARED, tick=round_idx)
+
+            # The protagonist runs a bounded retry loop with its (now stale)
+            # held expected_version. On version_mismatch it re-reads (refreshing
+            # the comparand) and retries; the retry lands.
+            landed = False
+            for attempt in range(LazyStrategy().max_cas_retries() + 1):
+                result = reg.commit_cas(
+                    art.id, protagonist, expected_version=protagonist_expected,
+                    content_hash=hashlib.sha256(
+                        f"prot-{round_idx}-{attempt}".encode()
+                    ).hexdigest(),
+                    tick=round_idx,
+                )
+                if isinstance(result, ConflictDetail):
+                    # Re-read: refresh the comparand to the observed current
+                    # version (mirrors reacquire()'s mandatory fresh read).
+                    assert result.reason == "version_mismatch"
+                    protagonist_expected = result.current_version
+                    continue
+                landed = True
+                observed_versions.append(result[0].version)
+                # The protagonist is now MODIFIED at this version; its next-round
+                # comparand is this version, and it drops back to SHARED.
+                protagonist_expected = result[0].version
+                reg.set_agent_state(art.id, protagonist, MESIState.SHARED, tick=round_idx)
+                break
+            assert landed, f"protagonist starved (no commit landed) in round {round_idx}"
+
+        # Bounded progress: every protagonist commit advanced the version, and
+        # the version is strictly monotonic across the whole run (no livelock,
+        # no regression / lost update).
+        assert observed_versions == sorted(observed_versions)
+        assert len(set(observed_versions)) == len(observed_versions)
+        # Final version reflects 2 commits/round (peer + protagonist) from N=1.
+        assert reg.get_artifact(art.id).version == 1 + 2 * rounds
+
+
+def test_r12_retry_exhaustion_surfaces_typed_terminal_no_silent_drop() -> None:
+    """R12 terminal. A writer whose retries are exhausted surfaces the typed
+    terminal ``CasRetriesExhausted`` — NEVER a silent drop. Driven through the
+    library ``AgentRuntime.write_cas`` retry loop with a peer that keeps the
+    version moving so every attempt loses."""
+    coordinator = CoordinatorService(ArtifactRegistry())
+    artifact = coordinator.register_artifact(name="plan.md", content="v1")
+
+    # Put `runtime` in SHARED (a lone fetch grants EXCLUSIVE; a co-reader
+    # downgrades it to SHARED so commit_cas's D4 precondition holds).
+    runtime = AgentRuntime(
+        agent_id=uuid4(), coordinator=coordinator, strategy=LazyStrategy()
+    )
+    coordinator.fetch(
+        FetchRequest(artifact_id=artifact.id, requesting_agent_id=runtime.agent_id, requested_at_tick=1)
+    )
+    coordinator.fetch(
+        FetchRequest(artifact_id=artifact.id, requesting_agent_id=uuid4(), requested_at_tick=1)
+    )
+    runtime.cache.put(
+        artifact.id,
+        runtime.strategy.on_fetch(
+            artifact_id=artifact.id, version=artifact.version,
+            state=MESIState.SHARED, now_tick=1,
+        ),
+    )
+
+    # A peer that ALWAYS commits first, on every attempt, so the protagonist's
+    # re-read is perpetually stale and it exhausts its retry budget. The peer is
+    # a fresh SHARED writer minted per call (the prior peer is invalidated by its
+    # own win, so a new identity keeps winning).
+    real_commit_cas = coordinator.commit_cas
+    attempt_count = {"n": 0}
+
+    def _winning_peer_then_real(**kwargs):  # type: ignore[no-untyped-def]
+        attempt_count["n"] += 1
+        peer = uuid4()
+        coordinator.fetch(
+            FetchRequest(artifact_id=artifact.id, requesting_agent_id=peer, requested_at_tick=1)
+        )
+        coordinator.fetch(
+            FetchRequest(artifact_id=artifact.id, requesting_agent_id=uuid4(), requested_at_tick=1)
+        )
+        peer_v = coordinator.registry.get_artifact(artifact.id).version
+        peer_res = real_commit_cas(
+            agent_id=peer, artifact_id=artifact.id,
+            expected_version=peer_v, content_hash=compute_content_hash(f"peer-{peer_v}"),
+        )
+        assert isinstance(peer_res, tuple)  # peer won, version advanced
+        # The protagonist's call now runs against the advanced version with its
+        # stale expected_version → guaranteed version_mismatch.
+        return real_commit_cas(**kwargs)
+
+    coordinator.commit_cas = _winning_peer_then_real  # type: ignore[assignment]
+    try:
+        with pytest.raises(CasRetriesExhausted) as excinfo:
+            runtime.write_cas(
+                artifact.id,
+                make_content=lambda entry: (f"prot-v{entry.local_version + 1}", None),
+                now_tick=2,
+            )
+    finally:
+        coordinator.commit_cas = real_commit_cas  # type: ignore[assignment]
+
+    # The terminal is typed and reports the full attempt count (no silent drop).
+    assert excinfo.value.attempts == LazyStrategy().max_cas_retries() + 1
+    assert attempt_count["n"] == LazyStrategy().max_cas_retries() + 1
+    # No silent drop: the protagonist's unconfirmed content never landed, and its
+    # cache is not left MODIFIED with a write that did not commit.
+    final = coordinator.registry.get_artifact(artifact.id)
+    entry = runtime.cache.get(artifact.id)
+    assert entry is not None
+    assert entry.state != MESIState.MODIFIED
+    # The protagonist's last attempted content is not the persisted writer.
+    last_writer_content = f"prot-v{final.version}"
+    assert runtime.content(artifact.id) != last_writer_content
+
+
+# ----------------------------------------------------------------------
+# Cross-process funnel — same property through the coordinator HTTP path
+# ----------------------------------------------------------------------
+
+
+class _Client:
+    """Tiny urllib client for the coordinator HTTP server. Returns (status, body)."""
+
+    def __init__(self, host: str, port: int, secret: str) -> None:
+        self.base = f"http://{host}:{port}"
+        self.headers = {
+            "Authorization": f"Bearer {secret}",
+            "Host": "127.0.0.1",
+            "Content-Type": "application/json",
+        }
+
+    def post(self, path: str, body: dict) -> tuple[int, dict]:
+        data = json.dumps(body).encode("utf-8")
+        req = urlrequest.Request(
+            self.base + path, data=data, method="POST", headers=dict(self.headers)
+        )
+        try:
+            with urlrequest.urlopen(req, timeout=10) as resp:
+                return resp.status, json.loads(resp.read().decode("utf-8") or "{}")
+        except urlerror.HTTPError as exc:
+            return exc.code, json.loads(exc.read().decode("utf-8") or "{}")
+
+
+_SID_NS = uuid.UUID("22222222-2222-4222-8222-222222222222")
+
+
+def _sid(label: str) -> str:
+    return str(uuid.uuid5(_SID_NS, f"occ-unit7:{label}"))
+
+
+def _hash(label: str) -> str:
+    return hashlib.sha256(label.encode()).hexdigest()
+
+
+@pytest.fixture
+def http_coordinator(tmp_path: Path):
+    server = CoordinatorHTTPServer(tmp_path, port=0, instance_id="unit7-instance")
+    server.serve_in_thread()
+    time.sleep(0.05)
+    try:
+        yield server
+    finally:
+        server.shutdown()
+
+
+@pytest.fixture
+def http_client(http_coordinator) -> _Client:
+    secret = load_secret(http_coordinator.coordinator_root)
+    assert secret is not None
+    return _Client("127.0.0.1", http_coordinator.port, secret)
+
+
+def _occ_pre_read_version(client: _Client, sid: str, path: str, h: str) -> int:
+    """pre-read a tracked path → register SHARED + seed, returning the version
+    an OCC writer uses as ``expected_version`` (two response shapes, mirroring
+    ``CoherentVolume._pre_read_version``)."""
+    s, b = client.post("/hooks/pre-read", {"session_id": sid, "path": path, "content_hash": h})
+    assert s == 200, b
+    if isinstance(b.get("version"), int):
+        return b["version"]
+    summary = b.get("summary")
+    if isinstance(summary, dict) and isinstance(summary.get("current_version"), int):
+        return summary["current_version"]
+    raise AssertionError(f"pre-read surfaced no OCC version: {b}")
+
+
+def _artifact_version(coordinator, path: str) -> int:
+    aid = coordinator.registry.lookup_artifact_id_by_name(path)
+    assert aid is not None
+    art = coordinator.registry.get_artifact(aid)
+    assert art is not None
+    return art.version
+
+
+def test_cross_process_funnel_two_writers_no_lost_update(
+    http_coordinator, http_client: _Client
+) -> None:
+    """The R11 property end-to-end through the coordinator HTTP path Unit 6
+    wired: two OCC clients each do pre-read → ``post-edit-cas`` with the SAME
+    stale ``expected_version`` (fixed stale buffers — distinct content from one
+    N), barrier-synced. Exactly one wins (v2), the loser gets a typed
+    ``version_mismatch``, and the final version is v1+1 (no lost update)."""
+    a_sid, b_sid = _sid("funnelA"), _sid("funnelB")
+    v1 = _occ_pre_read_version(http_client, a_sid, "plan.md", _hash("v1"))
+    assert _occ_pre_read_version(http_client, b_sid, "plan.md", _hash("v1")) == v1
+
+    barrier = threading.Barrier(2)
+    results: dict[str, tuple[int, dict]] = {}
+
+    def commit(sid: str, label: str) -> None:
+        # Fixed stale buffer: each client writes DISTINCT content derived from
+        # its label, both against the SAME expected_version v1 (NOT a re-fetch).
+        barrier.wait()
+        results[label] = http_client.post(
+            "/hooks/post-edit-cas",
+            {
+                "session_id": sid,
+                "path": "plan.md",
+                "success": True,
+                "content_hash": _hash(f"v2-{label}"),
+                "expected_version": v1,
+            },
+        )
+
+    threads = [
+        threading.Thread(target=commit, args=(a_sid, "A")),
+        threading.Thread(target=commit, args=(b_sid, "B")),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    wins = [lbl for lbl, (_, body) in results.items() if body.get("ok") is True]
+    losers = [lbl for lbl, (_, body) in results.items() if body.get("ok") is False]
+    assert len(wins) == 1, f"exactly one OCC client must win end-to-end: {results}"
+    assert len(losers) == 1
+    loser_body = results[losers[0]][1]
+    assert loser_body["reason"] == "version_mismatch"
+    assert "degraded" not in loser_body  # a clean typed conflict, not a degrade
+    # Final version is exactly v1+1 — the loser's stale buffer did NOT clobber.
+    assert _artifact_version(http_coordinator, "plan.md") == v1 + 1
+
+
+def test_cross_process_funnel_winner_body_is_n_plus_one(
+    http_coordinator, http_client: _Client
+) -> None:
+    """End-to-end sanity for the winning body shape: a single OCC client's
+    pre-read → post-edit-cas returns ``{ok: true, version: N+1}`` and the
+    coordinator's authoritative version matches (the funnel actually commits)."""
+    sid = _sid("funnelSolo")
+    v = _occ_pre_read_version(http_client, sid, "plan.md", _hash("solo-v1"))
+    s, b = http_client.post(
+        "/hooks/post-edit-cas",
+        {"session_id": sid, "path": "plan.md", "success": True,
+         "content_hash": _hash("solo-v2"), "expected_version": v},
+    )
+    assert s == 200
+    assert b == {"ok": True, "version": v + 1}
+    assert _artifact_version(http_coordinator, "plan.md") == v + 1

--- a/tests/test_occ_commit_cas.py
+++ b/tests/test_occ_commit_cas.py
@@ -543,3 +543,74 @@ def test_cross_process_funnel_winner_body_is_n_plus_one(
     assert s == 200
     assert b == {"ok": True, "version": v + 1}
     assert _artifact_version(http_coordinator, "plan.md") == v + 1
+
+
+# ----------------------------------------------------------------------
+# Watchdog late-completion residual (deferred; documented behavior)
+# ----------------------------------------------------------------------
+
+
+def test_watchdog_late_completion_is_false_negative_ack_never_lost_update(
+    db_path: Path,
+) -> None:
+    """The watchdog late-completion residual, pinned (T4 — deferred to the
+    cross-host follow-on, but its *safety boundary* is asserted here).
+
+    When a client's ``commit_cas`` is watchdog-degraded it raises fail-closed,
+    yet the coordinator's commit can still land LATE (after the client gave up).
+    This test pins what that late landing can and cannot do:
+
+    - UNCONTENDED (no peer bumped the version in the window): the late completion
+      WINS — version N→N+1 carrying the late writer's ``content_hash``. The client
+      already raised, so it never learned the write landed: a **false-negative
+      acknowledgment**, NOT a lost update. On its next read the client sees its
+      own bytes at N+1 and reconverges idempotently.
+    - CONTENDED (a peer committed N→N+1 inside the window): the SAME late
+      completion — still carrying the stale ``expected_version=N`` — gets a typed
+      :class:`ConflictDetail` (``current_version=N+1``), NOT a clobber. The
+      version CAS makes a late landing safe against an *acknowledged* peer write.
+
+    ⇒ the residual is a false-negative ack, never silent data loss. The only
+    deferred concern is the registry↔disk divergence it can leave (version N+1
+    recorded while the raising client wrote no on-disk bytes) — a cross-host
+    follow-on item, not a single-host correctness hole.
+    """
+    # --- Uncontended: the late completion lands as a clean monotonic bump. ---
+    with SqliteArtifactRegistry(db_path) as reg:
+        art, (writer,) = _seed_shared_writers(reg, 1, version=1)
+        late_hash = hashlib.sha256(b"late-uncontended").hexdigest()
+        result = reg.commit_cas(
+            art.id, writer, expected_version=1, content_hash=late_hash, tick=9
+        )
+        assert isinstance(result, tuple), "uncontended late completion must WIN"
+        updated, _ = result
+        assert updated.version == 2, "a benign phantom bump is N+1 (monotonic)"
+        assert updated.content_hash == late_hash, "the late writer's bytes are recorded"
+
+    # --- Contended: a peer's acked write is NOT clobbered by a late straggler. ---
+    db2 = db_path.parent / "state-contended.db"
+    with SqliteArtifactRegistry(db2) as reg:
+        art, (peer, straggler) = _seed_shared_writers(reg, 2, version=1)
+        peer_hash = hashlib.sha256(b"peer-acked").hexdigest()
+        peer_result = reg.commit_cas(
+            art.id, peer, expected_version=1, content_hash=peer_hash, tick=9
+        )
+        assert isinstance(peer_result, tuple), "the peer commit must land first"
+
+        # The straggler's watchdog-degraded commit lands LATE, still carrying the
+        # now-stale expected_version=1 → the version CAS rejects it as a conflict.
+        straggler_hash = hashlib.sha256(b"straggler-late").hexdigest()
+        late = reg.commit_cas(
+            art.id, straggler, expected_version=1, content_hash=straggler_hash, tick=10
+        )
+        assert isinstance(late, ConflictDetail), (
+            "a late completion must NOT clobber an acknowledged peer write"
+        )
+        assert late.current_version == 2
+
+        # The acked peer's bytes survive intact — the straggler's conflict caused
+        # no mutation, so there is no silent loss.
+        survived = reg.get_artifact(art.id)
+        assert survived is not None
+        assert survived.version == 2
+        assert survived.content_hash == peer_hash, "the acked peer's write must survive"

--- a/tests/test_property_invariants.py
+++ b/tests/test_property_invariants.py
@@ -11,8 +11,9 @@ from uuid import UUID
 from ccs.coordinator.registry import ArtifactRegistry
 from ccs.coordinator.service import CoordinatorService
 from ccs.core.exceptions import CoherenceError, InvariantViolationError
+from ccs.core.hashing import compute_content_hash
 from ccs.core.invariants import check_monotonic_version, check_single_writer
-from ccs.core.types import FetchRequest
+from ccs.core.types import ConflictDetail, FetchRequest
 
 
 def test_randomized_sequences_preserve_swmr_and_monotonic_versions() -> None:
@@ -23,9 +24,16 @@ def test_randomized_sequences_preserve_swmr_and_monotonic_versions() -> None:
         agents = [UUID(int=seed * 100 + i + 1) for i in range(4)]
 
         previous_version = artifact.version
+        # No-lost-update tracking (plan Unit 7): the highest version the
+        # registry has ever ACKNOWLEDGED as committed (returned a win for). The
+        # registry must never regress below this — an acknowledged write that
+        # later "disappears" is exactly the lost update the OCC CAS prevents.
+        highest_acked_version = artifact.version
         for step in range(180):
             agent = rng.choice(agents)
-            operation = rng.choice(("fetch", "write", "commit", "upgrade", "invalidate"))
+            operation = rng.choice(
+                ("fetch", "write", "commit", "commit_cas", "upgrade", "invalidate")
+            )
 
             try:
                 if operation == "fetch":
@@ -45,6 +53,32 @@ def test_randomized_sequences_preserve_swmr_and_monotonic_versions() -> None:
                         content=f"v{step}",
                         issued_at_tick=step,
                     )
+                elif operation == "commit_cas":
+                    # OCC compare-and-swap. Source expected_version from the
+                    # current registry version, but deliberately go stale on some
+                    # steps (current - 1) so both the win branch AND the typed
+                    # version_mismatch conflict are exercised. ConflictDetail is a
+                    # typed RETURN (never an exception) — handle it explicitly so
+                    # a lost win is not silently swallowed by the except below.
+                    current = svc.registry.get_artifact(artifact.id).version
+                    expected = max(0, current - rng.choice((0, 0, 1)))
+                    result = svc.commit_cas(
+                        agent_id=agent,
+                        artifact_id=artifact.id,
+                        expected_version=expected,
+                        content_hash=compute_content_hash(f"cas-{step}"),
+                        issued_at_tick=step,
+                    )
+                    if not isinstance(result, ConflictDetail):
+                        updated, _signals = result
+                        # A win must strictly advance and be acknowledged. Record
+                        # it so a later regression below this is caught as a lost
+                        # update.
+                        assert updated.version == current + 1, (
+                            f"CAS win must bump by exactly 1 at seed={seed} step={step}: "
+                            f"current={current} got={updated.version}"
+                        )
+                        highest_acked_version = max(highest_acked_version, updated.version)
                 elif operation == "upgrade":
                     svc.upgrade(agent_id=agent, artifact_id=artifact.id, issued_at_tick=step)
                 else:
@@ -56,7 +90,10 @@ def test_randomized_sequences_preserve_swmr_and_monotonic_versions() -> None:
                         issued_at_tick=step,
                     )
             except CoherenceError:
-                # Random operation sequences intentionally include invalid actions.
+                # Random operation sequences intentionally include invalid actions
+                # (e.g. commit_cas from an M/E holder, corruption expected>current,
+                # commit without a grant). These RAISE; a lost-update would instead
+                # be a silent version REGRESSION, caught by the assertion below.
                 pass
 
             state_map = svc.registry.get_state_map(artifact.id)
@@ -73,4 +110,11 @@ def test_randomized_sequences_preserve_swmr_and_monotonic_versions() -> None:
                     f"Monotonic version violation at seed={seed} step={step}: "
                     f"prev={previous_version} current={current_version}"
                 ) from exc
+            # No-lost-update: the registry must never fall below any version it
+            # already acknowledged as committed (across the whole op sequence,
+            # including the new commit_cas ops).
+            assert current_version >= highest_acked_version, (
+                f"lost update at seed={seed} step={step}: registry regressed to "
+                f"{current_version} below acknowledged-committed {highest_acked_version}"
+            )
             previous_version = current_version

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for the in-memory ArtifactRegistry OCC commit-CAS (plan Unit 2).
+
+Covers the same 3-outcome matrix as tests/test_sqlite_registry.py plus a
+sqlite/in-memory parity check, so the two registries (which share no base
+class) are guaranteed to return identical outcomes for identical inputs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.states import MESIState
+from ccs.core.types import Artifact, CasCorruption, ConflictDetail
+
+
+def _make_artifact(version: int = 1, content_hash: str = "h-init") -> Artifact:
+    return Artifact(id=uuid4(), name="plan.md", version=version, content_hash=content_hash)
+
+
+def _seed(reg: ArtifactRegistry, *, version: int = 1) -> tuple[UUID, UUID]:
+    """Register an artifact and put one agent in SHARED (OCC pre-commit state)."""
+    art = _make_artifact(version=version)
+    reg.register_artifact(art, content="v")
+    agent = uuid4()
+    reg.set_agent_state(art.id, agent, MESIState.SHARED, tick=1)
+    return art.id, agent
+
+
+# --------------------------------------------------------------------
+# 3-outcome matrix (in-memory)
+# --------------------------------------------------------------------
+
+
+def test_commit_cas_happy_bumps_version_and_modifies() -> None:
+    reg = ArtifactRegistry()
+    artifact_id, agent = _seed(reg, version=1)
+    result = reg.commit_cas(
+        artifact_id, agent, expected_version=1, content_hash="h-new", tick=7
+    )
+    assert isinstance(result, tuple)
+    updated, invalidated = result
+    assert updated.version == 2
+    assert updated.content_hash == "h-new"
+    assert invalidated == []
+    assert reg.get_agent_state(artifact_id, agent) == MESIState.MODIFIED
+    assert reg.granted_at_tick(agent, artifact_id) == 7
+
+
+def test_commit_cas_invalidates_non_invalid_peers() -> None:
+    reg = ArtifactRegistry()
+    artifact_id, agent = _seed(reg, version=1)
+    peer_shared, peer_invalid = uuid4(), uuid4()
+    reg.set_agent_state(artifact_id, peer_shared, MESIState.SHARED, tick=2)
+    reg.set_agent_state(artifact_id, peer_invalid, MESIState.SHARED, tick=2)
+    reg.set_agent_state(artifact_id, peer_invalid, MESIState.INVALID, tick=3)
+
+    updated, invalidated = reg.commit_cas(
+        artifact_id, agent, expected_version=1, content_hash="h-new", tick=9
+    )
+    assert updated.version == 2
+    assert invalidated == [peer_shared]
+    assert reg.get_agent_state(artifact_id, peer_shared) == MESIState.INVALID
+    assert reg.get_agent_state(artifact_id, agent) == MESIState.MODIFIED
+
+
+def test_commit_cas_version_mismatch_no_mutation() -> None:
+    reg = ArtifactRegistry()
+    artifact_id, _ = _seed(reg, version=5)
+    loser = uuid4()
+    reg.set_agent_state(artifact_id, loser, MESIState.SHARED, tick=2)
+    result = reg.commit_cas(
+        artifact_id, loser, expected_version=3, content_hash="h-stale", tick=10
+    )
+    assert result == ConflictDetail("version_mismatch", 5)
+    art = reg.get_artifact(artifact_id)
+    assert art.version == 5
+    assert art.content_hash == "h-init"
+    assert reg.get_agent_state(artifact_id, loser) == MESIState.SHARED
+
+
+def test_commit_cas_other_holder_no_mutation() -> None:
+    reg = ArtifactRegistry()
+    artifact_id, occ_writer = _seed(reg, version=1)
+    pessimistic = uuid4()
+    reg.set_agent_state(artifact_id, pessimistic, MESIState.EXCLUSIVE, tick=2)
+    result = reg.commit_cas(
+        artifact_id, occ_writer, expected_version=1, content_hash="h-new", tick=11
+    )
+    assert result == ConflictDetail("other_holder", 1)
+    assert reg.get_artifact(artifact_id).version == 1
+    assert reg.get_agent_state(artifact_id, occ_writer) == MESIState.SHARED
+    assert reg.get_agent_state(artifact_id, pessimistic) == MESIState.EXCLUSIVE
+
+
+def test_commit_cas_expected_greater_returns_corruption() -> None:
+    reg = ArtifactRegistry()
+    artifact_id, agent = _seed(reg, version=2)
+    result = reg.commit_cas(
+        artifact_id, agent, expected_version=9, content_hash="x", tick=1
+    )
+    assert isinstance(result, CasCorruption)
+    assert result.current_version == 2
+    assert not isinstance(result, ConflictDetail)
+    assert reg.get_artifact(artifact_id).version == 2
+
+
+def test_commit_cas_version_check_precedes_holder_check() -> None:
+    """A just-committed winner's MODIFIED must not mis-fire other_holder."""
+    reg = ArtifactRegistry()
+    artifact_id, winner = _seed(reg, version=1)
+    loser = uuid4()
+    reg.set_agent_state(artifact_id, loser, MESIState.SHARED, tick=2)
+    reg.commit_cas(artifact_id, winner, expected_version=1, content_hash="w", tick=5)
+    assert reg.get_agent_state(artifact_id, winner) == MESIState.MODIFIED
+    result = reg.commit_cas(
+        artifact_id, loser, expected_version=1, content_hash="l", tick=6
+    )
+    assert result == ConflictDetail("version_mismatch", 2)
+
+
+def test_commit_cas_unknown_artifact_raises_keyerror() -> None:
+    reg = ArtifactRegistry()
+    with pytest.raises(KeyError):
+        reg.commit_cas(uuid4(), uuid4(), expected_version=1, content_hash="x")
+
+
+def test_commit_cas_committer_with_no_prior_state_wins() -> None:
+    """An OCC writer in I (no prior state row) still wins a clean CAS → MODIFIED."""
+    reg = ArtifactRegistry()
+    art = _make_artifact(version=1)
+    reg.register_artifact(art, content="v")
+    fresh = uuid4()  # never had a state entry → effectively INVALID
+    updated, invalidated = reg.commit_cas(
+        art.id, fresh, expected_version=1, content_hash="h-new", tick=4
+    )
+    assert updated.version == 2
+    assert invalidated == []
+    assert reg.get_agent_state(art.id, fresh) == MESIState.MODIFIED
+    assert reg.granted_at_tick(fresh, art.id) == 4
+
+
+# --------------------------------------------------------------------
+# state_log mutation-then-log rollback (in-memory atomicity oracle)
+# --------------------------------------------------------------------
+
+
+def test_commit_cas_state_log_raise_rolls_back_seq_and_state() -> None:
+    """A state_log raise mid-CAS leaves version, _seq, and agent state
+    untouched (mutation-then-log parity with set_agent_state)."""
+    def hooky(entry: dict) -> None:
+        if entry["to_state"] == "MODIFIED" and entry["trigger"] == "commit_cas":
+            raise RuntimeError("simulated callback failure mid-CAS")
+
+    reg = ArtifactRegistry(state_log=hooky, instance_id="inst-cas")
+    art = _make_artifact(version=1)
+    reg.register_artifact(art, content="v")
+    agent, peer = uuid4(), uuid4()
+    reg.set_agent_state(art.id, agent, MESIState.SHARED, tick=1)  # seq 1
+    reg.set_agent_state(art.id, peer, MESIState.SHARED, tick=1)  # seq 2
+    assert reg._seq == 2
+
+    with pytest.raises(RuntimeError, match="simulated callback failure mid-CAS"):
+        reg.commit_cas(art.id, agent, expected_version=1, content_hash="h-new", tick=5)
+
+    # No mutation: version unchanged, both agents still SHARED.
+    assert reg.get_artifact(art.id).version == 1
+    assert reg.get_artifact(art.id).content_hash == "h-init"
+    assert reg.get_agent_state(art.id, agent) == MESIState.SHARED
+    assert reg.get_agent_state(art.id, peer) == MESIState.SHARED
+    # _seq rolled back to 2 (peer emission undone + failed committer reservation).
+    assert reg._seq == 2
+
+
+# --------------------------------------------------------------------
+# Parity: in-memory and sqlite return identical outcomes
+# --------------------------------------------------------------------
+
+
+def _build_pair(
+    tmp_path: Path,
+) -> tuple[ArtifactRegistry, SqliteArtifactRegistry]:
+    return ArtifactRegistry(), SqliteArtifactRegistry(tmp_path / "parity.db")
+
+
+def _normalize(result: object) -> object:
+    """Reduce a CasResult to a comparable shape: WIN → ('win', version,
+    n_invalidated); conflict/corruption compare by value directly."""
+    if isinstance(result, tuple):
+        updated, invalidated = result
+        return ("win", updated.version, len(invalidated))
+    return result
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    ["happy", "version_mismatch", "other_holder", "corruption", "with_peers"],
+)
+def test_commit_cas_parity_inmem_vs_sqlite(tmp_path: Path, scenario: str) -> None:
+    """Both registries must return identical outcomes for identical inputs."""
+    mem, sql = _build_pair(tmp_path)
+
+    def run(reg: ArtifactRegistry | SqliteArtifactRegistry) -> tuple:
+        art = _make_artifact(version=5, content_hash="h-init")
+        reg.register_artifact(art, content="v")
+        writer = uuid4()
+        reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
+
+        if scenario == "happy":
+            res = reg.commit_cas(art.id, writer, expected_version=5, content_hash="h", tick=2)
+        elif scenario == "version_mismatch":
+            res = reg.commit_cas(art.id, writer, expected_version=3, content_hash="h", tick=2)
+        elif scenario == "other_holder":
+            reg.set_agent_state(art.id, uuid4(), MESIState.EXCLUSIVE, tick=2)
+            res = reg.commit_cas(art.id, writer, expected_version=5, content_hash="h", tick=3)
+        elif scenario == "corruption":
+            res = reg.commit_cas(art.id, writer, expected_version=99, content_hash="h", tick=2)
+        else:  # with_peers
+            reg.set_agent_state(art.id, uuid4(), MESIState.SHARED, tick=2)
+            reg.set_agent_state(art.id, uuid4(), MESIState.SHARED, tick=2)
+            res = reg.commit_cas(art.id, writer, expected_version=5, content_hash="h", tick=3)
+
+        # Tuple of (outcome, post-version, committer-state) — all three must
+        # match across impls for true parity.
+        return (
+            _normalize(res),
+            reg.get_artifact(art.id).version,
+            reg.get_agent_state(art.id, writer),
+        )
+
+    try:
+        mem_out = run(mem)
+        sql_out = run(sql)
+        assert mem_out == sql_out, f"{scenario}: in-memory {mem_out} != sqlite {sql_out}"
+    finally:
+        sql.close()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -39,7 +39,7 @@ def _seed(reg: ArtifactRegistry, *, version: int = 1) -> tuple[UUID, UUID]:
 # --------------------------------------------------------------------
 
 
-def test_commit_cas_happy_bumps_version_and_modifies() -> None:
+def test_commit_cas_happy_bumps_version_and_shares() -> None:
     reg = ArtifactRegistry()
     artifact_id, agent = _seed(reg, version=1)
     result = reg.commit_cas(
@@ -50,8 +50,10 @@ def test_commit_cas_happy_bumps_version_and_modifies() -> None:
     assert updated.version == 2
     assert updated.content_hash == "h-new"
     assert invalidated == []
-    assert reg.get_agent_state(artifact_id, agent) == MESIState.MODIFIED
-    assert reg.granted_at_tick(agent, artifact_id) == 7
+    # An OCC writer holds no grant — it ends SHARED (not MODIFIED), with no
+    # granted_at_tick slot (SHARED is not an M∪E acquire).
+    assert reg.get_agent_state(artifact_id, agent) == MESIState.SHARED
+    assert reg.granted_at_tick(agent, artifact_id) is None
 
 
 def test_commit_cas_invalidates_non_invalid_peers() -> None:
@@ -68,7 +70,7 @@ def test_commit_cas_invalidates_non_invalid_peers() -> None:
     assert updated.version == 2
     assert invalidated == [peer_shared]
     assert reg.get_agent_state(artifact_id, peer_shared) == MESIState.INVALID
-    assert reg.get_agent_state(artifact_id, agent) == MESIState.MODIFIED
+    assert reg.get_agent_state(artifact_id, agent) == MESIState.SHARED
 
 
 def test_commit_cas_version_mismatch_no_mutation() -> None:
@@ -113,13 +115,15 @@ def test_commit_cas_expected_greater_returns_corruption() -> None:
 
 
 def test_commit_cas_version_check_precedes_holder_check() -> None:
-    """A just-committed winner's MODIFIED must not mis-fire other_holder."""
+    """The version branch fires before the holder branch, so a stale loser gets
+    version_mismatch (not other_holder). The winner ends SHARED (an OCC writer
+    holds no grant), so the discriminator here is purely the version check."""
     reg = ArtifactRegistry()
     artifact_id, winner = _seed(reg, version=1)
     loser = uuid4()
     reg.set_agent_state(artifact_id, loser, MESIState.SHARED, tick=2)
     reg.commit_cas(artifact_id, winner, expected_version=1, content_hash="w", tick=5)
-    assert reg.get_agent_state(artifact_id, winner) == MESIState.MODIFIED
+    assert reg.get_agent_state(artifact_id, winner) == MESIState.SHARED
     result = reg.commit_cas(
         artifact_id, loser, expected_version=1, content_hash="l", tick=6
     )
@@ -133,7 +137,8 @@ def test_commit_cas_unknown_artifact_raises_keyerror() -> None:
 
 
 def test_commit_cas_committer_with_no_prior_state_wins() -> None:
-    """An OCC writer in I (no prior state row) still wins a clean CAS → MODIFIED."""
+    """An OCC writer in I (no prior state row) still wins a clean CAS → SHARED
+    (an OCC writer holds no grant, so no granted_at_tick is set)."""
     reg = ArtifactRegistry()
     art = _make_artifact(version=1)
     reg.register_artifact(art, content="v")
@@ -143,8 +148,8 @@ def test_commit_cas_committer_with_no_prior_state_wins() -> None:
     )
     assert updated.version == 2
     assert invalidated == []
-    assert reg.get_agent_state(art.id, fresh) == MESIState.MODIFIED
-    assert reg.granted_at_tick(fresh, art.id) == 4
+    assert reg.get_agent_state(art.id, fresh) == MESIState.SHARED
+    assert reg.granted_at_tick(fresh, art.id) is None
 
 
 # --------------------------------------------------------------------
@@ -156,7 +161,9 @@ def test_commit_cas_state_log_raise_rolls_back_seq_and_state() -> None:
     """A state_log raise mid-CAS leaves version, _seq, and agent state
     untouched (mutation-then-log parity with set_agent_state)."""
     def hooky(entry: dict) -> None:
-        if entry["to_state"] == "MODIFIED" and entry["trigger"] == "commit_cas":
+        # The committer now ends SHARED (OCC writer holds no grant); raise on its
+        # emission. Peers emit INVALID, so SHARED uniquely targets the committer.
+        if entry["to_state"] == "SHARED" and entry["trigger"] == "commit_cas":
             raise RuntimeError("simulated callback failure mid-CAS")
 
     reg = ArtifactRegistry(state_log=hooky, instance_id="inst-cas")
@@ -241,3 +248,137 @@ def test_commit_cas_parity_inmem_vs_sqlite(tmp_path: Path, scenario: str) -> Non
         assert mem_out == sql_out, f"{scenario}: in-memory {mem_out} != sqlite {sql_out}"
     finally:
         sql.close()
+
+
+def test_commit_cas_win_omitting_size_tokens_preserves_value_parity(tmp_path: Path) -> None:
+    """FIX 2 parity: a WIN that omits ``size_tokens`` (the cross-process path
+    always passes None) PRESERVES the persisted value rather than NULLing it —
+    identically on BOTH registries. Without the fix the sqlite WIN wrote the raw
+    None into the UPDATE, silently zeroing size_tokens on every cross-process
+    OCC commit while the in-memory registry preserved it (a divergence)."""
+    mem, sql = _build_pair(tmp_path)
+
+    def run(reg: ArtifactRegistry | SqliteArtifactRegistry) -> tuple[int | None, int | None]:
+        art = Artifact(
+            id=uuid4(), name="plan.md", version=1, content_hash="h-init", size_tokens=42
+        )
+        reg.register_artifact(art, content="v")
+        writer = uuid4()
+        reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
+        # WIN with size_tokens OMITTED (defaults to None).
+        updated, _ = reg.commit_cas(
+            art.id, writer, expected_version=1, content_hash="h-new", tick=2
+        )
+        # Returned Artifact AND the persisted row must both keep the prior 42.
+        return updated.size_tokens, reg.get_artifact(art.id).size_tokens
+
+    try:
+        mem_out = run(mem)
+        sql_out = run(sql)
+        assert mem_out == (42, 42), f"in-memory did not preserve size_tokens: {mem_out}"
+        assert sql_out == (42, 42), f"sqlite did not preserve size_tokens: {sql_out}"
+        assert mem_out == sql_out
+    finally:
+        sql.close()
+
+
+def test_commit_cas_win_with_explicit_size_tokens_overwrites_parity(tmp_path: Path) -> None:
+    """Counterpart to the preserve test: a non-None ``size_tokens`` arg OVERWRITES
+    the persisted value on both registries (the preserve rule fires only on None)."""
+    mem, sql = _build_pair(tmp_path)
+
+    def run(reg: ArtifactRegistry | SqliteArtifactRegistry) -> tuple[int | None, int | None]:
+        art = Artifact(
+            id=uuid4(), name="plan.md", version=1, content_hash="h-init", size_tokens=42
+        )
+        reg.register_artifact(art, content="v")
+        writer = uuid4()
+        reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
+        updated, _ = reg.commit_cas(
+            art.id, writer, expected_version=1, content_hash="h-new",
+            size_tokens=99, tick=2,
+        )
+        return updated.size_tokens, reg.get_artifact(art.id).size_tokens
+
+    try:
+        assert run(mem) == (99, 99)
+        assert run(sql) == (99, 99)
+    finally:
+        sql.close()
+
+
+def test_commit_cas_inmem_win_updates_record_content_for_peer_fetch() -> None:
+    """FIX 4: an in-memory commit_cas WIN with ``content`` advances
+    ``record.content`` so a peer re-fetching via the service reads the winner's
+    NEW body — not the stale pre-CAS seed. Without the fix the version +
+    content_hash bumped but ``record.content`` kept the old bytes (silent content
+    staleness)."""
+    from ccs.coordinator.service import CoordinatorService
+    from ccs.core.types import FetchRequest
+
+    svc = CoordinatorService(ArtifactRegistry())
+    artifact = svc.register_artifact(name="plan.md", content="seed-v1")
+    winner = uuid4()
+    peer = uuid4()
+    # Two SHARED holders (a peer must exist so the later fetch grants SHARED, not
+    # EXCLUSIVE, and so the winner has someone to be coherent with).
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=winner, requested_at_tick=1))
+    svc.fetch(FetchRequest(artifact_id=artifact.id, requesting_agent_id=peer, requested_at_tick=2))
+
+    updated, _ = svc.commit_cas(
+        agent_id=winner,
+        artifact_id=artifact.id,
+        expected_version=artifact.version,
+        content_hash="h-new",
+        content="winner-v2",
+        issued_at_tick=3,
+    )
+    assert updated.version == 2
+
+    # Registry content advanced to the winner's body.
+    assert svc.registry.get_content(artifact.id) == "winner-v2"
+    # A peer re-fetch reads the NEW content at the new version (the peer was
+    # invalidated by the win; the fetch re-grants it SHARED@v2 with fresh bytes).
+    resp = svc.fetch(
+        FetchRequest(artifact_id=artifact.id, requesting_agent_id=peer, requested_at_tick=4)
+    )
+    assert resp.version == 2
+    assert resp.content == "winner-v2"
+
+
+def test_commit_cas_inmem_win_with_content_updates_retained_version() -> None:
+    """FIX 4 (retain_versions): the winning body is stored under the NEW version
+    in version_history (not the stale pre-CAS body)."""
+    reg = ArtifactRegistry(retain_versions=True)
+    art = _make_artifact(version=1)
+    reg.register_artifact(art, content="seed-v1")
+    writer = uuid4()
+    reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
+
+    reg.commit_cas(
+        art.id, writer, expected_version=1, content_hash="h-new",
+        content="winner-v2", tick=2,
+    )
+    # The retained snapshot for version 2 is the winner's body.
+    assert reg.get_content_at_version(art.id, 2) == "winner-v2"
+    # The live content is also the winner's body.
+    assert reg.get_content(art.id) == "winner-v2"
+
+
+def test_commit_cas_inmem_win_without_content_leaves_body_unchanged() -> None:
+    """FIX 4 default: when ``content`` is omitted (the cross-process / sqlite
+    path), the in-memory body is left unchanged — only version + content_hash
+    advance (prior content-coherence behaviour preserved)."""
+    reg = ArtifactRegistry()
+    art = _make_artifact(version=1)
+    reg.register_artifact(art, content="seed-v1")
+    writer = uuid4()
+    reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
+
+    updated, _ = reg.commit_cas(
+        art.id, writer, expected_version=1, content_hash="h-new", tick=2
+    )
+    assert updated.version == 2
+    assert updated.content_hash == "h-new"
+    # Body untouched (no content threaded).
+    assert reg.get_content(art.id) == "seed-v1"

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -486,8 +486,8 @@ def _seed_artifact_with_shared_writer(
     return art.id, agent
 
 
-def test_commit_cas_happy_bumps_version_and_modifies(db_path: Path) -> None:
-    """expected == current, no other E/M holder → version N+1, agent MODIFIED."""
+def test_commit_cas_happy_bumps_version_and_shares(db_path: Path) -> None:
+    """expected == current, no other E/M holder → version N+1, agent SHARED."""
     with SqliteArtifactRegistry(db_path) as reg:
         artifact_id, agent = _seed_artifact_with_shared_writer(reg, version=1)
         result = reg.commit_cas(
@@ -498,9 +498,10 @@ def test_commit_cas_happy_bumps_version_and_modifies(db_path: Path) -> None:
         assert updated.version == 2
         assert updated.content_hash == "h-new"
         assert invalidated == []
-        assert reg.get_agent_state(artifact_id, agent) == MESIState.MODIFIED
-        # S→M is an M∪E acquire → granted_at_tick set to the commit tick.
-        assert reg.granted_at_tick(agent, artifact_id) == 7
+        # An OCC writer holds no grant — it ends SHARED (not MODIFIED), and
+        # SHARED is not an M∪E acquire so no granted_at_tick slot is set.
+        assert reg.get_agent_state(artifact_id, agent) == MESIState.SHARED
+        assert reg.granted_at_tick(agent, artifact_id) is None
         # last_writer recorded on the artifact row.
         assert reg.last_writer_for(artifact_id) == agent
 
@@ -522,7 +523,7 @@ def test_commit_cas_invalidates_non_invalid_peers(db_path: Path) -> None:
         # Only the still-valid peer is invalidated; the already-INVALID one is not.
         assert invalidated == [peer_shared]
         assert reg.get_agent_state(artifact_id, peer_shared) == MESIState.INVALID
-        assert reg.get_agent_state(artifact_id, agent) == MESIState.MODIFIED
+        assert reg.get_agent_state(artifact_id, agent) == MESIState.SHARED
 
 
 def test_commit_cas_version_mismatch_no_mutation(db_path: Path) -> None:
@@ -587,17 +588,18 @@ def test_commit_cas_expected_greater_returns_corruption(db_path: Path) -> None:
 
 
 def test_commit_cas_version_check_precedes_holder_check(db_path: Path) -> None:
-    """A just-committed winner's MODIFIED state must NOT mis-fire other_holder
-    for a stale loser — the version branch fires first → version_mismatch."""
+    """The version branch fires before the holder branch → a stale loser gets
+    version_mismatch (not other_holder). The winner ends SHARED (an OCC writer
+    holds no grant), so the version check is the sole discriminator here."""
     with SqliteArtifactRegistry(db_path) as reg:
         artifact_id, winner = _seed_artifact_with_shared_writer(reg, version=1)
         loser = uuid4()
         reg.set_agent_state(artifact_id, loser, MESIState.SHARED, tick=2)
-        # Winner commits: version 1→2, winner now MODIFIED.
+        # Winner commits: version 1→2, winner now SHARED (no grant).
         reg.commit_cas(artifact_id, winner, expected_version=1, content_hash="w", tick=5)
-        assert reg.get_agent_state(artifact_id, winner) == MESIState.MODIFIED
-        # Loser retries at stale expected_version=1; winner holds MODIFIED.
-        # version_mismatch must win (not other_holder), proving branch order.
+        assert reg.get_agent_state(artifact_id, winner) == MESIState.SHARED
+        # Loser retries at stale expected_version=1; version_mismatch must win
+        # (not other_holder), proving branch order.
         result = reg.commit_cas(
             artifact_id, loser, expected_version=1, content_hash="l", tick=6
         )
@@ -627,18 +629,22 @@ def test_commit_cas_emits_state_log_for_committer_and_peers(db_path: Path) -> No
         emitted.clear()
 
         reg.commit_cas(art.id, agent, expected_version=1, content_hash="h-new", tick=5)
-        # One peer invalidation + one committer MODIFIED = 2 new entries.
+        # One peer invalidation + one committer SHARED = 2 new entries.
         assert len(emitted) == 2
         transitions = {(e["from_state"], e["to_state"]) for e in emitted}
         assert ("SHARED", "INVALID") in transitions
-        assert ("SHARED", "MODIFIED") in transitions
+        # The committer ends SHARED (OCC writer holds no grant): SHARED→SHARED.
+        assert ("SHARED", "SHARED") in transitions
         seqs = sorted(e["sequence_number"] for e in emitted)
         assert seqs == [3, 4]
         assert reg._seq == 4
-        # The MODIFIED entry carries the new content_hash; the invalidation does not.
-        mod_entry = next(e for e in emitted if e["to_state"] == "MODIFIED")
-        assert mod_entry["content_hash"] == "h-new"
-        assert mod_entry["version"] == 2
+        # The committer entry carries the new content_hash; the invalidation does
+        # not. (The committer is the SHARED→SHARED entry, not the peer→INVALID.)
+        committer_entry = next(
+            e for e in emitted if (e["from_state"], e["to_state"]) == ("SHARED", "SHARED")
+        )
+        assert committer_entry["content_hash"] == "h-new"
+        assert committer_entry["version"] == 2
         inv_entry = next(e for e in emitted if e["to_state"] == "INVALID")
         assert inv_entry["content_hash"] is None
         # sequence_number persisted to registry_meta.
@@ -652,11 +658,12 @@ def test_commit_cas_state_log_raise_rolls_back_seq_and_state(db_path: Path) -> N
     """Atomicity oracle (mirrors test_state_log_raise_rolls_back_seq_and_state):
     a state_log raise mid-CAS → ROLLBACK leaves version + _seq + agent state
     untouched, and registry_meta.sequence_number unchanged."""
-    # Raise on the committer's MODIFIED emission (seq 3): the peer invalidation
-    # (seq 3 candidate) is emitted first, the committer emission is the one that
-    # raises — forcing a rollback after the UPDATE + peer mutation already ran
-    # inside the transaction.
-    raise_on_to_state = "MODIFIED"
+    # Raise on the committer's SHARED emission (the committer now ends SHARED —
+    # an OCC writer holds no grant). The peer invalidation is emitted first
+    # (to_state INVALID), the committer emission is the one that raises — forcing
+    # a rollback after the UPDATE + peer mutation already ran inside the
+    # transaction. SHARED uniquely targets the committer (the peer goes →INVALID).
+    raise_on_to_state = "SHARED"
     emitted: list[dict] = []
 
     def hooky(entry: dict) -> None:

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -25,7 +25,7 @@ from ccs.coordinator.sqlite_registry import (
     SqliteArtifactRegistry,
 )
 from ccs.core.states import MESIState, TransientState
-from ccs.core.types import Artifact
+from ccs.core.types import Artifact, CasCorruption, ConflictDetail
 
 
 @pytest.fixture
@@ -467,3 +467,268 @@ def test_cor04_resolve_or_register_post_rollback_delete_raises_runtime_error(
             reg._conn = real_conn
     finally:
         reg.close()
+
+
+# --------------------------------------------------------------------
+# OCC commit-CAS (plan Unit 2)
+# --------------------------------------------------------------------
+
+
+def _seed_artifact_with_shared_writer(
+    reg: SqliteArtifactRegistry, *, version: int = 1
+) -> tuple[UUID, UUID]:
+    """Register an artifact at ``version`` and put one agent in SHARED (the OCC
+    writer's pre-commit state). Returns ``(artifact_id, agent_id)``."""
+    art = _make_artifact(version=version, content_hash="h-init")
+    reg.register_artifact(art, content="")
+    agent = uuid4()
+    reg.set_agent_state(art.id, agent, MESIState.SHARED, tick=1)
+    return art.id, agent
+
+
+def test_commit_cas_happy_bumps_version_and_modifies(db_path: Path) -> None:
+    """expected == current, no other E/M holder → version N+1, agent MODIFIED."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        artifact_id, agent = _seed_artifact_with_shared_writer(reg, version=1)
+        result = reg.commit_cas(
+            artifact_id, agent, expected_version=1, content_hash="h-new", tick=7
+        )
+        assert isinstance(result, tuple)
+        updated, invalidated = result
+        assert updated.version == 2
+        assert updated.content_hash == "h-new"
+        assert invalidated == []
+        assert reg.get_agent_state(artifact_id, agent) == MESIState.MODIFIED
+        # S→M is an M∪E acquire → granted_at_tick set to the commit tick.
+        assert reg.granted_at_tick(agent, artifact_id) == 7
+        # last_writer recorded on the artifact row.
+        assert reg.last_writer_for(artifact_id) == agent
+
+
+def test_commit_cas_invalidates_non_invalid_peers(db_path: Path) -> None:
+    """WIN invalidates every non-INVALID peer; returns their ids for signals."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        artifact_id, agent = _seed_artifact_with_shared_writer(reg, version=1)
+        peer_shared = uuid4()
+        peer_invalid = uuid4()
+        reg.set_agent_state(artifact_id, peer_shared, MESIState.SHARED, tick=2)
+        reg.set_agent_state(artifact_id, peer_invalid, MESIState.SHARED, tick=2)
+        reg.set_agent_state(artifact_id, peer_invalid, MESIState.INVALID, tick=3)
+
+        updated, invalidated = reg.commit_cas(
+            artifact_id, agent, expected_version=1, content_hash="h-new", tick=9
+        )
+        assert updated.version == 2
+        # Only the still-valid peer is invalidated; the already-INVALID one is not.
+        assert invalidated == [peer_shared]
+        assert reg.get_agent_state(artifact_id, peer_shared) == MESIState.INVALID
+        assert reg.get_agent_state(artifact_id, agent) == MESIState.MODIFIED
+
+
+def test_commit_cas_version_mismatch_no_mutation(db_path: Path) -> None:
+    """expected < current → version_mismatch ConflictDetail, NO mutation."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        artifact_id, _ = _seed_artifact_with_shared_writer(reg, version=5)
+        loser = uuid4()
+        reg.set_agent_state(artifact_id, loser, MESIState.SHARED, tick=2)
+        result = reg.commit_cas(
+            artifact_id, loser, expected_version=3, content_hash="h-stale", tick=10
+        )
+        assert result == ConflictDetail("version_mismatch", 5)
+        # No mutation: version unchanged, content_hash unchanged, state SHARED.
+        art = reg.get_artifact(artifact_id)
+        assert art.version == 5
+        assert art.content_hash == "h-init"
+        assert reg.get_agent_state(artifact_id, loser) == MESIState.SHARED
+
+
+def test_commit_cas_other_holder_no_mutation(db_path: Path) -> None:
+    """version matches but another agent holds E/M → other_holder, NO mutation."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        artifact_id, occ_writer = _seed_artifact_with_shared_writer(reg, version=1)
+        pessimistic = uuid4()
+        reg.set_agent_state(artifact_id, pessimistic, MESIState.EXCLUSIVE, tick=2)
+        result = reg.commit_cas(
+            artifact_id, occ_writer, expected_version=1, content_hash="h-new", tick=11
+        )
+        assert result == ConflictDetail("other_holder", 1)
+        assert reg.get_artifact(artifact_id).version == 1
+        assert reg.get_agent_state(artifact_id, occ_writer) == MESIState.SHARED
+        # The pessimistic holder is untouched.
+        assert reg.get_agent_state(artifact_id, pessimistic) == MESIState.EXCLUSIVE
+
+
+def test_commit_cas_modified_peer_also_trips_other_holder(db_path: Path) -> None:
+    """MODIFIED (not just EXCLUSIVE) peer trips other_holder."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        artifact_id, occ_writer = _seed_artifact_with_shared_writer(reg, version=1)
+        holder = uuid4()
+        reg.set_agent_state(artifact_id, holder, MESIState.EXCLUSIVE, tick=2)
+        reg.set_agent_state(artifact_id, holder, MESIState.MODIFIED, tick=3)
+        result = reg.commit_cas(
+            artifact_id, occ_writer, expected_version=1, content_hash="x", tick=4
+        )
+        assert result == ConflictDetail("other_holder", 1)
+
+
+def test_commit_cas_expected_greater_returns_corruption(db_path: Path) -> None:
+    """expected > current → CasCorruption sentinel (service maps to CoherenceError)."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        artifact_id, agent = _seed_artifact_with_shared_writer(reg, version=2)
+        result = reg.commit_cas(
+            artifact_id, agent, expected_version=9, content_hash="x", tick=1
+        )
+        assert isinstance(result, CasCorruption)
+        assert result.current_version == 2
+        # Corruption is distinct from a conflict.
+        assert not isinstance(result, ConflictDetail)
+        # No mutation.
+        assert reg.get_artifact(artifact_id).version == 2
+
+
+def test_commit_cas_version_check_precedes_holder_check(db_path: Path) -> None:
+    """A just-committed winner's MODIFIED state must NOT mis-fire other_holder
+    for a stale loser — the version branch fires first → version_mismatch."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        artifact_id, winner = _seed_artifact_with_shared_writer(reg, version=1)
+        loser = uuid4()
+        reg.set_agent_state(artifact_id, loser, MESIState.SHARED, tick=2)
+        # Winner commits: version 1→2, winner now MODIFIED.
+        reg.commit_cas(artifact_id, winner, expected_version=1, content_hash="w", tick=5)
+        assert reg.get_agent_state(artifact_id, winner) == MESIState.MODIFIED
+        # Loser retries at stale expected_version=1; winner holds MODIFIED.
+        # version_mismatch must win (not other_holder), proving branch order.
+        result = reg.commit_cas(
+            artifact_id, loser, expected_version=1, content_hash="l", tick=6
+        )
+        assert result == ConflictDetail("version_mismatch", 2)
+
+
+def test_commit_cas_unknown_artifact_raises_keyerror(db_path: Path) -> None:
+    with SqliteArtifactRegistry(db_path) as reg:
+        with pytest.raises(KeyError):
+            reg.commit_cas(uuid4(), uuid4(), expected_version=1, content_hash="x")
+
+
+def test_commit_cas_emits_state_log_for_committer_and_peers(db_path: Path) -> None:
+    """WIN emits one state_log entry per transition (peers→INVALID, committer→M),
+    with monotonic sequence numbers continuing from prior emissions."""
+    emitted: list[dict] = []
+    with SqliteArtifactRegistry(
+        db_path, state_log=emitted.append, instance_id="inst-cas"
+    ) as reg:
+        art = _make_artifact(version=1, content_hash="h-init")
+        reg.register_artifact(art, content="")
+        agent = uuid4()
+        peer = uuid4()
+        reg.set_agent_state(art.id, agent, MESIState.SHARED, tick=1)  # seq 1
+        reg.set_agent_state(art.id, peer, MESIState.SHARED, tick=1)  # seq 2
+        assert reg._seq == 2
+        emitted.clear()
+
+        reg.commit_cas(art.id, agent, expected_version=1, content_hash="h-new", tick=5)
+        # One peer invalidation + one committer MODIFIED = 2 new entries.
+        assert len(emitted) == 2
+        transitions = {(e["from_state"], e["to_state"]) for e in emitted}
+        assert ("SHARED", "INVALID") in transitions
+        assert ("SHARED", "MODIFIED") in transitions
+        seqs = sorted(e["sequence_number"] for e in emitted)
+        assert seqs == [3, 4]
+        assert reg._seq == 4
+        # The MODIFIED entry carries the new content_hash; the invalidation does not.
+        mod_entry = next(e for e in emitted if e["to_state"] == "MODIFIED")
+        assert mod_entry["content_hash"] == "h-new"
+        assert mod_entry["version"] == 2
+        inv_entry = next(e for e in emitted if e["to_state"] == "INVALID")
+        assert inv_entry["content_hash"] is None
+        # sequence_number persisted to registry_meta.
+        meta = dict(reg._conn.execute(
+            "SELECT key, value FROM registry_meta WHERE key='sequence_number'"
+        ).fetchall())
+        assert meta["sequence_number"] == "4"
+
+
+def test_commit_cas_state_log_raise_rolls_back_seq_and_state(db_path: Path) -> None:
+    """Atomicity oracle (mirrors test_state_log_raise_rolls_back_seq_and_state):
+    a state_log raise mid-CAS → ROLLBACK leaves version + _seq + agent state
+    untouched, and registry_meta.sequence_number unchanged."""
+    # Raise on the committer's MODIFIED emission (seq 3): the peer invalidation
+    # (seq 3 candidate) is emitted first, the committer emission is the one that
+    # raises — forcing a rollback after the UPDATE + peer mutation already ran
+    # inside the transaction.
+    raise_on_to_state = "MODIFIED"
+    emitted: list[dict] = []
+
+    def hooky(entry: dict) -> None:
+        if entry["to_state"] == raise_on_to_state and entry["trigger"] == "commit_cas":
+            raise RuntimeError("simulated callback failure mid-CAS")
+        emitted.append(entry)
+
+    with SqliteArtifactRegistry(
+        db_path, state_log=hooky, instance_id="inst-cas"
+    ) as reg:
+        art = _make_artifact(version=1, content_hash="h-init")
+        reg.register_artifact(art, content="")
+        agent = uuid4()
+        peer = uuid4()
+        reg.set_agent_state(art.id, agent, MESIState.SHARED, tick=1)  # seq 1
+        reg.set_agent_state(art.id, peer, MESIState.SHARED, tick=1)  # seq 2
+        assert reg._seq == 2
+
+        with pytest.raises(RuntimeError, match="simulated callback failure mid-CAS"):
+            reg.commit_cas(art.id, agent, expected_version=1, content_hash="h-new", tick=5)
+
+        # Everything rolled back: version still 1, content_hash still h-init.
+        art_now = reg.get_artifact(art.id)
+        assert art_now.version == 1
+        assert art_now.content_hash == "h-init"
+        # Agent state preserved (committer still SHARED, peer still SHARED — the
+        # peer's INVALID mutation was rolled back too).
+        assert reg.get_agent_state(art.id, agent) == MESIState.SHARED
+        assert reg.get_agent_state(art.id, peer) == MESIState.SHARED
+        # _seq rolled back to 2 (both the peer emission AND the failed committer
+        # reservation are undone).
+        assert reg._seq == 2
+        meta = dict(reg._conn.execute(
+            "SELECT key, value FROM registry_meta WHERE key='sequence_number'"
+        ).fetchall())
+        assert meta["sequence_number"] == "2"
+
+
+def test_commit_cas_concurrent_writers_exactly_one_wins(db_path: Path) -> None:
+    """Two barrier-synced OCC writers (both SHARED, same expected_version) race
+    on commit_cas → exactly one commits (version N+1, not N+2), the loser gets a
+    ConflictDetail. No silent clobber (R5 atomicity via BEGIN IMMEDIATE)."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        art = _make_artifact(version=1, content_hash="h-init")
+        reg.register_artifact(art, content="")
+        writers = [uuid4() for _ in range(8)]
+        for w in writers:
+            reg.set_agent_state(art.id, w, MESIState.SHARED, tick=1)
+
+        results: dict[UUID, object] = {}
+        barrier = threading.Barrier(len(writers))
+
+        def attempt(writer_id: UUID) -> None:
+            barrier.wait()
+            results[writer_id] = reg.commit_cas(
+                art.id, writer_id, expected_version=1,
+                content_hash=f"h-{writer_id.hex[:6]}", tick=5,
+            )
+
+        threads = [threading.Thread(target=attempt, args=(w,)) for w in writers]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        wins = [r for r in results.values() if isinstance(r, tuple)]
+        conflicts = [r for r in results.values() if isinstance(r, ConflictDetail)]
+        assert len(wins) == 1, f"expected exactly one win, got {len(wins)}"
+        assert len(conflicts) == len(writers) - 1
+        # Final version advanced by exactly one — no lost update / no clobber.
+        assert reg.get_artifact(art.id).version == 2
+        # Every loser saw version_mismatch (two OCC writers are both SHARED, so
+        # the loser is elected by the version check, never other_holder).
+        assert all(c.reason == "version_mismatch" for c in conflicts)
+        assert all(c.current_version == 2 for c in conflicts)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -13,6 +13,7 @@ from ccs.core.states import MESIState
 from ccs.simulation.engine import SimulationEngine
 from ccs.simulation.scenarios import load_scenario
 from ccs.strategies.access_count import AccessCountStrategy
+from ccs.strategies.base import SyncStrategy
 from ccs.strategies.blind_cache import BlindCacheStrategy
 from ccs.strategies.broadcast import BroadcastStrategy
 from ccs.strategies.eager import EagerStrategy
@@ -172,3 +173,94 @@ def test_broadcast_baseline_token_cost() -> None:
     expected = n * s * total_artifact_tokens
     ratio_delta = abs(metrics.tokens_broadcast - expected) / float(expected)
     assert ratio_delta < 0.05
+
+
+# --- OCC retry policy seam (Unit 4) -----------------------------------------
+#
+# These cover ONLY the policy surface on ``SyncStrategy``: the retry knobs are
+# concrete-with-default (not abstract, which would break all six concretes), and
+# nothing here adds an actor hook or an auto-escalation path. The "loop obeys the
+# knob" integration test belongs to Unit 5 (AgentRuntime), where the loop exists.
+
+# All concrete strategies a caller can construct, including the benchmark-only
+# blind cost-floor (reachable via ``build_strategy("blind")``).
+_ALL_CONCRETE_STRATEGIES = (
+    LazyStrategy(),
+    LeaseStrategy(),
+    EagerStrategy(),
+    AccessCountStrategy(),
+    BroadcastStrategy(),
+    BlindCacheStrategy(),
+)
+
+# Every name ``build_strategy`` accepts (mirrors the selector's branches).
+_REGISTERED_STRATEGY_NAMES = (
+    "blind",
+    "broadcast",
+    "eager",
+    "lazy",
+    "lease",
+    "access_count",
+    "access-count",
+    "accesscount",
+)
+
+
+def test_default_strategy_returns_sane_cas_retry_policy() -> None:
+    # Use the production default strategy as the representative for the base
+    # concrete-with-default policy.
+    strategy = LazyStrategy()
+
+    assert strategy.max_cas_retries() > 0
+    # Backoff is non-negative and deterministic for the full attempt window.
+    for attempt in range(strategy.max_cas_retries() + 1):
+        assert strategy.cas_backoff_ticks(attempt) >= 0
+        assert strategy.cas_backoff_ticks(attempt) == strategy.cas_backoff_ticks(attempt)
+
+
+def test_cas_backoff_first_retry_is_immediate_and_monotonic_nondecreasing() -> None:
+    strategy = LazyStrategy()
+
+    # First retry (attempt 0) is immediate so a lone transient conflict re-reads
+    # with no delay; a negative attempt clamps to no delay rather than erroring.
+    assert strategy.cas_backoff_ticks(0) == 0
+    assert strategy.cas_backoff_ticks(-1) == 0
+
+    # Schedule never decreases across the retry window (bounds livelock).
+    backoffs = [strategy.cas_backoff_ticks(attempt) for attempt in range(8)]
+    assert backoffs == sorted(backoffs)
+
+
+def test_no_auto_escalation_surface_on_any_strategy() -> None:
+    # D5: a CAS conflict must NEVER auto-escalate to EXCLUSIVE. Assert no method
+    # or attribute hinting at escalation exists on the ABC or any concrete.
+    forbidden_substrings = ("escalat", "exclusive", "auto_acquire", "force_acquire")
+    candidates = (SyncStrategy, *(type(s) for s in _ALL_CONCRETE_STRATEGIES))
+    for strategy_type in candidates:
+        for member in dir(strategy_type):
+            lowered = member.lower()
+            assert not any(token in lowered for token in forbidden_substrings), (
+                f"{strategy_type.__name__} exposes possible auto-escalation member '{member}'"
+            )
+
+
+def test_all_concrete_strategies_construct_and_inherit_default_cas_policy() -> None:
+    # No abstractmethod break: every concrete still instantiates, and each
+    # inherits the base concrete-with-default retry policy.
+    assert len(_ALL_CONCRETE_STRATEGIES) == 6
+    for strategy in _ALL_CONCRETE_STRATEGIES:
+        assert isinstance(strategy, SyncStrategy)
+        # Inherited (not overridden) -> identical to the base default.
+        assert strategy.max_cas_retries() == SyncStrategy.max_cas_retries(strategy)
+        assert strategy.max_cas_retries() > 0
+        assert strategy.cas_backoff_ticks(0) == 0
+        assert strategy.cas_backoff_ticks(1) >= 0
+
+
+@pytest.mark.parametrize("name", _REGISTERED_STRATEGY_NAMES)
+def test_build_strategy_still_builds_each_registered_name_with_cas_policy(name: str) -> None:
+    strategy = build_strategy(name)
+    assert isinstance(strategy, SyncStrategy)
+    # The new policy surface is reachable on every selector-built strategy.
+    assert strategy.max_cas_retries() > 0
+    assert strategy.cas_backoff_ticks(0) >= 0


### PR DESCRIPTION
## Summary
Implements the optimistic-concurrency commit (`commit_cas`) that prevents the true-concurrent, cross-process lost-update on a shared artifact under one coordinator (single host). OCC writers stay SHARED/INVALID and **bypass the pessimistic EXCLUSIVE acquire**; a commit-time version compare-and-swap elects exactly one winner, and the loser gets a typed conflict it retries — no silent overwrite.

- **Registry CAS** (`SqliteArtifactRegistry`/`ArtifactRegistry.commit_cas`): one atomic transaction does version-check → 3-outcome discriminate → conditional mutate (modeled on `resolve_or_register`); the version check precedes the holder check; `set_agent_state` bookkeeping is inlined.
- **Service** (`CoordinatorService.commit_cas`): enforces the SHARED/INVALID-only precondition, discriminates version_mismatch / other_holder / corruption, builds invalidation signals.
- **Typed conflict** (`ConflictDetail`) is returned, never raised; corruption raises `CoherenceError`.
- **Caller retry** (`AgentRuntime.write_cas` + `SyncStrategy` policy knobs): bounded retry with backoff; typed terminal (`CasRetriesExhausted`) on exhaustion — never a silent drop. The retry loop is the actor; strategies are policy.
- **Cross-process** (`POST /hooks/post-edit-cas` + `CoherentVolume.write_cas`): the OCC commit over HTTP, fail-closed — a degraded/timed-out CAS returns `{ok:false,…}` (never `ok:true`) so the client never mistakes it for success.

The watchdog late-completion residual (a phantom version bump, not a lost update) and full fencing are deferred to the cross-host follow-on (documented in-code).

## Test Plan
- [x] Full default suite: **1742 passed, 0 failed**
- [x] Concurrent-writer proof (`test_occ_commit_cas.py`): barrier-synced **fixed-stale-buffer** two-writer + N-writer (3/5/8) → exactly one commits, losers typed-conflicted, final version N+1, no silent clobber; also end-to-end through the HTTP `post-edit-cas` funnel with two clients
- [x] Bounded progress + typed terminal on retry-exhaustion (no silent drop)
- [x] Property test extended with `commit_cas` ops + a no-lost-update assertion
- [x] Both atomicity mutants verified to fail (version-guard removal; check/mutate split with the lock released) and reverted clean
- [x] ruff clean

Depends on #101 (the TLA+ amendment proving `NoLostUpdate`) — merge that first.
