### PR TITLE
fix(coherent-volume): gate write no-op-skip on actual on-disk hash

### DIFF
--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -397,10 +397,22 @@ class CoherentVolume:
             self._check_grant(resp, rel, phase="pre-edit")
 
         new_hash = self._sha256_bytes(data)
-        # No-op skip: bytes identical to our own last commit while we hold a fresh
-        # grant means the file already has them — skip the os.replace (no
-        # filesystem churn) but still finalize the grant via post-edit below.
-        if self._last_committed_hash.get(rel) != new_hash:
+        # No-op skip: when the file ALREADY holds these exact bytes, skip the
+        # os.replace (and its fsync) — but verify against the CURRENT on-disk
+        # hash, never the cached belief alone. _last_committed_hash is only a
+        # cheap fast-path gate (it avoids hashing the file on the common "bytes
+        # changed" write); a peer commit on a tracked-but-NON-strict glob
+        # overwrites the file while our cache still reads our OWN last hash and
+        # pre-edit re-grants without a deny. Trusting the cache there would skip
+        # the write, leaving the peer's bytes on disk while post-edit commits OUR
+        # hash — silent disk/coordinator divergence. Hashing the file is far
+        # cheaper than the atomic write+fsync it guards, so the skip stays a real
+        # optimization while being correct.
+        already_on_disk = (
+            self._last_committed_hash.get(rel) == new_hash
+            and self._disk_hash(abs_path) == new_hash
+        )
+        if not already_on_disk:
             try:
                 self._atomic_write(abs_path, data)
             except OSError:
@@ -495,6 +507,24 @@ class CoherentVolume:
             return b"".join(chunks)
         finally:
             os.close(fd)
+
+    def _disk_hash(self, abs_path: Path) -> str | None:
+        """SHA-256 of the CURRENT on-disk bytes, or ``None`` if the file is
+        absent/unreadable.
+
+        The write no-op-skip uses this to confirm the file ALREADY holds the
+        bytes being committed before skipping the ``os.replace``. A per-instance
+        cached hash (``_last_committed_hash``) can be stale across a peer commit:
+        on a tracked-but-non-strict glob the coordinator re-grants the write
+        without a deny, so the cache still reads this instance's OWN last hash
+        while disk holds the peer's bytes. The cache is therefore only a cheap
+        fast-path gate; the on-disk hash is the authority for whether a write is
+        truly a no-op. Reads via :meth:`_read_file_bytes` (raw ``os.read``) so it
+        is never self-intercepted by the ``install()`` open()-shim."""
+        try:
+            return self._sha256_bytes(self._read_file_bytes(abs_path))
+        except OSError:
+            return None
 
     def _atomic_write(self, abs_path: Path, data: bytes) -> None:
         """Durable, atomic replace via raw ``os.write`` + ``os.replace`` (NOT

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -508,7 +508,8 @@ class CoherentVolume:
         finally:
             os.close(fd)
 
-    def _disk_hash(self, abs_path: Path) -> str | None:
+    @staticmethod
+    def _disk_hash(abs_path: Path) -> str | None:
         """SHA-256 of the CURRENT on-disk bytes, or ``None`` if the file is
         absent/unreadable.
 
@@ -522,7 +523,7 @@ class CoherentVolume:
         truly a no-op. Reads via :meth:`_read_file_bytes` (raw ``os.read``) so it
         is never self-intercepted by the ``install()`` open()-shim."""
         try:
-            return self._sha256_bytes(self._read_file_bytes(abs_path))
+            return CoherentVolume._sha256_bytes(CoherentVolume._read_file_bytes(abs_path))
         except OSError:
             return None
 

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -397,17 +397,11 @@ class CoherentVolume:
             self._check_grant(resp, rel, phase="pre-edit")
 
         new_hash = self._sha256_bytes(data)
-        # No-op skip: when the file ALREADY holds these exact bytes, skip the
-        # os.replace (and its fsync) — but verify against the CURRENT on-disk
-        # hash, never the cached belief alone. _last_committed_hash is only a
-        # cheap fast-path gate (it avoids hashing the file on the common "bytes
-        # changed" write); a peer commit on a tracked-but-NON-strict glob
-        # overwrites the file while our cache still reads our OWN last hash and
-        # pre-edit re-grants without a deny. Trusting the cache there would skip
-        # the write, leaving the peer's bytes on disk while post-edit commits OUR
-        # hash — silent disk/coordinator divergence. Hashing the file is far
-        # cheaper than the atomic write+fsync it guards, so the skip stays a real
-        # optimization while being correct.
+        # No-op skip: skip the os.replace (and its fsync) only when the file
+        # ALREADY holds these bytes. _last_committed_hash is a cheap fast-path
+        # gate (it skips the disk read on the common "bytes changed" write); the
+        # CURRENT on-disk hash is the authority, because the cached belief alone
+        # can be stale across a peer commit (see _disk_hash for the full why).
         already_on_disk = (
             self._last_committed_hash.get(rel) == new_hash
             and self._disk_hash(abs_path) == new_hash

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -18,6 +18,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 from ccs.adapters.claude_code.lifecycle import (
     LifecycleConfig,
@@ -382,6 +383,69 @@ def test_identical_rewrite_skips_filesystem_write(
         vol.write("data/x.txt", b"committed")  # identical bytes -> no-op skip
         assert calls["n"] == 0  # os.replace NOT called the second time
         assert (tmp_path / "data/x.txt").read_bytes() == b"committed"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def _track_only(tmp_path: Path, glob: str = "data/**") -> None:
+    """Mark a glob TRACKED but NOT strict before the coordinator spawns.
+
+    Writes ``.coherence/tracked.yaml`` (so a peer commit invalidates a SHARED
+    view) while deliberately leaving ``strict_mode.yaml`` absent (so the re-grant
+    is warn-mode — never denied). ``managed=()`` volumes then attach to this
+    coordinator without the strict-mode requirement that ``managed`` globs carry.
+    """
+    coherence_dir = tmp_path / ".coherence"
+    coherence_dir.mkdir(parents=True, exist_ok=True)
+    (coherence_dir / "tracked.yaml").write_text(
+        yaml.safe_dump([glob], default_flow_style=False), encoding="utf-8"
+    )
+
+
+def test_no_op_skip_gated_on_disk_not_stale_cache(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """Regression (pre-existing since CoherentVolume v1): the write no-op-skip
+    must check the CURRENT on-disk bytes, not a per-instance cached hash a peer
+    commit left stale.
+
+    On a tracked-but-NON-strict glob, pre-edit RE-GRANTS (no strict deny), so the
+    skip's own check is the only thing between a stale belief and a silent skip.
+    A writes C (cache := H(C)); peer B overwrites with D (A is invalidated but,
+    non-strict, not denied); A writes C again. A's cache still reads
+    H(C) == H(C), so a cache-TRUSTING skip leaves B's D on disk while post-edit
+    commits H(C) — disk/coordinator divergence, and the next reader gets D under a
+    coordinator hash of C. The skip must fire only when the file ACTUALLY holds
+    the bytes, so A's rewrite lands C.
+    """
+    rel = "data/shared.txt"
+    _track_only(tmp_path)  # tracked but non-strict, before any coordinator spawns
+    target = _seed(tmp_path, rel=rel, content=b"v0")
+
+    vol_a = CoherentVolume(tmp_path, managed=(), config=fast_cfg)
+    vol_b = CoherentVolume(tmp_path, managed=(), config=fast_cfg)
+    try:
+        # Warn-mode setup sanity: both attached, and the coordinator is NOT strict
+        # for the path (so the later re-grant is not denied — the bug's precondition).
+        assert vol_a.is_attached and vol_b.is_attached
+        assert not vol_a.strict_mode_active()
+
+        c_bytes = b"content-from-A"
+        d_bytes = b"content-from-B-overwrite"
+
+        vol_a.read(rel)
+        vol_a.write(rel, c_bytes)  # A commits C: cache := H(C), disk == C
+        assert target.read_bytes() == c_bytes
+
+        vol_b.read(rel)  # B SHARED@C
+        vol_b.write(rel, d_bytes)  # B commits D: A -> INVALID, disk == D
+        assert target.read_bytes() == d_bytes
+
+        # A rewrites the SAME bytes it last committed. Non-strict -> pre-edit
+        # re-grants; A's cache still reads H(C). A cache-trusting no-op skip would
+        # leave B's D on disk (the bug); the disk-gated skip rewrites C.
+        vol_a.write(rel, c_bytes)
+        assert target.read_bytes() == c_bytes  # A's intent on disk, not B's stale D
     finally:
         stop_coordinator(tmp_path)
 

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -450,6 +450,36 @@ def test_no_op_skip_gated_on_disk_not_stale_cache(
         stop_coordinator(tmp_path)
 
 
+def test_no_op_skip_not_taken_when_disk_file_missing(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The no-op skip is gated on the on-disk hash, so a cache hit ALONE does not
+    skip the write. If the file is gone at write time (``_disk_hash`` -> None,
+    and None != new_hash), the write proceeds and recreates it. Pins the
+    ``_disk_hash`` missing-file branch the divergence fix relies on."""
+    import ccs.adapters.coherent_volume as cv_mod
+
+    _seed(tmp_path, rel="data/x.txt", content=b"orig")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.write("data/x.txt", b"committed")  # cache := H("committed"), disk holds it
+        (tmp_path / "data/x.txt").unlink()  # disk now diverges from the cached belief
+
+        calls = {"n": 0}
+        real_replace = cv_mod.os.replace
+
+        def counting_replace(src: object, dst: object) -> None:
+            calls["n"] += 1
+            real_replace(src, dst)
+
+        monkeypatch.setattr(cv_mod.os, "replace", counting_replace)
+        vol.write("data/x.txt", b"committed")  # same bytes, but the file is GONE
+        assert calls["n"] == 1  # skip NOT taken — the write recreated the file
+        assert (tmp_path / "data/x.txt").read_bytes() == b"committed"
+    finally:
+        stop_coordinator(tmp_path)
+
+
 def test_deny_raises_even_in_degrade_mode(
     tmp_path: Path, fast_cfg: LifecycleConfig
 ) -> None:

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -18,7 +18,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-import yaml
 
 from ccs.adapters.claude_code.lifecycle import (
     LifecycleConfig,
@@ -187,6 +186,21 @@ def _pair(tmp_path: Path, cfg: LifecycleConfig) -> tuple[CoherentVolume, Coheren
     vol_a = CoherentVolume(tmp_path, managed=("data/**",), config=cfg)
     vol_b = CoherentVolume(tmp_path, managed=("data/**",), config=cfg)
     return vol_a, vol_b
+
+
+def _track_only(tmp_path: Path, glob: str = "data/**") -> None:
+    """Mark a glob TRACKED but NOT strict before the coordinator spawns.
+
+    Writes ``.coherence/tracked.yaml`` (so a peer commit invalidates a SHARED
+    view) while deliberately leaving ``strict_mode.yaml`` absent (so the re-grant
+    is warn-mode — never denied). ``managed=()`` volumes then attach to this
+    coordinator without the strict-mode requirement that ``managed`` globs carry.
+    Reuses the coordinator's own ``_merge_yaml_list`` writer so the fixture tracks
+    the real tracked.yaml format instead of duplicating it.
+    """
+    coherence_dir = tmp_path / ".coherence"
+    coherence_dir.mkdir(parents=True, exist_ok=True)
+    CoherentVolume._merge_yaml_list(coherence_dir / "tracked.yaml", (glob,))
 
 
 def test_sibling_volume_attaches_to_strict_coordinator(
@@ -385,21 +399,6 @@ def test_identical_rewrite_skips_filesystem_write(
         assert (tmp_path / "data/x.txt").read_bytes() == b"committed"
     finally:
         stop_coordinator(tmp_path)
-
-
-def _track_only(tmp_path: Path, glob: str = "data/**") -> None:
-    """Mark a glob TRACKED but NOT strict before the coordinator spawns.
-
-    Writes ``.coherence/tracked.yaml`` (so a peer commit invalidates a SHARED
-    view) while deliberately leaving ``strict_mode.yaml`` absent (so the re-grant
-    is warn-mode — never denied). ``managed=()`` volumes then attach to this
-    coordinator without the strict-mode requirement that ``managed`` globs carry.
-    """
-    coherence_dir = tmp_path / ".coherence"
-    coherence_dir.mkdir(parents=True, exist_ok=True)
-    (coherence_dir / "tracked.yaml").write_text(
-        yaml.safe_dump([glob], default_flow_style=False), encoding="utf-8"
-    )
 
 
 def test_no_op_skip_gated_on_disk_not_stale_cache(


### PR DESCRIPTION
## Summary

- The pessimistic `CoherentVolume.write()` no-op-skip decided the file already held the bytes from a per-instance cached hash (`_last_committed_hash[rel]`), not from disk, and skipped the atomic `os.replace` when the cache matched.
- Across a peer commit on a **tracked-but-non-strict (warn-mode)** glob — where `pre-edit` re-grants instead of denying — that cache goes stale but still equals `new_hash`, so the write is skipped while `post-edit` commits this instance's hash. Result: **silent disk/coordinator divergence** (coordinator reports hash C, disk holds the peer's D; the next reader gets D under a hash of C). On a strict glob the coordinator denies the stale write, so this is specific to warn-mode tracked paths.
- **Fix:** gate the skip on the *actual* current on-disk hash via a new `_disk_hash()` helper; keep `_last_committed_hash` only as a cheap fast-path gate (the `and` short-circuits before the disk read on the common changed-bytes write, so no perf regression on normal writes).
- Pre-existing since CoherentVolume v1 (`a22affd`); the OCC `write_cas` path is untouched.

## Test Plan

- [x] New regression test `test_no_op_skip_gated_on_disk_not_stale_cache`: warn-mode tracked/non-strict coordinator (two `managed=()` volumes over a `tracked.yaml` with no `strict_mode.yaml`); A writes C → peer B writes D → A rewrites C → asserts the on-disk file equals C. Verified **red before** the fix (`assert b'content-from-B-overwrite' == b'content-from-A'`) and **green after**.
- [x] Existing no-op-skip tests still pass (the genuine no-op still skips `os.replace`; the grant is still finalized).
- [x] `pytest tests/adapters/test_coherent_volume.py -q` → 34 passed.
- [x] Full suite: 1659 passed, 3 skipped. (Two `test_claude_code_e2e` subprocess tests require the package console scripts on `PATH`; unaffected by this change.)
- [x] `ruff check src tests` clean.
