### PR TITLE
feat(coordinator): surface fresh-SHARED hash mismatch on pre-read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Alpha — APIs may change before `v1.0`.
 
 ### Added
 
+- **Fresh-SHARED hash-mismatch signal** (`/hooks/pre-read`): a SHARED holder
+  whose supplied `content_hash` mismatches the recorded artifact hash now gets
+  an additive `hash_differs: true` field on the fresh response, and the
+  coordinator bumps a new `fresh_shared_hash_mismatch_total` counter
+  (`/status?detail=metrics`). Previously the fresh-SHARED fast path returned
+  the version comparand with no validation — only INVALID/None-state reads
+  were hash-checked. A peer commit would have left the session INVALID, so a
+  mismatch implies an out-of-band write or commit→disk-write lag; the signal
+  makes that observable. Warn-mode semantics unchanged: the read is still
+  allowed, the key appears only when the mismatch fires, and sentinel
+  recorded hashes (`""` seeds, `"f" * 64` launch-gate injection) never fire
+  it.
 - **Concurrent lost-update demo** (`examples/concurrent_writers/`): a true-race
   reproduction of the v0.9.1 commit-CAS write path. Two threads update a shared
   total concurrently; `broken.py` loses an update (last writer wins over a plain

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -278,6 +278,15 @@ def validate_content_hash(content_hash: Any, *, required: bool) -> str | None:
     return None
 
 
+# Sentinel recorded hash carrying no real content claim: launch-gate
+# scenarios inject artifact rows with "f"*64 (no real SHA-256 matches it,
+# guaranteeing hash_differs on the stale path). The other no-claim seed —
+# "" from KTD-9 first observations without a caller hash — surfaces as
+# ``None`` on the Artifact, so truthiness checks already exclude it. The
+# fresh-SHARED mismatch signal must not fire against either.
+_F_SENTINEL_CONTENT_HASH = "f" * 64
+
+
 # ----------------------------------------------------------------------
 # Server shell
 # ----------------------------------------------------------------------
@@ -454,6 +463,17 @@ class CoordinatorHTTPServer:
         self._strict_mode_denials_total: int = 0
         self._strict_mode_routed_around_via_bash_total: int = 0
         self._audit_log_mode_drift_total: int = 0
+
+        # Defense-in-depth signal (PR #108 follow-up, 2026-06-11):
+        # fresh_shared_hash_mismatch_total counts pre-reads where a
+        # SHARED holder supplied a content_hash that mismatches the
+        # recorded (non-sentinel) artifact hash. A peer commit would
+        # have left the session INVALID, so a mismatch here implies an
+        # out-of-band write or the commit→disk-write lag observed via a
+        # warn-mode re-grant. The fresh response stays an allow (the
+        # plugin path is fail-open); this counter sizes the
+        # false-positive rate before any strict-mode deny knob is added.
+        self._fresh_shared_hash_mismatch_total: int = 0
         # Per-(session, path) "recent strict-deny" memory for route-around
         # detection. Bounded by the registry's own (session, artifact)
         # cardinality at worst — same upper bound as _stale_warned_pairs.
@@ -769,6 +789,15 @@ class CoordinatorHTTPServer:
         operator-visible signal to fix the mode."""
         self._audit_log_mode_drift_total += 1
 
+    def increment_fresh_shared_hash_mismatch(self) -> None:
+        """PR #108 follow-up: bumped when pre-read's fresh-SHARED branch
+        observes a caller content_hash that mismatches the recorded
+        non-sentinel artifact hash. The response stays fresh/allow — the
+        counter (plus the additive ``hash_differs`` response field) is
+        the observable. Advisory counter, same GIL-atomicity contract as
+        :meth:`increment_strict_mode_denial`."""
+        self._fresh_shared_hash_mismatch_total += 1
+
     def record_strict_deny(self, session_id: str, path: str) -> None:
         """v0.2 Unit 4 route-around tracker — store the (session, path)
         pair with monotonic timestamp so a subsequent pre-bash deny on
@@ -854,6 +883,7 @@ class CoordinatorHTTPServer:
             "strict_mode_routed_around_via_bash_total": self._strict_mode_routed_around_via_bash_total,
             "audit_log_mode_drift_total": self._audit_log_mode_drift_total,
             "stale_warning_reread_total": self._stale_warning_reread_total,
+            "fresh_shared_hash_mismatch_total": self._fresh_shared_hash_mismatch_total,
             "auth_401_total": self._auth_401_total,
         }
 
@@ -1282,7 +1312,28 @@ def _handle_pre_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
             # Reader has a valid grant on the current version. Unit 6:
             # include the version so an OCC writer can source
             # ``expected_version`` (additive — status clients ignore it).
-            return {"status": "fresh", "version": artifact.version}
+            fresh: dict[str, Any] = {"status": "fresh", "version": artifact.version}
+            # Defense-in-depth (PR #108 follow-up): a SHARED holder whose
+            # supplied disk hash mismatches the recorded content is
+            # anomalous — a peer commit would have left it INVALID — so a
+            # mismatch implies an out-of-band write or the commit→disk-
+            # write lag observed through a warn-mode re-grant. Surface it
+            # additively: the key appears ONLY when firing (exact-shape
+            # status clients are untouched) and the response stays an
+            # allow — the plugin path is fail-open by design; a
+            # strict-mode deny knob waits on this counter proving a
+            # ~zero false-positive rate. Sentinel recorded hashes carry
+            # no content claim and must not fire ("" seeds surface as
+            # None; the truthiness check covers them).
+            if (
+                content_hash
+                and artifact.content_hash
+                and artifact.content_hash != _F_SENTINEL_CONTENT_HASH
+                and content_hash != artifact.content_hash
+            ):
+                coordinator.increment_fresh_shared_hash_mismatch()
+                fresh["hash_differs"] = True
+            return fresh
 
         # Stale: either first time this session sees the artifact OR they
         # were invalidated by a peer commit.

--- a/tests/protocol_corpus/fixtures/warn_mode/08-status-default-tier-empty-workspace.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/08-status-default-tier-empty-workspace.json
@@ -27,6 +27,7 @@
       "coordinator_version": "<IGNORED>",
       "detail": "minimal",
       "endpoint_counters": "<IGNORED>",
+      "fresh_shared_hash_mismatch_total": 0,
       "handler_concurrency_overflows_total": 0,
       "in_flight_drain_timed_out": false,
       "intra_task_acquire_release_total": 0,

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -9,6 +9,7 @@ per-invocation warning-template variation.
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import json
 import os
@@ -269,6 +270,123 @@ def test_pre_read_missing_session_id_400(client: _Client) -> None:
 def test_pre_read_empty_path_400(client: _Client) -> None:
     status, body = client.post("/hooks/pre-read", {"session_id": _sid("s"), "path": ""})
     assert status == 400
+
+
+# ----------------------------------------------------------------------
+# /hooks/pre-read — fresh-SHARED hash-mismatch signal (PR #108 follow-up)
+# ----------------------------------------------------------------------
+
+
+def test_pre_read_fresh_shared_hash_mismatch_sets_hash_differs(client: _Client) -> None:
+    """Defense-in-depth (PR #108 follow-up): a SHARED holder re-reading
+    with a disk hash that mismatches the recorded content gets
+    ``hash_differs: true`` on the fresh response. A peer commit would
+    have left the session INVALID, so the mismatch implies an
+    out-of-band write — surfaced additively, never denied (the plugin
+    path stays fail-open)."""
+    client.post("/hooks/pre-read",
+                {"session_id": _sid("s1"), "path": "CLAUDE.md",
+                 "content_hash": _hash("on-disk-v1")})
+    status, body = client.post("/hooks/pre-read",
+                                {"session_id": _sid("s1"), "path": "CLAUDE.md",
+                                 "content_hash": _hash("out-of-band-edit")})
+    assert status == 200
+    assert body == {"status": "fresh", "version": 1, "hash_differs": True}
+
+
+def test_pre_read_fresh_shared_matching_hash_omits_hash_differs(client: _Client) -> None:
+    """Additive contract: the key appears ONLY when the mismatch fires.
+    A matching hash keeps the exact two-field fresh shape so
+    exact-shape status clients are untouched."""
+    client.post("/hooks/pre-read",
+                {"session_id": _sid("s1"), "path": "CLAUDE.md",
+                 "content_hash": _hash("on-disk-v1")})
+    status, body = client.post("/hooks/pre-read",
+                                {"session_id": _sid("s1"), "path": "CLAUDE.md",
+                                 "content_hash": _hash("on-disk-v1")})
+    assert status == 200
+    assert body == {"status": "fresh", "version": 1}
+
+
+def test_pre_read_fresh_shared_without_hash_omits_hash_differs(client: _Client) -> None:
+    """A SHARED re-read that supplies no content_hash has nothing to
+    compare — no signal, exact two-field shape."""
+    client.post("/hooks/pre-read",
+                {"session_id": _sid("s1"), "path": "CLAUDE.md",
+                 "content_hash": _hash("on-disk-v1")})
+    status, body = client.post("/hooks/pre-read",
+                                {"session_id": _sid("s1"), "path": "CLAUDE.md"})
+    assert status == 200
+    assert body == {"status": "fresh", "version": 1}
+
+
+def test_pre_read_fresh_shared_empty_seed_recorded_hash_never_fires(client: _Client) -> None:
+    """KTD-9 seeding without a caller hash records the "" sentinel
+    (surfaced as None by the registry); a later hash-bearing re-read
+    must not fire against it — there is no real content claim to
+    mismatch."""
+    client.post("/hooks/pre-read",
+                {"session_id": _sid("s1"), "path": "CLAUDE.md"})
+    status, body = client.post("/hooks/pre-read",
+                                {"session_id": _sid("s1"), "path": "CLAUDE.md",
+                                 "content_hash": _hash("real-disk-bytes")})
+    assert status == 200
+    assert body == {"status": "fresh", "version": 1}
+
+
+def test_pre_read_fresh_shared_f_sentinel_recorded_hash_never_fires(
+    coordinator, client: _Client,
+) -> None:
+    """The synthetic launch-gate sentinel ("f"*64) is not a real SHA-256
+    of any content; a SHARED holder re-reading against it must not fire
+    the signal. (The stale path's hash_differs deliberately DOES fire on
+    it — that asymmetry is the launch-gate contract.)"""
+    client.post("/hooks/pre-read",
+                {"session_id": _sid("s1"), "path": "CLAUDE.md",
+                 "content_hash": _hash("on-disk-v1")})
+    art_id = coordinator.registry.lookup_artifact_id_by_name("CLAUDE.md")
+    assert art_id is not None
+    art = coordinator.registry.get_artifact(art_id)
+    # Inject the sentinel directly into the artifact row (same shape the
+    # launch-gate synthetic SQLite injection produces); the session's
+    # SHARED grant is untouched.
+    coordinator.registry.set_artifact_and_content(
+        art_id, dataclasses.replace(art, content_hash="f" * 64), "",
+    )
+    status, body = client.post("/hooks/pre-read",
+                                {"session_id": _sid("s1"), "path": "CLAUDE.md",
+                                 "content_hash": _hash("on-disk-v1")})
+    assert status == 200
+    assert body == {"status": "fresh", "version": 1}
+
+
+def test_pre_read_fresh_shared_hash_mismatch_increments_counter(
+    coordinator, client: _Client,
+) -> None:
+    """Each firing bumps fresh_shared_hash_mismatch_total; matching
+    re-reads don't."""
+    before = coordinator._fresh_shared_hash_mismatch_total
+    client.post("/hooks/pre-read",
+                {"session_id": _sid("s1"), "path": "CLAUDE.md",
+                 "content_hash": _hash("on-disk-v1")})
+    client.post("/hooks/pre-read",
+                {"session_id": _sid("s1"), "path": "CLAUDE.md",
+                 "content_hash": _hash("on-disk-v1")})
+    assert coordinator._fresh_shared_hash_mismatch_total == before
+    client.post("/hooks/pre-read",
+                {"session_id": _sid("s1"), "path": "CLAUDE.md",
+                 "content_hash": _hash("out-of-band-edit")})
+    assert coordinator._fresh_shared_hash_mismatch_total == before + 1
+
+
+def test_status_metrics_exposes_fresh_shared_hash_mismatch_counter(client: _Client) -> None:
+    """fresh_shared_hash_mismatch_total visible in /status?detail=metrics
+    so an operator can size the false-positive rate before any
+    strict-mode deny knob is considered."""
+    status, body = client.get("/status?detail=metrics")
+    assert status == 200
+    assert "fresh_shared_hash_mismatch_total" in body
+    assert isinstance(body["fresh_shared_hash_mismatch_total"], int)
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `/hooks/pre-read`'s fresh-SHARED fast path returned `{status: fresh, version}` without comparing the caller-supplied `content_hash` against the recorded artifact hash — only INVALID/None-state reads were hash-checked. A client arriving SHARED with mismatched disk bytes got a version comparand with no signal; this was one of the two stacked causes behind #108's silent on-disk lost update (the conflict-path re-read could bless stale bytes).
- A SHARED holder with mismatched disk is anomalous (a peer commit would have left it INVALID — it implies an out-of-band write or commit→disk-write lag seen through a warn-mode re-grant), so the branch now surfaces it as defense in depth: the fresh response gains `hash_differs: true` **only when the mismatch fires**, and a new `fresh_shared_hash_mismatch_total` counter is exposed via `/status?detail=metrics`.
- Deliberately **no deny**: the plugin path stays fail-open (warn-mode semantics unchanged); a strict-mode-only deny is a possible follow-up knob once the counter shows a ~zero false-positive rate. Sentinel recorded hashes (`""` KTD-9 seeds, `"f"*64` launch-gate injection) never fire the signal; the stale path's `hash_differs` (which deliberately fires on the sentinel) is untouched.
- Complements #108, which fixed the client side (comparand from one hash-checked None-state read); this closes the coordinator-side observability gap for any other client arriving SHARED with divergent disk bytes.

## Test Plan

- [x] 7 new tests in `tests/test_claude_code_coordinator_server.py`: mismatch sets the field, matching/absent hash keeps the exact two-field shape, both sentinels never fire, counter increments only on firing, counter visible in `/status?detail=metrics`
- [x] Full `tests/test_claude_code_coordinator_server.py` — 161 passed
- [x] Adjacent response-shape suites (`tests/integration/test_strict_mode.py`, `tests/protocol_corpus/`, `tests/test_claude_code_contract.py`, `tests/test_claude_code_hook_client.py`) — 51 passed
- [x] `tests/adapters/test_coherent_volume.py` + `tests/test_concurrent_writers_demo.py` against the changed server — 56 passed
- [x] `ruff check` clean