### PR TITLE
fix(coherent-volume): release the write() grant on any in-window error

### DIFF
--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -493,31 +493,35 @@ class CoherentVolume:
         if resp is not None:
             self._check_grant(resp, rel, phase="pre-edit")
 
-        new_hash = self._sha256_bytes(data)
-        # No-op skip: skip the os.replace (and its fsync) only when the file
-        # ALREADY holds these bytes. _last_committed_hash is a cheap fast-path
-        # gate (it skips the disk read on the common "bytes changed" write); the
-        # CURRENT on-disk hash is the authority, because the cached belief alone
-        # can be stale across a peer commit (see _disk_hash for the full why).
-        already_on_disk = (
-            self._last_committed_hash.get(rel) == new_hash
-            and self._disk_hash(abs_path) == new_hash
-        )
-        if not already_on_disk:
-            try:
+        # EXCLUSIVE grant is now held. ANY failure before the post-edit commit
+        # must release it via the coordinator's tool-failure path (success:false),
+        # not only an OSError from the atomic write: an unexpected error while
+        # hashing the data or the on-disk file (e.g. MemoryError on a very large
+        # file) would otherwise orphan the grant until the crash-recovery sweep.
+        try:
+            new_hash = self._sha256_bytes(data)
+            # No-op skip: skip the os.replace (and its fsync) only when the file
+            # ALREADY holds these bytes. _last_committed_hash is a cheap fast-path
+            # gate (it skips the disk read on the common "bytes changed" write); the
+            # CURRENT on-disk hash is the authority, because the cached belief alone
+            # can be stale across a peer commit (see _disk_hash for the full why).
+            already_on_disk = (
+                self._last_committed_hash.get(rel) == new_hash
+                and self._disk_hash(abs_path) == new_hash
+            )
+            if not already_on_disk:
                 self._atomic_write(abs_path, data)
-            except OSError:
-                # The FS write failed AFTER pre-edit granted EXCLUSIVE. Release the
-                # grant via the coordinator's tool-failure path so it is not
-                # orphaned until the sweep, then re-raise the original error.
-                # Best-effort release — a release failure must not mask the OSError.
-                with contextlib.suppress(Exception):
-                    _coordinator_post(
-                        self._endpoint,
-                        "/hooks/post-edit",
-                        {"session_id": self._session_id, "path": rel, "success": False},
-                    )
-                raise
+        except Exception:
+            # Release the grant so it is not orphaned until the sweep, then
+            # re-raise the original error. Best-effort release — a release failure
+            # must not mask it.
+            with contextlib.suppress(Exception):
+                _coordinator_post(
+                    self._endpoint,
+                    "/hooks/post-edit",
+                    {"session_id": self._session_id, "path": rel, "success": False},
+                )
+            raise
 
         post_resp = self._post(
             "/hooks/post-edit",

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -1162,6 +1162,45 @@ def test_fs_write_failure_releases_grant(
         stop_coordinator(tmp_path)
 
 
+def _raise_runtime(*_args: object, **_kwargs: object) -> str:
+    raise RuntimeError("simulated non-OSError in the pre-write window")
+
+
+def test_non_oserror_in_write_window_releases_grant(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A NON-OSError raised after pre-edit granted EXCLUSIVE but before the
+    post-edit commit (here from _disk_hash, in the no-op-skip check) must still
+    release the grant via post-edit success:false — not orphan it until the
+    crash-recovery sweep. The original handler caught only OSError around
+    _atomic_write, leaving the hashing / disk-read window unprotected."""
+    import ccs.adapters.coherent_volume as cv_mod
+
+    _seed(tmp_path, rel="data/x.txt", content=b"orig")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.write("data/x.txt", b"same")  # cache := H("same") so _disk_hash is reached next
+
+        posts: list[tuple[str, dict]] = []
+        real_post = cv_mod._coordinator_post
+
+        def spy(endpoint: object, path: str, payload: dict) -> object:
+            posts.append((path, dict(payload)))
+            return real_post(endpoint, path, payload)
+
+        monkeypatch.setattr(cv_mod, "_coordinator_post", spy)
+        monkeypatch.setattr(vol, "_disk_hash", _raise_runtime)  # non-OSError in the window
+
+        with pytest.raises(RuntimeError):
+            vol.write("data/x.txt", b"same")  # cache hit -> _disk_hash -> RuntimeError
+
+        assert any(
+            p == "/hooks/post-edit" and pay.get("success") is False for p, pay in posts
+        ), "a non-OSError in the post-grant window must release the grant"
+    finally:
+        stop_coordinator(tmp_path)
+
+
 def test_no_op_skip_still_finalizes_grant(
     tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- After `write()`'s pre-edit grants EXCLUSIVE, the grant-release-on-failure path (`post-edit success:false`) lived inside an `except OSError` wrapping **only** `_atomic_write`. But `new_hash = self._sha256_bytes(data)` and the no-op-skip's `self._disk_hash(abs_path)` run **after the grant, before that try** — so a **non-`OSError`** there (e.g. `MemoryError` on a very large file) propagated out of `write()` without releasing the grant, orphaning the EXCLUSIVE grant until the crash-recovery sweep reclaimed it.
- **Fix:** wrap the whole post-grant → pre-commit window (hash + no-op-skip check + atomic write) in one `try`, and release the grant via `post-edit success:false` on **any** `Exception` before re-raising.
- Pre-existing window; PR #103's no-op-skip fix added the `_disk_hash` call into it. Pessimistic `write()` path only — the OCC `write_cas` path is untouched.

## Test Plan

- [x] New regression test `test_non_oserror_in_write_window_releases_grant`: monkeypatches `_disk_hash` to raise a non-`OSError` in the post-grant window and asserts a `post-edit success:false` is still posted. Verified **red before** / **green after**.
- [x] `test_fs_write_failure_releases_grant` (the OSError path) still passes — broadening `OSError` → `Exception` does not regress it.
- [x] `pytest tests/adapters/test_coherent_volume.py -q` → 50 passed; `ruff check src tests` clean.
