### PR TITLE
fix(coordinator): preserve fresh-path version through notice surfacing

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1190,10 +1190,12 @@ def _handle_pre_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
     A pre-read response can shape one of three ways:
 
     1. **Fresh (first observation OR already-seen valid grant)** —
-       returns ``{"status": "fresh"}`` (no ``hookSpecificOutput``).
-       The ``work_with_notice_surfacing`` wrapper at the bottom of
+       returns ``{"status": "fresh", ...}`` (no ``hookSpecificOutput``;
+       additive keys like Unit 6 ``version`` ride along). The
+       ``work_with_notice_surfacing`` wrapper at the bottom of
        this handler pops pending notices on this exact shape and
-       attaches ``hookSpecificOutput.additionalContext`` if any
+       attaches ``hookSpecificOutput.additionalContext`` onto the
+       work() payload — additive keys must survive — if any
        notices were pending. Fresh response → wrapper drains.
 
     2. **Stale (peer commit invalidated us)** — the stale branch
@@ -1426,8 +1428,11 @@ def _handle_pre_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
             notices = coordinator.registry.pop_pending_notices(agent_id)
             if notices:
                 notice_text = _build_preemption_text(coordinator, notices)
+                # Spread work()'s payload so additive fresh-path keys
+                # (Unit 6 ``version``) survive the notice attachment —
+                # rebuilding a literal dict here drops them.
                 return {
-                    "status": "fresh",
+                    **result,
                     "hookSpecificOutput": _payloads.emit_allow(
                         source="pre_read_fresh_with_notice",
                         additional_context=notice_text,

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -581,6 +581,46 @@ def test_a1_preemption_surfaces_on_victim_next_pre_read(client: _Client) -> None
     assert y[:8] in msg, f"prose should name the preempter session prefix; got: {msg}"
 
 
+def test_a1_fresh_with_notice_preserves_version_field(client: _Client) -> None:
+    """A1 × Unit 6: notice surfacing on the FRESH pre-read path must keep
+    the additive ``version`` key alongside ``hookSpecificOutput``.
+
+    Regression: the ``work_with_notice_surfacing`` wrapper rebuilt the
+    fresh response as a literal dict, dropping ``version`` — an OCC
+    writer sourcing expected_version from the read then CAS'd against 0
+    and burned a wasted version_mismatch round-trip."""
+    x = _sid("X"); y = _sid("Y")
+    # X first-reads task.md — seeds v1 + grants SHARED, so the re-read
+    # below (after the preemption on a DIFFERENT artifact) stays fresh.
+    status, body = client.post("/hooks/pre-read",
+                               {"session_id": x, "path": "task.md",
+                                "content_hash": _hash("t1")})
+    assert status == 200
+    assert body == {"status": "fresh", "version": 1}
+    # X acquires EXCLUSIVE on plan.md; Y pre-edits plan.md, silently
+    # preempting X — a preemption notice queues for X.
+    client.post("/hooks/pre-edit", {"session_id": x, "path": "plan.md"})
+    client.post("/hooks/pre-edit", {"session_id": y, "path": "plan.md"})
+    # X's next hook is a pre-read of task.md (still SHARED → fresh): the
+    # wrapper drains the pending notice onto this fresh response.
+    status, body = client.post("/hooks/pre-read",
+                               {"session_id": x, "path": "task.md",
+                                "content_hash": _hash("t1")})
+    assert status == 200, body
+    assert body.get("status") == "fresh", body
+    assert "hookSpecificOutput" in body, (
+        f"fresh pre-read after a preemption must surface the notice; got {body}"
+    )
+    msg = body["hookSpecificOutput"]["additionalContext"]
+    assert "plan.md" in msg and y[:8] in msg, (
+        f"notice prose should name the preempted artifact + preempter; got: {msg}"
+    )
+    assert body.get("version") == 1, (
+        "fresh-with-notice response must preserve the Unit 6 version key "
+        f"(OCC writers source expected_version from it); got {body}"
+    )
+
+
 def test_a1_preemption_surfaces_on_victim_next_pre_edit(client: _Client) -> None:
     """A1: surface preemption even when X's next hook is pre-edit, not pre-read."""
     x = _sid("X"); y = _sid("Y")


### PR DESCRIPTION
## Summary
- `_handle_pre_read`'s notice-surfacing wrapper rebuilt fresh responses as a literal dict, dropping the additive Unit 6 `version` field whenever a pending preemption notice was attached
- Consequence: an OCC writer sourcing `expected_version` from a fresh-with-notice read (`CoherentVolume._read_with_version` falls back to 0) CAS'd against 0 and lost cleanly with `version_mismatch` — fail-safe, but one wasted retry round-trip after any preemption
- Fix: spread `work()`'s payload (`{**result, "hookSpecificOutput": ...}`) so additive fresh-path keys survive; this also future-proofs the fresh-path `hash_differs` field from #109
- COR-03 notice-drain contract unchanged: same `status == "fresh" and "hookSpecificOutput" not in result` gate, same single-consumer pop; the stale path still drains its own notices

## Test Plan
- [x] New regression test `test_a1_fresh_with_notice_preserves_version_field`: victim holds SHARED on `task.md`, gets preempted on `plan.md` by a peer pre-edit, then pre-reads `task.md` — asserts the fresh response carries both the notice and `version`. Verified it fails against the unfixed code (`assert None == 1`)
- [x] Full `tests/test_claude_code_coordinator_server.py`: 155 passed
- [x] Protocol corpus (`-m protocol_corpus`): 32 passed — no fixture changes needed (fixtures are single-request so none can queue a preemption notice; the first-observation fixture already tolerates `version` via `optional_keys`)
- [x] ruff clean on both changed files