### PR TITLE
feat(examples): add concurrent lost-update demo for commit-CAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,19 @@ Alpha — APIs may change before `v1.0`.
 
 ## [Unreleased]
 
-(Nothing yet.)
+### Added
+
+- **Concurrent lost-update demo** (`examples/concurrent_writers/`): a true-race
+  reproduction of the v0.9.1 commit-CAS write path. Two threads update a shared
+  total concurrently; `broken.py` loses an update (last writer wins over a plain
+  file), `fixed.py` runs the identical race through `CoherentVolume.write_cas` and
+  preserves both (the loser is told `version_mismatch`, reacquires, and re-applies
+  on the winner's value via its `make_content` closure). The rung-2 (concurrent,
+  single-host) analog of the rung-1 sequential `examples/coherent_volume` demo —
+  it surfaces the race the invalidation-deny model cannot catch. Offline; the
+  fixed case spawns a local coordinator subprocess. Run:
+  `python -m examples.concurrent_writers.main`. Tests:
+  `tests/test_concurrent_writers_demo.py`.
 
 ## [0.9.1] — 2026-06-10
 

--- a/examples/concurrent_writers/README.md
+++ b/examples/concurrent_writers/README.md
@@ -1,0 +1,69 @@
+# Concurrent lost-update demo (commit-CAS)
+
+Two agents update the same shared value **at the same time**. Without
+coordination, one update is silently lost (last writer wins). With
+`CoherentVolume.write_cas` — the optimistic commit-CAS write path shipped in
+**v0.9.1** — the coordinator elects one winner, the loser is *told* it lost
+(a typed, retryable conflict, never a silent drop), and it re-applies its update
+on the winner's value. Both updates survive.
+
+```bash
+python -m examples.concurrent_writers.main
+```
+
+No API keys, no network. The broken case is pure offline file I/O; the fixed
+case spawns a local coordinator subprocess and tears it down afterward.
+
+## What it shows
+
+| | Mechanism | Result |
+|---|---|---|
+| `broken.py` | two threads read the same value, then both write blindly over a plain file | **one update lost** — `final ∈ {105, 110}`, not `115` |
+| `fixed.py` | the same race through `CoherentVolume.write_cas` | **both updates survive** — `final == 115` |
+
+A read-barrier forces both writers to read the start value before either writes,
+so the broken case loses an update *every* run (which writer wins is timing; that
+an update is lost is not). The fixed case's winner is likewise non-deterministic,
+but its invariant — `final == start + every delta` — is not.
+
+## How `write_cas` prevents the loss
+
+```python
+vol.write_cas("data/tally.txt", lambda current: str(int(current) + delta).encode())
+```
+
+`write_cas` reads the current value (→ SHARED), derives the new bytes from it via
+your `make_content` closure, and commits through the coordinator's
+version-checked CAS. Two concurrent writers cannot both land the same version:
+the serialized commit picks a winner, and the loser receives `version_mismatch`,
+[`reacquire()`](../coherent_volume/README.md)s a fresh identity + a **mandatory**
+fresh read, and **re-invokes `make_content` on the new value** before retrying
+(bounded by `MAX_CAS_REACQUIRES`; on exhaustion it raises `CasRetriesExhausted`,
+never a silent drop). Re-deriving intent against the latest state is what turns
+the retry into an *update* rather than a stale overwrite — so a closure that
+ignores its `current` argument defeats the guard (the one fundamental OCC-proof
+boundary).
+
+## How this differs from `examples/coherent_volume`
+
+| | `examples/coherent_volume` | `examples/concurrent_writers` (here) |
+|---|---|---|
+| Failure | **sequential** stale-overwrite | **concurrent** lost update |
+| Capability rung | 1 (sequential, single-host) | 2 (concurrent, single-host) |
+| Mechanism | MESI invalidation → sticky `INVALID` deny + `reacquire()` | optimistic commit-CAS (`write_cas`) |
+| Why CAS is needed | a peer commit invalidates the stale reader before it writes | the racy acquire can grant *both* writers — only a version-checked commit elects the winner |
+
+The invalidation-deny model catches a writer whose read was *superseded before it
+wrote*. It cannot catch two writers that read the same version and race to commit
+— the acquire is non-atomic, so both can be granted. Commit-CAS closes exactly
+that gap.
+
+## Scope (honest)
+
+Single-host: a loopback coordinator over SQLite-WAL. **Cross-host** concurrent
+writers (a network coordinator + a durable cross-host registry) are the
+demand-gated follow-on — see the roadmap's *Epic — Cross-Host Concurrency*
+(Pieces #3–#5). Until that ships, multi-host prospects are pattern-only.
+
+Verified by `formal/tla/OCC.tla` (`NoLostUpdate`) and `formal/tla/Fencing.tla`
+(`NoStaleApply`), both model-checked. Tests: `tests/test_concurrent_writers_demo.py`.

--- a/examples/concurrent_writers/__init__.py
+++ b/examples/concurrent_writers/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Concurrent lost-update demo for the v0.9.1 commit-CAS write path (Epic Piece #6).
+
+Where ``examples/coherent_volume`` shows a *sequential* stale-overwrite (rung 1 —
+invalidation-deny + reacquire), this shows the *concurrent* case (rung 2): two
+threads race the same shared total, and ``CoherentVolume.write_cas`` (the
+optimistic commit-CAS path) elects one winner while the loser is told it lost
+(typed conflict) and re-applies on the fresh value — so both updates survive.
+
+``broken.py`` reproduces the lost update under a true race over plain files;
+``fixed.py`` runs the identical race through ``write_cas``. Run both side by side
+with ``python -m examples.concurrent_writers.main``.
+
+Scope: single-host (loopback coordinator + SQLite-WAL). Cross-host concurrency is
+the demand-gated follow-on (roadmap § Epic — Cross-Host Concurrency, Pieces #3–#5).
+"""

--- a/examples/concurrent_writers/broken.py
+++ b/examples/concurrent_writers/broken.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Broken case: two CONCURRENT writers, one update silently lost.
+
+Unlike ``examples/coherent_volume`` (a *sequential* stale-overwrite), this is a
+true race: two threads read the same shared total at the same value, then both
+write back a value computed from that read. With no coordination, the second
+write to land silently overwrites the first — the classic concurrent lost
+update. ``fixed.py`` runs the identical race through ``CoherentVolume.write_cas``,
+where the loser is told it lost and re-applies, so both updates survive.
+
+A read-barrier makes the *outcome class* deterministic — both threads read the
+start value before either writes, so exactly one delta survives — while a
+write-lock keeps the file from tearing. The lost update is therefore a logical
+consequence of the shared stale read, not a corrupted file. Offline; no
+coordinator (that is the point).
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+_START = 100
+_A_ADDS = 10
+_B_ADDS = 5
+_SCENARIO = (
+    f"two agents CONCURRENTLY update a shared total "
+    f"(start={_START}; A adds {_A_ADDS}, B adds {_B_ADDS})"
+)
+
+
+def run_broken() -> dict[str, object]:
+    """Two threads race a read→write with no coherence; one update is lost.
+
+    Returns a structured trace so the runner and tests assert the lost update
+    without parsing prose.
+    """
+    workspace = Path(tempfile.mkdtemp(prefix="concurrent_writers_broken_"))
+    target = workspace / "tally.txt"
+    try:
+        target.write_text(str(_START))
+
+        both_have_read = threading.Barrier(2)  # force both reads before either write
+        write_lock = threading.Lock()  # keep the physical write from tearing
+
+        def writer(delta: int) -> None:
+            view = int(target.read_text().strip())  # both read the same start value...
+            both_have_read.wait()  # ...before either writes
+            with write_lock:
+                # Blind write from the stale read — no check that the value moved.
+                target.write_text(str(view + delta))
+
+        threads = [
+            threading.Thread(target=writer, args=(_A_ADDS,)),
+            threading.Thread(target=writer, args=(_B_ADDS,)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        final = int(target.read_text().strip())
+        expected = _START + _A_ADDS + _B_ADDS
+        return {
+            "scenario": _SCENARIO,
+            "expected_total": expected,  # 115 if both updates survived
+            "final_total": final,  # 110 or 105 — exactly one delta lost
+            "lost_update": final != expected,
+        }
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def main() -> int:
+    trace = run_broken()
+    print("BROKEN (no coherence) — two concurrent writers over a plain file")
+    print(f"  scenario: {trace['scenario']}")
+    print(
+        f"  LOST UPDATE: {trace['lost_update']}  "
+        f"(final={trace['final_total']}, expected={trace['expected_total']})"
+    )
+    # Exit code reflects the invariant so an agent can use this as a gate.
+    return 0 if trace["lost_update"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/concurrent_writers/fixed.py
+++ b/examples/concurrent_writers/fixed.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Fixed case: the same concurrent race, made safe by CoherentVolume.write_cas.
+
+N threads, each with its own CoherentVolume attached to one local coordinator,
+run the identical read→write race as ``broken.py`` — but through ``write_cas``,
+the optimistic (commit-CAS) write path shipped in v0.9.1. Each writer reads the
+shared total and attempts to commit; the coordinator's serialized commit elects
+one winner, and the loser is told ``version_mismatch`` (a typed, retryable
+conflict — never a silent drop), reacquires (re-mint identity + mandatory fresh
+read), re-derives its update from the winner's value via ``make_content``, and
+retries. Every update survives.
+
+This is the rung-2 guarantee the *sequential* demo (``examples/coherent_volume``)
+cannot make: surviving a TRUE concurrent same-key race, not just a sequenced
+stale-overwrite. The winner is non-deterministic; the invariant — final total =
+start + the sum of every delta, no silent loss — is not. ``make_content`` is
+re-invoked per attempt, so re-deriving intent against the latest state is what
+turns the retry into an *update* rather than a stale overwrite.
+
+Single-host scope (loopback coordinator + SQLite-WAL); spawns a local
+coordinator subprocess (no network, no API keys) and tears it down in finally.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+# A spawned coordinator subprocess must import ``ccs`` too; propagate the src
+# path so the demo also runs from a bare checkout (harmless when installed).
+_pp = os.environ.get("PYTHONPATH", "")
+if str(SRC_ROOT) not in _pp.split(os.pathsep):
+    os.environ["PYTHONPATH"] = f"{SRC_ROOT}{os.pathsep}{_pp}" if _pp else str(SRC_ROOT)
+
+from ccs.adapters.claude_code.lifecycle import LifecycleConfig, stop_coordinator
+from ccs.adapters.coherent_volume import CoherentVolume
+
+_START = 100
+_A_ADDS = 10
+_B_ADDS = 5
+_REL = "data/tally.txt"
+_MANAGED = ("data/**",)
+_SCENARIO = (
+    f"two agents CONCURRENTLY update a shared total "
+    f"(start={_START}; A adds {_A_ADDS}, B adds {_B_ADDS})"
+)
+
+# Snappy local spawn for a one-command demo; no idle shutdown mid-run.
+_DEMO_CFG = LifecycleConfig(
+    idle_shutdown_sec=0,
+    sweep_interval_sec=0.1,
+    port_file_retry_attempts=40,
+    port_file_retry_interval_sec=0.05,
+    connect_retry_attempts=20,
+    connect_retry_interval_sec=0.05,
+)
+
+
+def _race_write_cas(deltas: list[int], start: int) -> tuple[int, list[int]]:
+    """Run ``len(deltas)`` threads that each add their delta to a shared tally
+    via ``write_cas``, concurrently, against one coordinator.
+
+    Returns ``(final_total, attempts_per_writer)``. ``attempts_per_writer[i] > 1``
+    means writer ``i`` lost a race and re-applied on the fresh value (the typed
+    conflict + retry), surfaced observably without reaching into the protocol.
+    Raises if any writer fails (e.g. ``CasRetriesExhausted``) — a failed guarantee
+    must never be swallowed.
+    """
+    n = len(deltas)
+    workspace = Path(tempfile.mkdtemp(prefix="concurrent_writers_fixed_"))
+    target = workspace / _REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(str(start))
+
+    # The first instance spawns the coordinator; the rest are siblings that
+    # attach to it. One instance per thread — write_cas is not thread-safe
+    # within a single instance, so each writer owns its own volume.
+    volumes = [CoherentVolume(workspace, managed=_MANAGED, config=_DEMO_CFG)]
+    try:
+        volumes += [
+            CoherentVolume(workspace, managed=_MANAGED, config=_DEMO_CFG)
+            for _ in range(n - 1)
+        ]
+
+        at_the_line = threading.Barrier(n)  # maximize commit overlap → exercise the race
+        attempts = [0] * n
+        errors: dict[int, BaseException] = {}
+
+        def writer(i: int) -> None:
+            def make_content(current: bytes) -> bytes:
+                attempts[i] += 1  # one per attempt; > 1 ⇒ this writer retried
+                return str(int(current.decode().strip() or "0") + deltas[i]).encode()
+
+            try:
+                at_the_line.wait()
+                volumes[i].write_cas(_REL, make_content)
+            except BaseException as exc:  # noqa: BLE001 — capture; re-raise in main thread
+                errors[i] = exc
+
+        threads = [threading.Thread(target=writer, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        if errors:
+            i, exc = next(iter(errors.items()))
+            raise RuntimeError(f"writer {i} failed: {exc!r}") from exc
+
+        return int(target.read_text().strip()), attempts
+    finally:
+        stop_coordinator(workspace)
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def run_fixed() -> dict[str, object]:
+    """Two threads race ``write_cas``; both updates survive (the rung-2 analog of
+    ``run_broken``). Returns a structured trace for side-by-side asserts."""
+    final, attempts = _race_write_cas([_A_ADDS, _B_ADDS], _START)
+    expected = _START + _A_ADDS + _B_ADDS
+    return {
+        "scenario": _SCENARIO,
+        "expected_total": expected,  # 115
+        "final_total": final,  # 115 — both updates survived
+        "lost_update": final != expected,
+        "attempts_a": attempts[0],
+        "attempts_b": attempts[1],
+        "total_attempts": sum(attempts),
+        "race_observed": sum(attempts) > len(attempts),  # ≥1 writer retried
+    }
+
+
+def main() -> int:
+    trace = run_fixed()
+    print("FIXED (CoherentVolume.write_cas) — two concurrent writers, both updates survive")
+    print(f"  scenario: {trace['scenario']}")
+    print(
+        f"  attempts: A={trace['attempts_a']}, B={trace['attempts_b']}  "
+        f"(race observed: {trace['race_observed']})"
+    )
+    print(
+        f"  LOST UPDATE: {trace['lost_update']}  "
+        f"(final={trace['final_total']}, expected={trace['expected_total']})"
+    )
+    # Exit code reflects the invariant so an agent can use this as a gate.
+    return 0 if not trace["lost_update"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/concurrent_writers/main.py
+++ b/examples/concurrent_writers/main.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Side-by-side runner for the concurrent lost-update demo (Epic Piece #6).
+
+Runs the broken case (two racing writers, no coherence → one update silently
+lost) and the fixed case (the same race through CoherentVolume.write_cas → the
+loser is told it lost and re-applies → both updates survive), and prints the
+divergence. The broken case is offline; the fixed case spawns a local
+coordinator subprocess (no API keys, no network).
+
+    python -m examples.concurrent_writers.main
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from examples.concurrent_writers import broken, fixed
+
+
+def main() -> int:
+    print("Concurrent lost-update demo (commit-CAS, v0.9.1).")
+    print("Same concurrent read→write race both times; only the coordination differs.\n")
+    broken_trace = broken.run_broken()
+    broken.main()
+    print("")
+    fixed_trace = fixed.run_fixed()
+    fixed.main()
+
+    print("\nTakeaway: under a true race, blind writes silently drop an update")
+    print("(last writer wins). write_cas elects one winner and tells the loser it")
+    print("lost — it reacquires the current value and re-applies, so both survive.")
+    print("Sequential coherence (examples/coherent_volume) can't catch this race;")
+    print("commit-CAS can. Single-host scope — cross-host is the demand-gated next rung.")
+
+    # Exit non-zero if the demo's invariant did not hold (broken must lose, fixed
+    # must preserve) so CI / a reader can trust the run rather than eyeball it.
+    ok = bool(broken_trace["lost_update"]) and not bool(fixed_trace["lost_update"])
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+# Comparing notes on multi-agent coherence?
+# https://github.com/hipvlady/agent-coherence/discussions

--- a/tests/test_concurrent_writers_demo.py
+++ b/tests/test_concurrent_writers_demo.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Offline tests for the concurrent lost-update demo (Epic Piece #6).
+
+True-concurrency, not sequenced: the broken case proves two racing writers lose
+an update with no coordination; the fixed case proves CoherentVolume.write_cas
+(commit-CAS, v0.9.1) preserves every update under the same race — the loser is
+told it lost and re-applies. The winner is non-deterministic; the asserted
+property is the invariant (final total = start + the sum of deltas, no silent
+loss), never timing or which writer won. The fixed case spawns a local
+coordinator subprocess (no network).
+"""
+
+from __future__ import annotations
+
+from examples.concurrent_writers.broken import run_broken
+from examples.concurrent_writers.fixed import run_fixed
+
+# --- broken case (no coherence) --------------------------------------------
+
+
+def test_broken_loses_an_update_under_concurrency() -> None:
+    trace = run_broken()
+    assert trace["lost_update"] is True
+    assert trace["expected_total"] == 115  # both updates should have survived
+    assert trace["final_total"] in (105, 110)  # exactly one delta survived
+
+
+def test_broken_always_loses_across_runs() -> None:
+    # The read-barrier makes the outcome class deterministic: an update is lost
+    # every run (which writer wins is timing; that one is lost is not).
+    assert all(run_broken()["lost_update"] is True for _ in range(10))
+
+
+# --- fixed case (CoherentVolume.write_cas / commit-CAS) --------------------
+
+
+def test_fixed_preserves_both_updates_under_concurrency() -> None:
+    trace = run_fixed()
+    assert trace["lost_update"] is False
+    assert trace["final_total"] == 115  # both updates survived the race
+    assert trace["expected_total"] == 115
+    # make_content runs at least once per writer; a winner-take-all run needs no
+    # retry, so we assert the floor, not the conflict (timing-dependent).
+    assert trace["attempts_a"] >= 1
+    assert trace["attempts_b"] >= 1
+
+
+def test_fixed_invariant_holds_across_runs() -> None:
+    # The winner varies run to run; the invariant must not.
+    assert all(run_fixed()["final_total"] == 115 for _ in range(3))
+
+
+# --- the divergence the demo exists to show --------------------------------
+
+
+def test_broken_and_fixed_diverge_on_the_same_race() -> None:
+    # Same concurrent read→write race and starting value; only coherence differs.
+    broken_trace = run_broken()
+    fixed_trace = run_fixed()
+    assert broken_trace["lost_update"] is True  # update lost
+    assert fixed_trace["lost_update"] is False  # both survived
+    assert broken_trace["scenario"] == fixed_trace["scenario"]


### PR DESCRIPTION
## Summary
- Adds `examples/concurrent_writers/` — a true-race reproduction of the v0.9.1 commit-CAS write path, the concurrent analog of the existing sequential `examples/coherent_volume` demo.
- `broken.py`: two threads read the same shared total, then write blindly over a plain file → one update is silently lost (last writer wins).
- `fixed.py`: the same race through `CoherentVolume.write_cas` → the loser is told `version_mismatch`, reacquires (re-mint identity + mandatory fresh read), and re-applies its update on the winner's value via its `make_content` closure → both updates survive.

## Why
The existing `examples/coherent_volume` demo shows a *sequential* stale-overwrite (invalidation-deny + reacquire). It cannot show a *concurrent* race: two writers reading the same version can both be granted, and only a version-checked commit elects the winner. This demo exercises exactly that — the commit-CAS path shipped in v0.9.1.

## Test Plan
- [x] `tests/test_concurrent_writers_demo.py` — 5 tests: broken loses every run; fixed preserves both; the invariant holds across runs; broken vs fixed diverge on the same race.
- [x] `python -m examples.concurrent_writers.main` end-to-end: broken → one update lost; fixed → both survive (115).
- [x] `tools/check_architecture.py` clean; `ruff check tests/` clean.

## Scope
- Offline; the fixed case spawns a local coordinator subprocess (no network, no API keys).
- Single-host scope (loopback coordinator + SQLite-WAL); cross-host is out of scope. The demo asserts the two-writer guarantee; heavier single-host contention is bounded by the client retry budget and not claimed here.
- CHANGELOG `[Unreleased]` updated.