### PR TITLE
feat(coordinator): single-host read-generation fence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,12 @@ cost-benchmark-check: cost-benchmark  ## Re-run the cost sweep, then drift-check
 TLA2TOOLS := formal/tla/lib/tla2tools.jar
 TLC := java -XX:+UseParallelGC -cp $(TLA2TOOLS) tlc2.TLC -workers auto
 
-tla-check:  ## Run TLC model checker on MESI, CrashRecovery, and OCC specs
+tla-check:  ## Run TLC model checker on MESI, CrashRecovery, OCC, and Fencing specs
 	@java -version 2>&1 | head -1 | grep -qE '"(1[7-9]|[2-9][0-9])\.' || { echo "ERROR: Java 17+ required for TLC model checker"; exit 1; }
 	$(TLC) -config formal/tla/MESI_Standalone.cfg formal/tla/MESI_Standalone.tla
 	$(TLC) -config formal/tla/CrashRecovery_CI.cfg formal/tla/CrashRecovery.tla
 	$(TLC) -config formal/tla/OCC_CI.cfg formal/tla/OCC.tla
+	$(TLC) -config formal/tla/Fencing_CI.cfg formal/tla/Fencing.tla
 
 help:  ## List available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # agent-coherence
 
-**The coherence layer for multi-agent systems — vendor-neutral, framework-agnostic.**
+**`agent-coherence` makes "agent A silently clobbered agent B's `plan.md`" impossible — a vendor-neutral MESI + optimistic-concurrency coordinator for agent state, with the safety invariants machine-checked in TLA+.**
 
-When agents share state, one of them is reading a stale copy. The next write lands on a version that has already moved — a lost write, or a divergent view two agents now disagree on, and the error propagates to every decision downstream. `agent-coherence` makes that moment visible and serves the current version on the next read instead of rebroadcasting the full artifact every turn. Same library, same protocol, across LangGraph, CrewAI, AutoGen, the OpenAI Agents SDK, and any custom orchestrator. Same behavior regardless of which model provider (Anthropic, OpenAI, Google, Mistral, open-source) the agents talk to.
+Two agents share an artifact — a `plan.md`, a store key, a `memory.json`. One reads it and works; meanwhile a peer commits a newer version; the first writes back anyway. Last write wins, the peer's work is silently gone, nothing errors, and every downstream decision builds on the wrong version. `agent-coherence` turns that silent clobber into a loud, typed refusal: MESI-style ownership and invalidation over shared artifacts, optimistic commit-CAS for concurrent writers, and a read-generation fence for crash-reclaimed ones — a stale write is denied or returned as a retryable conflict, never silently applied. Same library, same protocol, across LangGraph, CrewAI, AutoGen, the OpenAI Agents SDK, plain files shared across processes (`CoherentVolume`), and any custom orchestrator. Same behavior regardless of which model provider (Anthropic, OpenAI, Google, Mistral, open-source) the agents talk to.
 
 [![CI](https://github.com/hipvlady/agent-coherence/actions/workflows/ci.yml/badge.svg)](https://github.com/hipvlady/agent-coherence/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/agent-coherence)](https://pypi.org/project/agent-coherence/)
@@ -27,9 +27,33 @@ from ccs.adapters import CCSStore
 store = CCSStore(strategy="lazy")
 ```
 
-`store.get()`, `store.put()`, `store.search()` keep working unchanged. Savings show up immediately on any workload where multiple agents read the same artifact more often than they write it.
+`store.get()`, `store.put()`, `store.search()` keep working unchanged — reads now serve the current version, and a write from a stale view can't silently land.
+
+```python
+# Plain files shared across processes / sessions — no framework required
+from ccs.adapters.coherent_volume import CoherentVolume
+
+vol = CoherentVolume(workspace_root, managed=("plans/**",))
+plan = vol.read("plans/plan.md")           # tracked read — your view is registered
+vol.write("plans/plan.md", revised_plan)   # stale view? denied fail-closed → vol.reacquire() and re-derive
+```
 
 `agent-coherence-replay` — invariant-replay for any CoherenceAdapterCore-mediated agent system. LangGraph capture verified in v1 via `CCSStore.record_to(path)`; CrewAI / AutoGen wired through the same seam but unverified — file an issue if it breaks.
+
+## What it guarantees
+
+Each row is a safety invariant model-checked with TLA+/TLC. `make tla-check` runs all four specs in CI on every push, and every spec carries a documented mutant that must fail — the invariants are load-bearing, not decorative.
+
+| The silent failure | What happens instead | Mechanism | Invariant |
+|---|---|---|---|
+| **Stale-read overwrite** — an agent acts on an old snapshot and writes over a newer version (two sessions, one `plan.md`) | the write is **denied fail-closed**; the writer must `reacquire()` and read the current version | MESI single-writer ownership + invalidation | `SingleWriter`, `MonotonicVersion` |
+| **Concurrent lost update** — two writers hit the same key and both "succeed" | exactly one wins; the loser gets a **typed conflict + bounded retry**, never a silent drop | optimistic commit-CAS (`write_cas`) | `NoLostUpdate` |
+| **Reclaim-zombie write** — a stalled writer is reclaimed by crash recovery, wakes later, and lands its stale commit; the version never moved, so a version check passes | the commit is **rejected** with a typed `stale_read_generation` conflict | read-generation fence — reclamation bumps the artifact's ownership epoch, checked atomically at commit | `NoStaleApply` |
+| **Dead owner blocks the fleet** — a crashed agent holds EXCLUSIVE forever | the heartbeat/TTL sweep reclaims the grant (on by default) | crash-recovery sweep | sweep invariants I3–I6 |
+
+**Scope, honestly:** the guarantees hold for writers that go through the coordinator, under a single coordinator (one host). Concurrent same-key writers on one host are covered; cross-host fencing is on the roadmap, demand-gated — if you need it, [open an issue](https://github.com/hipvlady/agent-coherence/issues/new). Specs, the invariant ↔ implementation map, and the mutant recipes live in [`formal/tla/`](formal/tla/README.md).
+
+**Correctness is the wedge; the token savings come with it.** Writes publish ~12-token invalidation signals instead of rebroadcasting full artifacts, so read-heavy fleets stop re-paying for state they already hold:
 
 | Workload | Agents | Reads:Writes | Hit rate | Savings |
 |---|---|---|---|---|
@@ -42,7 +66,9 @@ store = CCSStore(strategy="lazy")
 ---
 
 - 📖 [User guide](docs/guide.md) — installation, namespace convention, strategies, observability, telemetry, examples, full API reference
+- 🧮 [Formal verification](formal/tla/README.md) — the four TLA+ specs, invariant ↔ implementation map, mutant recipes
 - 🩺 [`ccs-diagnose` CLI](docs/ccs-diagnose.md) — find divergent reads in your existing LangGraph graph without changing any code
+- 🧩 [Claude Code plugin](https://github.com/hipvlady/agent-coherence-plugin) — cross-session coherence for the prose rules (CLAUDE.md, plan.md) parallel Claude Code sessions share
 - 🔍 [Why coherence matters](docs/why-coherence-matters.md) — the gap across LangGraph, CrewAI, AutoGen, and Claude Agent SDK
 - 🔐 [Security & supply chain](docs/security.md) — kill switches, hash-pinned install, attestation verification, threat model
 - 📜 [Changelog](CHANGELOG.md) — version history
@@ -52,21 +78,25 @@ store = CCSStore(strategy="lazy")
 
 Each shared artifact is cached locally per agent and reads serve from the local cache when that copy is fresh. Writes commit to a coordinator, which sends lightweight invalidation signals (~12 tokens) to peers so the next read fetches the new version instead of rebroadcasting the full artifact. Consistency is single-writer-multiple-reader per artifact with bounded staleness — peers re-fetch on next read.
 
+Two write disciplines share the same guarantee. **Pessimistic:** acquire EXCLUSIVE, commit; a writer whose view went stale is denied and must `reacquire()`. **Optimistic:** `write_cas` — read, compute, commit-CAS; the loser of a race gets a typed conflict and bounded retry. Crash recovery composes with both: reclaiming a stalled grant bumps the artifact's ownership epoch, so a reclaimed writer that completes later is rejected at commit even when the version is unchanged (the read-generation fence).
+
 Five synchronization strategies ship out of the box: `lazy` (default), `eager`, `lease` (TTL-based), `access_count`, and `broadcast`. Pick the one that matches your workload's read/write ratio and how aggressively cached reads should refresh.
 
 ## Architecture
 
 - **Protocol** (`ccs.core`, `ccs.strategies`) — coherence state machine and synchronization strategies; no framework dependencies.
-- **Coordinator** (`ccs.coordinator`) — authority service tracking directory state, publishing invalidations, and reclaiming stale grants (crash recovery).
-- **Adapters** (`ccs.adapters`) — framework integrations for LangGraph, CrewAI, and AutoGen (~100 lines each), plus an experimental OpenAI Agents SDK adapter (`Session`-cache coherence + `RunHooks`).
+- **Coordinator** (`ccs.coordinator`) — authority service tracking directory state, publishing invalidations, arbitrating commit-CAS, and reclaiming stale grants (crash recovery + read-generation fence).
+- **Adapters** (`ccs.adapters`) — framework integrations for LangGraph, CrewAI, and AutoGen (~100 lines each), an experimental OpenAI Agents SDK adapter (`Session`-cache coherence + `RunHooks`), and `CoherentVolume` for plain files shared across processes.
 - **Simulation** (`ccs.simulation`) — deterministic tick-driven engine for scenario benchmarks with failure injection.
 - **Event bus** (`ccs.bus`) — pluggable transport for invalidation signals; in-memory by default, swap in Redis, Kafka, NATS, or gRPC streams for production.
 
-Protocol safety properties (single-writer, monotonic versioning, crash-recovery sweep invariants) are model-checked with [TLA+/TLC](formal/tla/README.md). The `tla-check` CI job runs TLC on every push and PR.
+Protocol safety properties — single-writer, monotonic versioning, the crash-recovery sweep invariants, the OCC no-lost-update, and the reclamation fence's no-stale-apply — are model-checked with [TLA+/TLC](formal/tla/README.md). The `tla-check` CI job runs all four specs on every push and PR.
 
 ## Status
 
-**`v0.8.4.3` released — `ccs-diagnose` heatmap report clarity.** A patch over `v0.8.4.2`: the Per-Artifact Heatmap note now explains why the "Event That Matters Most" panel (ranked by rework impact) and the heatmap row-1 (ranked by multi-writer coordination signal) can name different artifacts, preventing reader confusion in shared reports. Also closes test-coverage and documentation residuals from the v0.8.4.2 heatmap re-rank. No API or core-protocol changes. See [CHANGELOG.md](CHANGELOG.md). The v0.8.3 crash-recovery deprecation cycle and the upcoming v0.9.0 default flip are unaffected.
+**`v0.9.0` released — crash recovery on by default, plus `CoherentVolume` and a temporal cost benchmark.** The crash-recovery default flips from `enabled=False` to **`enabled=True`**, so a bare `CCSStore()` / `CoherenceAdapterCore()` now reclaims stale grants automatically — pass `CrashRecoveryConfig(enabled=False)` to opt out. Byte-identity preservation under the default config now requires explicit `CrashRecoveryConfig(enabled=False)` to reproduce v0.8.x output. Adds `CoherentVolume` — a shared-workspace adapter that fails closed on stale overwrites — and a simulation cost benchmark for temporal source-drift. No wire-protocol changes. See [CHANGELOG.md](CHANGELOG.md).
+
+**Landed on `dev`, unreleased:** the optimistic commit-CAS write API (`commit_cas` / `write_cas` — concurrent same-key lost updates resolve to one winner plus typed, retryable conflicts; `NoLostUpdate` model-checked) and the single-host read-generation fence (crash-reclaimed writers can't land stale commits; `NoStaleApply` model-checked).
 
 See [CHANGELOG.md](CHANGELOG.md) for the full version history and [releases](https://github.com/hipvlady/agent-coherence/releases) for tagged artifacts. Alpha — APIs may change before `v1.0`.
 

--- a/formal/tla/Fencing.cfg
+++ b/formal/tla/Fencing.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION FencingSpec
+
+CONSTANTS
+    NumAgents = 3
+    NumArtifacts = 1
+    MaxTicks = 6
+    HeartbeatTimeout = 3
+    MaxHoldTicks = 5
+    None = None
+
+INVARIANTS
+    FencingTypeOK
+    SingleWriter
+    MonotonicVersion
+    SweepExclusivity
+    TriggerExclusivity
+    TickMonotonicity
+    SlotPreservedThroughSHARED
+    ReadGenBounded
+    NoStaleApply

--- a/formal/tla/Fencing.tla
+++ b/formal/tla/Fencing.tla
@@ -1,0 +1,215 @@
+----------------------------- MODULE Fencing -----------------------------
+(* Read-generation fence amendment to the MESI + crash-recovery protocol.
+   Closes the watchdog reclaim-zombie hole that OCC commit-CAS (OCC.tla)
+   leaves open: a writer whose ownership/read-claim was reclaimed by the
+   sweep, but whose version has not moved, can still apply a stale write
+   (the "phantom version-bump"). The fence keys on a per-artifact
+   generation, not on the version, so it catches the reclaim even when the
+   version is unchanged.
+
+   Plan: docs/plans/2026-06-09-001-feat-fencing-single-host-plan.md (Unit 1).
+   Origin: docs/brainstorms/2026-06-09-fencing-single-host-requirements.md.
+   Composes with CrashRecovery via EXTENDS (a sibling amendment to OCC.tla).
+
+   Adds:
+     - ownerGeneration : per-artifact monotonic counter, bumped on every
+                         sweep reclamation (atomic with the M/E -> I
+                         transition).
+     - readGeneration  : the ownerGeneration each agent captured when it
+                         last ESTABLISHED ITS WRITE-CLAIM (a genuine read
+                         for the OCC path, an E/M acquire for the pessimistic
+                         path). None until captured -- absent operand.
+     - staleApply      : a sticky history flag -- TRUE iff any commit ever
+                         applied a write from a read-generation older than
+                         the artifact's current ownerGeneration (a stale
+                         apply -- the exact failure the fence prevents).
+     - ObserveGenAction  : an agent captures the current ownerGeneration into
+                           its slot. DECOUPLED from the acquire/fetch on
+                           purpose (mirrors OCC.tla's ObserveAction), so the
+                           sweep can interleave BETWEEN capture and commit --
+                           the non-atomic-capture hazard the plan-review
+                           required this spec to model.
+     - FencingSweepAction: SweepAction + bump ownerGeneration on each
+                           reclaimed artifact, atomically.
+     - FencingCommitAction: the generation-guarded commit. WIN iff
+                            readGeneration = ownerGeneration (strict-> reject,
+                            EQUALITY ADMITS); else a clean no-op conflict
+                            (the typed-conflict analog -- never a silent
+                            drop). Absent readGeneration => cannot commit
+                            (absent-operand = reject).
+
+   KEY MODELING DECISION (the crux). The fence is UNIFORM across both write
+   paths, and its safety depends only on (readGeneration vs ownerGeneration),
+   not on the committer's MESI state. So a single FencingCommitAction models
+   BOTH the pessimistic commit and the OCC commit_cas, guarded. We therefore
+   REPLACE the inherited unguarded commit (CRCommitAction) and the inherited
+   SweepAction with their fenced equivalents -- in the fence world every
+   version-bumping commit is generation-guarded and every reclaim bumps the
+   generation. The capture is available to an agent in any state (it models
+   "established a claim at this generation"): this is exactly the plan-review
+   P0 fix -- capture at the claim-establishing point (fetch OR E/M acquire),
+   not fetch-only, so a legitimate pessimistic acquire-without-content-read
+   still has a valid operand and is admitted.
+
+   LIVENESS is discharged as safety + prose, consistent with OCC.tla and the
+   repo's safety-only TLC convention (README). TLC checks the NoStaleApply
+   safety invariant only.
+
+   DELIBERATELY OUT OF THIS SPEC (modeled empirically in the plan's Unit 8,
+   or in a follow-on amendment): (a) coordinator restart -- in TLA the state
+   IS the durable truth, so "lost in-memory mirror" has no analog; the
+   durable-counter-rejects property is an implementation/test property.
+   (b) the coordinator_epoch / delete-and-recreate wipe reset -- under the
+   plan's RECOMMENDED migration option (a) (additive columns, no
+   user_version bump) there is no wipe-reset, so the epoch is conditional on
+   option (b) and is left to a spec amendment if (b) is chosen (see plan
+   Unit 2). The CORE fence safety -- capture/sweep-bump/guarded-commit and
+   the non-atomic-capture interleaving -- is what NoStaleApply proves here. *)
+
+EXTENDS CrashRecovery
+
+(* Generation space bound for finite model checking: each sweep bumps a
+   reclaimed artifact's generation by 1, and sweeps are bounded by the tick
+   horizon, so ownerGeneration never needs to exceed MaxTicks. *)
+MaxGen == MaxTicks
+
+VARIABLES ownerGeneration, readGeneration, staleApply
+
+fenceVars == <<allVars, ownerGeneration, readGeneration, staleApply>>
+
+--------------------------------------------------------------------
+(* Initialization *)
+--------------------------------------------------------------------
+
+FencingInit ==
+    /\ CRInit
+    /\ ownerGeneration = [art \in Artifacts |-> 0]
+    /\ readGeneration  = [ag \in Agents |-> [art \in Artifacts |-> None]]
+    /\ staleApply = FALSE
+
+--------------------------------------------------------------------
+(* ObserveGenAction: an agent captures the current ownerGeneration into its
+   slot -- the moment it establishes a write-claim (fetch read-set OR E/M
+   acquire). Decoupled from the acquire/fetch action so the sweep can fire
+   between capture and commit (the non-atomic-capture hazard). *)
+--------------------------------------------------------------------
+
+ObserveGenAction ==
+    \E ag \in Agents, art \in Artifacts :
+        /\ readGeneration' = [readGeneration EXCEPT ![ag][art] = ownerGeneration[art]]
+        /\ UNCHANGED <<baseVars, crVars, ownerGeneration, staleApply>>
+
+--------------------------------------------------------------------
+(* FencingCommitAction: generation-guarded commit (both paths, uniform).
+   WIN     iff readGeneration = ownerGeneration (equality admits).
+   CONFLICT otherwise (read-generation superseded by a reclaim) -- clean
+            no-op. Absent readGeneration => cannot fire (absent operand). *)
+--------------------------------------------------------------------
+
+FencingCommitAction ==
+    \E ag \in Agents, art \in Artifacts :
+        /\ readGeneration[ag][art] /= None          (* absent operand => reject (cannot commit) *)
+        /\ version[art] < MaxVersion                (* finite bound *)
+        /\ LET rg == readGeneration[ag][art]
+               og == ownerGeneration[art]
+           IN \/ (* WIN: claim is current -> apply the write (bump version). *)
+                 /\ rg = og
+                 /\ version' = [version EXCEPT ![art] = version[art] + 1]
+                 (* Records a stale apply iff this commit landed on a
+                    superseded read-generation. The WIN guard `rg = og`
+                    makes `rg < og` always FALSE here. The mutant (remove
+                    the `rg = og` conjunct above) lets a superseded commit
+                    win and flips staleApply -> TRUE, which TLC reports as a
+                    NoStaleApply violation. This is what gives the invariant
+                    teeth. *)
+                 /\ staleApply' = (staleApply \/ (rg < og))
+              \/ (* CONFLICT: rg < og (reclaimed since the claim) -- clean
+                    no-op: no version bump, no mutation. The formal analog of
+                    "typed StaleReadGeneration conflict, never a silent
+                    drop". *)
+                 /\ ~(rg = og)
+                 /\ UNCHANGED <<version, staleApply>>
+        /\ UNCHANGED <<clock, mesiState, lastHeartbeat, grantedAtTick,
+                       lastReclamation, ownerGeneration, readGeneration>>
+
+--------------------------------------------------------------------
+(* FencingSweepAction: SweepAction + bump ownerGeneration on every reclaimed
+   artifact, atomically with the M/E -> I transition. Re-derives the
+   reclaimSet from CrashRecovery.SweepAction (which cannot be reached from
+   outside its LET) so the generation bump is part of the same atomic step. *)
+--------------------------------------------------------------------
+
+FencingSweepAction ==
+    /\ clock > 0
+    /\ LET snapshot == { <<ag, art>> \in (Agents \X Artifacts) :
+                           mesiState[art][ag] \in MorE }
+           reclaimSet == { <<ag, art>> \in snapshot :
+                             SweepTrigger(ag, art) /= None }
+           reclaimedArts == { art \in Artifacts :
+                                \E ag \in Agents : <<ag, art>> \in reclaimSet }
+       IN /\ reclaimSet /= {}
+          /\ \A art \in reclaimedArts : ownerGeneration[art] < MaxGen
+          /\ mesiState' = [art \in Artifacts |->
+               [ag \in Agents |->
+                   IF <<ag, art>> \in reclaimSet THEN "I"
+                   ELSE mesiState[art][ag]]]
+          /\ grantedAtTick' = [ag \in Agents |-> [art \in Artifacts |->
+               IF <<ag, art>> \in reclaimSet THEN None
+               ELSE grantedAtTick[ag][art]]]
+          /\ lastReclamation' = [ag \in Agents |-> [art \in Artifacts |->
+               IF <<ag, art>> \in reclaimSet
+               THEN <<SweepTrigger(ag, art), clock>>
+               ELSE lastReclamation[ag][art]]]
+          /\ ownerGeneration' = [art \in Artifacts |->
+               IF art \in reclaimedArts THEN ownerGeneration[art] + 1
+               ELSE ownerGeneration[art]]
+    /\ UNCHANGED <<clock, version, lastHeartbeat, readGeneration, staleApply>>
+
+--------------------------------------------------------------------
+(* Specification *)
+--------------------------------------------------------------------
+
+(* Inherited CR actions keep the fence variables unchanged. CRWriteAction
+   models the pessimistic E/M acquire; CRFetchAction the read -> S. The
+   unguarded CRCommitAction and the inherited SweepAction are DELIBERATELY
+   replaced by FencingCommitAction and FencingSweepAction (the crux modeling
+   decision above). *)
+FencingNext ==
+    \/ (CRFetchAction      /\ UNCHANGED <<ownerGeneration, readGeneration, staleApply>>)
+    \/ (CRWriteAction      /\ UNCHANGED <<ownerGeneration, readGeneration, staleApply>>)
+    \/ (CRInvalidateAction /\ UNCHANGED <<ownerGeneration, readGeneration, staleApply>>)
+    \/ (CRTickAction       /\ UNCHANGED <<ownerGeneration, readGeneration, staleApply>>)
+    \/ (HeartbeatAction    /\ UNCHANGED <<ownerGeneration, readGeneration, staleApply>>)
+    \/ FencingSweepAction
+    \/ ObserveGenAction
+    \/ FencingCommitAction
+
+FencingSpec == FencingInit /\ [][FencingNext]_fenceVars
+
+--------------------------------------------------------------------
+(* Invariants *)
+--------------------------------------------------------------------
+
+FencingTypeOK ==
+    /\ CRTypeOK
+    /\ staleApply \in BOOLEAN
+    /\ \A art \in Artifacts : ownerGeneration[art] \in 0..MaxGen
+    /\ \A ag \in Agents, art \in Artifacts :
+         readGeneration[ag][art] \in ({None} \cup (0..MaxGen))
+
+(* Sanity: a captured read-generation never exceeds the artifact's current
+   ownerGeneration (the counter only grows; a captured value is a past
+   value). If this ever failed, the WIN/CONFLICT discrimination would be
+   ill-founded. *)
+ReadGenBounded ==
+    \A ag \in Agents, art \in Artifacts :
+        readGeneration[ag][art] /= None =>
+            readGeneration[ag][art] <= ownerGeneration[art]
+
+(* The headline safety property: no commit ever applied a write whose
+   read-generation was superseded by a reclaim. SingleWriter,
+   MonotonicVersion, and the CR invariants (I3-I6) are inherited and
+   re-checked to validate composition. *)
+NoStaleApply == staleApply = FALSE
+
+==========================================================================

--- a/formal/tla/Fencing_CI.cfg
+++ b/formal/tla/Fencing_CI.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION FencingSpec
+
+CONSTANTS
+    NumAgents = 2
+    NumArtifacts = 1
+    MaxTicks = 4
+    HeartbeatTimeout = 2
+    MaxHoldTicks = 3
+    None = None
+
+INVARIANTS
+    FencingTypeOK
+    SingleWriter
+    MonotonicVersion
+    SweepExclusivity
+    TriggerExclusivity
+    TickMonotonicity
+    SlotPreservedThroughSHARED
+    ReadGenBounded
+    NoStaleApply

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -1,6 +1,6 @@
 # TLA+ Formal Verification
 
-TLC model checking for the MESI coherence protocol and crash-recovery extension.
+TLC model checking for the MESI coherence protocol, its crash-recovery extension, the optimistic commit-CAS (OCC), and the read-generation fence.
 
 ## What is modeled
 
@@ -11,7 +11,8 @@ TLC model checking for the MESI coherence protocol and crash-recovery extension.
   trigger ordering. Corresponds to `enforce_stable_grant_timeouts` in `service.py`.
 - **Heartbeat liveness** — monotonic heartbeat recording per agent.
 - **Reclamation slot lifecycle** — slot preserved through I→S, cleared on I→M∪E re-acquire.
-- **Optimistic commit-CAS (OCC)** — a version-checked commit (`commit_cas`) that bypasses the pessimistic acquire: an S/I writer reads the version (`ObserveAction`), then commits only if its observed version still matches and no other agent holds M∪E. Closes the concurrent lost-update. Corresponds to the `commit_cas` implementation (see `docs/plans/2026-06-08-001-feat-occ-write-api-same-host-v1-plan.md`).
+- **Optimistic commit-CAS (OCC)** — a version-checked commit (`commit_cas`) that bypasses the pessimistic acquire: an S/I writer reads the version (`ObserveAction`), then commits only if its observed version still matches and no other agent holds M∪E. Closes the concurrent lost-update. Corresponds to `commit_cas` in `src/ccs/coordinator/`.
+- **Read-generation fence (Fencing)** — a per-artifact ownership epoch (`ownerGeneration`) bumped atomically on every sweep reclamation, captured into `readGeneration` when an agent establishes its write-claim (`ObserveGenAction` — deliberately decoupled so the sweep can interleave between capture and commit), and enforced by a generation-guarded commit (`FencingCommitAction`): a writer whose captured generation was superseded by a reclamation is rejected even when the version is unchanged — the reclaim-zombie write the version CAS cannot see. Corresponds to `owner_generation` / `read_generation` in `src/ccs/coordinator/`.
 
 ## What is deliberately out of scope
 
@@ -38,6 +39,9 @@ formal/tla/
 ├── OCC.tla                 # amendment: EXTENDS CrashRecovery, adds commit-CAS
 ├── OCC.cfg                 # TLC config: 3 agents (local deep runs)
 ├── OCC_CI.cfg              # TLC config: 2 agents (CI, fits 5-min budget)
+├── Fencing.tla             # amendment: EXTENDS CrashRecovery, adds the read-generation fence
+├── Fencing.cfg             # TLC config: 3 agents (local deep runs)
+├── Fencing_CI.cfg          # TLC config: 2 agents (CI, fits 5-min budget)
 ├── lib/
 │   └── tla2tools.jar       # committed TLC binary (see version below)
 └── README.md               # this file
@@ -46,7 +50,7 @@ formal/tla/
 ## Running TLC
 
 ```bash
-# Both models (recommended)
+# All four specs (recommended)
 make tla-check
 
 # Individual models
@@ -58,6 +62,9 @@ java -XX:+UseParallelGC -cp formal/tla/lib/tla2tools.jar tlc2.TLC \
 
 java -XX:+UseParallelGC -cp formal/tla/lib/tla2tools.jar tlc2.TLC \
   -config formal/tla/OCC_CI.cfg formal/tla/OCC.tla -workers auto
+
+java -XX:+UseParallelGC -cp formal/tla/lib/tla2tools.jar tlc2.TLC \
+  -config formal/tla/Fencing_CI.cfg formal/tla/Fencing.tla -workers auto
 ```
 
 Requires Java 17+. CI uses Temurin via `actions/setup-java`.
@@ -66,14 +73,16 @@ Requires Java 17+. CI uses Temurin via `actions/setup-java`.
 
 | ID | TLA+ Name | Checked In | Description |
 |----|-----------|-----------|-------------|
-| I1 | `SingleWriter` | All three | At most one agent holds M∪E per artifact |
-| I2 | `MonotonicVersion` | All three | Artifact version never decreases (≥ 1) |
-| — | `TypeOK` / `CRTypeOK` / `OCCTypeOK` | All three | State variables have correct types and bounds |
-| I3 | `SweepExclusivity` | CrashRecovery, OCC | No (agent, artifact) reclaimed twice in one tick |
-| I4 | `TriggerExclusivity` | CrashRecovery, OCC | Each reclamation has exactly one trigger |
-| I5 | `TickMonotonicity` | CrashRecovery, OCC | `lastHeartbeat` never decreases |
-| I6 | `SlotPreservedThroughSHARED` | CrashRecovery, OCC | Reclamation slot persists across I→S, cleared only on I→M∪E |
+| I1 | `SingleWriter` | All four | At most one agent holds M∪E per artifact |
+| I2 | `MonotonicVersion` | All four | Artifact version never decreases (≥ 1) |
+| — | `TypeOK` / `CRTypeOK` / `OCCTypeOK` / `FencingTypeOK` | All four | State variables have correct types and bounds |
+| I3 | `SweepExclusivity` | CrashRecovery, OCC, Fencing | No (agent, artifact) reclaimed twice in one tick |
+| I4 | `TriggerExclusivity` | CrashRecovery, OCC, Fencing | Each reclamation has exactly one trigger |
+| I5 | `TickMonotonicity` | CrashRecovery, OCC, Fencing | `lastHeartbeat` never decreases |
+| I6 | `SlotPreservedThroughSHARED` | CrashRecovery, OCC, Fencing | Reclamation slot persists across I→S, cleared only on I→M∪E |
 | — | `NoLostUpdate` | OCC | No successful `commit_cas` ever landed on a stale observed version — the concurrent lost-update is prevented |
+| — | `ReadGenBounded` | Fencing | A captured read-generation never exceeds the artifact's current ownership epoch |
+| — | `NoStaleApply` | Fencing | No commit ever applied a write whose captured read-generation was superseded by a reclamation — the reclaim-zombie write is prevented |
 
 I7 (FlagOffByteIdentity) is a code-level property and is not modelable in TLA+.
 
@@ -93,6 +102,10 @@ I7 (FlagOffByteIdentity) is a code-level property and is not modelable in TLA+.
 | `SingleWriter` | `check_single_writer()` in `src/ccs/core/invariants.py` |
 | `MonotonicVersion` | `check_monotonic_version()` in `src/ccs/core/invariants.py` |
 | `NoLostUpdate` | concurrent-writer test (`tests/test_occ_commit_cas.py`) |
+| `ObserveGenAction` | `read_generation` capture in `set_agent_state` (fetch / E∪M acquire) |
+| `FencingSweepAction` | the `owner_generation` bump on reclaim triggers in `set_agent_state` |
+| `FencingCommitAction` | the generation guard in `commit_cas` + `set_artifact_and_content(fence_agent_id=…)` |
+| `NoStaleApply` | dual-registry parity + regression suite (`tests/test_fencing.py`) |
 
 The model abstracts away transient states — the implementation's
 `enforce_transient_timeouts` and transient-skip rule in the sweep are not modeled.
@@ -109,7 +122,7 @@ non-decreasing) holds regardless of the bound.
 
 ## CI time budget
 
-Target: **5 minutes** total for both models.
+Target: **5 minutes** total across the four specs.
 
 | Model | Config | Agents | Artifacts | MaxTicks | Distinct States | Wall Time |
 |-------|--------|--------|-----------|----------|----------------|-----------|
@@ -118,6 +131,8 @@ Target: **5 minutes** total for both models.
 | CrashRecovery (local) | `CrashRecovery.cfg` | 3 | 2 | 12 | — | ~30+ min |
 | OCC (CI) | `OCC_CI.cfg` | 2 | 1 | 4 | 1,372,720 | ~47s |
 | OCC (local) | `OCC.cfg` | 3 | 1 | 6 | — | minutes |
+| Fencing (CI) | `Fencing_CI.cfg` | 2 | 1 | 4 | 2,832,014 | ~67s |
+| Fencing (local) | `Fencing.cfg` | 3 | 1 | 6 | — | minutes |
 
 CI uses `CrashRecovery_CI.cfg` (2 agents, MaxTicks=6) to fit the budget.
 The full 3-agent config (`CrashRecovery.cfg`) is for local deep runs:
@@ -147,6 +162,12 @@ and confirm TLC finds a counterexample:
    `make tla-check`. TLC should fail with a `NoLostUpdate` violation, showing a
    trace where one writer commits on a version another writer already advanced.
    (Verified 2026-06-08: violation found in ~1s.)
+
+4. **NoStaleApply mutation**: In `Fencing.tla`, remove the `/\ rg = og` conjunct
+   from `FencingCommitAction`'s WIN branch (so a superseded writer can win). Run
+   `make tla-check`. TLC should fail with a `NoStaleApply` violation, showing a
+   trace where a sweep-reclaimed writer's commit lands on a bumped ownership
+   epoch. (Verified 2026-06-09: violation found in <1s, 570 distinct states.)
 
 These mutations are run manually during development to validate TLC's
 bug-detection capability. The mutated files are not committed.

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1732,8 +1732,10 @@ def _handle_post_edit_cas(req: _RequestProtocol, coordinator: CoordinatorHTTPSer
 
     - WIN → ``{ok: true, version: N+1}``.
     - :class:`~ccs.core.types.ConflictDetail` → ``{ok: false,
-      reason: "version_mismatch"|"other_holder", current_version: N}`` — a
-      clean typed conflict, NOT a degrade. The client re-reads + retries.
+      reason: "version_mismatch"|"other_holder"|"stale_read_generation",
+      current_version: N}`` — a clean typed conflict, NOT a degrade. The client
+      re-reads + retries. ``stale_read_generation`` is the read-generation
+      fence: the caller's captured claim was superseded by a sweep reclamation.
     - retry-eligible transient precondition
       (:class:`~ccs.core.exceptions.OccCallerTransientError`: a peer
       invalidated the caller between its read and this CAS) → ``{ok: false,

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -62,8 +62,10 @@ from ccs.coordinator.service import CoordinatorService
 from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
 from ccs.core.exceptions import (
     OCC_CALLER_TRANSIENT_REASON,
+    STALE_READ_GENERATION_REASON,
     CoherenceError,
     OccCallerTransientError,
+    StaleReadGeneration,
 )
 from ccs.core.states import MESIState
 from ccs.core.types import ConflictDetail
@@ -1653,6 +1655,17 @@ def _handle_post_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer)
                 issued_at_tick=now,
                 content_hash=content_hash,
             )
+        except StaleReadGeneration:
+            # Read-generation fence: a sweep reclaimed this committer in the race
+            # window between its grant and this commit. Surface the STABLE machine
+            # reason (not str(exc)) so the client classifier matches exactly. The
+            # reclaim already released the grant, so there is nothing to release
+            # here. The {ok: false} body reads as a definite reject (fail-closed).
+            current_artifact = coordinator.registry.get_artifact(artifact_id)
+            body: dict = {"ok": False, "reason": STALE_READ_GENERATION_REASON}
+            if current_artifact is not None:
+                body["current_version"] = current_artifact.version
+            return body
         except CoherenceError as exc:
             # A1 + F4: if this commit failed because the grant was preempted
             # silently, enrich the reason with the preemption context so

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -67,6 +67,7 @@ from ccs.cli._coherence_client import (
 )
 from ccs.core.exceptions import (
     OCC_CALLER_TRANSIENT_REASON,
+    STALE_READ_GENERATION_REASON,
     CasRetriesExhausted,
     CoherenceDegradedWarning,
     CoherenceError,
@@ -903,7 +904,15 @@ class CoherentVolume:
     # The transient literal is the SHARED constant the coordinator server emits,
     # so a reword on either side can't drift the retry classification.
     _CAS_RETRY_REASONS: frozenset[str] = frozenset(
-        {"version_mismatch", "other_holder", OCC_CALLER_TRANSIENT_REASON}
+        {
+            "version_mismatch",
+            "other_holder",
+            OCC_CALLER_TRANSIENT_REASON,
+            # Read-generation fence: a reclaimed reader's OCC commit_cas returns
+            # ConflictDetail("stale_read_generation"); retry via reacquire +
+            # fresh read (the next fetch captures the current generation).
+            STALE_READ_GENERATION_REASON,
+        }
     )
 
     def _classify_cas_response(self, resp: dict) -> Literal["win", "conflict", "raise"]:

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -922,7 +922,10 @@ class CoherentVolume:
         - ``ok: false`` with a retry-eligible reason → ``"conflict"`` (reacquire
           + retry). Matched EXACTLY against :attr:`_CAS_RETRY_REASONS`: the
           typed ``ConflictDetail`` reasons (``version_mismatch`` /
-          ``other_holder``) AND ``caller_in_transient_state`` — when a peer
+          ``other_holder`` / ``stale_read_generation`` — the read-generation
+          fence: the caller's captured claim was superseded by a sweep
+          reclamation; a reacquire + fresh read mints a current claim)
+          AND ``caller_in_transient_state`` — when a peer
           invalidates this instance in the window BETWEEN its fresh read and its
           CAS, the coordinator leaves an invalidation transient that
           ``commit_cas`` rejects as a precondition; that is a lost race, not

--- a/src/ccs/agent/runtime.py
+++ b/src/ccs/agent/runtime.py
@@ -91,7 +91,18 @@ class AgentRuntime:
         content_hash: str | None = None,
         size_tokens: int | None = None,
     ) -> tuple[Artifact, list[InvalidationSignal]]:
-        """Write new artifact content through coordinator protocol."""
+        """Write new artifact content through coordinator protocol.
+
+        Raises:
+            StaleReadGeneration: the read-generation fence rejected the commit —
+                a sweep reclaimed this agent's claim in the race window between
+                acquire and commit (``ccs.core.exceptions``). Retry-eligible,
+                but THIS path has no built-in retry loop (unlike ``write_cas``):
+                the caller re-acquires / re-reads and calls ``write()`` again.
+            CoherenceError: the grant was already reclaimed before commit (the
+                error names the reclaim trigger and tick), or another protocol
+                precondition failed.
+        """
         if content_hash is not None:
             computed = compute_content_hash(content)
             if content_hash != computed:

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -110,6 +110,12 @@ class ArtifactRegistry:
         """Return the artifact's ownership epoch (read-generation fence)."""
         return self._records[artifact_id].owner_generation
 
+    def get_read_generation(self, artifact_id: UUID, agent_id: UUID) -> Optional[int]:
+        """Return the generation an agent captured at its last claim, or None
+        (the absent operand the commit guard rejects) if it never established
+        one."""
+        return self._records[artifact_id].read_generation_by_agent.get(agent_id)
+
     def set_artifact_and_content(
         self,
         artifact_id: UUID,
@@ -181,6 +187,13 @@ class ArtifactRegistry:
             # holder fails the generation check. Only sweep triggers bump.
             if trigger in RECLAIM_TRIGGERS:
                 record.owner_generation += 1
+
+        # Read-generation fence: capture the current ownership epoch into the
+        # agent's read_generation when it establishes/refreshes a write-claim --
+        # an E/M acquire (P0 fix: includes a pessimistic acquire with no prior
+        # content read) or a genuine fetch read. Atomic (GIL) with the grant.
+        if (new_in_me and not prev_in_me) or trigger == "fetch":
+            record.read_generation_by_agent[agent_id] = record.owner_generation
 
         if self._state_log is not None:
             self._seq += 1

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -111,9 +111,9 @@ class ArtifactRegistry:
         return self._records[artifact_id].owner_generation
 
     def get_read_generation(self, artifact_id: UUID, agent_id: UUID) -> Optional[int]:
-        """Return the generation an agent captured at its last claim, or None
-        (the absent operand the commit guard rejects) if it never established
-        one."""
+        """Return the generation an agent captured at its last claim, or None if
+        it never established a fence claim (a plain OCC writer that version-CAS,
+        not the fence, arbitrates)."""
         return self._records[artifact_id].read_generation_by_agent.get(agent_id)
 
     def set_artifact_and_content(
@@ -279,6 +279,18 @@ class ArtifactRegistry:
         )
         if other_holder:
             return ConflictDetail("other_holder", current)
+
+        # Read-generation fence: reject a committer whose CAPTURED read-claim
+        # was superseded by a sweep reclamation. A reclaimed M/E holder kept its
+        # stale read_generation (captured at acquire), so it is caught here even
+        # though the version is unchanged and no peer holds M/E -- exactly what
+        # version-CAS cannot catch. An ABSENT read_generation means the committer
+        # never established a fence claim: a plain OCC writer whose lost-update
+        # protection is version-CAS (checked above), so it is admitted. Strict->;
+        # equality admits. Server-side; no commit_cas signature change.
+        read_gen = record.read_generation_by_agent.get(agent_id)
+        if read_gen is not None and read_gen < record.owner_generation:
+            return ConflictDetail("stale_read_generation", current)
 
         # ---- WIN ----
         next_version = current + 1

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -36,6 +36,14 @@ class ArtifactRecord:
     version_history: dict[int, str] = field(default_factory=dict)
     granted_at_tick_by_agent: dict[UUID, int] = field(default_factory=dict)
     last_reclamation_by_agent: dict[UUID, ReclamationSlot] = field(default_factory=dict)
+    # Read-generation fence (single-host Piece #2). owner_generation is the
+    # per-artifact ownership epoch, bumped on every sweep reclamation;
+    # read_generation_by_agent[ag] is the owner_generation an agent captured
+    # when it last established its write-claim (a genuine read OR an E/M
+    # acquire). An ABSENT key (== None) is the absent operand => reject at
+    # commit. The counter only grows (resets to 0 per construction in-memory).
+    owner_generation: int = 0
+    read_generation_by_agent: dict[UUID, int] = field(default_factory=dict)
 
 
 class ArtifactRegistry:
@@ -59,6 +67,10 @@ class ArtifactRegistry:
         self._state_log = state_log
         self._agent_names = agent_names
         self._instance_id: str = instance_id if instance_id is not None else str(uuid4())
+        # Read-generation fence: per-construction nonce. In-memory resets every
+        # construction; the (coordinator_epoch, owner_generation) pair lets the
+        # Unit 5 commit guard fail a read captured under a prior epoch.
+        self._coordinator_epoch: str = uuid4().hex
         self._seq: int = 0
         self._retain_versions = retain_versions
 

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -17,6 +17,13 @@ CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
 ReclamationSlot: TypeAlias = tuple[str, int]  # (trigger, tick)
 _M_OR_E_STATES: frozenset[MESIState] = frozenset({MESIState.MODIFIED, MESIState.EXCLUSIVE})
 
+# The sweep-reclaim triggers (CoordinatorService.enforce_stable_grant_timeouts).
+# An M/E -> INVALID transition carrying one of these bumps the artifact's
+# owner_generation (the read-generation fence). A peer-invalidation INVALID
+# (any other trigger) does NOT bump -- that path moves the version, so
+# version-CAS already catches a stale write. Shared with SqliteArtifactRegistry.
+RECLAIM_TRIGGERS: frozenset[str] = frozenset({"reclaim_heartbeat", "reclaim_max_hold"})
+
 # OCC commit-CAS result (plan Unit 2) — parity with SqliteArtifactRegistry.
 # WIN = (updated_artifact, invalidated_agent_ids); loss = ConflictDetail;
 # impossible state = CasCorruption. None is raised by the registry.
@@ -99,6 +106,10 @@ class ArtifactRegistry:
         record = self._records.get(artifact_id)
         return record.content if record else None
 
+    def get_owner_generation(self, artifact_id: UUID) -> int:
+        """Return the artifact's ownership epoch (read-generation fence)."""
+        return self._records[artifact_id].owner_generation
+
     def set_artifact_and_content(
         self,
         artifact_id: UUID,
@@ -164,6 +175,12 @@ class ArtifactRegistry:
                 record.last_reclamation_by_agent.pop(agent_id, None)
         elif prev_in_me:
             record.granted_at_tick_by_agent.pop(agent_id, None)
+            # Read-generation fence: a sweep reclamation of this M/E grant bumps
+            # the artifact's ownership epoch, atomically (GIL) with the INVALID
+            # transition, so a commit by the reclaimed (or any pre-reclaim)
+            # holder fails the generation check. Only sweep triggers bump.
+            if trigger in RECLAIM_TRIGGERS:
+                record.owner_generation += 1
 
         if self._state_log is not None:
             self._seq += 1

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -9,8 +9,8 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Optional, TypeAlias
 from uuid import UUID, uuid4
 
-from ccs.core.states import MESIState, TransientState
 from ccs.core.exceptions import STALE_READ_GENERATION_REASON, StaleReadGeneration
+from ccs.core.states import MESIState, TransientState
 from ccs.core.types import Artifact, CasCorruption, ConflictDetail
 
 CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
@@ -18,12 +18,26 @@ CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
 ReclamationSlot: TypeAlias = tuple[str, int]  # (trigger, tick)
 _M_OR_E_STATES: frozenset[MESIState] = frozenset({MESIState.MODIFIED, MESIState.EXCLUSIVE})
 
-# The sweep-reclaim triggers (CoordinatorService.enforce_stable_grant_timeouts).
-# An M/E -> INVALID transition carrying one of these bumps the artifact's
-# owner_generation (the read-generation fence). A peer-invalidation INVALID
-# (any other trigger) does NOT bump -- that path moves the version, so
-# version-CAS already catches a stale write. Shared with SqliteArtifactRegistry.
-RECLAIM_TRIGGERS: frozenset[str] = frozenset({"reclaim_heartbeat", "reclaim_max_hold"})
+# The coordinator-side EVICTION triggers: the stable-grant sweep
+# (CoordinatorService.enforce_stable_grant_timeouts -> reclaim_heartbeat /
+# reclaim_max_hold) and the transient-timeout fail-safe
+# (enforce_transient_timeouts -> "timeout"). An M/E -> INVALID transition
+# carrying one of these bumps the artifact's owner_generation (the
+# read-generation fence) -- the holder's claim was revoked WITHOUT a version
+# move, which is exactly what version-CAS cannot see. A peer-invalidation
+# INVALID (any other trigger) does NOT bump: that path moves the version, so
+# version-CAS already catches a stale write. Duplicated in
+# SqliteArtifactRegistry; pinned equal by the parity test.
+RECLAIM_TRIGGERS: frozenset[str] = frozenset(
+    {"reclaim_heartbeat", "reclaim_max_hold", "timeout"}
+)
+
+# Triggers that mark a GENUINE content read for read-generation capture (the
+# E/M-acquire capture is keyed on the state transition, not the trigger).
+# Service.fetch() emits "fetch"; a rename there without updating this constant
+# would silently disable capture on reads -- pinned equal across registries by
+# the parity test, same discipline as RECLAIM_TRIGGERS.
+CLAIM_CAPTURE_TRIGGERS: frozenset[str] = frozenset({"fetch"})
 
 # OCC commit-CAS result (plan Unit 2) — parity with SqliteArtifactRegistry.
 # WIN = (updated_artifact, invalidated_agent_ids); loss = ConflictDetail;
@@ -75,9 +89,12 @@ class ArtifactRegistry:
         self._state_log = state_log
         self._agent_names = agent_names
         self._instance_id: str = instance_id if instance_id is not None else str(uuid4())
-        # Read-generation fence: per-construction nonce. In-memory resets every
-        # construction; the (coordinator_epoch, owner_generation) pair lets the
-        # Unit 5 commit guard fail a read captured under a prior epoch.
+        # coordinator_epoch: seeded for the CROSS-HOST fence follow-on
+        # (demand-gated; a client-carried token would compare it). NOT used in
+        # any guard yet -- the single-host fence keys only on owner_generation,
+        # and a wiped/recreated store also wipes the read_generation rows, so
+        # there is no pre-wipe claim for an epoch to fail. Kept so the durable
+        # store identity exists from day one.
         self._coordinator_epoch: str = uuid4().hex
         self._seq: int = 0
         self._retain_versions = retain_versions
@@ -111,7 +128,7 @@ class ArtifactRegistry:
         """Return the artifact's ownership epoch (read-generation fence)."""
         return self._records[artifact_id].owner_generation
 
-    def get_read_generation(self, artifact_id: UUID, agent_id: UUID) -> Optional[int]:
+    def get_read_generation(self, artifact_id: UUID, agent_id: UUID) -> int | None:
         """Return the generation an agent captured at its last claim, or None if
         it never established a fence claim (a plain OCC writer that version-CAS,
         not the fence, arbitrates)."""
@@ -210,7 +227,12 @@ class ArtifactRegistry:
         # agent's read_generation when it establishes/refreshes a write-claim --
         # an E/M acquire (P0 fix: includes a pessimistic acquire with no prior
         # content read) or a genuine fetch read. Atomic (GIL) with the grant.
-        if (new_in_me and not prev_in_me) or trigger == "fetch":
+        # The INVALID guard hardens the fetch leg: no current fetch path grants
+        # INVALID, but a future cache-miss-INVALID fetch must not mint a fresh
+        # claim for an unfenced zombie.
+        if (new_in_me and not prev_in_me) or (
+            trigger in CLAIM_CAPTURE_TRIGGERS and state != MESIState.INVALID
+        ):
             record.read_generation_by_agent[agent_id] = record.owner_generation
 
         if self._state_log is not None:

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Optional, TypeAlias
 from uuid import UUID, uuid4
 
 from ccs.core.states import MESIState, TransientState
+from ccs.core.exceptions import STALE_READ_GENERATION_REASON, StaleReadGeneration
 from ccs.core.types import Artifact, CasCorruption, ConflictDetail
 
 CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
@@ -123,13 +124,30 @@ class ArtifactRegistry:
         content: str,
         *,
         last_writer: Optional[UUID] = None,
+        fence_agent_id: Optional[UUID] = None,
     ) -> None:
-        """Replace artifact metadata/content for an existing record."""
+        """Replace artifact metadata/content for an existing record.
+
+        Read-generation fence (pessimistic ``commit()`` path): when
+        ``fence_agent_id`` is given, reject -- atomically (GIL) with the persist
+        -- if that committer's captured read_generation was superseded by a
+        sweep reclamation (the race the service's earlier get_agent_state check
+        misses). A ``None`` fence_agent_id (source-churn) is unguarded.
+        """
+        record = self._records[artifact_id]
+        if fence_agent_id is not None:
+            read_gen = record.read_generation_by_agent.get(fence_agent_id)
+            if read_gen is not None and read_gen < record.owner_generation:
+                raise StaleReadGeneration(
+                    f"{STALE_READ_GENERATION_REASON} agent={fence_agent_id} "
+                    f"artifact={artifact_id} read_gen={read_gen} "
+                    f"owner_gen={record.owner_generation}"
+                )
         if self._retain_versions:
-            self._records[artifact_id].version_history[artifact.version] = content
-        self._records[artifact_id].artifact = artifact
-        self._records[artifact_id].content = content
-        self._records[artifact_id].last_writer = last_writer
+            record.version_history[artifact.version] = content
+        record.artifact = artifact
+        record.content = content
+        record.last_writer = last_writer
 
     def get_content_at_version(self, artifact_id: UUID, version: int) -> str | None:
         """Return content for a specific version, if retained."""

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -16,6 +16,7 @@ from ccs.core.exceptions import (
     OCC_CALLER_TRANSIENT_REASON,
     CoherenceError,
     OccCallerTransientError,
+    StaleReadGeneration,
 )
 from ccs.core.hashing import compute_content_hash
 from ccs.core.invariants import check_monotonic_version, check_single_writer
@@ -301,7 +302,18 @@ class CoordinatorService:
         content_hash: str | None = None,
         size_tokens: int | None = None,
     ) -> tuple[Artifact, list[InvalidationSignal]]:
-        """Commit modified content, increment version, and invalidate peers."""
+        """Commit modified content, increment version, and invalidate peers.
+
+        Raises:
+            CoherenceError: the committer does not hold M/E (e.g. its grant was
+                already reclaimed — the error names the reclaim trigger/tick).
+            StaleReadGeneration: the read-generation fence fired — a sweep
+                reclaimed this committer in the race window between the state
+                check above and the version persist (``ccs.core.exceptions``).
+                Retry-eligible: ``reacquire()`` / re-acquire, take a fresh read,
+                and re-commit; there is no built-in retry loop on this path
+                (unlike ``write_cas``).
+        """
         artifact = self._require_artifact(artifact_id)
         agent_state = self.registry.get_agent_state(artifact_id, agent_id)
         if agent_state not in {MESIState.EXCLUSIVE, MESIState.MODIFIED}:
@@ -332,16 +344,25 @@ class CoordinatorService:
             size_tokens=size_tokens if size_tokens is not None else artifact.size_tokens,
             depends_on=artifact.depends_on,
         )
-        self.registry.set_artifact_and_content(
-            artifact_id,
-            updated,
-            content,
-            last_writer=agent_id,
-            # Read-generation fence: reject atomically with the version bump if a
-            # sweep reclaimed this committer in the race window between the
-            # get_agent_state check above and here (raises StaleReadGeneration).
-            fence_agent_id=agent_id,
-        )
+        try:
+            self.registry.set_artifact_and_content(
+                artifact_id,
+                updated,
+                content,
+                last_writer=agent_id,
+                # Read-generation fence: reject atomically with the version bump
+                # if a sweep reclaimed this committer in the race window between
+                # the get_agent_state check above and here.
+                fence_agent_id=agent_id,
+            )
+        except StaleReadGeneration:
+            # The MWB transient set above must not outlive a fence reject:
+            # a stuck MWB blocks this agent's next commit_cas (transient
+            # precondition) and makes the stable-grant sweep skip the pair
+            # until the transient timeout. The reclaim already dropped the
+            # grant, so clearing the transient is the only cleanup needed.
+            self.registry.clear_agent_transient(artifact_id, agent_id)
+            raise
 
         signals: list[InvalidationSignal] = []
         for peer_id, state in self.registry.get_state_map(artifact_id).items():
@@ -412,9 +433,12 @@ class CoordinatorService:
         - :class:`CasCorruption` (``expected_version > current``) → raise
           ``CoherenceError`` — corruption / a second coordinator on the store,
           non-retryable.
-        - :class:`ConflictDetail` (``version_mismatch`` / ``other_holder``) →
-          returned UNCHANGED, with **no mutation and no invalidation signals**
-          (it is a typed return, never an exception).
+        - :class:`ConflictDetail` (``version_mismatch`` / ``other_holder`` /
+          ``stale_read_generation``) → returned UNCHANGED, with **no mutation
+          and no invalidation signals** (it is a typed return, never an
+          exception). ``stale_read_generation`` is the read-generation fence:
+          the committer's captured claim was superseded by a sweep reclamation;
+          retry-eligible via reacquire + fresh read.
         - WIN ``(updated_artifact, invalidated_ids)`` → the registry has already
           done the peer-invalidation + committer S/I→SHARED transition
           atomically (the OCC writer holds no grant, so it ends SHARED — which

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -337,6 +337,10 @@ class CoordinatorService:
             updated,
             content,
             last_writer=agent_id,
+            # Read-generation fence: reject atomically with the version bump if a
+            # sweep reclaimed this committer in the race window between the
+            # get_agent_state check above and here (raises StaleReadGeneration).
+            fence_agent_id=agent_id,
         )
 
         signals: list[InvalidationSignal] = []

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -242,13 +242,14 @@ class SqliteArtifactRegistry:
             c.execute(
                 """
                 CREATE TABLE artifacts (
-                    id              TEXT PRIMARY KEY,
-                    name            TEXT NOT NULL UNIQUE,
-                    version         INTEGER NOT NULL,
-                    content_hash    TEXT NOT NULL,
-                    size_tokens     INTEGER,
-                    last_writer_id  TEXT,
-                    updated_at      REAL NOT NULL
+                    id               TEXT PRIMARY KEY,
+                    name             TEXT NOT NULL UNIQUE,
+                    version          INTEGER NOT NULL,
+                    owner_generation INTEGER NOT NULL DEFAULT 0,
+                    content_hash     TEXT NOT NULL,
+                    size_tokens      INTEGER,
+                    last_writer_id   TEXT,
+                    updated_at       REAL NOT NULL
                 )
                 """
             )
@@ -264,6 +265,7 @@ class SqliteArtifactRegistry:
                     granted_at_tick      INTEGER,
                     last_reclaim_trigger TEXT,
                     last_reclaim_tick    INTEGER,
+                    read_generation      INTEGER,
                     PRIMARY KEY (artifact_id, agent_id),
                     FOREIGN KEY (artifact_id) REFERENCES artifacts(id) ON DELETE CASCADE
                 )
@@ -303,9 +305,14 @@ class SqliteArtifactRegistry:
                 )
                 """
             )
+            seed_epoch = uuid4().hex
             c.execute(
-                "INSERT INTO registry_meta (key, value) VALUES (?, ?), (?, ?)",
-                ("instance_id", seed_id, "sequence_number", "0"),
+                "INSERT INTO registry_meta (key, value) VALUES (?, ?), (?, ?), (?, ?)",
+                (
+                    "instance_id", seed_id,
+                    "sequence_number", "0",
+                    "coordinator_epoch", seed_epoch,
+                ),
             )
             # PRAGMA is transactional inside an explicit BEGIN; cannot take
             # parameter bindings, so SCHEMA_USER_VERSION (int constant) is
@@ -322,6 +329,7 @@ class SqliteArtifactRegistry:
             raise
         self._instance_id = seed_id
         self._seq = 0
+        self._coordinator_epoch = seed_epoch
 
     def _rehydrate_meta(self, instance_id_override: str | None) -> None:
         """Load _instance_id + _seq from registry_meta. Caller holds lock."""
@@ -353,6 +361,48 @@ class SqliteArtifactRegistry:
             )
             """
         )
+        # Read-generation fence (Piece #2) forward-compat: additively add the
+        # fence columns + coordinator_epoch to dbs created before the fence.
+        # user_version stays unchanged (additive, plan option (a); same posture
+        # as pending_notices above) so an older binary can still open the db.
+        self._ensure_fence_columns()
+        epoch_row = self._conn.execute(
+            "SELECT value FROM registry_meta WHERE key = 'coordinator_epoch'"
+        ).fetchone()
+        self._coordinator_epoch = epoch_row[0]
+
+    def _ensure_fence_columns(self) -> None:
+        """Additively add the read-generation fence columns + coordinator_epoch
+        to a pre-fence database. Idempotent (PRAGMA-guarded); user_version stays
+        unchanged. Caller holds the lock; runs in one explicit transaction so a
+        SIGKILL mid-add cannot leave a half-applied column set."""
+        c = self._conn
+        art_cols = {row[1] for row in c.execute("PRAGMA table_info(artifacts)").fetchall()}
+        state_cols = {
+            row[1] for row in c.execute("PRAGMA table_info(agent_states)").fetchall()
+        }
+        c.execute("BEGIN IMMEDIATE")
+        try:
+            if "owner_generation" not in art_cols:
+                c.execute(
+                    "ALTER TABLE artifacts ADD COLUMN owner_generation "
+                    "INTEGER NOT NULL DEFAULT 0"
+                )
+            if "read_generation" not in state_cols:
+                # Nullable: a pre-fence grant captured no generation; NULL is the
+                # absent operand the commit guard rejects.
+                c.execute("ALTER TABLE agent_states ADD COLUMN read_generation INTEGER")
+            c.execute(
+                "INSERT OR IGNORE INTO registry_meta (key, value) VALUES (?, ?)",
+                ("coordinator_epoch", uuid4().hex),
+            )
+            c.execute("COMMIT")
+        except BaseException:
+            try:
+                c.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
 
     # ------------------------------------------------------------------
     # Connection lifecycle

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -73,8 +73,8 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Optional, TypeAlias
 from uuid import UUID, uuid4
 
-from ccs.core.states import MESIState, TransientState
 from ccs.core.exceptions import STALE_READ_GENERATION_REASON, StaleReadGeneration
+from ccs.core.states import MESIState, TransientState
 from ccs.core.types import Artifact, CasCorruption, ConflictDetail
 
 CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
@@ -88,11 +88,19 @@ v0.1 raises on mismatch; v0.2 will add real migration dispatch when needed."""
 ReclamationSlot: TypeAlias = tuple[str, int]
 _M_OR_E_STATES: frozenset[MESIState] = frozenset({MESIState.MODIFIED, MESIState.EXCLUSIVE})
 
-# Sweep-reclaim triggers — an M/E -> INVALID carrying one of these bumps the
-# artifact's owner_generation (read-generation fence). Duplicated from
-# registry.py (the two registries share no base class); the dual-registry
-# parity test pins them equal.
-RECLAIM_TRIGGERS: frozenset[str] = frozenset({"reclaim_heartbeat", "reclaim_max_hold"})
+# Coordinator-side eviction triggers (the stable-grant sweep's two reclaim
+# triggers + the transient-timeout fail-safe) — an M/E -> INVALID carrying one
+# of these bumps the artifact's owner_generation (read-generation fence): the
+# claim was revoked without a version move, which version-CAS cannot see.
+# Duplicated from registry.py (the two registries share no base class); the
+# dual-registry parity test pins them equal.
+RECLAIM_TRIGGERS: frozenset[str] = frozenset(
+    {"reclaim_heartbeat", "reclaim_max_hold", "timeout"}
+)
+
+# Genuine-content-read triggers for read-generation capture (mirrors
+# registry.py; pinned equal by the parity test). Service.fetch() emits "fetch".
+CLAIM_CAPTURE_TRIGGERS: frozenset[str] = frozenset({"fetch"})
 
 # OCC commit-CAS result (plan Unit 2). A WIN is ``(updated_artifact,
 # invalidated_agent_ids)`` — the service layer turns the id list into
@@ -376,20 +384,32 @@ class SqliteArtifactRegistry:
         epoch_row = self._conn.execute(
             "SELECT value FROM registry_meta WHERE key = 'coordinator_epoch'"
         ).fetchone()
+        if epoch_row is None:
+            raise SchemaVersionError(
+                f"coordinator_epoch missing from registry_meta at {self._db_path}; "
+                f"the database may be partially upgraded or corrupted. "
+                f"Delete and restart to rehydrate."
+            )
         self._coordinator_epoch = epoch_row[0]
 
     def _ensure_fence_columns(self) -> None:
         """Additively add the read-generation fence columns + coordinator_epoch
-        to a pre-fence database. Idempotent (PRAGMA-guarded); user_version stays
-        unchanged. Caller holds the lock; runs in one explicit transaction so a
-        SIGKILL mid-add cannot leave a half-applied column set."""
+        to a pre-fence database. Idempotent; user_version stays unchanged.
+        Caller holds the lock; runs in one explicit transaction so a SIGKILL
+        mid-add cannot leave a half-applied column set. The PRAGMA introspection
+        runs INSIDE the BEGIN IMMEDIATE: two processes opening the same
+        pre-fence db serialize on the write lock, and the loser re-reads the
+        schema after the winner's commit — so it sees the columns as present
+        and no-ops instead of crashing on a duplicate-column ALTER."""
         c = self._conn
-        art_cols = {row[1] for row in c.execute("PRAGMA table_info(artifacts)").fetchall()}
-        state_cols = {
-            row[1] for row in c.execute("PRAGMA table_info(agent_states)").fetchall()
-        }
         c.execute("BEGIN IMMEDIATE")
         try:
+            art_cols = {
+                row[1] for row in c.execute("PRAGMA table_info(artifacts)").fetchall()
+            }
+            state_cols = {
+                row[1] for row in c.execute("PRAGMA table_info(agent_states)").fetchall()
+            }
             if "owner_generation" not in art_cols:
                 c.execute(
                     "ALTER TABLE artifacts ADD COLUMN owner_generation "
@@ -541,10 +561,13 @@ class SqliteArtifactRegistry:
                         (artifact_id.hex, fence_agent_id.hex),
                     ).fetchone()
                     if rg_row is not None and rg_row[0] is not None:
-                        owner_gen = self._conn.execute(
+                        og_row = self._conn.execute(
                             "SELECT owner_generation FROM artifacts WHERE id = ?",
                             (artifact_id.hex,),
-                        ).fetchone()[0]
+                        ).fetchone()
+                        if og_row is None:
+                            raise KeyError(f"artifact {artifact_id} not in registry")
+                        owner_gen = og_row[0]
                         if rg_row[0] < owner_gen:
                             # Raise inside the try; the except below ROLLBACKs
                             # and re-raises (no double rollback).
@@ -771,7 +794,11 @@ class SqliteArtifactRegistry:
                 # write-claim (E/M acquire -- P0 fix, incl. acquire-without-read
                 # -- or a fetch read), atomic with the grant in this BEGIN
                 # IMMEDIATE. The agent_states row exists after the upsert above.
-                if (new_in_me and not prev_in_me) or trigger == "fetch":
+                # INVALID guard on the fetch leg: a future cache-miss-INVALID
+                # fetch must not mint a fresh claim for an unfenced zombie.
+                if (new_in_me and not prev_in_me) or (
+                    trigger in CLAIM_CAPTURE_TRIGGERS and state != MESIState.INVALID
+                ):
                     self._conn.execute(
                         "UPDATE agent_states SET read_generation = "
                         "(SELECT owner_generation FROM artifacts WHERE id = ?) "
@@ -1217,11 +1244,13 @@ class SqliteArtifactRegistry:
                     (artifact_id.hex, agent_id.hex),
                 ).fetchone()
                 if rg_row is not None and rg_row[0] is not None:
-                    owner_gen = self._conn.execute(
+                    og_row = self._conn.execute(
                         "SELECT owner_generation FROM artifacts WHERE id = ?",
                         (artifact_id.hex,),
-                    ).fetchone()[0]
-                    if rg_row[0] < owner_gen:
+                    ).fetchone()
+                    if og_row is None:
+                        raise KeyError(f"artifact {artifact_id} not in registry")
+                    if rg_row[0] < og_row[0]:
                         self._conn.execute("COMMIT")
                         return ConflictDetail("stale_read_generation", current)
 

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -74,6 +74,7 @@ from typing import Any, Callable, Iterable, Optional, TypeAlias
 from uuid import UUID, uuid4
 
 from ccs.core.states import MESIState, TransientState
+from ccs.core.exceptions import STALE_READ_GENERATION_REASON, StaleReadGeneration
 from ccs.core.types import Artifact, CasCorruption, ConflictDetail
 
 CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
@@ -518,14 +519,40 @@ class SqliteArtifactRegistry:
         content: str,
         *,
         last_writer: Optional[UUID] = None,
+        fence_agent_id: Optional[UUID] = None,
     ) -> None:
         """Replace artifact metadata for an existing record. ``content`` is
         ignored per KTD-13 — content_hash on the artifact is the source of
-        truth for staleness comparison."""
+        truth for staleness comparison.
+
+        Read-generation fence (pessimistic ``commit()`` path): when
+        ``fence_agent_id`` is given, reject -- atomically with the version
+        persist in this BEGIN IMMEDIATE -- if that committer's captured
+        read_generation was superseded by a sweep reclamation. A ``None``
+        fence_agent_id (source-churn) is unguarded."""
         del content  # KTD-13: not persisted
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
+                if fence_agent_id is not None:
+                    rg_row = self._conn.execute(
+                        "SELECT read_generation FROM agent_states "
+                        "WHERE artifact_id = ? AND agent_id = ?",
+                        (artifact_id.hex, fence_agent_id.hex),
+                    ).fetchone()
+                    if rg_row is not None and rg_row[0] is not None:
+                        owner_gen = self._conn.execute(
+                            "SELECT owner_generation FROM artifacts WHERE id = ?",
+                            (artifact_id.hex,),
+                        ).fetchone()[0]
+                        if rg_row[0] < owner_gen:
+                            # Raise inside the try; the except below ROLLBACKs
+                            # and re-raises (no double rollback).
+                            raise StaleReadGeneration(
+                                f"{STALE_READ_GENERATION_REASON} agent={fence_agent_id} "
+                                f"artifact={artifact_id} read_gen={rg_row[0]} "
+                                f"owner_gen={owner_gen}"
+                            )
                 self._conn.execute(
                     """
                     UPDATE artifacts

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -87,6 +87,12 @@ v0.1 raises on mismatch; v0.2 will add real migration dispatch when needed."""
 ReclamationSlot: TypeAlias = tuple[str, int]
 _M_OR_E_STATES: frozenset[MESIState] = frozenset({MESIState.MODIFIED, MESIState.EXCLUSIVE})
 
+# Sweep-reclaim triggers — an M/E -> INVALID carrying one of these bumps the
+# artifact's owner_generation (read-generation fence). Duplicated from
+# registry.py (the two registries share no base class); the dual-registry
+# parity test pins them equal.
+RECLAIM_TRIGGERS: frozenset[str] = frozenset({"reclaim_heartbeat", "reclaim_max_hold"})
+
 # OCC commit-CAS result (plan Unit 2). A WIN is ``(updated_artifact,
 # invalidated_agent_ids)`` — the service layer turns the id list into
 # ``InvalidationSignal``s. A loss is a typed ``ConflictDetail`` (retry-eligible,
@@ -404,6 +410,16 @@ class SqliteArtifactRegistry:
                 pass
             raise
 
+    def get_owner_generation(self, artifact_id: UUID) -> int:
+        """Return the artifact's ownership epoch (read-generation fence)."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT owner_generation FROM artifacts WHERE id = ?", (artifact_id.hex,)
+            ).fetchone()
+            if row is None:
+                raise KeyError(f"artifact {artifact_id} not in registry")
+            return row[0]
+
     # ------------------------------------------------------------------
     # Connection lifecycle
     # ------------------------------------------------------------------
@@ -668,6 +684,17 @@ class SqliteArtifactRegistry:
                 if version_row is None:
                     raise KeyError(f"artifact {artifact_id} not in registry")
                 version = version_row[0]
+
+                # Read-generation fence: on a sweep reclamation (M/E -> INVALID
+                # via a reclaim trigger) bump the artifact's ownership epoch,
+                # atomically with the state transition in this BEGIN IMMEDIATE,
+                # so a commit by the reclaimed holder fails the generation check.
+                if prev_in_me and not new_in_me and trigger in RECLAIM_TRIGGERS:
+                    self._conn.execute(
+                        "UPDATE artifacts SET owner_generation = owner_generation + 1 "
+                        "WHERE id = ?",
+                        (artifact_id.hex,),
+                    )
 
                 # Upsert agent state.
                 if prior_row is None:

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -421,9 +421,9 @@ class SqliteArtifactRegistry:
             return row[0]
 
     def get_read_generation(self, artifact_id: UUID, agent_id: UUID) -> int | None:
-        """Return the generation an agent captured at its last claim, or None
-        (the absent operand the commit guard rejects) if it never established
-        one."""
+        """Return the generation an agent captured at its last claim, or None if
+        it never established a fence claim (a plain OCC writer that version-CAS,
+        not the fence, arbitrates)."""
         with self._lock:
             row = self._conn.execute(
                 "SELECT read_generation FROM agent_states "
@@ -1175,6 +1175,28 @@ class SqliteArtifactRegistry:
                 if other_holder is not None:
                     self._conn.execute("COMMIT")
                     return ConflictDetail("other_holder", current)
+
+                # Read-generation fence: reject a committer whose CAPTURED
+                # read-claim was superseded by a sweep reclamation (a reclaimed
+                # M/E holder kept its stale read_generation -- version unchanged,
+                # no other M/E holder, so version-CAS cannot catch it). An ABSENT
+                # read_generation (missing row or NULL) means a plain OCC writer
+                # that never established a fence claim -- version-CAS protects it,
+                # so admit. Strict->; equality admits. Server-side, no signature
+                # change.
+                rg_row = self._conn.execute(
+                    "SELECT read_generation FROM agent_states "
+                    "WHERE artifact_id = ? AND agent_id = ?",
+                    (artifact_id.hex, agent_id.hex),
+                ).fetchone()
+                if rg_row is not None and rg_row[0] is not None:
+                    owner_gen = self._conn.execute(
+                        "SELECT owner_generation FROM artifacts WHERE id = ?",
+                        (artifact_id.hex,),
+                    ).fetchone()[0]
+                    if rg_row[0] < owner_gen:
+                        self._conn.execute("COMMIT")
+                        return ConflictDetail("stale_read_generation", current)
 
                 # ---- WIN: mutate atomically ----
                 next_version = current + 1

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -420,6 +420,18 @@ class SqliteArtifactRegistry:
                 raise KeyError(f"artifact {artifact_id} not in registry")
             return row[0]
 
+    def get_read_generation(self, artifact_id: UUID, agent_id: UUID) -> int | None:
+        """Return the generation an agent captured at its last claim, or None
+        (the absent operand the commit guard rejects) if it never established
+        one."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT read_generation FROM agent_states "
+                "WHERE artifact_id = ? AND agent_id = ?",
+                (artifact_id.hex, agent_id.hex),
+            ).fetchone()
+            return row[0] if row is not None else None
+
     # ------------------------------------------------------------------
     # Connection lifecycle
     # ------------------------------------------------------------------
@@ -726,6 +738,19 @@ class SqliteArtifactRegistry:
                             """,
                             (state.name, granted_at_tick, artifact_id.hex, agent_id.hex),
                         )
+
+                # Read-generation fence: capture the current ownership epoch into
+                # the agent's read_generation when it establishes/refreshes a
+                # write-claim (E/M acquire -- P0 fix, incl. acquire-without-read
+                # -- or a fetch read), atomic with the grant in this BEGIN
+                # IMMEDIATE. The agent_states row exists after the upsert above.
+                if (new_in_me and not prev_in_me) or trigger == "fetch":
+                    self._conn.execute(
+                        "UPDATE agent_states SET read_generation = "
+                        "(SELECT owner_generation FROM artifacts WHERE id = ?) "
+                        "WHERE artifact_id = ? AND agent_id = ?",
+                        (artifact_id.hex, artifact_id.hex, agent_id.hex),
+                    )
 
                 # Mutation-then-log: emit state_log BEFORE commit. If the callback
                 # raises, ROLLBACK undoes the agent_states change AND we decrement

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -13,9 +13,27 @@ from __future__ import annotations
 # reword on one side would otherwise silently break the other's retry routing.
 OCC_CALLER_TRANSIENT_REASON = "caller_in_transient_state"
 
+# Read-generation fence (Piece #2): the reason a commit is rejected because the
+# committer's read_generation is older than the artifact's current
+# owner_generation -- its captured claim was superseded by a sweep reclamation.
+# Retry-eligible (reacquire + fresh read + re-commit). Shared by the
+# ConflictDetail reason (OCC path) and the StaleReadGeneration exception
+# (pessimistic path) so the two surfaces cannot drift.
+STALE_READ_GENERATION_REASON = "stale_read_generation"
+
 
 class CoherenceError(Exception):
     """Base error for coherence domain failures."""
+
+
+class StaleReadGeneration(CoherenceError):
+    """The read-generation fence rejected a commit: the committer's
+    read_generation is older than the artifact's current owner_generation --
+    its captured ownership/read-claim was superseded by a sweep reclamation. Raised on the pessimistic ``commit()`` path; the OCC
+    ``commit_cas`` path returns a :class:`ConflictDetail` with the same reason
+    instead. Retry-eligible: ``reacquire()`` + fresh read + re-commit. Carries
+    ``STALE_READ_GENERATION_REASON`` so the client classifier matches it
+    exactly (never on the human message)."""
 
 
 class OccCallerTransientError(CoherenceError):

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -29,7 +29,9 @@ class CoherenceError(Exception):
 class StaleReadGeneration(CoherenceError):
     """The read-generation fence rejected a commit: the committer's
     read_generation is older than the artifact's current owner_generation --
-    its captured ownership/read-claim was superseded by a sweep reclamation. Raised on the pessimistic ``commit()`` path; the OCC
+    its captured ownership/read-claim was superseded by a sweep reclamation.
+
+    Raised on the pessimistic ``commit()`` path; the OCC
     ``commit_cas`` path returns a :class:`ConflictDetail` with the same reason
     instead. Retry-eligible: ``reacquire()`` + fresh read + re-commit. Carries
     ``STALE_READ_GENERATION_REASON`` so the client classifier matches it

--- a/src/ccs/core/types.py
+++ b/src/ccs/core/types.py
@@ -44,7 +44,7 @@ class ConflictDetail:
 
     Returned (never raised) by the registry ``commit_cas`` primitive and the
     service ``commit_cas`` orchestration when a compare-and-swap loses the
-    race (OCC write API, plan R2 / R-OCC-2). The two retry-eligible reasons:
+    race (OCC write API, plan R2 / R-OCC-2). The three retry-eligible reasons:
 
     - ``"version_mismatch"`` — the caller's ``expected_version`` is *behind*
       the registry's current version (another writer committed first). Two
@@ -53,6 +53,12 @@ class ConflictDetail:
     - ``"other_holder"`` — the version matched, but a *pessimistic* peer holds
       MODIFIED or EXCLUSIVE during the OCC compute window (OCC-vs-pessimistic
       coexistence guard). Not how two OCC writers are arbitrated.
+    - ``"stale_read_generation"`` — the version matched and no peer holds M/E,
+      but the committer's CAPTURED read_generation was superseded by a sweep
+      reclamation — the read-generation fence (Piece #2). Only the generation
+      catches this; version-CAS cannot (the version is unchanged on a
+      no-successor reclaim). An absent read_generation is NOT this conflict
+      (a plain OCC writer is arbitrated by version-CAS).
 
     Both are retry-eligible (re-read → recompute → retry). ``current_version``
     is the registry's authoritative version at the point the conflict was
@@ -61,7 +67,7 @@ class ConflictDetail:
     ``ConflictDetail``) and the service layer raises ``CoherenceError`` for it.
     """
 
-    reason: Literal["version_mismatch", "other_holder"]
+    reason: Literal["version_mismatch", "other_holder", "stale_read_generation"]
     current_version: int
 
 

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -1338,3 +1338,18 @@ def test_read_outside_root_raises(tmp_path: Path, fast_cfg: LifecycleConfig) -> 
             vol.read("/etc/hostname")  # absolute, outside the workspace root
     finally:
         stop_coordinator(tmp_path)
+
+
+def test_stale_read_generation_is_cas_retry_eligible() -> None:
+    """The read-generation fence reject reason is retry-eligible on the OCC
+    cross-process path (reacquire + fresh read) -- classified 'conflict', not a
+    terminal 'raise', and matched EXACTLY against the shared constant. Tested
+    spawn-free: _classify_cas_response reads only the class attr."""
+    from ccs.core.exceptions import STALE_READ_GENERATION_REASON
+
+    assert STALE_READ_GENERATION_REASON in CoherentVolume._CAS_RETRY_REASONS
+    classify = CoherentVolume._classify_cas_response
+    stub = type("_Stub", (), {"_CAS_RETRY_REASONS": CoherentVolume._CAS_RETRY_REASONS})()
+    assert classify(stub, {"ok": False, "reason": STALE_READ_GENERATION_REASON}) == "conflict"
+    assert classify(stub, {"ok": True}) == "win"
+    assert classify(stub, {"ok": False, "reason": "commit_cas_corruption"}) == "raise"

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -1345,11 +1345,16 @@ def test_stale_read_generation_is_cas_retry_eligible() -> None:
     cross-process path (reacquire + fresh read) -- classified 'conflict', not a
     terminal 'raise', and matched EXACTLY against the shared constant. Tested
     spawn-free: _classify_cas_response reads only the class attr."""
+    from unittest.mock import MagicMock
+
     from ccs.core.exceptions import STALE_READ_GENERATION_REASON
 
     assert STALE_READ_GENERATION_REASON in CoherentVolume._CAS_RETRY_REASONS
     classify = CoherentVolume._classify_cas_response
-    stub = type("_Stub", (), {"_CAS_RETRY_REASONS": CoherentVolume._CAS_RETRY_REASONS})()
+    # spec'd mock: any future self-attribute the classifier grows raises
+    # AttributeError here instead of silently returning a MagicMock value.
+    stub = MagicMock(spec=CoherentVolume)
+    stub._CAS_RETRY_REASONS = CoherentVolume._CAS_RETRY_REASONS
     assert classify(stub, {"ok": False, "reason": STALE_READ_GENERATION_REASON}) == "conflict"
     assert classify(stub, {"ok": True}) == "win"
     assert classify(stub, {"ok": False, "reason": "commit_cas_corruption"}) == "raise"

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -2709,6 +2709,48 @@ def test_adv004_post_edit_after_reclamation_returns_reclaimed_message(
     assert "preempted by session" not in body.get("reason", "")
 
 
+def test_post_edit_fence_reject_returns_stable_reason(
+    coordinator, client: _Client,
+) -> None:
+    """End-to-end: the read-generation fence race window — the grant is still
+    EXCLUSIVE but a sweep superseded the claim (owner_generation advanced
+    between commit()'s state check and the version persist). post-edit must
+    return the STABLE stale_read_generation reason (exact constant, not
+    str(exc)) plus current_version, land no phantom bump, and leak no MWB
+    transient."""
+    from ccs.adapters.claude_code.coordinator_server import session_to_agent_id
+    from ccs.core.exceptions import STALE_READ_GENERATION_REASON
+
+    sid = _sid("fence-race")
+    agent_id = session_to_agent_id(sid)
+    client.post("/hooks/pre-edit", {"session_id": sid, "path": "plan.md"})
+    artifact_id = coordinator.registry.lookup_artifact_id_by_name("plan.md")
+    assert artifact_id is not None
+
+    # Manufacture the race: generation advances while the state stays E
+    # (a direct bump stands in for the sweep firing mid-commit; autocommit
+    # connection, so no transaction is held open against the server).
+    coordinator.registry._conn.execute(
+        "UPDATE artifacts SET owner_generation = owner_generation + 1 WHERE id = ?",
+        (artifact_id.hex,),
+    )
+    before = coordinator.registry.get_artifact(artifact_id).version
+
+    s, body = client.post("/hooks/post-edit", {
+        "session_id": sid,
+        "path": "plan.md",
+        "content_hash": _hash("fence-late"),
+        "success": True,
+    })
+    assert s == 200, body
+    assert body.get("ok") is False
+    assert body.get("reason") == STALE_READ_GENERATION_REASON
+    assert body.get("current_version") == before
+    # No phantom version bump; no leaked MWB transient (review P1 regression).
+    assert coordinator.registry.get_artifact(artifact_id).version == before
+    assert coordinator.registry.get_agent_transient(artifact_id, agent_id) is None
+
+
 def test_adv004_sweep_on_reclaim_callback_exception_does_not_break_sweep(
     coordinator,
 ) -> None:

--- a/tests/test_fence_signature_guard.py
+++ b/tests/test_fence_signature_guard.py
@@ -14,6 +14,7 @@ import inspect
 
 import pytest
 
+from ccs.adapters.coherent_volume import CoherentVolume
 from ccs.agent.runtime import AgentRuntime
 from ccs.coordinator.service import CoordinatorService
 
@@ -45,6 +46,8 @@ _PUBLIC_WRITE_APIS = [
     CoordinatorService.commit_cas,
     AgentRuntime.write,
     AgentRuntime.write_cas,
+    CoherentVolume.write,
+    CoherentVolume.write_cas,
 ]
 
 

--- a/tests/test_fence_signature_guard.py
+++ b/tests/test_fence_signature_guard.py
@@ -1,0 +1,60 @@
+"""R7 -- the read-generation fence stays SERVER-SIDE.
+
+A CI-enforced terminal invariant: no public write API may accept a
+client-supplied generation/fence argument. This test IS the boundary, not a
+documentation promise. The day a write API needs a generation as input is the
+cross-host enforcement step (a client-carried fence token) -- which is out of
+scope until demand-pulled, and must fail this test until then. Same discipline
+as the plugin's TERMINAL_DENIAL_CLASSES lock.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from ccs.agent.runtime import AgentRuntime
+from ccs.coordinator.service import CoordinatorService
+
+# Argument names that would indicate a generation/fence VALUE crossing into the
+# write path as a client-supplied input.
+#
+# Note: ``fence_agent_id`` is deliberately NOT here. It is an agent_id known
+# server-side on the pessimistic commit() path (not a client-supplied
+# generation), and it lives on the internal registry primitive
+# ``set_artifact_and_content`` -- not a public write API. The fence's
+# ``read_generation`` / ``owner_generation`` are read server-side from the
+# registry, never passed in.
+_FENCE_ARG_NAMES = frozenset(
+    {
+        "generation",
+        "owner_generation",
+        "read_generation",
+        "fence",
+        "fence_token",
+        "fence_generation",
+        "expected_generation",
+    }
+)
+
+# The public, client-facing write APIs. None may take a generation argument.
+_PUBLIC_WRITE_APIS = [
+    CoordinatorService.write,
+    CoordinatorService.commit,
+    CoordinatorService.commit_cas,
+    AgentRuntime.write,
+    AgentRuntime.write_cas,
+]
+
+
+@pytest.mark.parametrize("fn", _PUBLIC_WRITE_APIS, ids=lambda f: f.__qualname__)
+def test_no_public_write_api_accepts_a_generation_argument(fn) -> None:
+    params = set(inspect.signature(fn).parameters)
+    leaked = params & _FENCE_ARG_NAMES
+    assert not leaked, (
+        f"{fn.__qualname__} accepts a generation/fence argument {leaked}; the "
+        "read-generation fence must stay server-side (R7). Promoting it to a "
+        "client argument is the cross-host enforcement step -- out of scope "
+        "until demand-pulled. Remove the argument or open the cross-host work."
+    )

--- a/tests/test_fencing.py
+++ b/tests/test_fencing.py
@@ -53,6 +53,11 @@ def test_parity_owner_generation_bumps_on_reclaim_only(registry) -> None:
     reg.set_agent_state(art.id, b, MESIState.EXCLUSIVE, trigger="write", tick=11)
     reg.set_agent_state(art.id, b, MESIState.INVALID, trigger="peer_invalidation", tick=12)
     assert reg.get_owner_generation(art.id) == 1
+    # The OTHER reclaim trigger (max-hold) bumps too — both sweep triggers
+    # behave identically on both registries.
+    reg.set_agent_state(art.id, b, MESIState.EXCLUSIVE, trigger="write", tick=13)
+    reg.set_agent_state(art.id, b, MESIState.INVALID, trigger="reclaim_max_hold", tick=20)
+    assert reg.get_owner_generation(art.id) == 2
 
 
 def test_parity_read_generation_captured_at_claim(registry) -> None:
@@ -95,9 +100,72 @@ def test_parity_pessimistic_fence_rejects_superseded_committer(registry) -> None
 
 
 def test_reclaim_trigger_constants_are_equal_across_registries() -> None:
-    """The RECLAIM_TRIGGERS constant is duplicated (the registries share no base
-    class); this pins the two copies equal so the bump can never diverge."""
+    """The RECLAIM_TRIGGERS / CLAIM_CAPTURE_TRIGGERS constants are duplicated
+    (the registries share no base class); this pins the copies equal so the
+    bump and the capture can never silently diverge. The capture pin also
+    guards the service.fetch() trigger string: a rename there without updating
+    the constants would silently disable read-generation capture on fetches."""
+    from ccs.coordinator.registry import CLAIM_CAPTURE_TRIGGERS as MEM_CAPTURE
     from ccs.coordinator.registry import RECLAIM_TRIGGERS as IN_MEMORY
+    from ccs.coordinator.sqlite_registry import CLAIM_CAPTURE_TRIGGERS as SQL_CAPTURE
     from ccs.coordinator.sqlite_registry import RECLAIM_TRIGGERS as SQLITE
 
-    assert IN_MEMORY == SQLITE == frozenset({"reclaim_heartbeat", "reclaim_max_hold"})
+    assert IN_MEMORY == SQLITE == frozenset(
+        {"reclaim_heartbeat", "reclaim_max_hold", "timeout"}
+    )
+    assert MEM_CAPTURE == SQL_CAPTURE == frozenset({"fetch"})
+
+
+def test_transient_timeout_eviction_bumps_and_fences(registry) -> None:
+    """Review gated-fix regression: the transient-timeout fail-safe
+    (enforce_transient_timeouts -> trigger="timeout") is a coordinator-side
+    eviction too — it must bump owner_generation so a post-eviction zombie
+    commit_cas is rejected by the fence (the version never moved, so
+    version-CAS alone would have admitted it)."""
+    reg = registry
+    art = _register(reg)
+    a = uuid4()
+    reg.set_agent_state(art.id, a, MESIState.EXCLUSIVE, trigger="write", tick=1)  # claim g0
+    # Transient-timeout fail-safe evicts the M/E holder.
+    reg.set_agent_state(art.id, a, MESIState.INVALID, trigger="timeout", tick=10)
+    assert reg.get_owner_generation(art.id) == 1
+    # The zombie's commit_cas (version unchanged, no other holder, stale claim)
+    # is rejected — previously this was admitted via equality on gen 0.
+    res = reg.commit_cas(art.id, a, expected_version=1, content_hash="zombie")
+    assert isinstance(res, ConflictDetail)
+    assert res.reason == "stale_read_generation"
+    assert reg.get_artifact(art.id).version == 1
+
+
+def test_commit_fence_raise_clears_mwb_transient(registry) -> None:
+    """Regression (review P1): a fence reject inside service.commit() must not
+    leak the MWB transient it set moments earlier — a stuck MWB blocks the
+    agent's next commit_cas (transient precondition) and makes the stable-grant
+    sweep skip the pair until the transient timeout. Manufactures the exact
+    race window: the grant is still EXCLUSIVE but a sweep superseded the claim
+    (owner_generation advanced between commit()'s state check and the
+    version persist)."""
+    from ccs.coordinator.service import CoordinatorService
+    from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry as _Sqlite
+
+    reg = registry
+    art = _register(reg)
+    service = CoordinatorService(reg)
+    a = uuid4()
+    # Pessimistic acquire WITHOUT a prior fetch (P0-fix path): captures gen 0.
+    service.write(agent_id=a, artifact_id=art.id, issued_at_tick=1)
+    # Manufacture the race: generation advances while the state stays E.
+    if isinstance(reg, _Sqlite):
+        reg._conn.execute(
+            "UPDATE artifacts SET owner_generation = owner_generation + 1 WHERE id = ?",
+            (art.id.hex,),
+        )
+    else:
+        reg._records[art.id].owner_generation += 1
+
+    with pytest.raises(StaleReadGeneration):
+        service.commit(agent_id=a, artifact_id=art.id, content="late", issued_at_tick=2)
+
+    # The MWB transient is cleared (not leaked) and no phantom bump landed.
+    assert reg.get_agent_transient(art.id, a) is None
+    assert reg.get_artifact(art.id).version == 1

--- a/tests/test_fencing.py
+++ b/tests/test_fencing.py
@@ -1,0 +1,103 @@
+"""Read-generation fence (Piece #2) -- dual-registry parity harness (R4b).
+
+A NET-NEW parametrized harness (none existed -- the closest precedent,
+test_occ_commit_cas.py, tests each registry in separate functions) that runs the
+SAME fence assertions against BOTH ArtifactRegistry (in-memory) and
+SqliteArtifactRegistry. Asserts on version / owner_generation, never on content
+bytes (sqlite keeps no content per KTD-13). The two registries share no base
+class, so this is the guard against silent divergence -- including the
+duplicated RECLAIM_TRIGGERS constant. Uses a fixed-stale-buffer arm (a reclaimed
+holder's captured read_generation), not a refetch-safe read->+1->write arm.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.exceptions import StaleReadGeneration
+from ccs.core.states import MESIState
+from ccs.core.types import Artifact, ConflictDetail
+
+
+@pytest.fixture(params=["in_memory", "sqlite"])
+def registry(request, tmp_path: Path):
+    """Yield each registry implementation in turn so every test runs against
+    both, identically."""
+    if request.param == "in_memory":
+        yield ArtifactRegistry()
+    else:
+        with SqliteArtifactRegistry(tmp_path / "state.db") as reg:
+            yield reg
+
+
+def _register(reg) -> Artifact:
+    art = Artifact(id=uuid4(), name="plan.md", version=1, content_hash="h")
+    reg.register_artifact(art, content="ignored")
+    return art
+
+
+def test_parity_owner_generation_bumps_on_reclaim_only(registry) -> None:
+    reg = registry
+    art = _register(reg)
+    a, b = uuid4(), uuid4()
+    assert reg.get_owner_generation(art.id) == 0
+    reg.set_agent_state(art.id, a, MESIState.EXCLUSIVE, trigger="write", tick=1)
+    reg.set_agent_state(art.id, a, MESIState.INVALID, trigger="reclaim_heartbeat", tick=10)
+    assert reg.get_owner_generation(art.id) == 1
+    # A peer-invalidation (non-reclaim trigger) does NOT bump.
+    reg.set_agent_state(art.id, b, MESIState.EXCLUSIVE, trigger="write", tick=11)
+    reg.set_agent_state(art.id, b, MESIState.INVALID, trigger="peer_invalidation", tick=12)
+    assert reg.get_owner_generation(art.id) == 1
+
+
+def test_parity_read_generation_captured_at_claim(registry) -> None:
+    reg = registry
+    art = _register(reg)
+    a, b, c = uuid4(), uuid4(), uuid4()
+    assert reg.get_read_generation(art.id, c) is None  # never claimed
+    reg.set_agent_state(art.id, a, MESIState.EXCLUSIVE, trigger="write", tick=1)  # acquire
+    assert reg.get_read_generation(art.id, a) == 0
+    reg.set_agent_state(art.id, b, MESIState.SHARED, trigger="fetch", tick=2)  # fetch read
+    assert reg.get_read_generation(art.id, b) == 0
+    # A reclaim preserves a's captured value (it is NOT refreshed).
+    reg.set_agent_state(art.id, a, MESIState.INVALID, trigger="reclaim_heartbeat", tick=10)
+    assert reg.get_read_generation(art.id, a) == 0
+
+
+def test_parity_commit_cas_fence_rejects_superseded_reader(registry) -> None:
+    reg = registry
+    art = _register(reg)
+    a = uuid4()
+    reg.set_agent_state(art.id, a, MESIState.EXCLUSIVE, trigger="write", tick=1)  # read_gen 0
+    reg.set_agent_state(art.id, a, MESIState.INVALID, trigger="reclaim_heartbeat", tick=10)  # owner_gen 1
+    # Fixed-stale-buffer arm: a's captured read_generation (0) < owner (1).
+    res = reg.commit_cas(art.id, a, expected_version=1, content_hash="new")
+    assert isinstance(res, ConflictDetail)
+    assert res.reason == "stale_read_generation"
+    assert reg.get_artifact(art.id).version == 1  # no phantom bump
+
+
+def test_parity_pessimistic_fence_rejects_superseded_committer(registry) -> None:
+    reg = registry
+    art = _register(reg)
+    a = uuid4()
+    reg.set_agent_state(art.id, a, MESIState.EXCLUSIVE, trigger="write", tick=1)
+    reg.set_agent_state(art.id, a, MESIState.INVALID, trigger="reclaim_heartbeat", tick=10)
+    stale = Artifact(id=art.id, name="plan.md", version=2, content_hash="stale")
+    with pytest.raises(StaleReadGeneration):
+        reg.set_artifact_and_content(art.id, stale, "x", last_writer=a, fence_agent_id=a)
+    assert reg.get_artifact(art.id).version == 1
+
+
+def test_reclaim_trigger_constants_are_equal_across_registries() -> None:
+    """The RECLAIM_TRIGGERS constant is duplicated (the registries share no base
+    class); this pins the two copies equal so the bump can never diverge."""
+    from ccs.coordinator.registry import RECLAIM_TRIGGERS as IN_MEMORY
+    from ccs.coordinator.sqlite_registry import RECLAIM_TRIGGERS as SQLITE
+
+    assert IN_MEMORY == SQLITE == frozenset({"reclaim_heartbeat", "reclaim_max_hold"})

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -879,3 +879,35 @@ def test_owner_generation_bumps_on_reclaim_only(db_path: Path) -> None:
         reg.set_agent_state(art.id, b, MESIState.EXCLUSIVE, trigger="write", tick=23)
         reg.set_agent_state(art.id, b, MESIState.SHARED, trigger="downgrade", tick=24)
         assert reg.get_owner_generation(art.id) == 2
+
+
+def test_read_generation_captured_at_claim(db_path: Path) -> None:
+    """read_generation is captured at the claim-establishing point: an E/M
+    acquire (incl. acquire-WITHOUT-a-prior-read -- the P0 fix) and a fetch read.
+    A never-claimed agent has None (absent operand). A reclaim does NOT refresh
+    the captured value; the next claim captures the new generation."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        art = Artifact(id=uuid4(), name="plan.md", version=1, content_hash="h")
+        reg.register_artifact(art, content="ignored")
+        a, b, c = uuid4(), uuid4(), uuid4()
+
+        # Never-claimed agent: absent operand.
+        assert reg.get_read_generation(art.id, c) is None
+
+        # Pessimistic acquire WITHOUT a prior fetch (the P0 fix) captures gen 0.
+        reg.set_agent_state(art.id, a, MESIState.EXCLUSIVE, trigger="write", tick=1)
+        assert reg.get_read_generation(art.id, a) == 0
+        # A fetch read captures too.
+        reg.set_agent_state(art.id, b, MESIState.SHARED, trigger="fetch", tick=2)
+        assert reg.get_read_generation(art.id, b) == 0
+
+        # Reclaim a -> owner_generation bumps to 1, but a's captured value is
+        # PRESERVED (the reclaim does not refresh it) -- this is what makes a's
+        # later commit fail the generation guard.
+        reg.set_agent_state(art.id, a, MESIState.INVALID, trigger="reclaim_heartbeat", tick=10)
+        assert reg.get_owner_generation(art.id) == 1
+        assert reg.get_read_generation(art.id, a) == 0
+
+        # A fresh re-acquire by a captures the NEW generation (1).
+        reg.set_agent_state(art.id, a, MESIState.EXCLUSIVE, trigger="write", tick=11)
+        assert reg.get_read_generation(art.id, a) == 1

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -739,3 +739,114 @@ def test_commit_cas_concurrent_writers_exactly_one_wins(db_path: Path) -> None:
         # the loser is elected by the version check, never other_holder).
         assert all(c.reason == "version_mismatch" for c in conflicts)
         assert all(c.current_version == 2 for c in conflicts)
+
+
+# ----------------------------------------------------------------------
+# Read-generation fence (Piece #2) — Unit 2: additive schema, no migration
+# ----------------------------------------------------------------------
+
+
+def _build_pre_fence_db(db_path: Path, art_id: str, ag_id: str) -> None:
+    """Create a v1 state.db with the schema as it existed BEFORE the
+    read-generation fence (no owner_generation / read_generation columns, no
+    coordinator_epoch), with one artifact + one M-grant, user_version = 1."""
+    import sqlite3
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            "CREATE TABLE artifacts (id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE, "
+            "version INTEGER NOT NULL, content_hash TEXT NOT NULL, size_tokens INTEGER, "
+            "last_writer_id TEXT, updated_at REAL NOT NULL)"
+        )
+        conn.execute("CREATE INDEX idx_artifacts_name ON artifacts(name)")
+        conn.execute(
+            "CREATE TABLE agent_states (artifact_id TEXT NOT NULL, agent_id TEXT NOT NULL, "
+            "state TEXT NOT NULL, transient_state TEXT, transient_tick INTEGER, "
+            "granted_at_tick INTEGER, last_reclaim_trigger TEXT, last_reclaim_tick INTEGER, "
+            "PRIMARY KEY (artifact_id, agent_id), "
+            "FOREIGN KEY (artifact_id) REFERENCES artifacts(id) ON DELETE CASCADE)"
+        )
+        conn.execute(
+            "CREATE TABLE heartbeats (agent_id TEXT PRIMARY KEY, last_tick INTEGER NOT NULL)"
+        )
+        conn.execute("CREATE TABLE registry_meta (key TEXT PRIMARY KEY, value TEXT)")
+        conn.execute(
+            "INSERT INTO registry_meta (key, value) VALUES (?, ?), (?, ?)",
+            ("instance_id", "fixed-instance", "sequence_number", "7"),
+        )
+        conn.execute(
+            "INSERT INTO artifacts (id, name, version, content_hash, updated_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (art_id, "plan.md", 3, "deadbeef", 1.0),
+        )
+        conn.execute(
+            "INSERT INTO agent_states (artifact_id, agent_id, state) VALUES (?, ?, ?)",
+            (art_id, ag_id, "M"),
+        )
+        conn.execute("PRAGMA user_version = 1")
+        conn.execute("COMMIT")
+    finally:
+        conn.close()
+
+
+def test_fresh_db_has_fence_schema(db_path: Path) -> None:
+    """A freshly initialized db carries the fence columns + coordinator_epoch,
+    and (option (a)) does NOT advance user_version beyond the existing v1."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        art_cols = {r[1] for r in reg._conn.execute("PRAGMA table_info(artifacts)").fetchall()}
+        state_cols = {
+            r[1] for r in reg._conn.execute("PRAGMA table_info(agent_states)").fetchall()
+        }
+        assert "owner_generation" in art_cols
+        assert "read_generation" in state_cols
+        assert reg._coordinator_epoch
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 1
+
+
+def test_pre_fence_db_upgrades_in_place_additively(db_path: Path) -> None:
+    """A v1 db created before the fence gains the columns + coordinator_epoch
+    additively on open, WITHOUT a user_version bump; existing rows backfill to
+    owner_generation = 0 / read_generation = NULL, and prior meta is preserved.
+    Re-open is idempotent and the epoch is stable."""
+    art_id, ag_id = str(uuid4()), str(uuid4())
+    _build_pre_fence_db(db_path, art_id, ag_id)
+
+    with SqliteArtifactRegistry(db_path) as reg:
+        art_cols = {r[1] for r in reg._conn.execute("PRAGMA table_info(artifacts)").fetchall()}
+        state_cols = {
+            r[1] for r in reg._conn.execute("PRAGMA table_info(agent_states)").fetchall()
+        }
+        assert "owner_generation" in art_cols
+        assert "read_generation" in state_cols
+        # Existing rows backfill: artifact -> 0, grant -> NULL (absent operand).
+        assert (
+            reg._conn.execute(
+                "SELECT owner_generation FROM artifacts WHERE id = ?", (art_id,)
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            reg._conn.execute(
+                "SELECT read_generation FROM agent_states "
+                "WHERE artifact_id = ? AND agent_id = ?",
+                (art_id, ag_id),
+            ).fetchone()[0]
+            is None
+        )
+        # Epoch seeded + loaded; user_version NOT bumped (option (a)).
+        assert reg._coordinator_epoch
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 1
+        # Prior meta preserved (no clobber of instance_id / sequence_number).
+        assert reg._instance_id == "fixed-instance"
+        assert reg._seq == 7
+        epoch1 = reg._coordinator_epoch
+
+    # Idempotent re-open: no error, columns intact, epoch stable.
+    with SqliteArtifactRegistry(db_path) as reg2:
+        assert reg2._coordinator_epoch == epoch1
+        art_cols2 = {
+            r[1] for r in reg2._conn.execute("PRAGMA table_info(artifacts)").fetchall()
+        }
+        assert "owner_generation" in art_cols2

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -950,3 +950,40 @@ def test_commit_cas_fence_rejects_superseded_reader(db_path: Path) -> None:
         res3 = reg.commit_cas(art.id, c, expected_version=2, content_hash="x")
         assert not isinstance(res3, ConflictDetail)
         assert reg.get_artifact(art.id).version == 3
+
+
+def test_set_artifact_and_content_fence_rejects_stale_committer(db_path: Path) -> None:
+    """The pessimistic guarded primitive (set_artifact_and_content with
+    fence_agent_id) rejects a committer whose captured read_generation was
+    superseded by a reclaim, atomically with the version persist -- closing the
+    commit() race. A fresh committer persists; committer=None is unguarded."""
+    from ccs.core.exceptions import StaleReadGeneration
+
+    with SqliteArtifactRegistry(db_path) as reg:
+        art = Artifact(id=uuid4(), name="plan.md", version=1, content_hash="h")
+        reg.register_artifact(art, content="ignored")
+        a, b = uuid4(), uuid4()
+
+        # a acquires E (read_generation=0), then is reclaimed (owner_generation
+        # -> 1; a's read_generation preserved at 0).
+        reg.set_agent_state(art.id, a, MESIState.EXCLUSIVE, trigger="write", tick=1)
+        reg.set_agent_state(art.id, a, MESIState.INVALID, trigger="reclaim_heartbeat", tick=10)
+
+        # a's guarded persist is rejected; the version does NOT advance.
+        stale = Artifact(id=art.id, name="plan.md", version=2, content_hash="stale")
+        with pytest.raises(StaleReadGeneration):
+            reg.set_artifact_and_content(art.id, stale, "x", last_writer=a, fence_agent_id=a)
+        assert reg.get_artifact(art.id).version == 1
+
+        # b acquires E AFTER the reclaim -> captures the current generation (1)
+        # -> its guarded persist succeeds.
+        reg.set_agent_state(art.id, b, MESIState.EXCLUSIVE, trigger="write", tick=11)
+        ok = Artifact(id=art.id, name="plan.md", version=2, content_hash="ok")
+        reg.set_artifact_and_content(art.id, ok, "x", last_writer=b, fence_agent_id=b)
+        assert reg.get_artifact(art.id).version == 2
+
+        # committer=None (external source churn) is unguarded -- persists even
+        # though no agent established a claim.
+        src = Artifact(id=art.id, name="plan.md", version=3, content_hash="src")
+        reg.set_artifact_and_content(art.id, src, "x")
+        assert reg.get_artifact(art.id).version == 3

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -850,3 +850,32 @@ def test_pre_fence_db_upgrades_in_place_additively(db_path: Path) -> None:
             r[1] for r in reg2._conn.execute("PRAGMA table_info(artifacts)").fetchall()
         }
         assert "owner_generation" in art_cols2
+
+
+def test_owner_generation_bumps_on_reclaim_only(db_path: Path) -> None:
+    """A sweep reclamation (M/E -> INVALID via a reclaim trigger) bumps the
+    artifact's owner_generation monotonically; a peer-invalidation or a clean
+    downgrade does NOT bump (version-CAS covers those)."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        art = Artifact(id=uuid4(), name="plan.md", version=1, content_hash="h")
+        reg.register_artifact(art, content="ignored")
+        a, b = uuid4(), uuid4()
+        assert reg.get_owner_generation(art.id) == 0
+
+        reg.set_agent_state(art.id, a, MESIState.EXCLUSIVE, trigger="write", tick=1)
+        reg.set_agent_state(art.id, a, MESIState.INVALID, trigger="reclaim_heartbeat", tick=10)
+        assert reg.get_owner_generation(art.id) == 1  # reclaim bumps
+
+        reg.set_agent_state(art.id, b, MESIState.EXCLUSIVE, trigger="write", tick=11)
+        reg.set_agent_state(art.id, b, MESIState.INVALID, trigger="reclaim_max_hold", tick=20)
+        assert reg.get_owner_generation(art.id) == 2  # monotonic across reclaims
+
+        # Peer-invalidation (non-reclaim trigger) does NOT bump.
+        reg.set_agent_state(art.id, a, MESIState.EXCLUSIVE, trigger="write", tick=21)
+        reg.set_agent_state(art.id, a, MESIState.INVALID, trigger="peer_invalidation", tick=22)
+        assert reg.get_owner_generation(art.id) == 2
+
+        # Clean downgrade E -> SHARED does NOT bump.
+        reg.set_agent_state(art.id, b, MESIState.EXCLUSIVE, trigger="write", tick=23)
+        reg.set_agent_state(art.id, b, MESIState.SHARED, trigger="downgrade", tick=24)
+        assert reg.get_owner_generation(art.id) == 2

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -987,3 +987,27 @@ def test_set_artifact_and_content_fence_rejects_stale_committer(db_path: Path) -
         src = Artifact(id=art.id, name="plan.md", version=3, content_hash="src")
         reg.set_artifact_and_content(art.id, src, "x")
         assert reg.get_artifact(art.id).version == 3
+
+
+def test_fence_columns_present_epoch_absent_recovers(db_path: Path) -> None:
+    """A db whose fence COLUMNS exist but whose coordinator_epoch was never
+    seeded (partial prior upgrade) opens cleanly: _ensure_fence_columns skips
+    the duplicate ALTERs and the INSERT OR IGNORE seeds the missing epoch."""
+    import sqlite3
+
+    # hex ids: the registry's lookups key on UUID.hex (the pre-fence builder
+    # stores ids verbatim, so dashed ids would miss the hex-keyed lookup).
+    art_id, ag_id = uuid4().hex, uuid4().hex
+    _build_pre_fence_db(db_path, art_id, ag_id)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "ALTER TABLE artifacts ADD COLUMN owner_generation INTEGER NOT NULL DEFAULT 0"
+    )
+    conn.execute("ALTER TABLE agent_states ADD COLUMN read_generation INTEGER")
+    conn.commit()
+    conn.close()
+
+    with SqliteArtifactRegistry(db_path) as reg:
+        assert reg._coordinator_epoch  # seeded on this open
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 1
+        assert reg.get_owner_generation(UUID(art_id)) == 0

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -911,3 +911,42 @@ def test_read_generation_captured_at_claim(db_path: Path) -> None:
         # A fresh re-acquire by a captures the NEW generation (1).
         reg.set_agent_state(art.id, a, MESIState.EXCLUSIVE, trigger="write", tick=11)
         assert reg.get_read_generation(art.id, a) == 1
+
+
+def test_commit_cas_fence_rejects_superseded_reader(db_path: Path) -> None:
+    """OCC commit_cas returns ConflictDetail('stale_read_generation') when the
+    committer's read_generation was superseded by a reclaim -- version
+    unchanged, no other holder, so version-CAS cannot catch it (the headline
+    reclaim-zombie case). A re-fetch (fresh read_generation) then wins; a
+    never-fetched committer is rejected as an absent operand."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        art = Artifact(id=uuid4(), name="plan.md", version=1, content_hash="h")
+        reg.register_artifact(art, content="ignored")
+        a, c = uuid4(), uuid4()
+
+        # A acquires E (captures read_generation=0), then is reclaimed
+        # (owner_generation -> 1; A's read_generation preserved at 0).
+        reg.set_agent_state(art.id, a, MESIState.EXCLUSIVE, trigger="write", tick=1)
+        reg.set_agent_state(art.id, a, MESIState.INVALID, trigger="reclaim_heartbeat", tick=10)
+        assert reg.get_owner_generation(art.id) == 1
+
+        # A commits via OCC: version still matches (1), no other holder, but the
+        # generation fence rejects the superseded read -- no phantom bump.
+        res = reg.commit_cas(art.id, a, expected_version=1, content_hash="new")
+        assert isinstance(res, ConflictDetail)
+        assert res.reason == "stale_read_generation"
+        assert reg.get_artifact(art.id).version == 1
+
+        # A re-fetches -> fresh read_generation=1 -> the commit now wins.
+        reg.set_agent_state(art.id, a, MESIState.SHARED, trigger="fetch", tick=11)
+        res2 = reg.commit_cas(art.id, a, expected_version=1, content_hash="new2")
+        assert not isinstance(res2, ConflictDetail)
+        assert reg.get_artifact(art.id).version == 2
+
+        # A never-claimed committer has no captured claim to supersede, so the
+        # fence does NOT reject it -- version-CAS alone arbitrates (here the
+        # version matches, so it wins). The fence only rejects a captured-then-
+        # superseded read.
+        res3 = reg.commit_cas(art.id, c, expected_version=2, content_hash="x")
+        assert not isinstance(res3, ConflictDetail)
+        assert reg.get_artifact(art.id).version == 3


### PR DESCRIPTION
## Summary

Closes the watchdog reclaim-zombie hole that OCC commit-CAS cannot: when the crash-recovery sweep reclaims a stalled owner but the artifact version has not moved, a reclaimed writer could still apply a stale write (a "phantom version-bump") — version-CAS can't see it (version unchanged, no successor holder).

**Mechanism — a read-generation fence:**
- A per-artifact monotonic `owner_generation`, bumped atomically on every sweep reclamation (reclaim triggers only; a peer-invalidation does not bump — that path moves the version, so version-CAS already catches it).
- A server-side `read_generation` captured at the claim-establishing point (an E/M acquire **or** a fetch), preserved through a reclaim.
- An atomic commit-time guard on **both** write paths: reject when a committer's captured read_generation was superseded by a reclaim. OCC returns a typed, retry-eligible `ConflictDetail("stale_read_generation")`; the pessimistic path raises `StaleReadGeneration`. **No public `commit_cas` / `write_cas` signature change** — the fence stays server-side, enforced by a CI signature-guard test.

An absent `read_generation` admits (a plain OCC writer that never established a fence claim is arbitrated by version-CAS); only a *captured-then-superseded* read is rejected.

**Schema** is additive (no `user_version` bump): a pre-fence DB gains the columns on open, so an older binary can still open a fence-equipped DB — non-destructive revert.

**Formal verification:** `formal/tla/Fencing.tla` proves `NoStaleApply` across 2.8M states; the documented mutant (remove the read=owner guard) trips it. Wired into `make tla-check` as the fourth spec.

## Test Plan
- [x] `make tla-check` green (MESI → CrashRecovery → OCC → Fencing) + mutant verified
- [x] New: schema migration, reclaim bump, read capture, OCC + pessimistic guards, the cross-process classifier, the R7 signature-guard, and a net-new dual-registry parity harness (both registries pinned equal)
- [x] Existing suites green — registry / sqlite / coordinator / OCC / coherent_volume / coordinator_server — no regression

8 commits, one per implementation unit: TLA spec → schema → reclaim bump → read capture → OCC guard → pessimistic guard → cross-process wiring → verification.


## Docs

- **README repositioned** around the now-landed guarantee set: tagline leads with the silent-clobber failure + the MESI/OCC/fence mechanism + the TLA+-checked invariants; new "What it guarantees" table (failure → behavior → mechanism → invariant) with an explicit single-host scope statement; `CoherentVolume` quickstart added beside the `CCSStore` one; Status carries the v0.9.0 release note forward plus the unreleased dev work. Savings table/figures byte-identical (cost framed as the secondary benefit).
- **`formal/tla/README.md`** gains the Fencing rows the spec work owed it: modeled-behavior bullet, file layout, run command, `ReadGenBounded`/`NoStaleApply` invariant rows, spec→implementation mapping, the CI-budget row, and mutant recipe #4 (verified).
