### PR TITLE
fix(coherent-volume): close write_cas on-disk lost update under concurrent contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,45 @@ Alpha — APIs may change before `v1.0`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`CoherentVolume.write_cas` on-disk lost update under high same-key
+  contention.** Surfaced by the concurrent-writers demo in CI (≥5 concurrent
+  `write_cas` writers): the stale-deny recovery inside `write_cas` paired the
+  bytes from `reacquire()` with a version comparand resolved by a *separate,
+  later* read — and `reacquire()`'s read left the re-minted identity SHARED, so
+  that follow-up read hit the coordinator's fresh-SHARED pre-read branch, which
+  returns the version **without** re-checking the disk bytes' hash. A peer
+  commit landing between the two reads paired STALE bytes with a FRESH version;
+  the commit-CAS checks only the version, so `make_content` derived from the
+  stale bytes and *won* — silently dropping the peer's update on disk (the
+  protocol-level `NoLostUpdate` invariant held: the version-bump count was
+  right, but the persisted value was wrong). Fixed by re-minting identity
+  WITHOUT a read on every retry (`_remint()`), so each attempt's comparand
+  `(bytes, version)` pair comes from ONE hash-checked None-state read; a
+  stale-bytes/fresh-version split is now structurally unrepresentable, and a
+  lagging-disk read is denied and retried rather than committed. The denied
+  read no longer counts against the commit budget (`MAX_CAS_REACQUIRES` keeps
+  its documented "total commit attempts" meaning); a never-clearing view is
+  separately bounded by a consecutive-denied-streak limit, which also replaces
+  the previous (misdiagnosed) "coordinator may be wedged" raise — that state is
+  the transient disk-write-after-commit window, and now retries. Both
+  terminals are typed (`CasRetriesExhausted` / `CoherenceError`); `write_cas`
+  never returns success without its update landing. Regression:
+  `tests/test_concurrent_writers_demo.py::test_fixed_under_higher_contention_holds_the_honest_invariant`.
+
 ### Added
 
 - **Concurrent lost-update demo** (`examples/concurrent_writers/`): a true-race
   reproduction of the v0.9.1 commit-CAS write path. Two threads update a shared
   total concurrently; `broken.py` loses an update (last writer wins over a plain
   file), `fixed.py` runs the identical race through `CoherentVolume.write_cas` and
-  preserves both (the loser is told `version_mismatch`, reacquires, and re-applies
-  on the winner's value via its `make_content` closure). The rung-2 (concurrent,
-  single-host) analog of the rung-1 sequential `examples/coherent_volume` demo —
-  it surfaces the race the invalidation-deny model cannot catch. Offline; the
-  fixed case spawns a local coordinator subprocess. Run:
-  `python -m examples.concurrent_writers.main`. Tests:
+  preserves both (the loser is told `version_mismatch`, re-mints identity +
+  re-reads, and re-applies on the winner's value via its `make_content` closure).
+  The rung-2 (concurrent, single-host) analog of the rung-1 sequential
+  `examples/coherent_volume` demo — it surfaces the race the invalidation-deny
+  model cannot catch. Offline; the fixed case spawns a local coordinator
+  subprocess. Run: `python -m examples.concurrent_writers.main`. Tests:
   `tests/test_concurrent_writers_demo.py`.
 
 ## [0.9.1] — 2026-06-10

--- a/examples/concurrent_writers/README.md
+++ b/examples/concurrent_writers/README.md
@@ -36,13 +36,14 @@ vol.write_cas("data/tally.txt", lambda current: str(int(current) + delta).encode
 your `make_content` closure, and commits through the coordinator's
 version-checked CAS. Two concurrent writers cannot both land the same version:
 the serialized commit picks a winner, and the loser receives `version_mismatch`,
-[`reacquire()`](../coherent_volume/README.md)s a fresh identity + a **mandatory**
-fresh read, and **re-invokes `make_content` on the new value** before retrying
-(bounded by `MAX_CAS_REACQUIRES`; on exhaustion it raises `CasRetriesExhausted`,
-never a silent drop). Re-deriving intent against the latest state is what turns
-the retry into an *update* rather than a stale overwrite — so a closure that
-ignores its `current` argument defeats the guard (the one fundamental OCC-proof
-boundary).
+re-mints a fresh identity, takes ONE fresh **hash-checked** read (the bytes and
+the version comparand always come from the same validated read — never from two
+reads a peer could commit between), and **re-invokes `make_content` on the new
+value** before retrying (the commit budget is `MAX_CAS_REACQUIRES`; on
+exhaustion it raises `CasRetriesExhausted`, never a silent drop). Re-deriving
+intent against the latest state is what turns the retry into an *update* rather
+than a stale overwrite — so a closure that ignores its `current` argument
+defeats the guard (the one fundamental OCC-proof boundary).
 
 ## How this differs from `examples/coherent_volume`
 
@@ -65,5 +66,18 @@ writers (a network coordinator + a durable cross-host registry) are the
 demand-gated follow-on — see the roadmap's *Epic — Cross-Host Concurrency*
 (Pieces #3–#5). Until that ships, multi-host prospects are pattern-only.
 
+**Contention bound.** The guarantee `write_cas` makes is *every update lands,
+or a typed error is raised* — never a silent loss. Under sustained same-key
+contention approaching the commit budget (`MAX_CAS_REACQUIRES` = 8 → 9 CAS
+attempts; ~8+ writers racing the SAME key at once), a writer can exhaust the
+budget and raise `CasRetriesExhausted` — the honest fail-closed terminal, not a
+dropped update. The 2-writer demo (and fleets up to roughly the budget) converge
+cleanly.
+
 Verified by `formal/tla/OCC.tla` (`NoLostUpdate`) and `formal/tla/Fencing.tla`
-(`NoStaleApply`), both model-checked. Tests: `tests/test_concurrent_writers_demo.py`.
+(`NoStaleApply`), both model-checked — these cover the *protocol*. The
+client-integration path (`CoherentVolume.write_cas` over HTTP + the real
+filesystem) is covered by the regression tests here: the comparand bytes and
+version are always taken from one hash-checked read, so a stale read can never
+win the version CAS (see `test_fixed_under_higher_contention_holds_the_honest_invariant`).
+Tests: `tests/test_concurrent_writers_demo.py`.

--- a/examples/concurrent_writers/fixed.py
+++ b/examples/concurrent_writers/fixed.py
@@ -8,9 +8,10 @@ run the identical read→write race as ``broken.py`` — but through ``write_cas
 the optimistic (commit-CAS) write path shipped in v0.9.1. Each writer reads the
 shared total and attempts to commit; the coordinator's serialized commit elects
 one winner, and the loser is told ``version_mismatch`` (a typed, retryable
-conflict — never a silent drop), reacquires (re-mint identity + mandatory fresh
-read), re-derives its update from the winner's value via ``make_content``, and
-retries. Every update survives.
+conflict — never a silent drop), re-mints its identity, takes one fresh
+hash-checked read (bytes + version comparand from the SAME read), re-derives its
+update from the winner's value via ``make_content``, and retries. Every update
+survives.
 
 This is the rung-2 guarantee the *sequential* demo (``examples/coherent_volume``)
 cannot make: surviving a TRUE concurrent same-key race, not just a sequenced

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -77,14 +77,23 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["CoherentVolume", "coherent_workspace", "install", "uninstall"]
 
-# Plan Unit 6 (R6): client-side bound on the OCC reacquire→re-commit loop in
+# Plan Unit 6 (R6): client-side bound on the OCC re-mint→re-commit loop in
 # :meth:`CoherentVolume.write_cas`. Mirrors ``SyncStrategy.max_cas_retries``
 # (the in-process library knob) — the HTTP path runs its own bounded loop via
-# ``reacquire()`` rather than the ``AgentRuntime``/``SyncStrategy`` loop (which
-# governs only the in-process library path). Total commit attempts is
-# ``MAX_CAS_REACQUIRES + 1`` (initial + retries); on exhaustion ``write_cas``
-# raises :class:`~ccs.core.exceptions.CasRetriesExhausted` (a typed terminal,
-# never a silent drop).
+# ``_remint()`` + a fresh hash-checked read rather than the
+# ``AgentRuntime``/``SyncStrategy`` loop (which governs only the in-process
+# library path). Bounds TWO independent failure modes, both fail-closed:
+#
+# - Total commit (CAS POST) attempts is ``MAX_CAS_REACQUIRES + 1`` (initial +
+#   retries); on exhaustion ``write_cas`` raises
+#   :class:`~ccs.core.exceptions.CasRetriesExhausted` (a typed terminal, never
+#   a silent drop). A stale-denied comparand read never POSTs, so it does NOT
+#   consume this budget.
+# - CONSECUTIVE stale-denied comparand reads are bounded at
+#   ``MAX_CAS_REACQUIRES + 1``; on exhaustion ``write_cas`` raises
+#   :class:`~ccs.core.exceptions.CoherenceError` (a view that never clears —
+#   wedged coordinator / perpetually lagging disk — must not spin). A clean
+#   read resets the streak.
 MAX_CAS_REACQUIRES = 8
 
 
@@ -559,11 +568,31 @@ class CoherentVolume:
         Re-minting the identity resets this instance's view of *every* path, not
         just ``path`` — other tracked paths should be re-read before writing.
         """
+        self._remint()  # fresh identity -> no INVALID; has committed nothing
+        # MANDATORY fresh read under the new identity -> SHARED@current.
+        return self.read(path)
+
+    def _remint(self) -> None:
+        """Re-mint coordinator identity (shed ``INVALID`` + any invalidation
+        transient) WITHOUT a read — the OCC :meth:`write_cas` retry primitive.
+
+        Distinct from :meth:`reacquire` (re-mint **and** a read): reacquire's
+        read registers the fresh identity as ``SHARED``, after which the
+        ``write_cas`` loop's next :meth:`_read_with_version` hits the
+        coordinator's *fresh-SHARED* pre-read branch, which returns the version
+        WITHOUT re-checking the disk bytes' hash. That pairs a possibly-stale
+        on-disk read with a fresh version — and because the commit-CAS checks
+        only the *version*, a ``make_content()`` over the stale bytes would WIN
+        and silently drop a peer's update (an on-disk lost update; the
+        protocol-level ``NoLostUpdate`` still holds — the version-bump count is
+        right — but the persisted value is wrong). Re-minting WITHOUT a read
+        keeps the loop's next ``_read_with_version`` a **None-state, HASH-CHECKED**
+        read (warn on hash match, deny on mismatch), so its ``(bytes, version)``
+        comparand pair is always validated.
+        """
         with self._lock:
             self._session_id = str(uuid.uuid4())  # fresh identity -> no INVALID
             self._last_committed_hash.clear()  # the new identity has committed nothing
-        # MANDATORY fresh read under the new identity -> SHARED@current.
-        return self.read(path)
 
     def write_cas(
         self,
@@ -581,13 +610,30 @@ class CoherentVolume:
         cannot both land the same version — the loser is told ``version_mismatch``
         and retries. The pessimistic ``write()`` path is untouched.
 
-        Conflict recovery follows the :meth:`reacquire` contract: on a
-        ``version_mismatch`` / ``other_holder`` conflict the loop
-        ``reacquire()``s (re-mint identity + a MANDATORY fresh read), re-derives
-        the bytes from the fresh view via ``make_content``, and retries —
+        Conflict recovery: on a ``version_mismatch`` / ``other_holder`` conflict
+        (or a stale-read deny) the loop re-mints identity (:meth:`_remint` —
+        sheds ``INVALID``, but does NOT do reacquire's read; that read would route
+        the next comparand read through the coordinator's unchecked *fresh-SHARED*
+        branch and re-open the lost update), then on the next attempt does ONE
+        hash-checked fresh read whose ``(bytes, version)`` pair is validated,
+        re-derives the bytes from that view via ``make_content``, and retries —
         bounded by :data:`MAX_CAS_REACQUIRES`. On exhaustion it raises
         :class:`~ccs.core.exceptions.CasRetriesExhausted` (a typed terminal,
         NEVER a silent drop).
+
+        **Contention bound.** The commit budget is :data:`MAX_CAS_REACQUIRES`
+        (=8 → 9 CAS attempts); each lost race (a peer winning the version)
+        costs one. Under very high single-host contention — more concurrent
+        writers racing the SAME key than the budget — a writer can exhaust it
+        and raise :class:`~ccs.core.exceptions.CasRetriesExhausted`. A
+        stale-denied comparand read (the transient window where a peer's commit
+        landed but its disk write hasn't) does NOT consume the commit budget;
+        instead CONSECUTIVE denied reads are separately bounded (also at
+        ``MAX_CAS_REACQUIRES + 1``) and raise ``CoherenceError`` if the view
+        never clears. Both terminals are the honest fail-closed outcome,
+        **never** a silent lost update: the invariant this method guarantees is
+        *final == start + every applied delta, OR a typed raise* — a successful
+        return always means the update landed.
 
         ``make_content`` is invoked once per attempt with the freshly-read
         current bytes and returns the bytes to commit — re-deriving the caller's
@@ -612,8 +658,8 @@ class CoherentVolume:
 
         **Not thread-safe (A5).** Overlapping use of this instance from another
         thread raises ``CoherenceError`` (the single-op guard). The internal
-        :meth:`reacquire` retries run on the SAME thread, so they re-enter the
-        guard rather than tripping it — one instance per thread.
+        re-mint + re-read retries run on the SAME thread under the guard already
+        held by this call — one instance per thread.
         """
         with self._single_op_guard():
             self._write_cas_impl(path, make_content)
@@ -637,37 +683,53 @@ class CoherentVolume:
             return
 
         last_current_version = -1
-        max_attempts = MAX_CAS_REACQUIRES + 1
-        for attempt in range(max_attempts):
+        max_attempts = MAX_CAS_REACQUIRES + 1  # commit (CAS POST) budget
+        cas_attempts = 0
+        denied_streak = 0  # CONSECUTIVE stale-denied comparand reads
+        while True:
             # Fresh read each attempt. _read_with_version returns the bytes, the
-            # coordinator's authoritative version (the OCC comparand), and
-            # whether the read was a sticky strict-deny — i.e. this instance is
-            # INVALID and the pre-read did NOT re-grant SHARED (KTD-T). An
-            # INVALID writer cannot CAS (the coordinator's invalidation left a
-            # transient that commit_cas rejects as a precondition), so recovery
-            # is the reacquire() contract: re-mint identity (no INVALID /
-            # transient) + a MANDATORY fresh read → clean SHARED@current.
+            # coordinator's authoritative version (the OCC comparand), and whether
+            # the read was a strict-deny (stale_denied — this instance is INVALID,
+            # or a re-minted identity whose disk read does not match the recorded
+            # content). The comparand read ALWAYS runs under a None-state identity
+            # (the first read's, or a _remint()ed one), so the coordinator
+            # HASH-CHECKS it: warn (re-grant SHARED) on a hash match, deny on a
+            # mismatch. That is exactly what makes (current_bytes,
+            # expected_version) a VALIDATED pair — current_bytes is the content
+            # the coordinator records at expected_version, so make_content()
+            # derives the successor from the right state. (Re-minting WITHOUT a
+            # read is the point: reacquire()'s read would leave the identity
+            # SHARED and route the next comparand read through the coordinator's
+            # fresh-SHARED branch, which returns the version WITHOUT a hash
+            # check — see _remint() / KTD-LU.)
             current_bytes, expected_version, stale_denied = self._read_with_version(rel)
             if stale_denied:
-                # This instance is INVALID (sticky strict-deny) → it cannot CAS
-                # until it reacquires (re-mint identity clears INVALID + the
-                # invalidation transient). reacquire() returns the fresh bytes;
-                # _read_with_version then re-resolves the version under the fresh
-                # identity. A warn-mode stale read here is fine — the fresh
-                # identity has no transient, so it can CAS.
-                if attempt >= max_attempts - 1:
-                    last_current_version = max(last_current_version, expected_version)
-                    break
-                current_bytes = self.reacquire(rel)
-                _aid, expected_version, refused_again = self._read_with_version(rel)
-                if refused_again:
-                    # A fresh-minted identity is brand new (no prior INVALID), so
-                    # a strict-deny here is impossible in normal operation — it
-                    # means the coordinator is wedged. Fail closed, do not spin.
+                # Cannot CAS from this view: INVALID, or the disk lags a just-
+                # committed version whose peer write has not landed yet
+                # (hash_differs under strict). Re-mint identity (sheds INVALID +
+                # the invalidation transient) and RE-READ — once the peer's disk
+                # write lands, the hash-checked None-state read yields a validated
+                # comparand pair. A denied read never POSTs a commit, so it does
+                # NOT consume the CAS budget (max_attempts counts *commit
+                # attempts*, keeping MAX_CAS_REACQUIRES' documented semantic);
+                # instead the CONSECUTIVE-denied streak is bounded so a
+                # never-clearing view (wedged coordinator, perpetually lagging
+                # disk, a starving foreign writer) still fails closed instead of
+                # spinning. A clean read resets the streak.
+                last_current_version = max(last_current_version, expected_version)
+                denied_streak += 1
+                if denied_streak > MAX_CAS_REACQUIRES:
                     raise CoherenceError(
-                        f"OCC reacquire did not clear INVALID for {rel}; "
-                        "coordinator may be wedged"
+                        f"OCC comparand read of {rel} stayed strict-denied across "
+                        f"{denied_streak} consecutive reads under re-minted "
+                        "identities; cannot establish a clean (bytes, version) "
+                        "view to CAS from — the on-disk content may be lagging "
+                        "peer commits or the coordinator may be wedged. No write "
+                        "landed (fail-closed)."
                     )
+                self._remint()
+                continue
+            denied_streak = 0
 
             data = bytes(make_content(current_bytes))
             new_hash = self._sha256_bytes(data)
@@ -677,6 +739,7 @@ class CoherentVolume:
             # disk (a denied/degraded CAS landing on disk would be the very
             # lost-update this guards). Contrast the pessimistic write(), which
             # writes between pre-edit (EXCLUSIVE held) and post-edit.
+            cas_attempts += 1
             resp = self._post(
                 "/hooks/post-edit-cas",
                 {
@@ -710,23 +773,26 @@ class CoherentVolume:
                 return
             if outcome == "conflict":
                 last_current_version = self._cas_current_version(resp, last_current_version)
-                # Recover via the reacquire() contract before the next attempt so
-                # expected_version + make_content() see the winner's state.
-                if attempt < max_attempts - 1:
-                    self.reacquire(rel)
+                if cas_attempts >= max_attempts:
+                    # Every allowed commit attempt lost the race — typed
+                    # terminal, never a silent drop. (last_current_version is
+                    # the latest version the loser observed.)
+                    raise CasRetriesExhausted(
+                        artifact_id=rel,
+                        attempts=cas_attempts,
+                        last_current_version=last_current_version,
+                    )
+                # Re-mint (NOT reacquire) before the next attempt so the next
+                # comparand read is a hash-checked None-state read that sees the
+                # winner's state — reacquire()'s read would route it through the
+                # unchecked fresh-SHARED branch and could pair stale bytes with a
+                # fresh version (the on-disk lost update; see _remint() / KTD-LU).
+                self._remint()
                 continue
             # outcome == "raise": a deny, corruption, or the fail-closed
             # commit_unconfirmed degrade body — ALWAYS raises in both modes.
             # Nothing was written to disk (the CAS did not win).
             raise CoherenceError(self._deny_reason(resp))
-
-        # Every allowed attempt lost the race — typed terminal, never a silent
-        # drop. (last_current_version is the latest version the loser observed.)
-        raise CasRetriesExhausted(
-            artifact_id=rel,
-            attempts=max_attempts,
-            last_current_version=last_current_version,
-        )
 
     # --- coordinator I/O helpers --------------------------------------------
 

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -26,6 +26,7 @@ from ccs.adapters.claude_code.lifecycle import (
     stop_coordinator,
 )
 from ccs.adapters.coherent_volume import (
+    MAX_CAS_REACQUIRES,
     CoherentVolume,
     coherent_workspace,
     install,
@@ -896,9 +897,9 @@ def test_guard_released_after_op_allows_subsequent_ops(
 
 # ---------------------------------------------------------------------------
 # T2 — write_cas recovery from a STICKY strict-deny (KTD-T), plus the
-# coordinator-wedged guard. Distinct from the conflict-classify convergence
+# bounded fail-closed terminal. Distinct from the conflict-classify convergence
 # above: here B is INVALID at CAS time, so the stale-deny branch (NOT a
-# version_mismatch conflict) drives the reacquire.
+# version_mismatch conflict) drives the re-mint + retry.
 # ---------------------------------------------------------------------------
 
 
@@ -907,9 +908,9 @@ def test_write_cas_recovers_from_sticky_strict_deny_and_converges(
 ) -> None:
     """T2: a peer commit leaves THIS volume INVALID (sticky strict-deny). The
     very first OCC read inside write_cas is a strict-deny (stale_denied), so
-    write_cas must reacquire() (re-mint identity → clears INVALID + the
-    invalidation transient) and commit the rebased bytes — converge, NOT raise.
-    No lost update: B's commit is rebased on A's v2."""
+    write_cas must re-mint identity (clears INVALID + the invalidation transient)
+    and commit the rebased bytes — converge, NOT raise. No lost update: B's
+    commit is rebased on A's v2."""
     from ccs.cli._coherence_client import post as _cpost
 
     target = _seed(tmp_path, content=b"v1")
@@ -933,10 +934,11 @@ def test_write_cas_recovers_from_sticky_strict_deny_and_converges(
             seen.append(current)
             return current + b"\nrebased-by-B"
 
-        # write_cas drives the stale-deny branch → reacquire → fresh read → CAS.
+        # write_cas drives the stale-deny branch → re-mint → fresh hash-checked
+        # read → CAS.
         vol_b.write_cas("data/shared.txt", make)
         assert target.read_bytes() == b"v2-from-A\nrebased-by-B"
-        # The winning attempt derived from A's v2 (re-read via reacquire), never
+        # The winning attempt derived from A's v2 (re-read after re-mint), never
         # the stale v1 buffer.
         assert b"v2-from-A" in seen[-1]
         assert not vol_b.is_degraded  # a deny/recovery is enforcement, not infra
@@ -944,14 +946,20 @@ def test_write_cas_recovers_from_sticky_strict_deny_and_converges(
         stop_coordinator(tmp_path)
 
 
-def test_write_cas_raises_when_reacquire_cannot_clear_invalid(
+def test_write_cas_fails_closed_with_typed_terminal_when_reads_stay_denied(
     tmp_path: Path, fast_cfg: LifecycleConfig
 ) -> None:
-    """T2: the coordinator-wedged guard. If a fresh-minted identity STILL reads
-    as a strict-deny (impossible in normal operation — a brand-new identity has
-    no prior INVALID), write_cas must fail closed with a clear CoherenceError and
-    NOT spin forever. Simulated by stubbing _read_with_version to report
-    stale_denied on both the fresh read AND the post-reacquire re-read."""
+    """T2: a comparand read that NEVER clears (every read is a strict-deny) must
+    fail closed with a TYPED terminal — never a silent drop and never an
+    infinite spin. The loop re-mints identity (NOT reacquire(), whose read would
+    route the next comparand read through the coordinator's unchecked
+    fresh-SHARED branch — the on-disk lost-update hole) and re-reads, bounded by
+    the CONSECUTIVE-denied-streak limit (a denied read never POSTs a commit, so
+    it must not consume the CAS budget — that one counts commit attempts).
+    Crucially make_content() runs ONLY after a read that is NOT denied, so a
+    perpetually-denied artifact derives and commits NOTHING — there is no stale
+    buffer to land. Simulated by stubbing _read_with_version to always report
+    stale_denied."""
     _seed(tmp_path, content=b"v1")
     vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
     try:
@@ -959,8 +967,7 @@ def test_write_cas_raises_when_reacquire_cannot_clear_invalid(
         calls = {"n": 0}
 
         def always_denied(rel: str):
-            # (bytes, version, stale_denied) — always denied → the fresh read is
-            # denied AND the re-read after reacquire is denied (refused_again).
+            # (bytes, version, stale_denied) — every comparand read is a deny.
             calls["n"] += 1
             return (b"v1", 1, True)
 
@@ -972,11 +979,14 @@ def test_write_cas_raises_when_reacquire_cannot_clear_invalid(
             made["called"] = True
             return b"should-not-commit"
 
-        with pytest.raises(CoherenceError, match="wedged"):
+        # Typed terminal (the denied-streak bound), never a silent loss.
+        with pytest.raises(CoherenceError, match="stayed strict-denied"):
             vol.write_cas("data/shared.txt", make)
-        # No spin: fresh read (1) + post-reacquire re-read (2) = exactly 2 calls,
-        # then it raises before ever deriving/committing bytes.
-        assert calls["n"] == 2
+        # Bounded, not an infinite spin: exactly MAX_CAS_REACQUIRES + 1
+        # consecutive denied reads, then the typed raise.
+        assert calls["n"] == MAX_CAS_REACQUIRES + 1
+        # make_content NEVER ran: a denied read derives/commits no bytes, so a
+        # stale buffer can never land (the on-disk lost update is impossible).
         assert made["called"] is False
     finally:
         stop_coordinator(tmp_path)

--- a/tests/test_concurrent_writers_demo.py
+++ b/tests/test_concurrent_writers_demo.py
@@ -14,8 +14,9 @@ coordinator subprocess (no network).
 
 from __future__ import annotations
 
+from ccs.core.exceptions import CasRetriesExhausted, CoherenceError
 from examples.concurrent_writers.broken import run_broken
-from examples.concurrent_writers.fixed import run_fixed
+from examples.concurrent_writers.fixed import _race_write_cas, run_fixed
 
 # --- broken case (no coherence) --------------------------------------------
 
@@ -62,3 +63,46 @@ def test_broken_and_fixed_diverge_on_the_same_race() -> None:
     assert broken_trace["lost_update"] is True  # update lost
     assert fixed_trace["lost_update"] is False  # both survived
     assert broken_trace["scenario"] == fixed_trace["scenario"]
+
+
+# --- higher-contention regression: the HONEST invariant --------------------
+#
+# Regression for the commit-CAS on-disk lost update (2026-06-10, PR #107). Under
+# contention higher than the 2-writer demo, the stale-deny recovery in
+# write_cas paired the comparand bytes with a SEPARATELY-resolved version (and
+# routed the re-read through the coordinator's unchecked fresh-SHARED branch), so
+# make_content() could win a version-CAS over STALE bytes and silently drop a
+# peer's update — final < N with NO exception. Fixed by re-minting identity
+# WITHOUT a read, so every comparand read is a hash-checked None-state read whose
+# (bytes, version) pair is validated. See
+# docs/solutions/logic-errors/ for the writeup.
+
+
+def test_fixed_under_higher_contention_holds_the_honest_invariant() -> None:
+    """Every run must satisfy the HONEST invariant: final == start + every delta
+    (no update lost), OR a TYPED fail-closed raise (CasRetriesExhausted /
+    CoherenceError under very high contention) — but NEVER a silent loss (a run
+    that RETURNS yet dropped an update). The strict ``final == N`` form is timing-
+    flaky (it reds on the acceptable fail-closed terminal too); this asserts the
+    real guarantee write_cas makes."""
+    n = 5  # > the 2-writer demo; exercises the stale-deny recovery path
+    start = 0
+    saw_completion = False
+    for _ in range(6):
+        try:
+            final, attempts = _race_write_cas([1] * n, start)
+        except RuntimeError as exc:
+            # A failed guarantee must be a TYPED terminal, never a swallowed
+            # silent loss. _race_write_cas re-raises the writer's error as the
+            # RuntimeError's __cause__.
+            assert isinstance(exc.__cause__, (CasRetriesExhausted, CoherenceError)), (
+                f"fail-closed must be typed, got {exc.__cause__!r}"
+            )
+            continue
+        # Returned without raising → EVERY update survived (no silent drop).
+        assert final == start + n, f"SILENT LOST UPDATE: final={final}, expected={start + n}"
+        assert sum(attempts) >= n  # make_content ran at least once per writer
+        saw_completion = True
+    # Contention is real but bounded; at n=5 at least one run should complete
+    # rather than every run exhausting (guards against a degenerate always-raise).
+    assert saw_completion, "every run fail-closed at n=5 — retry budget too tight?"


### PR DESCRIPTION
## Summary

Fixes a **silent on-disk lost update** in `CoherentVolume.write_cas` under concurrent same-key contention (≥5 writers), first observed in CI on Linux (py3.11/3.12) while building `examples/concurrent_writers`: 5 concurrent adders finished with `final < 5` and **no exception** — violating the API's "never a silent drop" contract at the client-integration layer. The TLA⁺ `NoLostUpdate` protocol invariant was not violated (the version-bump count stayed correct); the persisted file value was wrong.

## Root cause (two stacked client-side causes)

1. **Split comparand.** The stale-deny recovery inside `_write_cas_impl` took `current_bytes` from `reacquire()` and `expected_version` from a *separate, later* read. A peer commit between the two paired STALE bytes with a FRESH version — and the commit-CAS checks only the version, so `make_content` derived from stale bytes and **won**, overwriting the peer's update on disk.
2. **The follow-up read was unchecked.** `reacquire()`'s mandatory read leaves the re-minted identity SHARED, so the next pre-read takes the coordinator's fresh-SHARED branch — which returns the version **without** a content-hash check. The conflict path had the same hole (reacquire → next loop read arrives SHARED). The content-hash gate only runs on INVALID/None-state reads.

A side effect of the same window: a fresh identity reading disk that lags a just-committed version (winner hasn't `os.replace`d yet) was misdiagnosed as a wedged coordinator and raised spuriously.

## Fix

- New private `_remint()`: re-mint identity **without** a read. Every `write_cas` retry (stale-deny and CAS-conflict) uses it, so each attempt's `(bytes, version)` comparand comes from **one hash-checked None-state read** — the stale-bytes/fresh-version split is structurally unrepresentable, and a lagging-disk read is denied + retried rather than committed.
- Denied reads never POST a commit, so they no longer consume the commit budget (`MAX_CAS_REACQUIRES` keeps its documented "total commit attempts" meaning). Consecutive denied reads get their own bound (same constant) → typed `CoherenceError`, replacing the misdiagnosed "coordinator may be wedged" raise.
- Public `reacquire()` behavior is unchanged (re-mint + mandatory read remains the pessimistic-path recovery contract).

## Validation

Instrumented delay-injection harness (event-logged; injection inside the recovery windows reproduced the loss deterministically on macOS, matching the CI signature):

| Scenario | Before fix | After fix |
|---|---|---|
| Injected reacquire-window delay, N=5, 25 runs | 2 silent losses + 17 spurious raises | 25/25 clean |
| Natural N=5 (150) / N=7 (120) | losses observed at N=5..7 | 0 silent losses; 270/270 clean |
| Natural N=9 (100) + 4 injected matrices (~280 runs) | — | 0 silent losses (N=9 exhausts ~half: typed `CasRetriesExhausted`, the documented contention bound) |

`final == start + every delta, OR a typed raise` — never a silent loss — now holds in every run observed (~1400 total).

## Test plan

- [x] New regression: `test_fixed_under_higher_contention_holds_the_honest_invariant` (n=5; asserts the honest invariant, so the fail-closed terminal can't flake it)
- [x] `test_write_cas_raises_when_reacquire_cannot_clear_invalid` → `test_write_cas_fails_closed_with_typed_terminal_when_reads_stay_denied` (asserts the new consecutive-streak terminal + that `make_content` never runs on a denied view)
- [x] Affected suites pass (71: coherent_volume adapters, OCC commit-CAS, both demos) + broader sweep (328: ccsstore, adapters, agent_runtime, crash_recovery, fence guard, coordinator server)
- [x] `python -m examples.concurrent_writers.main` exit 0
- [x] Ruff: zero new findings vs baseline

Docs updated: `write_cas` docstring (contention bound), `MAX_CAS_REACQUIRES` semantics, demo README scope note, CHANGELOG (Unreleased → Fixed).