### PR TITLE
feat(coordinator): bounded durable version retention + read-at-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,25 @@ Alpha — APIs may change before `v1.0`.
   (`NoCollectedRead` + a versioned-read-is-a-no-op action property), wired into
   `make tla-check`.
 
+### Changed
+
+- **`SqliteArtifactRegistry(retain_versions=True)` is now supported** —
+  previously it raised `NotImplementedError`. Callers that relied on that raise
+  as a feature gate ("durable retention impossible here") no longer get the
+  signal from the constructor; consult `retention_meta()` (the persisted
+  `(enabled, policy)` surface) or the new `RetentionPolicy` parameter to detect
+  and control durable retention. Content bytes now land in `state.db` when (and
+  only when) this flag is on — see `docs/security.md` for the 0600 posture.
+- **`commit_cas(..., content=None)` under retention no longer records the prior
+  body under the new version.** The old behavior silently retained the STALE
+  previous body as the new version's snapshot (history poisoning, observable
+  only through retention reads). A `content=None` WIN now records nothing for
+  the new version: `get_content_at_version(new_version)` returns `None` and
+  `read_at_version(new_version)` (once it is history) rejects `not_retained`.
+  Relatedly, `get_content_at_version` is now annotated `str | bytes | None` on
+  both registries — bytes bodies round-trip as `bytes` (they always did on the
+  in-process path; the annotation was wrong).
+
 ## [0.9.2] — 2026-06-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to `agent-coherence` are documented here. The format follows
 
 Alpha — APIs may change before `v1.0`.
 
+## [Unreleased]
+
+### Added
+
+- **Bounded, durable version retention + read-at-version.** The coordinator can
+  retain a bounded history of committed artifact versions and serve any retained
+  `(artifact, version)` through `CoordinatorService.read_at_version(...)`,
+  returning a typed `VersionedContent` or a `VersionedReadRejection` over six
+  wire-stable reasons. Opt in per registry with `RetentionPolicy(max_versions=K,
+  max_age_seconds=T)` — **off by default**. The in-memory registry retains in
+  process; `SqliteArtifactRegistry` retains durably across a coordinator restart
+  for in-process embedders, behind the store's first real schema-version bump
+  (v1 → v2, applied automatically and atomically; durable content storage is
+  opt-in and flips no existing deployment silently). `agent-coherence-replay
+  resolve --db <state.db> --artifact <path|uuid> --version <n>` reads bytes at a
+  version from a stored coordinator, content-safe by default (metadata only
+  unless `--include-content` / `--output-file`). Read-at-version is an
+  off-protocol read — it grants no MESI state and captures no read-generation
+  fence claim (R6/R7). Formally modelled in `formal/tla/Retention.tla`
+  (`NoCollectedRead` + a versioned-read-is-a-no-op action property), wired into
+  `make tla-check`.
+
 ## [0.9.2] — 2026-06-11
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,13 @@ cost-benchmark-check: cost-benchmark  ## Re-run the cost sweep, then drift-check
 TLA2TOOLS := formal/tla/lib/tla2tools.jar
 TLC := java -XX:+UseParallelGC -cp $(TLA2TOOLS) tlc2.TLC -workers auto
 
-tla-check:  ## Run TLC model checker on MESI, CrashRecovery, OCC, and Fencing specs
+tla-check:  ## Run TLC model checker on MESI, CrashRecovery, OCC, Fencing, and Retention specs
 	@java -version 2>&1 | head -1 | grep -qE '"(1[7-9]|[2-9][0-9])\.' || { echo "ERROR: Java 17+ required for TLC model checker"; exit 1; }
 	$(TLC) -config formal/tla/MESI_Standalone.cfg formal/tla/MESI_Standalone.tla
 	$(TLC) -config formal/tla/CrashRecovery_CI.cfg formal/tla/CrashRecovery.tla
 	$(TLC) -config formal/tla/OCC_CI.cfg formal/tla/OCC.tla
 	$(TLC) -config formal/tla/Fencing_CI.cfg formal/tla/Fencing.tla
+	$(TLC) -config formal/tla/Retention_CI.cfg formal/tla/Retention.tla
 
 help:  ## List available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ vol.write("plans/plan.md", revised_plan)   # stale view? denied fail-closed → 
 
 ## What it guarantees
 
-Each row is a safety invariant model-checked with TLA+/TLC. `make tla-check` runs all four specs in CI on every push, and every spec carries a documented mutant that must fail — the invariants are load-bearing, not decorative.
+Each row is a safety invariant model-checked with TLA+/TLC. `make tla-check` runs all five specs in CI on every push, and every spec carries a documented mutant that must fail — the invariants are load-bearing, not decorative.
 
 | The silent failure | What happens instead | Mechanism | Invariant |
 |---|---|---|---|
@@ -66,7 +66,7 @@ Each row is a safety invariant model-checked with TLA+/TLC. `make tla-check` run
 ---
 
 - 📖 [User guide](docs/guide.md) — installation, namespace convention, strategies, observability, telemetry, examples, full API reference
-- 🧮 [Formal verification](formal/tla/README.md) — the four TLA+ specs, invariant ↔ implementation map, mutant recipes
+- 🧮 [Formal verification](formal/tla/README.md) — the five TLA+ specs, invariant ↔ implementation map, mutant recipes
 - 🩺 [`ccs-diagnose` CLI](docs/ccs-diagnose.md) — find divergent reads in your existing LangGraph graph without changing any code
 - 🧩 [Claude Code plugin](https://github.com/hipvlady/agent-coherence-plugin) — cross-session coherence for the prose rules (CLAUDE.md, plan.md) parallel Claude Code sessions share
 - 🔍 [Why coherence matters](docs/why-coherence-matters.md) — the gap across LangGraph, CrewAI, AutoGen, and Claude Agent SDK
@@ -90,7 +90,7 @@ Five synchronization strategies ship out of the box: `lazy` (default), `eager`, 
 - **Simulation** (`ccs.simulation`) — deterministic tick-driven engine for scenario benchmarks with failure injection.
 - **Event bus** (`ccs.bus`) — pluggable transport for invalidation signals; in-memory by default, swap in Redis, Kafka, NATS, or gRPC streams for production.
 
-Protocol safety properties — single-writer, monotonic versioning, the crash-recovery sweep invariants, the OCC no-lost-update, and the reclamation fence's no-stale-apply — are model-checked with [TLA+/TLC](formal/tla/README.md). The `tla-check` CI job runs all four specs on every push and PR.
+Protocol safety properties — single-writer, monotonic versioning, the crash-recovery sweep invariants, the OCC no-lost-update, the reclamation fence's no-stale-apply, and version retention's no-collected-read — are model-checked with [TLA+/TLC](formal/tla/README.md). The `tla-check` CI job runs all five specs on every push and PR.
 
 ## Status
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -26,19 +26,20 @@ full command-line toolset, and the API reference.
 6. [State transitions log](#state-transitions-log)
 7. [Content audit log](#content-audit-log)
 8. [Crash recovery](#crash-recovery)
-9. [Inline benchmark mode](#inline-benchmark-mode)
-10. [Telemetry](#telemetry)
-11. [Graceful degradation](#graceful-degradation)
-12. [Examples](#examples)
-13. [Real-workload benchmarks](#real-workload-benchmarks)
-14. [Benchmarking your own workload](#benchmarking-your-own-workload)
-15. [`ccs-diagnose` — detect stale reads](#ccs-diagnose--detect-stale-reads)
-16. [Replay (v0.8.2+)](#replay-v082)
-17. [Command-line tools](#command-line-tools)
-18. [API reference](#api-reference)
-19. [Low-level adapter API](#low-level-adapter-api)
-20. [CrewAI and AutoGen adapters](#crewai-and-autogen-adapters)
-21. [OpenAI Agents SDK adapter (experimental)](#openai-agents-sdk-adapter-experimental)
+9. [Version retention and read-at-version](#version-retention-and-read-at-version)
+10. [Inline benchmark mode](#inline-benchmark-mode)
+11. [Telemetry](#telemetry)
+12. [Graceful degradation](#graceful-degradation)
+13. [Examples](#examples)
+14. [Real-workload benchmarks](#real-workload-benchmarks)
+15. [Benchmarking your own workload](#benchmarking-your-own-workload)
+16. [`ccs-diagnose` — detect stale reads](#ccs-diagnose--detect-stale-reads)
+17. [Replay (v0.8.2+)](#replay-v082)
+18. [Command-line tools](#command-line-tools)
+19. [API reference](#api-reference)
+20. [Low-level adapter API](#low-level-adapter-api)
+21. [CrewAI and AutoGen adapters](#crewai-and-autogen-adapters)
+22. [OpenAI Agents SDK adapter (experimental)](#openai-agents-sdk-adapter-experimental)
 
 ---
 
@@ -431,6 +432,91 @@ versioning, and crash-recovery sweep invariants, see
 [`formal/tla/README.md`](../formal/tla/README.md).
 
 ---
+
+## Version retention and read-at-version
+
+By default the coordinator keeps only the **current** version of each artifact.
+Opt in to retaining a bounded history, and you can read back the exact bytes of
+an earlier version.
+
+### Enabling
+
+Pass a `RetentionPolicy` to the registry (retention is off unless
+`retain_versions=True`):
+
+```python
+from ccs.coordinator.retention import RetentionPolicy
+
+policy = RetentionPolicy(max_versions=16, max_age_seconds=None)
+```
+
+`max_versions` keeps the K most-recent versions (including the current one,
+which is never collected); `max_age_seconds` expires versions older than T
+wall-clock seconds. Either axis can be `None` to disable it. GC is amortized —
+it runs inline as new versions are committed; there is no background sweep.
+
+### Durability
+
+The in-memory `ArtifactRegistry` retains versions for the life of the process.
+`SqliteArtifactRegistry` retains them **durably**, surviving a coordinator
+restart, for in-process embedders. Enabling durable retention adds an
+`artifact_versions` table via the store's first real schema-version bump
+(v1 → v2), applied automatically and atomically the first time a v1 database is
+opened. Durable retention is opt-in — a deployment that doesn't enable it stores
+no version content. (The Claude Code hook/HTTP coordinator carries only content
+hashes on the wire, so durable retention there is inert: there are no bodies to
+store. It is an in-process-embedder feature.)
+
+### Reading a version
+
+```python
+result = service.read_at_version(artifact_id, version)
+```
+
+The result is either a `VersionedContent` (`content`, `version`, `captured_at`,
+`coordinator_epoch`) or a typed `VersionedReadRejection` whose `reason` is one of
+six wire-stable constants:
+
+| Reason | Meaning |
+|---|---|
+| `retention_off` | The registry is not retaining versions. |
+| `unknown_artifact` | No such artifact. |
+| `not_retained` | The version is not in the retained history (never captured, or collected / expired). |
+| `current_version` | The requested version is the current one — read it through the normal `read` / `fetch` path, not the history surface. |
+| `future_version` | The version is greater than the current version. |
+| `epoch_mismatch` | The optional `expected_epoch` did not match (the store was reset). |
+
+`read_at_version` is an **off-protocol read**: it grants no MESI state, joins no
+invalidation set, and captures no read-generation fence claim — versioned reads
+never affect a concurrent writer. It serves history only; current content is
+always read through the protocol path.
+
+### Reading from a stored coordinator
+
+`agent-coherence-replay resolve` answers "bytes at version k" against a
+`.coherence/state.db` on disk — useful for audit and post-hoc inspection:
+
+```bash
+agent-coherence-replay resolve --db ./.coherence/state.db \
+    --artifact plans/plan.md --version 2 --json
+```
+
+The store is opened **read-only** (never created, never migrated). Output is
+content-safe by default — `version`, `coordinator_epoch`, `captured_at`, content
+hash and length — and emits the retained bytes only with `--include-content`
+(base64 for binary) or `--output-file` (raw, written `0600`), so secrets don't
+leak into terminals or CI logs. Each rejection reason and store error maps to a
+distinct exit code with the wire-stable `reason` in the JSON envelope.
+
+### Honesty boundary
+
+Retention records and serves the bytes the coordinator committed at each version;
+it does not make an agent's *use* of an old version safe. An agent that reads a
+fresh current version through the protocol but writes content derived from an
+older retained version still commits a fence-legal write of stale meaning — the
+coherence guarantee is "write from the bytes your latest read returned," and
+read-at-version makes an older version easy to fetch, so keep writes anchored to
+the current read.
 
 ## Inline benchmark mode
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -73,6 +73,50 @@ exists (`SessionDirectoryNotEmptyError`) to prevent silent multi-instance
 trace interleave. No content is read by `agent-coherence-replay` from any
 location other than the explicit `session_dir` argument.
 
+### Durable version retention (opt-in)
+
+`SqliteArtifactRegistry` can durably retain a bounded history of committed
+artifact versions (enabled with `retain_versions=True` plus a `RetentionPolicy`;
+**off by default**). This is the one place the coordinator's durable store holds
+artifact **content bytes** rather than only `content_hash` — a deliberate,
+bounded reversal of the prior hash-only posture, scoped to retained versions and
+to in-process embedders (the Claude Code hook/HTTP coordinator topology is
+unchanged and stays hash-only).
+
+| File | Path | Mode | Holds |
+|---|---|---|---|
+| Version store | `<workspace>/.coherence/state.db` (`artifact_versions` table) | `0600` | Retained version bodies (str/bytes), bounded by the configured `max_versions` / `max_age_seconds` |
+
+What this means for sensitive content:
+
+- **Content on disk.** With retention on, version bodies are written to
+  `state.db`. The file and its `-wal` / `-shm` sidecars are created `0600`
+  *before* the first write — there is no umask window — and `.coherence` is
+  `0700`. Migrating an older database re-applies `0600` and warns once. Bodies
+  can contain whatever your artifacts contain (credentials, PII), so treat the
+  file as sensitive: never commit it to git, and copy it only with mode
+  preserved (`install -m 0600` / `cp -p`) — a copy is as sensitive as the
+  content.
+- **Capture at registration.** A version body is captured when an artifact is
+  first registered, not only on write, so a merely-observed artifact's initial
+  body can land on disk.
+- **Deletion, not unreachability.** Collecting a version (policy GC) or an epoch
+  reset (delete-and-recreate of `state.db`) *deletes* the rows, but SQLite may
+  keep freed-page residue in the file and its WAL until a checkpoint / `VACUUM`.
+  To purge rotated content fully, remove `state.db` together with its `-wal` and
+  `-shm` sidecars. Disabling retention does **not** purge existing rows — they
+  stay readable; purge is a re-open under a tighter policy or an epoch reset.
+- **What a retained version is.** The store records the content the coordinator
+  *committed* at that version — not necessarily the bytes a client later
+  persisted elsewhere.
+
+The read side (`CoordinatorService.read_at_version`, `agent-coherence-replay
+resolve`) opens the store **read-only** and returns retained bytes only on
+explicit request; the replay CLI is metadata-only by default and emits bodies
+only via `--include-content` / `--output-file`, so terminals, CI logs, and shell
+history don't capture content inadvertently. No HTTP route serves version
+content.
+
 ## Hash-pinned install for security-sensitive users
 
 For reproducible installs with full dependency-graph pinning:

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -1,6 +1,6 @@
 # TLA+ Formal Verification
 
-TLC model checking for the MESI coherence protocol, its crash-recovery extension, the optimistic commit-CAS (OCC), and the read-generation fence.
+TLC model checking for the MESI coherence protocol, its crash-recovery extension, the optimistic commit-CAS (OCC), the read-generation fence, and bounded version retention with read-at-version.
 
 ## What is modeled
 
@@ -13,18 +13,23 @@ TLC model checking for the MESI coherence protocol, its crash-recovery extension
 - **Reclamation slot lifecycle** — slot preserved through I→S, cleared on I→M∪E re-acquire.
 - **Optimistic commit-CAS (OCC)** — a version-checked commit (`commit_cas`) that bypasses the pessimistic acquire: an S/I writer reads the version (`ObserveAction`), then commits only if its observed version still matches and no other agent holds M∪E. Closes the concurrent lost-update. Corresponds to `commit_cas` in `src/ccs/coordinator/`.
 - **Read-generation fence (Fencing)** — a per-artifact ownership epoch (`ownerGeneration`) bumped atomically on every sweep reclamation, captured into `readGeneration` when an agent establishes its write-claim (`ObserveGenAction` — deliberately decoupled so the sweep can interleave between capture and commit), and enforced by a generation-guarded commit (`FencingCommitAction`): a writer whose captured generation was superseded by a reclamation is rejected even when the version is unchanged — the reclaim-zombie write the version CAS cannot see. Corresponds to `owner_generation` / `read_generation` in `src/ccs/coordinator/`.
+- **Bounded version retention + read-at-version (Retention)** — a per-artifact K-bounded history of committed versions (`history`, content abstracted as the version number), extended and garbage-collected atomically inside the fence-guarded commit (`RetentionCommitAction` — commit + retain + K-GC are one action, mirroring the same-transaction capture discipline), plus an off-protocol read-at-version request (`VersionedReadAction`) proven to be a protocol no-op. Every inherited invariant is re-checked with retention composed in — safety **preservation**, not behavioral equivalence (no refinement mapping). Corresponds to the retention capture points and `CoordinatorService.read_at_version` (plan: `docs/plans/2026-06-10-001-feat-version-retention-read-at-version-plan.md`).
 
 ## What is deliberately out of scope
 
 | Exclusion | Reason |
 |-----------|--------|
-| Transient states (ISG, IED, EIA, SIA, MWB, MSA) | Covered by `enforce_transient_timeouts`; do not interact with the crash-recovery sweep beyond the skip rule |
+| Transient states (ISG, IED, EIA, SIA, MWB, MSA) | Covered by `enforce_transient_timeouts`; do not interact with the crash-recovery sweep beyond the skip rule. Note the fence-coverage nuance: the implementation's `trigger="timeout"` transient eviction does **not** bump `owner_generation` — Fencing and Retention model only the sweep triggers (heartbeat / max_hold) and claim no eviction coverage beyond them |
+| Coordinator restart / epoch reset | In TLA+ the model state IS the durable truth, so "lost in-memory mirror" has no analog (`Fencing.tla` restart exclusion). Retention inherits this: restart-survival of retained rows is an implementation/test property (replay-resolver restart proof), not modelable here |
 | Network partitions | Deferred until partition-safe reclamation scheme lands |
 | Agent-side caching / `ArtifactCache` | Data-plane concern; protocol model is control-plane only |
 | Token-savings / cost metrics | Observability, not correctness |
 | Strategy-specific behavior (lease TTL, access counts, broadcast) | Strategies compose atop the base protocol; invariants hold regardless of strategy |
-| `delete` operation | Artifact deletion invalidates all holders but does not interact with the sweep. Model assumes a fixed artifact set |
-| Full liveness proofs | TLC checks safety invariants; liveness is not checked (bounded models make temporal liveness checks infeasible at this scale). OCC's progress / no-starvation obligation is likewise discharged as a safety property (`NoLostUpdate` + a clean no-op conflict) plus a prose argument, not a temporal check |
+| `delete` operation | Artifact deletion invalidates all holders but does not interact with the sweep. `Artifacts` is a CONSTANT throughout the chain — live-membership guards on every inherited action would be a disproportionate rewrite. Delete-drops-history (cascade) is owned by Python tests |
+| `register_artifact` | No register action exists anywhere in the chain; Retention's initial state retains version 1, covering the trivial case. Per-capture-point coverage is owned by the Python parity suite |
+| Retention policy changes across runs | `MaxRetained` (K) is a per-run CONSTANT; a re-opened store is equivalent to a fresh bounded store. Policy persistence/toggles are owned by Python tests |
+| Behavioral equivalence (refinement mapping) | `Retention.tla` proves safety **preservation** — the inherited invariants re-checked with retention enabled — not behavioral equivalence to Fencing, which would need a refinement mapping |
+| Full liveness proofs | TLC checks safety invariants; liveness is not checked (bounded models make temporal liveness checks infeasible at this scale). OCC's progress / no-starvation obligation is likewise discharged as a safety property (`NoLostUpdate` + a clean no-op conflict) plus a prose argument, not a temporal check. The Retention action property `[][...]_v` is a safety-shaped action check, not a liveness check |
 
 ## File layout
 
@@ -42,6 +47,9 @@ formal/tla/
 ├── Fencing.tla             # amendment: EXTENDS CrashRecovery, adds the read-generation fence
 ├── Fencing.cfg             # TLC config: 3 agents (local deep runs)
 ├── Fencing_CI.cfg          # TLC config: 2 agents (CI, fits 5-min budget)
+├── Retention.tla           # amendment: EXTENDS Fencing, adds bounded retention + read-at-version
+├── Retention.cfg           # TLC config: 3 agents (local deep runs)
+├── Retention_CI.cfg        # TLC config: 2 agents, MaxRetained=2 (CI, fits 5-min budget)
 ├── lib/
 │   └── tla2tools.jar       # committed TLC binary (see version below)
 └── README.md               # this file
@@ -50,7 +58,7 @@ formal/tla/
 ## Running TLC
 
 ```bash
-# All four specs (recommended)
+# All five specs (recommended)
 make tla-check
 
 # Individual models
@@ -65,6 +73,9 @@ java -XX:+UseParallelGC -cp formal/tla/lib/tla2tools.jar tlc2.TLC \
 
 java -XX:+UseParallelGC -cp formal/tla/lib/tla2tools.jar tlc2.TLC \
   -config formal/tla/Fencing_CI.cfg formal/tla/Fencing.tla -workers auto
+
+java -XX:+UseParallelGC -cp formal/tla/lib/tla2tools.jar tlc2.TLC \
+  -config formal/tla/Retention_CI.cfg formal/tla/Retention.tla -workers auto
 ```
 
 Requires Java 17+. CI uses Temurin via `actions/setup-java`.
@@ -73,16 +84,18 @@ Requires Java 17+. CI uses Temurin via `actions/setup-java`.
 
 | ID | TLA+ Name | Checked In | Description |
 |----|-----------|-----------|-------------|
-| I1 | `SingleWriter` | All four | At most one agent holds M∪E per artifact |
-| I2 | `MonotonicVersion` | All four | Artifact version never decreases (≥ 1) |
-| — | `TypeOK` / `CRTypeOK` / `OCCTypeOK` / `FencingTypeOK` | All four | State variables have correct types and bounds |
-| I3 | `SweepExclusivity` | CrashRecovery, OCC, Fencing | No (agent, artifact) reclaimed twice in one tick |
-| I4 | `TriggerExclusivity` | CrashRecovery, OCC, Fencing | Each reclamation has exactly one trigger |
-| I5 | `TickMonotonicity` | CrashRecovery, OCC, Fencing | `lastHeartbeat` never decreases |
-| I6 | `SlotPreservedThroughSHARED` | CrashRecovery, OCC, Fencing | Reclamation slot persists across I→S, cleared only on I→M∪E |
+| I1 | `SingleWriter` | All five | At most one agent holds M∪E per artifact |
+| I2 | `MonotonicVersion` | All five | Artifact version never decreases (≥ 1) |
+| — | `TypeOK` / `CRTypeOK` / `OCCTypeOK` / `FencingTypeOK` / `RetentionTypeOK` | All five | State variables have correct types and bounds (Retention additionally pins the history domain ⊆ `1..MaxVersion`, row count ≤ `MaxRetained`, and the marker-is-the-version content abstraction) |
+| I3 | `SweepExclusivity` | CrashRecovery, OCC, Fencing, Retention | No (agent, artifact) reclaimed twice in one tick |
+| I4 | `TriggerExclusivity` | CrashRecovery, OCC, Fencing, Retention | Each reclamation has exactly one trigger |
+| I5 | `TickMonotonicity` | CrashRecovery, OCC, Fencing, Retention | `lastHeartbeat` never decreases |
+| I6 | `SlotPreservedThroughSHARED` | CrashRecovery, OCC, Fencing, Retention | Reclamation slot persists across I→S, cleared only on I→M∪E |
 | — | `NoLostUpdate` | OCC | No successful `commit_cas` ever landed on a stale observed version — the concurrent lost-update is prevented |
-| — | `ReadGenBounded` | Fencing | A captured read-generation never exceeds the artifact's current ownership epoch |
-| — | `NoStaleApply` | Fencing | No commit ever applied a write whose captured read-generation was superseded by a reclamation — the reclaim-zombie write is prevented |
+| — | `ReadGenBounded` | Fencing, Retention | A captured read-generation never exceeds the artifact's current ownership epoch |
+| — | `NoStaleApply` | Fencing, Retention | No commit ever applied a write whose captured read-generation was superseded by a reclamation — the reclaim-zombie write is prevented. Re-checked in Retention to prove retention preserves the fence |
+| — | `NoCollectedRead` | Retention | No versioned read ever observed a hole inside the promised K-window strictly below the current version — the GC never collects what the bounded-retention contract promises (current version included, by construction) |
+| — | `ReadAtVersionIsProtocolNoOp` | Retention (action property, cfg `PROPERTY`) | `[][VersionedReadAction => UNCHANGED fenceVars]_retentionVars` — any transition satisfying the read action changes no MESI/crash-recovery/fence variable. A state invariant cannot express this: a fence-refreshing read is extensionally identical to a legitimate `ObserveGenAction`, so only an action-level check can catch it |
 
 I7 (FlagOffByteIdentity) is a code-level property and is not modelable in TLA+.
 
@@ -106,6 +119,10 @@ I7 (FlagOffByteIdentity) is a code-level property and is not modelable in TLA+.
 | `FencingSweepAction` | the `owner_generation` bump on reclaim triggers in `set_agent_state` |
 | `FencingCommitAction` | the generation guard in `commit_cas` + `set_artifact_and_content(fence_agent_id=…)` |
 | `NoStaleApply` | dual-registry parity + regression suite (`tests/test_fencing.py`) |
+| `RetentionCommitAction` | the version-bumping registry capture points — `set_artifact_and_content` and `commit_cas` WIN — retaining + inline K-GC (`collectible_versions`) in the same transaction / apply step as the commit; `register_artifact`'s capture is the model's initial state (plan Units 2–3) |
+| `VersionedReadAction` | `CoordinatorService.read_at_version()` — off-protocol read; never calls `set_agent_state`/`set_agent_transient`, so no fence capture and no MESI transition (plan Unit 4) |
+| `NoCollectedRead` | bounded-retention parity suite (`tests/test_retention.py`, plan Units 2–5) |
+| `ReadAtVersionIsProtocolNoOp` | fence non-capture + MESI non-interaction regression tests (plan Unit 4) |
 
 The model abstracts away transient states — the implementation's
 `enforce_transient_timeouts` and transient-skip rule in the sweep are not modeled.
@@ -122,7 +139,7 @@ non-decreasing) holds regardless of the bound.
 
 ## CI time budget
 
-Target: **5 minutes** total across the four specs.
+Target: **5 minutes** total across the five specs (measured 4min 32s sequential on a machine that reproduces the reference Fencing time — snug; treat further spec additions as needing their own budget review).
 
 | Model | Config | Agents | Artifacts | MaxTicks | Distinct States | Wall Time |
 |-------|--------|--------|-----------|----------|----------------|-----------|
@@ -133,6 +150,17 @@ Target: **5 minutes** total across the four specs.
 | OCC (local) | `OCC.cfg` | 3 | 1 | 6 | — | minutes |
 | Fencing (CI) | `Fencing_CI.cfg` | 2 | 1 | 4 | 2,832,014 | ~67s |
 | Fencing (local) | `Fencing.cfg` | 3 | 1 | 6 | — | minutes |
+| Retention (CI) | `Retention_CI.cfg` | 2 | 1 | 4 | 2,832,014 | ~115s |
+| Retention (local) | `Retention.cfg` | 3 | 1 | 6 | >95M | hours |
+
+Retention's distinct-state count **equals** Fencing's by design: the retained history is a
+deterministic function of the version window (content abstracted as the version number)
+and the read action is a stutter in the correct spec, so retention adds transitions and
+per-transition checks (~1.7× Fencing's wall time; 30,483,363 generated vs 28,142,923)
+but zero state-space dimensions. The local 3-agent config is overnight-class, not a
+quick check: measured ≥95M distinct states (703M generated, queue still growing) at the
+40-minute mark on 8 cores — and since the distinct space equals Fencing's, that is also
+the true size of `Fencing.cfg`'s local space.
 
 CI uses `CrashRecovery_CI.cfg` (2 agents, MaxTicks=6) to fit the budget.
 The full 3-agent config (`CrashRecovery.cfg`) is for local deep runs:
@@ -169,5 +197,51 @@ and confirm TLC finds a counterexample:
    trace where a sweep-reclaimed writer's commit lands on a bumped ownership
    epoch. (Verified 2026-06-09: violation found in <1s, 570 distinct states.)
 
+5. **Retention atomicity mutation (crash window)**: In `Retention.tla`, split
+   `RetentionCommitAction`'s retain from its version bump into two separately-
+   interleavable actions: in the WIN branch replace the
+   `LET newVer == ... IN /\ version' = ... /\ history' = RetainAndCollect(art, newVer)`
+   block with `/\ version' = [version EXCEPT ![art] = version[art] + 1]`
+   `/\ UNCHANGED history`, and add a standalone
+   `RetainAction == \E art \in Artifacts : history' = RetainAndCollect(art, version[art]) /\ UNCHANGED <<every other variable>>`
+   as a new disjunct of `RetentionNext`. Run TLC on `Retention_CI.cfg`. TLC
+   should fail with a `NoCollectedRead` violation: two commits land with no
+   retain between them and a versioned read observes the hole inside the
+   K-window — the exact crash window the same-transaction capture discipline
+   excludes. (Verified 2026-06-11: violation found in ~1s, 3,749 states
+   generated.)
+
+6. **Retention fence-refresh mutation**: In `Retention.tla`, make
+   `VersionedReadAction` refresh the reader's fence: remove `readGeneration`
+   from its `UNCHANGED` tuple, bind a reader (`\E ag \in Agents`), and add
+   `readGeneration' = [readGeneration EXCEPT ![ag][art] = ownerGeneration[art]]`.
+   Run TLC on `Retention_CI.cfg`. TLC should fail with an
+   `Action property ReadAtVersionIsProtocolNoOp is violated` error. Note that
+   every state INVARIANT — `NoStaleApply` included — stays green on the
+   violating trace: the refreshed claim is extensionally identical to a
+   legitimate `ObserveGenAction`, which is exactly why the read-no-op claim is
+   checked as an action property. (Verified 2026-06-11: violation found in
+   <1s, 1,370 states generated.)
+
+7. **Retention GC-eats-current mutation**: In `Retention.tla`, flip the GC's
+   oldest-row selection in `RetainAndCollect` from
+   `CHOOSE m \in dom : \A w \in dom : m <= w` to `m >= w` (the GC now drops the
+   NEWEST row — the just-committed current version — once the row count
+   exceeds `MaxRetained`). Run TLC on `Retention_CI.cfg`. TLC should fail with
+   a `NoCollectedRead` violation once a later commit moves the current version
+   past the collected one. This also demonstrates the K-eviction path is
+   genuinely exercised within the CI bounds. (Verified 2026-06-11: violation
+   found in ~2s, 9,892 states generated.)
+
+8. **Retention capture-skip mutation**: In `Retention.tla`, drop the retain
+   from `RetentionCommitAction`'s WIN branch
+   (`history' = RetainAndCollect(art, newVer)` → `UNCHANGED history`). Run TLC
+   on `Retention_CI.cfg`. TLC should fail with a `NoCollectedRead` violation:
+   commits advance the version while history still holds only the initial row,
+   and a read inside the K-window observes the never-retained version.
+   (Verified 2026-06-11: violation found in ~2s, 4,485 states generated.)
+
 These mutations are run manually during development to validate TLC's
-bug-detection capability. The mutated files are not committed.
+bug-detection capability. The mutated files are not committed. Recipes 5–8
+run TLC directly on `Retention_CI.cfg` (mutating `Retention.tla` cannot affect
+the other four specs, so the full `make tla-check` adds nothing).

--- a/formal/tla/Retention.cfg
+++ b/formal/tla/Retention.cfg
@@ -1,0 +1,25 @@
+SPECIFICATION RetentionSpec
+
+CONSTANTS
+    NumAgents = 3
+    NumArtifacts = 1
+    MaxTicks = 6
+    HeartbeatTimeout = 3
+    MaxHoldTicks = 5
+    MaxRetained = 2
+    None = None
+
+INVARIANTS
+    RetentionTypeOK
+    SingleWriter
+    MonotonicVersion
+    SweepExclusivity
+    TriggerExclusivity
+    TickMonotonicity
+    SlotPreservedThroughSHARED
+    ReadGenBounded
+    NoStaleApply
+    NoCollectedRead
+
+PROPERTY
+    ReadAtVersionIsProtocolNoOp

--- a/formal/tla/Retention.tla
+++ b/formal/tla/Retention.tla
@@ -1,0 +1,323 @@
+---------------------------- MODULE Retention ----------------------------
+(* Bounded version-retention amendment to the fenced MESI protocol.
+   Proves that retaining a K-bounded history of committed versions, and
+   serving read-at-version requests from it, changes NOTHING about the
+   coordinator protocol: every inherited safety invariant (single-writer,
+   monotonic versioning, the crash-recovery I3-I6 family, NoStaleApply)
+   is re-checked with retention enabled, and a versioned read is proven
+   to be a protocol no-op.
+
+   Plan: docs/plans/2026-06-10-001-feat-version-retention-read-at-version-plan.md
+   (Unit 1). Origin: the 2026-06-10 version-retention requirements brief
+   (docs/brainstorms/).
+   Models R4 (GC invisible, current never collectible), R6 (fence
+   non-capture), R7 (off-protocol read), R8 (this spec), and the atomic
+   half of R3 (capture happens atomically at commit).
+
+   Adds:
+     - history       : per-artifact map version -> retained content marker.
+                       Content is abstracted as the version number itself:
+                       within a behavior the content at (artifact, version)
+                       is unique (monotonic versions, one committer per
+                       version), so the marker is distinct per version yet
+                       deterministic. A richer marker (e.g. the writer id)
+                       would only add a decorative state-space dimension --
+                       no checked property reads the marker value -- and
+                       measured against the Fencing_CI budget that dimension
+                       is what blows the CI gate. Real byte payloads are
+                       out of the question for the same reason.
+     - collectedRead : a sticky history flag -- TRUE iff a versioned read
+                       ever observed a hole inside the K-window strictly
+                       below the current version, i.e. the service would
+                       have had to answer for a version the bounded-
+                       retention contract promises is servable but which
+                       was collected (or never retained). Mirrors the
+                       staleApply / lostUpdate idiom: the flag flips only
+                       when the modeled implementation would have done the
+                       wrong thing; the correct spec never sets it.
+     - MaxRetained   : the K bound. K counts retained rows INCLUDING the
+                       current version's row; the current version is never
+                       collectible (R4). Mirrors RetentionPolicy.max_versions.
+     - RetentionCommitAction : FencingCommitAction + atomic retain + inline
+                       K-GC (see crux below).
+     - VersionedReadAction   : a read-at-version request -- a pure protocol
+                       no-op (see below).
+
+   KEY MODELING DECISION (the crux). Fencing's crux is that a SINGLE
+   FencingCommitAction models BOTH the pessimistic commit and the OCC
+   commit_cas, because the fence guard is uniform across both paths. The
+   retention capture inherits that uniformity: the implementation retains
+   inside the SAME sqlite transaction / same GIL-atomic apply step as the
+   commit it captures, on every capture point. So Retention REPLACES the
+   one FencingCommitAction with RetentionCommitAction: identical guard,
+   identical protocol effect, PLUS extend history with the new version and
+   apply inline K-GC -- commit + retain + GC are ONE action, atomic by
+   construction. Per-capture-point coverage (pessimistic vs commit_cas vs
+   register_artifact) is discharged by the Python parity suite, not TLC.
+   Mutant recipe 5 (README) splits the retain from the bump into two
+   separately-interleavable actions -- the exact crash window the
+   same-transaction discipline excludes -- and TLC then finds the
+   NoCollectedRead violation.
+
+   THE READ IS A PROTOCOL NO-OP -- and how that is checked. The
+   implementation's read_at_version never calls set_agent_state /
+   set_agent_transient: no MESI transition, no invalidation membership,
+   no read_generation capture (R6/R7 hold by construction there).
+   VersionedReadAction models this: it leaves EVERY protocol variable
+   unchanged (base MESI vars, crash-recovery vars, ownerGeneration,
+   readGeneration, staleApply). Structural UNCHANGED alone is not
+   checkable evidence, though: a mutated read that refreshes the reader's
+   readGeneration produces transitions extensionally identical to a
+   legitimate ObserveGenAction, so no state invariant (NoStaleApply
+   included) can see it. The no-op claim is therefore checked as an
+   explicit TLC ACTION PROPERTY:
+
+       ReadAtVersionIsProtocolNoOp ==
+           [][VersionedReadAction => UNCHANGED fenceVars]_retentionVars
+
+   TLC evaluates [][A]_v action properties on every explored transition
+   (cheap, no liveness graph), so mutant recipe 6 -- the fence-refreshing
+   read -- has a defined failure signal: the property fires even though
+   NoStaleApply stays green. The alternative encoding (a ghost variable
+   capturing pre/post fence-state equality) was rejected because it adds a
+   state dimension; the action property adds none.
+
+   MODELING SCOPE OF THE READ. The reader carries NO agent binding: on
+   this path the requester has no protocol identity (R7) -- the read's
+   effect (none) is the same for every agent. Mutant recipe 6 reintroduces
+   an agent binder to express the fence-refresh bug. The requested version
+   ranges over ServableHistory(art): the K-window STRICTLY below the
+   current version -- the only requests whose answer depends on retention
+   state. Requests outside it -- at the current version (R5
+   current_version rejection), below the window (honest not_retained for
+   a legitimately collected version), or above the current version
+   (future_version) -- are structurally identical typed rejections with
+   the same empty effect and can never flip the flag even in mutants;
+   enumerating them would only add stutter transitions and TLC time, so
+   the Python request-surface tests (plan Unit 4) own them.
+
+   K=1 CAVEAT. With MaxRetained = 1 the window strictly below the current
+   version is empty, so the read action is never enabled, collectedRead
+   can never flip, and the flag has no teeth (the GC also never has a
+   non-current row to drop). Both cfgs therefore use MaxRetained = 2,
+   which keeps K-eviction reachable inside the version bound AND gives
+   mutants 5/7/8 a violation to find. The ASSUME below only enforces the
+   implementation floor (max_versions >= 1, RetentionPolicy.__post_init__).
+
+   DELIBERATELY NOT MODELED (one-line whys; README out-of-scope table):
+     (a) artifact delete -- Artifacts is a CONSTANT throughout the module
+         chain; delete-drops-history (cascade) is owned by Python tests.
+     (b) register_artifact -- no register action exists in the chain; the
+         initial state retains version 1, covering the trivial case.
+     (c) retention-policy changes across runs -- MaxRetained is a per-run
+         CONSTANT; a re-opened store is equivalent to a fresh bounded store.
+     (d) coordinator restart / durability -- inherited exclusion from
+         Fencing (in TLA the state IS the durable truth); restart-survival
+         of retained rows is an implementation/test property (replay
+         resolver, plan Unit 6).
+
+   KNOWN SIBLING GAP (do not over-claim): the implementation's
+   trigger="timeout" transient eviction does NOT bump owner_generation;
+   only the crash-recovery sweep triggers (heartbeat / max_hold) do. This
+   spec models exactly the sweep that Fencing models and claims no
+   eviction coverage beyond it.
+
+   WHAT IS PROVEN: safety PRESERVATION -- the inherited invariants still
+   hold with the retention machinery composed in, plus NoCollectedRead and
+   the read-no-op action property. NOT proven: behavioral equivalence to
+   Fencing (that would need a refinement mapping; deliberately out of
+   scope). LIVENESS is discharged as safety + prose per the repo's
+   safety-only TLC convention (README). *)
+
+EXTENDS Fencing
+
+CONSTANT MaxRetained
+
+(* Implementation floor: RetentionPolicy(max_versions < 1) is a ValueError. *)
+ASSUME MaxRetained >= 1
+
+VARIABLES history, collectedRead
+
+retentionVars == <<fenceVars, history, collectedRead>>
+
+--------------------------------------------------------------------
+(* Retention helpers *)
+--------------------------------------------------------------------
+
+(* The versions the K-bound contract promises are servable: the newest
+   MaxRetained versions, current included (K counts the current row).
+   In the correct spec DOMAIN history[art] equals this window at every
+   reachable state -- every commit retains its version and the GC keeps
+   exactly the newest K rows. *)
+MustRetain(art) ==
+    LET lo == IF version[art] > MaxRetained
+              THEN version[art] - MaxRetained + 1
+              ELSE 1
+    IN lo..version[art]
+
+(* The load-bearing request range for the modeled read: the K-window
+   STRICTLY below the current version. Requests at the current version
+   (R5 current_version rejection) and below the window (honest
+   not_retained for a legitimately collected version) are structurally
+   identical empty-effect rejections that can never flip the flag -- even
+   in mutants -- so enumerating them would only add stutter transitions
+   and TLC time; the Python request-surface tests (plan Unit 4) own them. *)
+ServableHistory(art) ==
+    LET lo == IF version[art] > MaxRetained
+              THEN version[art] - MaxRetained + 1
+              ELSE 1
+    IN lo..(version[art] - 1)
+
+(* Retain newVer and apply inline K-GC in one step: extend the map, then
+   drop the oldest row iff the row count exceeds MaxRetained (row-count
+   semantics, matching collectible_versions in the implementation). A
+   single drop suffices: every extend adds exactly one row to a map the
+   GC already bounded at MaxRetained, so the domain never exceeds
+   MaxRetained + 1 in any reachable state -- including under the README
+   mutants, whose retain steps also GC in-step. The drop selects the
+   OLDEST row, so with MaxRetained >= 1 the GC can NEVER drop the newest
+   (current) version -- R4's "current never collectible" holds by
+   construction. Mutant recipe 7 (README) flips the selection to the
+   newest row, making the current version collectible. *)
+RetainAndCollect(art, newVer) ==
+    LET extended == [v \in (DOMAIN history[art]) \cup {newVer} |->
+                        IF v = newVer THEN newVer ELSE history[art][v]]
+        dom == DOMAIN extended
+        oldest == CHOOSE m \in dom : \A w \in dom : m <= w
+        keep == IF Cardinality(dom) <= MaxRetained THEN dom ELSE dom \ {oldest}
+    IN [history EXCEPT ![art] = [v \in keep |-> extended[v]]]
+
+(* The wrong thing the sticky flag records: a request for a version the
+   contract promises (inside the K-window, strictly below current -- the
+   current version is answered by the protocol path / current_version
+   rejection, never by history) whose row is absent -- collected or never
+   retained. The correct spec keeps DOMAIN history[art] = MustRetain(art),
+   so this is unreachable-TRUE; mutants 5/7/8 make it reachable. *)
+WouldServeCollected(art, v) ==
+    /\ v < version[art]
+    /\ v \in MustRetain(art)
+    /\ v \notin DOMAIN history[art]
+
+--------------------------------------------------------------------
+(* Initialization *)
+--------------------------------------------------------------------
+
+(* Version 1 exists at init (MESI Init); its retained row models the
+   register_artifact capture -- the trivial case of the unmodeled
+   register action (see header note (b)). *)
+RetentionInit ==
+    /\ FencingInit
+    /\ history = [art \in Artifacts |-> [v \in {1} |-> 1]]
+    /\ collectedRead = FALSE
+
+--------------------------------------------------------------------
+(* RetentionCommitAction: FencingCommitAction + atomic retain + K-GC.
+   Guard and protocol effect are IDENTICAL to Fencing's commit (equality
+   admits, conflict is a clean no-op, absent operand rejects); the WIN
+   branch additionally extends history with the new version and collects
+   beyond K -- one atomic action, the same-transaction discipline.
+   Replaces the inherited FencingCommitAction (the crux above). *)
+--------------------------------------------------------------------
+
+RetentionCommitAction ==
+    \E ag \in Agents, art \in Artifacts :
+        /\ readGeneration[ag][art] /= None          (* absent operand => reject (cannot commit) *)
+        /\ version[art] < MaxVersion                (* finite bound *)
+        /\ LET rg == readGeneration[ag][art]
+               og == ownerGeneration[art]
+           IN \/ (* WIN: claim is current -> apply the write AND retain it,
+                    atomically. Version bump, history extend, and K-GC are
+                    one step -- mutant recipe 5 splits them and TLC finds
+                    the crash-window NoCollectedRead violation. *)
+                 /\ rg = og
+                 /\ LET newVer == version[art] + 1
+                    IN /\ version' = [version EXCEPT ![art] = newVer]
+                       /\ history' = RetainAndCollect(art, newVer)
+                 (* Same teeth as Fencing: the WIN guard `rg = og` makes
+                    `rg < og` always FALSE here; removing the guard (the
+                    Fencing mutant) lets a superseded commit win and TLC
+                    reports a NoStaleApply violation. *)
+                 /\ staleApply' = (staleApply \/ (rg < og))
+              \/ (* CONFLICT: rg < og (reclaimed since the claim) -- clean
+                    no-op: no version bump, no mutation, and NO capture
+                    (rejected writes leave history unchanged). *)
+                 /\ ~(rg = og)
+                 /\ UNCHANGED <<version, staleApply, history>>
+        /\ UNCHANGED <<clock, mesiState, lastHeartbeat, grantedAtTick,
+                       lastReclamation, ownerGeneration, readGeneration,
+                       collectedRead>>
+
+--------------------------------------------------------------------
+(* VersionedReadAction: a read-at-version request. A pure protocol no-op:
+   every protocol variable is listed UNCHANGED (the action property below
+   re-checks this against the action, not just its syntax). The only
+   writable slot is the sticky bug flag, and the correct spec never sets
+   it (WouldServeCollected is unreachable-TRUE). No reader binding: the
+   requester has no protocol identity on this path (R7). *)
+--------------------------------------------------------------------
+
+(* The UNCHANGED tuple is deliberately hoisted OUTSIDE the quantifiers
+   and ordered by how often each variable changes (mesiState first, not
+   declaration order): the action property below re-evaluates this
+   formula on every explored transition, and protocol transitions must
+   falsify it on the first compared variable without ever enumerating
+   the window (TLC evaluates conjuncts in order). Semantically identical
+   to the nested, declaration-ordered form. *)
+VersionedReadAction ==
+    /\ UNCHANGED <<mesiState, readGeneration, version, lastHeartbeat,
+                   clock, grantedAtTick, lastReclamation, ownerGeneration,
+                   staleApply, history>>
+    /\ \E art \in Artifacts :
+         \E v \in ServableHistory(art) :
+           collectedRead' = (collectedRead \/ WouldServeCollected(art, v))
+
+--------------------------------------------------------------------
+(* Specification *)
+--------------------------------------------------------------------
+
+(* Inherited actions keep the retention variables unchanged. The fence
+   wrapping mirrors Fencing's own Next; FencingCommitAction is DELIBERATELY
+   replaced by RetentionCommitAction (the crux modeling decision above) --
+   in the retention world every version-bumping commit retains atomically. *)
+RetentionNext ==
+    \/ (CRFetchAction      /\ UNCHANGED <<ownerGeneration, readGeneration, staleApply, history, collectedRead>>)
+    \/ (CRWriteAction      /\ UNCHANGED <<ownerGeneration, readGeneration, staleApply, history, collectedRead>>)
+    \/ (CRInvalidateAction /\ UNCHANGED <<ownerGeneration, readGeneration, staleApply, history, collectedRead>>)
+    \/ (CRTickAction       /\ UNCHANGED <<ownerGeneration, readGeneration, staleApply, history, collectedRead>>)
+    \/ (HeartbeatAction    /\ UNCHANGED <<ownerGeneration, readGeneration, staleApply, history, collectedRead>>)
+    \/ (FencingSweepAction /\ UNCHANGED <<history, collectedRead>>)
+    \/ (ObserveGenAction   /\ UNCHANGED <<history, collectedRead>>)
+    \/ RetentionCommitAction
+    \/ VersionedReadAction
+
+RetentionSpec == RetentionInit /\ [][RetentionNext]_retentionVars
+
+--------------------------------------------------------------------
+(* Invariants *)
+--------------------------------------------------------------------
+
+RetentionTypeOK ==
+    /\ FencingTypeOK
+    /\ collectedRead \in BOOLEAN
+    /\ \A art \in Artifacts :
+         /\ DOMAIN history[art] \subseteq (1..MaxVersion)
+         /\ Cardinality(DOMAIN history[art]) <= MaxRetained
+         (* Pins the content abstraction: the marker IS the version. *)
+         /\ \A v \in DOMAIN history[art] : history[art][v] = v
+
+(* The headline retention property: no versioned read ever observed a
+   collected (or never-retained) version inside the promised K-window.
+   NoStaleApply, SingleWriter, MonotonicVersion, and the CR invariants
+   (I3-I6) are inherited and re-checked to validate composition --
+   safety preservation, not behavioral equivalence (header note). *)
+NoCollectedRead == collectedRead = FALSE
+
+(* The read-no-op ACTION PROPERTY (cfg: PROPERTY, not INVARIANT): any
+   transition satisfying VersionedReadAction changes no fence/MESI/CR
+   variable. This is what catches a fence-refreshing read (mutant 6),
+   which no state invariant can see -- a refreshed claim is
+   indistinguishable from a legitimate ObserveGenAction. *)
+ReadAtVersionIsProtocolNoOp ==
+    [][VersionedReadAction => UNCHANGED fenceVars]_retentionVars
+
+==========================================================================

--- a/formal/tla/Retention_CI.cfg
+++ b/formal/tla/Retention_CI.cfg
@@ -1,0 +1,25 @@
+SPECIFICATION RetentionSpec
+
+CONSTANTS
+    NumAgents = 2
+    NumArtifacts = 1
+    MaxTicks = 4
+    HeartbeatTimeout = 2
+    MaxHoldTicks = 3
+    MaxRetained = 2
+    None = None
+
+INVARIANTS
+    RetentionTypeOK
+    SingleWriter
+    MonotonicVersion
+    SweepExclusivity
+    TriggerExclusivity
+    TickMonotonicity
+    SlotPreservedThroughSHARED
+    ReadGenBounded
+    NoStaleApply
+    NoCollectedRead
+
+PROPERTY
+    ReadAtVersionIsProtocolNoOp

--- a/src/ccs/cli/coherence_replay.py
+++ b/src/ccs/cli/coherence_replay.py
@@ -27,13 +27,22 @@ a resolve outcome from a replay outcome by exit code alone:
 - ``2`` — ≥1 SKIPPED with ``opted_out=False`` (manifest declared the
   stream but the file is missing — capture-side bug; surfaces as a
   distinct exit code so CI catches it instead of treating it as clean).
+  **Exit 2 is ALSO argparse's usage-error exit code** (missing/unknown/
+  mistyped arguments — BOTH modes): argparse exits 2 before either mode's
+  handler runs, so a bare exit-2 status is ambiguous between "capture bug"
+  and "bad invocation". The streams disambiguate: an argparse error prints
+  usage prose to stderr (and, when ``--json`` is among argv, ALSO emits a
+  ``{"kind": "error", "exit_code": 2, "reason": "argument_error", ...}``
+  envelope on stdout), while a capture-bug exit 2 emits findings output.
 - ``3`` — trace error (``MultiInstanceTraceError``, ``TraceCorruptionError``,
   ``ManifestMissingOrUnreadableError``). The exception's message is printed to
   stderr verbatim; tracebacks are caught so partners get the actionable
   next-step pointer instead of Python internals.
 - ``4`` — internal error (any other uncaught exception). Decouples CLI bugs
   from CONFIRMED breach (exit 1) so agents triage cleanly. The exception type +
-  message land on stderr; Python tracebacks are swallowed.
+  message land on stderr; Python tracebacks are swallowed. Under ``--json`` an
+  error envelope (``exit_code: 4``) is emitted on stdout first, keeping the
+  NDJSON stream self-contained on every exit path.
 
 ``resolve``-mode exit codes (5+) — one per read-at-version rejection reason and
 one per resolver open/lookup error, so a script branches on the code (and the
@@ -66,7 +75,14 @@ JSON ``reason`` slug) without parsing prose:
 
 A ``ValueError`` from the service (``--version < 1``, caller misuse) is NOT a
 resolver reason; ``resolve`` mode surfaces it as exit ``4`` (internal/usage)
-with the message on stderr.
+with the message on stderr. A ``--output-file`` that names an existing symlink
+is refused the same way (exit ``4``): the writer never follows a link, so a
+pre-planted symlink cannot redirect retained bytes.
+
+Mode-dispatch escape hatch: the literal first token ``resolve`` always selects
+the subcommand, so a session directory literally named ``resolve`` must be
+passed with a path spelling — ``./resolve`` (or an absolute path) — which never
+matches the bare token and routes to the default replay mode.
 
 Pipe-close handling: ``BrokenPipeError`` (e.g., from ``| head -5``) exits ``0``
 in both modes — consumer-closed-pipe is not a failure mode and should not poison
@@ -108,9 +124,19 @@ import hashlib
 import json
 import sys
 from pathlib import Path
-from typing import Sequence
+from typing import TYPE_CHECKING, NoReturn, Sequence
 
+from ccs.core.exceptions import (
+    CURRENT_VERSION_REASON,
+    EPOCH_MISMATCH_REASON,
+    FUTURE_VERSION_REASON,
+    NOT_RETAINED_REASON,
+    READ_AT_VERSION_REASONS,
+    RETENTION_OFF_REASON,
+    UNKNOWN_ARTIFACT_REASON,
+)
 from ccs.replay import (
+    ReplayConfigurationError,
     ReplayTraceError,
     SessionDirectoryNotFoundError,
     load,
@@ -118,6 +144,9 @@ from ccs.replay import (
 )
 from ccs.replay.formatters import emit_human, emit_json
 from ccs.replay.predicates import Finding, SummaryFinding
+
+if TYPE_CHECKING:  # pragma: no cover — typing only
+    from ccs.core.types import VersionedContent, VersionedReadRejection
 
 _VALID_INVARIANTS: tuple[str, ...] = (
     "single-writer",
@@ -141,14 +170,84 @@ _VALID_INVARIANTS: tuple[str, ...] = (
 # raise a ResolverError (it never imports the resolver).
 _TRACE_ERRORS: tuple[type[ReplayTraceError], ...] = (ReplayTraceError,)
 
-# resolve-mode exit codes (5+) — keyed by the wire-stable read_at_version reason
-# so the mapping is impossible to drift from the constants in core.exceptions.
-# Imported lazily inside the resolve path to honor the no-eager-optional-import
-# discipline (this dict is built there, not at module import).
-_RESOLVE_REJECTION_EXIT_CODE_NOTE = (
-    "current_version=5 not_retained=6 unknown_artifact=7 retention_off=8 "
-    "epoch_mismatch=9 future_version=10"
+# resolve-mode exit codes (5+) — keyed by the wire-stable read_at_version
+# reasons so the mapping cannot drift from the constants in core.exceptions.
+# Module-level (not lazy): ``ccs.core.exceptions`` is the dependency-free core
+# layer, so importing it eagerly keeps ``import ccs.cli.coherence_replay``
+# cheap — the no-eager-optional-import discipline only fences the coordinator
+# surface, which stays lazy inside the resolve path.
+_RESOLVE_REJECTION_EXIT_CODES: dict[str, int] = {
+    CURRENT_VERSION_REASON: 5,
+    NOT_RETAINED_REASON: 6,
+    UNKNOWN_ARTIFACT_REASON: 7,
+    RETENTION_OFF_REASON: 8,
+    EPOCH_MISMATCH_REASON: 9,
+    FUTURE_VERSION_REASON: 10,
+}
+
+# Human hint per reason — rendered into the resolve epilog NEXT TO the exit
+# code so the --help table is GENERATED from the mapping above and cannot drift
+# from it by hand-editing.
+_RESOLVE_REJECTION_HINTS: dict[str, str] = {
+    CURRENT_VERSION_REASON: "use the protocol fetch path for current",
+    NOT_RETAINED_REASON: "never captured / K-evicted / T-expired",
+    UNKNOWN_ARTIFACT_REASON: "id unknown; deleted == never-existed",
+    RETENTION_OFF_REASON: "retention never enabled for this store",
+    EPOCH_MISMATCH_REASON: "--expected-epoch != store epoch",
+    FUTURE_VERSION_REASON: "version > current; hints at a 2nd coordinator",
+}
+
+# Import-time exhaustiveness pin: a reason added to (or renamed in)
+# READ_AT_VERSION_REASONS without a matching exit code / epilog hint must fail
+# LOUDLY at import, not as a KeyError mid-resolve or a silently stale --help.
+if (
+    set(_RESOLVE_REJECTION_EXIT_CODES) != set(READ_AT_VERSION_REASONS)
+    or set(_RESOLVE_REJECTION_HINTS) != set(READ_AT_VERSION_REASONS)
+):
+    raise RuntimeError(
+        "ccs.cli.coherence_replay: the resolve-mode rejection exit-code map "
+        "and epilog hints must cover READ_AT_VERSION_REASONS exactly "
+        f"(codes={sorted(_RESOLVE_REJECTION_EXIT_CODES)}, "
+        f"hints={sorted(_RESOLVE_REJECTION_HINTS)}, "
+        f"reasons={sorted(READ_AT_VERSION_REASONS)}). Update "
+        "_RESOLVE_REJECTION_EXIT_CODES and _RESOLVE_REJECTION_HINTS together "
+        "with the reason constants in ccs.core.exceptions."
+    )
+
+# Compact reason=code note for the DEFAULT parser's epilog pointer (generated
+# from the mapping; insertion order is the exit-code order).
+_RESOLVE_REJECTION_EXIT_CODE_NOTE = " ".join(
+    f"{reason}={code}" for reason, code in _RESOLVE_REJECTION_EXIT_CODES.items()
 )
+
+
+class _ReplayArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser whose usage-error path can also emit the --json envelope.
+
+    argparse handles a bad invocation by printing usage prose to stderr and
+    exiting 2 — BEFORE either mode's guarded handler runs, so the normal
+    envelope logic can never fire. For ``--json`` consumers stdout must stay
+    self-contained on EVERY exit path, so ``main`` flips
+    ``emit_json_error_envelope`` when ``--json`` is among argv and this
+    override emits the standard error envelope (``exit_code: 2``) on stdout
+    first. The stderr prose and the exit status 2 are preserved exactly
+    (``super().error`` raises ``SystemExit(2)``).
+    """
+
+    emit_json_error_envelope: bool = False
+
+    def error(self, message: str) -> NoReturn:
+        if self.emit_json_error_envelope:
+            _emit_json_line(
+                {
+                    "kind": "error",
+                    "exit_code": 2,
+                    "reason": "argument_error",
+                    "exception": "ArgumentError",
+                    "message": message,
+                }
+            )
+        super().error(message)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -161,7 +260,7 @@ def build_parser() -> argparse.ArgumentParser:
     begins with the literal ``resolve`` token, so adding the new mode never
     changes how a bare positional is parsed (no subparser shadows it).
     """
-    parser = argparse.ArgumentParser(
+    parser = _ReplayArgumentParser(
         prog="agent-coherence-replay",
         description=(
             "Replay a captured coordinator session and report invariant "
@@ -177,7 +276,12 @@ def build_parser() -> argparse.ArgumentParser:
             "     (also: BrokenPipeError — consumer closed the pipe early)\n"
             "  1  >=1 CONFIRMED invariant breach\n"
             "  2  >=1 SKIPPED for a stream declared but absent on disk "
-            "(capture bug)\n"
+            "(capture bug).\n"
+            "     ALSO argparse's usage-error exit (bad/missing arguments, "
+            "both modes);\n"
+            "     with --json among argv the usage error additionally emits a "
+            "JSON error\n"
+            "     envelope (exit_code 2, reason argument_error) on stdout\n"
             "  3  Trace error (manifest missing, MULTI_INSTANCE_TRACE, "
             "TRACE_CORRUPTION_DUPLICATE_SEQ)\n"
             "  4  Internal error (uncaught exception; CLI bug — file an issue)\n"
@@ -189,6 +293,11 @@ def build_parser() -> argparse.ArgumentParser:
             "instance-id mismatch); 12 store error (needs_recovery / db_busy / "
             "db_corrupt / schema_version_mismatch); 13 unknown_artifact_path. "
             "See 'resolve --help'.\n"
+            "  A session directory literally named 'resolve' must be passed "
+            "with a path\n"
+            "  spelling (./resolve or absolute) — the bare first token "
+            "'resolve' always\n"
+            "  selects the subcommand.\n"
         ),
     )
     parser.add_argument(
@@ -253,7 +362,14 @@ def build_resolve_parser() -> argparse.ArgumentParser:
     parser stays byte-identical. Content-safe by default: ``--include-content``
     and ``--output-file`` are the only ways retained bytes leave the process.
     """
-    parser = argparse.ArgumentParser(
+    # The per-reason rows are GENERATED from _RESOLVE_REJECTION_EXIT_CODES (+
+    # hints) so the rendered --help can never drift from the implemented
+    # mapping; the import-time pin above guarantees both cover the reason set.
+    rejection_rows = "\n".join(
+        f"  {code:<3} {reason} ({_RESOLVE_REJECTION_HINTS[reason]})"
+        for reason, code in _RESOLVE_REJECTION_EXIT_CODES.items()
+    )
+    parser = _ReplayArgumentParser(
         prog="agent-coherence-replay resolve",
         description=(
             "Resolve 'bytes at version k' against a (restarted) coordinator "
@@ -269,17 +385,17 @@ def build_resolve_parser() -> argparse.ArgumentParser:
         epilog=(
             "Exit codes (resolve mode):\n"
             "  0   WIN — retained bytes resolved at the requested version\n"
-            "  5   current_version (use the protocol fetch path for current)\n"
-            "  6   not_retained (never captured / K-evicted / T-expired)\n"
-            "  7   unknown_artifact (id unknown; deleted == never-existed)\n"
-            "  8   retention_off (retention never enabled for this store)\n"
-            "  9   epoch_mismatch (--expected-epoch != store epoch)\n"
-            "  10  future_version (version > current; hints at a 2nd coordinator)\n"
+            "  2   argument/usage error from the parser (argparse-native; with "
+            "--json among\n"
+            "      argv a JSON error envelope is still emitted on stdout)\n"
+            "  4   usage error past parsing (--version < 1, --output-file is a "
+            "symlink) or\n"
+            "      internal error (shared with the default mode)\n"
+            f"{rejection_rows}\n"
             "  11  config error: missing --db, or --instance-id mismatch\n"
             "  12  store error: needs_recovery / db_busy / db_corrupt / "
             "schema_version_mismatch\n"
             "  13  unknown_artifact_path (--artifact path matched no row)\n"
-            "  4   usage error (e.g. --version < 1) or internal error\n"
         ),
     )
     parser.add_argument(
@@ -335,9 +451,11 @@ def build_resolve_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help=(
-            "Write the RAW retained bytes to this path (created at 0o600). The "
-            "metadata still goes to stdout. Use this instead of "
-            "--include-content when piping binary content."
+            "Write the RAW retained bytes to this path (created at 0o600, "
+            "written atomically via a same-directory temp file). An existing "
+            "symlink at the path is refused (exit 4) — the writer never "
+            "follows links. The metadata still goes to stdout. Use this "
+            "instead of --include-content when piping binary content."
         ),
     )
     parser.add_argument(
@@ -390,10 +508,19 @@ def main(argv: Sequence[str] | None = None) -> int:
       (CONFIRMED breach) so agents triage cleanly.
     """
     argv_list = list(sys.argv[1:] if argv is None else argv)
+    # The bare literal token ONLY selects the subcommand: a path spelling of a
+    # session dir named "resolve" (./resolve, /x/resolve) carries a separator
+    # and can never equal the bare word, so it routes to the default replay
+    # mode — the documented escape hatch for that collision (see the epilog).
     if argv_list and argv_list[0] == "resolve":
         return _run_resolve_guarded(argv_list[1:])
 
-    args = build_parser().parse_args(argv_list)
+    parser = build_parser()
+    # Flip the argparse usage-error path into envelope mode by peeking argv:
+    # a parse failure never produces a Namespace, so the flag cannot come from
+    # parse_args itself.
+    parser.emit_json_error_envelope = "--json" in argv_list
+    args = parser.parse_args(argv_list)
     try:
         return _run(args)
     except BrokenPipeError:
@@ -421,6 +548,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"agent-coherence-replay: {exc}", file=sys.stderr)
         return 3
     except Exception as exc:  # noqa: BLE001 — intentional translate-and-return
+        # Same self-contained-stdout discipline as exit 3: --json consumers
+        # get a parseable envelope even when the CLI itself is the bug.
+        if args.json:
+            _emit_json_line(
+                {
+                    "kind": "error",
+                    "exit_code": 4,
+                    "exception": type(exc).__name__,
+                    "message": str(exc),
+                }
+            )
         print(
             f"agent-coherence-replay: internal error: "
             f"{type(exc).__name__}: {exc}",
@@ -491,11 +629,16 @@ def _run_resolve_guarded(resolve_argv: Sequence[str]) -> int:
     ``BrokenPipeError`` → exit 0 (pipe closed). Resolver errors and rejections
     are handled INSIDE ``_run_resolve`` (each mapped to its own 5+ exit code);
     anything else uncaught → exit 4 with the type/message on stderr (no
-    traceback), matching the default mode's internal-error contract. A
-    ``ValueError`` (``--version < 1``) is caller misuse → exit 4 as a usage
-    error.
+    traceback) plus, under ``--json``, an error envelope on stdout — matching
+    the default mode's internal-error contract. A ``ValueError``
+    (``--version < 1``) and a ``ReplayConfigurationError`` raised past parse
+    time (``--output-file`` is a symlink) are caller misuse → exit 4 as usage
+    errors.
     """
-    args = build_resolve_parser().parse_args(list(resolve_argv))
+    resolve_argv_list = list(resolve_argv)
+    parser = build_resolve_parser()
+    parser.emit_json_error_envelope = "--json" in resolve_argv_list
+    args = parser.parse_args(resolve_argv_list)
     try:
         return _run_resolve(args)
     except BrokenPipeError:
@@ -505,30 +648,28 @@ def _run_resolve_guarded(resolve_argv: Sequence[str]) -> int:
         # resolver reason. Surface on stderr (+ JSON envelope) and exit 4.
         _emit_resolve_error_envelope(args, reason="usage_error", exit_code=4, exc=exc)
         return 4
+    except ReplayConfigurationError as exc:
+        # Config misuse detected PAST parse time (e.g. --output-file names an
+        # existing symlink). Same usage-error surface as ValueError. The
+        # instance-id mismatch (also a ReplayConfigurationError) never reaches
+        # here — _run_resolve maps it to exit 11 first.
+        _emit_resolve_error_envelope(args, reason="usage_error", exit_code=4, exc=exc)
+        return 4
     except Exception as exc:  # noqa: BLE001 — intentional translate-and-return
-        print(
-            f"agent-coherence-replay resolve: internal error: "
-            f"{type(exc).__name__}: {exc}",
-            file=sys.stderr,
-        )
+        # Keep stdout self-contained for --json consumers on the unexpected
+        # path too (the ValueError arm above already does); stderr prose stays.
+        _emit_resolve_internal_error(args, exc)
         return 4
 
 
 def _run_resolve(args: argparse.Namespace) -> int:
     """Resolve one version and render the content-safe output. Returns exit code.
 
-    Lazy imports (optional-extra discipline): the resolver + reason constants are
-    imported HERE, not at module top, so ``import ccs.cli.coherence_replay`` does
-    not pull the coordinator surface.
+    Lazy imports (optional-extra discipline): the resolver (which pulls the
+    coordinator surface) is imported HERE, not at module top, so ``import
+    ccs.cli.coherence_replay`` stays cheap. The reason constants + exit-code
+    map live at module level (``ccs.core.exceptions`` is dependency-free).
     """
-    from ccs.core.exceptions import (
-        CURRENT_VERSION_REASON,
-        EPOCH_MISMATCH_REASON,
-        FUTURE_VERSION_REASON,
-        NOT_RETAINED_REASON,
-        RETENTION_OFF_REASON,
-        UNKNOWN_ARTIFACT_REASON,
-    )
     from ccs.core.types import VersionedContent, VersionedReadRejection
     from ccs.replay.resolver import (
         ResolverError,
@@ -538,16 +679,6 @@ def _run_resolve(args: argparse.Namespace) -> int:
         ResolverUnknownArtifactPathError,
         resolve_version,
     )
-
-    # Per-rejection exit code, keyed on the wire-stable reason so it cannot drift.
-    rejection_exit_codes = {
-        CURRENT_VERSION_REASON: 5,
-        NOT_RETAINED_REASON: 6,
-        UNKNOWN_ARTIFACT_REASON: 7,
-        RETENTION_OFF_REASON: 8,
-        EPOCH_MISMATCH_REASON: 9,
-        FUTURE_VERSION_REASON: 10,
-    }
 
     request = ResolverRequest(
         db_path=args.db,
@@ -574,8 +705,8 @@ def _run_resolve(args: argparse.Namespace) -> int:
         return 12
 
     if isinstance(outcome, VersionedReadRejection):
-        exit_code = rejection_exit_codes[outcome.reason]
-        _emit_resolve_rejection(args, outcome)
+        exit_code = _RESOLVE_REJECTION_EXIT_CODES[outcome.reason]
+        _emit_resolve_rejection(args, outcome, exit_code=exit_code)
         return exit_code
 
     assert isinstance(outcome, VersionedContent)
@@ -596,36 +727,77 @@ def _content_metadata(content: str | bytes) -> tuple[str, int]:
 
 
 def _write_output_file(path: Path, content: str | bytes) -> None:
-    """Write RAW bytes to ``path`` at mode 0o600 (race-free at creation).
+    """Write RAW bytes to ``path`` at mode 0o600, atomically, never via a symlink.
 
-    Pre-creates the file via ``os.open(O_CREAT, 0o600)`` BEFORE writing so the
-    bytes never land in a file that briefly existed world-readable (the
-    audit_log / state.db 0600-at-creation pattern). A ``str`` body is written as
-    utf-8; ``bytes`` verbatim.
+    Three guarantees (each is a hardening fix over the original direct-write):
+
+    - **No symlink follow.** The target is probed with ``O_NOFOLLOW``: an
+      existing symlink at ``path`` fails with ``ELOOP`` and is refused via the
+      replay layer's typed config error — a pre-planted link can never redirect
+      retained bytes (and the final ``os.replace`` would only ever REPLACE the
+      link inode, never write through it; the probe refuses even that).
+    - **Atomic publish.** Bytes land in a same-directory ``mkstemp`` temp file
+      (created 0600 by mkstemp's contract, umask-independent) and reach
+      ``path`` only via ``os.replace`` — a mid-write failure unlinks the temp
+      and leaves the target absent or with its prior content intact, never
+      partial/empty.
+    - **0600 always.** The published inode IS the 0600 temp file, so even an
+      operator-broadened pre-existing target ends at 0600 (replace swaps the
+      inode; no chmod window).
+
+    A ``str`` body is written as utf-8; ``bytes`` verbatim.
     """
+    import errno
     import os
+    import tempfile
 
     raw = content.encode("utf-8") if isinstance(content, str) else content
-    fd = os.open(str(path), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+
+    # Symlink probe: no O_CREAT (a missing target is fine — ENOENT passes) and
+    # no O_TRUNC (must not clobber prior content before the temp write lands).
     try:
-        with os.fdopen(fd, "wb") as fh:
-            fh.write(raw)
+        probe_fd = os.open(str(path), os.O_WRONLY | os.O_NOFOLLOW)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise ReplayConfigurationError(
+                f"--output-file {path} is a symlink; refusing to write retained "
+                f"bytes through a link. Pass the real destination path instead."
+            ) from exc
+        if exc.errno != errno.ENOENT:
+            raise
+    else:
+        os.close(probe_fd)
+
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=path.name + ".", suffix=".tmp"
+    )
+    try:
+        fh = os.fdopen(fd, "wb")
     except BaseException:
-        # If fdopen failed before taking ownership, close the raw fd.
+        # fdopen itself failed — the raw fd is still OURS to close. (Once
+        # fdopen succeeds the file object owns the fd; closing it again there
+        # would double-close a possibly re-used descriptor.)
+        os.close(fd)
         try:
-            os.close(fd)
+            os.unlink(tmp_name)
         except OSError:
             pass
         raise
-    # Tighten in case an operator-broadened pre-existing file kept a wider mode
-    # (O_CREAT does not chmod an existing file).
     try:
-        os.chmod(str(path), 0o600)
-    except OSError:
-        pass
+        with fh:
+            fh.write(raw)
+        os.replace(tmp_name, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
 
-def _emit_resolve_content(args: argparse.Namespace, outcome) -> None:
+def _emit_resolve_content(
+    args: argparse.Namespace, outcome: VersionedContent
+) -> None:
     """Render a WIN — metadata always; bytes only via --include-content/--output-file."""
     content = outcome.content
     content_hash, content_length = _content_metadata(content)
@@ -684,22 +856,31 @@ def _emit_resolve_content(args: argparse.Namespace, outcome) -> None:
     _write_human_block("\n".join(lines))
 
 
-def _emit_resolve_rejection(args: argparse.Namespace, rejection) -> None:
-    """Render a typed rejection — reason slug + version metadata, NO body."""
-    payload = {
-        "kind": "rejected",
-        "exit_code": None,  # filled by the caller's exit-code map; informational
-        "reason": rejection.reason,
-        "artifact_id": str(rejection.artifact_id),
-        "requested_version": rejection.requested_version,
-        "current_version": rejection.current_version,
-        "coordinator_epoch": rejection.coordinator_epoch,
-    }
+def _emit_resolve_rejection(
+    args: argparse.Namespace,
+    rejection: VersionedReadRejection,
+    *,
+    exit_code: int,
+) -> None:
+    """Render a typed rejection — reason slug + version metadata, NO body.
+
+    ``exit_code`` is the REAL per-reason code the caller is about to return
+    (from ``_RESOLVE_REJECTION_EXIT_CODES``), included in the JSON envelope so
+    a scripted consumer reading only stdout sees the same signal the process
+    exit status carries — the same field the error envelopes already emit.
+    """
     if args.json:
-        # Drop the placeholder exit_code (the process exit code is authoritative;
-        # keeping a null here would mislead a scripted consumer).
-        payload.pop("exit_code")
-        _emit_json_line(payload)
+        _emit_json_line(
+            {
+                "kind": "rejected",
+                "exit_code": exit_code,
+                "reason": rejection.reason,
+                "artifact_id": str(rejection.artifact_id),
+                "requested_version": rejection.requested_version,
+                "current_version": rejection.current_version,
+                "coordinator_epoch": rejection.coordinator_epoch,
+            }
+        )
         return
     lines = [
         f"read-at-version rejected: {rejection.reason}",
@@ -733,7 +914,32 @@ def _emit_resolve_error_envelope(
     print(f"agent-coherence-replay resolve: {exc}", file=sys.stderr)
 
 
-def _emit_json_line(payload: dict) -> None:
+def _emit_resolve_internal_error(args: argparse.Namespace, exc: Exception) -> None:
+    """Emit the resolve mode's exit-4 internal-error: envelope (if --json) + stderr.
+
+    The unexpected-exception twin of :func:`_emit_resolve_error_envelope` —
+    same envelope shape with ``reason: internal_error``, plus the default
+    mode's distinctive ``internal error:`` stderr prose so a human log reader
+    can tell a CLI bug from caller misuse at a glance.
+    """
+    if getattr(args, "json", False):
+        _emit_json_line(
+            {
+                "kind": "error",
+                "exit_code": 4,
+                "reason": "internal_error",
+                "exception": type(exc).__name__,
+                "message": str(exc),
+            }
+        )
+    print(
+        f"agent-coherence-replay resolve: internal error: "
+        f"{type(exc).__name__}: {exc}",
+        file=sys.stderr,
+    )
+
+
+def _emit_json_line(payload: dict[str, object]) -> None:
     """Write one JSON object + newline to stdout with an explicit flush.
 
     write+flush (not ``print``) so a downstream ``BrokenPipeError`` surfaces

--- a/src/ccs/cli/coherence_replay.py
+++ b/src/ccs/cli/coherence_replay.py
@@ -3,53 +3,108 @@
 
 """``agent-coherence-replay`` — invariant replay CLI (Unit 5 of D v1).
 
-Walks a captured session directory (manifest.json + per-stream JSONL)
-through the predicate engine and emits human-readable or JSON findings.
+Two modes share one console script:
 
-Exit-code mapping resolved in plan Open Question P1-A (mirrors
-``docs/proposals/replay_trace_format.md`` §7.3):
+1. **Default — invariant replay** (``agent-coherence-replay <session_dir>``):
+   walks a captured session directory (manifest.json + per-stream JSONL)
+   through the predicate engine and emits human-readable or JSON findings.
+2. **``resolve`` subcommand** (Unit 6 of item N v1 / R5b): answers "bytes at
+   version k" against a (restarted) coordinator ``.coherence/state.db`` by
+   opening it READ-ONLY and calling ``read_at_version`` — the restart-survival
+   proof. Additive; the bare positional invocation above is byte-for-byte
+   unchanged (see :func:`main` for how the modes are dispatched without the
+   subparser shadowing a plain ``<session_dir>`` argument).
+
+Exit-code mapping — the default mode owns ``0–4`` (resolved in plan Open
+Question P1-A; mirrors ``docs/proposals/replay_trace_format.md`` §7.3); the
+``resolve`` mode DELIBERATELY EXTENDS the space with ``5+`` so a script can tell
+a resolve outcome from a replay outcome by exit code alone:
 
 - ``0`` — clean OR all SKIPPED entries are compliance opt-outs
-  (``opted_out=True``) declared in ``manifest.streams``.
+  (``opted_out=True``) declared in ``manifest.streams``; ALSO a resolve WIN
+  (retained bytes found at the requested version).
 - ``1`` — ≥1 CONFIRMED breach.
 - ``2`` — ≥1 SKIPPED with ``opted_out=False`` (manifest declared the
   stream but the file is missing — capture-side bug; surfaces as a
   distinct exit code so CI catches it instead of treating it as clean).
-- ``3`` — trace error (``MultiInstanceTraceError``,
-  ``TraceCorruptionError``, ``ManifestMissingOrUnreadableError``). The
-  exception's message is printed to stderr verbatim; tracebacks are
-  caught so partners get the actionable next-step pointer instead of
-  Python internals.
-- ``4`` — internal error (any other uncaught exception). Decouples
-  CLI bugs from CONFIRMED breach (exit 1) so agents triage cleanly.
-  The exception type + message land on stderr; Python tracebacks are
-  swallowed.
+- ``3`` — trace error (``MultiInstanceTraceError``, ``TraceCorruptionError``,
+  ``ManifestMissingOrUnreadableError``). The exception's message is printed to
+  stderr verbatim; tracebacks are caught so partners get the actionable
+  next-step pointer instead of Python internals.
+- ``4`` — internal error (any other uncaught exception). Decouples CLI bugs
+  from CONFIRMED breach (exit 1) so agents triage cleanly. The exception type +
+  message land on stderr; Python tracebacks are swallowed.
 
-Pipe-close handling: ``BrokenPipeError`` (e.g., from ``| head -5``)
-exits ``0`` — consumer-closed-pipe is not a failure mode and should
-not poison exit-code-driven CI pipelines.
+``resolve``-mode exit codes (5+) — one per read-at-version rejection reason and
+one per resolver open/lookup error, so a script branches on the code (and the
+JSON ``reason`` slug) without parsing prose:
 
-AMBIGUOUS suppression resolved in plan Open Question P1-B: per-finding
-output suppresses AMBIGUOUS by default; ``--include-ambiguous`` opts
-in. Summary ALWAYS counts AMBIGUOUS, and the callout fires when count
-exceeds ``--ambiguous-threshold`` (default 10), naming both remedies.
+- ``5``  — ``current_version`` rejection (history surface serves history only;
+  current bytes are read via the protocol fetch path, never here).
+- ``6``  — ``not_retained`` rejection (the version is in range but no servable
+  row exists: never captured, K-evicted, or T-expired — deliberately one
+  reason).
+- ``7``  — ``unknown_artifact`` rejection (the artifact id is unknown to the
+  registry; deleted ≡ never-existed).
+- ``8``  — ``retention_off`` rejection (retention was never enabled for this
+  store).
+- ``9``  — ``epoch_mismatch`` rejection (``--expected-epoch`` != the store
+  epoch; the store was reset since the caller captured it).
+- ``10`` — ``future_version`` rejection (version > current — hints at a second
+  coordinator writing the same store).
+- ``11`` — resolver CONFIG error: the ``--db`` path is missing (no store
+  materialized), OR an ``--instance-id`` cross-check disagreed with the store's
+  persisted identity. (Both are caller/config misuse.)
+- ``12`` — resolver STORE error: the store needs recovery (hot WAL a read-only
+  conn cannot replay), is locked (SQLITE_BUSY), is corrupt (non-sqlite), or is a
+  v1/wrong-schema db (read-only mode performs no migration). The JSON ``reason``
+  slug distinguishes ``needs_recovery`` / ``db_busy`` / ``db_corrupt`` /
+  ``schema_version_mismatch`` so scripts stay precise within this class.
+- ``13`` — resolver LOOKUP error: a workspace-path selector matched no
+  ``artifacts.name`` row (a by-path miss; distinct from the by-id
+  ``unknown_artifact`` rejection above so the two never blur).
 
-JSON error envelope (Gated #15 resolution): when ``--json`` is active
-and a trace error fires (exit 3), a final NDJSON object is written to
-stdout before the human prose hits stderr::
+A ``ValueError`` from the service (``--version < 1``, caller misuse) is NOT a
+resolver reason; ``resolve`` mode surfaces it as exit ``4`` (internal/usage)
+with the message on stderr.
+
+Pipe-close handling: ``BrokenPipeError`` (e.g., from ``| head -5``) exits ``0``
+in both modes — consumer-closed-pipe is not a failure mode and should not poison
+exit-code-driven CI pipelines.
+
+AMBIGUOUS suppression resolved in plan Open Question P1-B: per-finding output
+suppresses AMBIGUOUS by default; ``--include-ambiguous`` opts in. Summary ALWAYS
+counts AMBIGUOUS, and the callout fires when count exceeds
+``--ambiguous-threshold`` (default 10), naming both remedies.
+
+JSON error envelope (Gated #15 resolution): when ``--json`` is active and a
+trace error fires (exit 3), a final NDJSON object is written to stdout before
+the human prose hits stderr::
 
     {"kind": "error", "exit_code": 3, "exception": "<ClassName>",
      "message": "..."}
 
-Keeps stdout self-contained for ``--json`` consumers; the stderr line
-remains for human log tailing. The pre-flight session-directory check
-raises ``SessionDirectoryNotFoundError`` (a ``ReplayTraceError``
-subclass) so the envelope logic stays centralized in the outer catch.
+Keeps stdout self-contained for ``--json`` consumers; the stderr line remains
+for human log tailing. The pre-flight session-directory check raises
+``SessionDirectoryNotFoundError`` (a ``ReplayTraceError`` subclass) so the
+envelope logic stays centralized in the outer catch.
+
+Content-safe-by-default (``resolve`` mode security decision, plan Unit 6
+Approach): the DEFAULT output (human + ``--json``) carries METADATA ONLY —
+``version``, ``coordinator_epoch``, ``captured_at``, ``content_hash``
+(sha-256 over the bytes), ``content_length`` — plus a machine-readable
+``reason`` on rejection. Retained BYTES reach stdout/a file ONLY via an explicit
+``--include-content`` (base64 for BLOB/bytes with a ``content_encoding`` field;
+str as-is) or ``--output-file`` (raw bytes, file created at ``0o600``). This is
+the first surface piping retained bytes outside the 0600-protected store —
+terminals, CI logs, and shell history must not capture secrets by default.
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -78,20 +133,46 @@ _VALID_INVARIANTS: tuple[str, ...] = (
 # new trace-error subclass auto-routes correctly without touching this
 # handler — the previous tuple-based shape needed to be edited each
 # time a new error class was added.
+#
+# NOTE: the Unit 6 ``ResolverError`` family also subclasses
+# ``ReplayTraceError``, but ``resolve`` mode is dispatched BEFORE this guard
+# (its own try/except in ``_run_resolve_guarded``), so resolver errors never
+# fall through to the exit-3 default handler. The default replay path can never
+# raise a ResolverError (it never imports the resolver).
 _TRACE_ERRORS: tuple[type[ReplayTraceError], ...] = (ReplayTraceError,)
+
+# resolve-mode exit codes (5+) — keyed by the wire-stable read_at_version reason
+# so the mapping is impossible to drift from the constants in core.exceptions.
+# Imported lazily inside the resolve path to honor the no-eager-optional-import
+# discipline (this dict is built there, not at module import).
+_RESOLVE_REJECTION_EXIT_CODE_NOTE = (
+    "current_version=5 not_retained=6 unknown_artifact=7 retention_off=8 "
+    "epoch_mismatch=9 future_version=10"
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Build the DEFAULT-mode (invariant replay) parser.
+
+    Byte-compatibility contract: this parser is byte-for-byte the pre-Unit-6
+    parser — a plain ``agent-coherence-replay <session_dir>`` parses exactly as
+    before. The ``resolve`` subcommand is a SEPARATE parser
+    (:func:`build_resolve_parser`); ``main`` dispatches to it only when ``argv``
+    begins with the literal ``resolve`` token, so adding the new mode never
+    changes how a bare positional is parsed (no subparser shadows it).
+    """
     parser = argparse.ArgumentParser(
         prog="agent-coherence-replay",
         description=(
             "Replay a captured coordinator session and report invariant "
             "breaches. Consumes the trace format documented in "
-            "docs/proposals/replay_trace_format.md."
+            "docs/proposals/replay_trace_format.md. For read-at-version "
+            "resolution against a (restarted) coordinator store, use the "
+            "'resolve' subcommand: agent-coherence-replay resolve --help."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
-            "Exit codes:\n"
+            "Exit codes (default replay mode):\n"
             "  0  Clean OR all SKIPPED reasons opted out via manifest streams=\n"
             "     (also: BrokenPipeError — consumer closed the pipe early)\n"
             "  1  >=1 CONFIRMED invariant breach\n"
@@ -100,6 +181,14 @@ def build_parser() -> argparse.ArgumentParser:
             "  3  Trace error (manifest missing, MULTI_INSTANCE_TRACE, "
             "TRACE_CORRUPTION_DUPLICATE_SEQ)\n"
             "  4  Internal error (uncaught exception; CLI bug — file an issue)\n"
+            "\n"
+            "Read-at-version resolution: 'agent-coherence-replay resolve "
+            "--db <state.db> --artifact <path|uuid> --version <n>'.\n"
+            "  resolve exit codes EXTEND the space (5+): "
+            f"{_RESOLVE_REJECTION_EXIT_CODE_NOTE}; 11 config error (missing db / "
+            "instance-id mismatch); 12 store error (needs_recovery / db_busy / "
+            "db_corrupt / schema_version_mismatch); 13 unknown_artifact_path. "
+            "See 'resolve --help'.\n"
         ),
     )
     parser.add_argument(
@@ -157,29 +246,154 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def build_resolve_parser() -> argparse.ArgumentParser:
+    """Build the ``resolve`` subcommand parser (read-at-version; Unit 6 / R5b).
+
+    A standalone parser (prog ``agent-coherence-replay resolve``) so the default
+    parser stays byte-identical. Content-safe by default: ``--include-content``
+    and ``--output-file`` are the only ways retained bytes leave the process.
+    """
+    parser = argparse.ArgumentParser(
+        prog="agent-coherence-replay resolve",
+        description=(
+            "Resolve 'bytes at version k' against a (restarted) coordinator "
+            "store. Opens .coherence/state.db READ-ONLY (never migrates, never "
+            "creates) and calls read_at_version. Output is content-safe by "
+            "default (metadata only); retained bytes leave the process ONLY via "
+            "--include-content or --output-file. Note: a rejection can become "
+            "servable history the moment a peer commits a newer version, and "
+            "current bytes are never served here (read those via the protocol "
+            "fetch path)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Exit codes (resolve mode):\n"
+            "  0   WIN — retained bytes resolved at the requested version\n"
+            "  5   current_version (use the protocol fetch path for current)\n"
+            "  6   not_retained (never captured / K-evicted / T-expired)\n"
+            "  7   unknown_artifact (id unknown; deleted == never-existed)\n"
+            "  8   retention_off (retention never enabled for this store)\n"
+            "  9   epoch_mismatch (--expected-epoch != store epoch)\n"
+            "  10  future_version (version > current; hints at a 2nd coordinator)\n"
+            "  11  config error: missing --db, or --instance-id mismatch\n"
+            "  12  store error: needs_recovery / db_busy / db_corrupt / "
+            "schema_version_mismatch\n"
+            "  13  unknown_artifact_path (--artifact path matched no row)\n"
+            "  4   usage error (e.g. --version < 1) or internal error\n"
+        ),
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        required=True,
+        help=(
+            "Path to the coordinator .coherence/state.db to resolve against. "
+            "Opened READ-ONLY; a missing path fails (exit 11) and NEVER creates "
+            "a fresh store."
+        ),
+    )
+    parser.add_argument(
+        "--artifact",
+        required=True,
+        help=(
+            "Artifact selector: a workspace path (artifacts.name, UNIQUE) or a "
+            "raw artifact UUID. A path that matches no row fails (exit 13); an "
+            "unknown UUID returns the unknown_artifact rejection (exit 7)."
+        ),
+    )
+    parser.add_argument(
+        "--version",
+        type=int,
+        required=True,
+        help=(
+            "The 1-based version to resolve. Must be >= 1 (sub-1 is a usage "
+            "error, exit 4). version == current is rejected (exit 5); the "
+            "history surface serves history only."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Emit a single JSON object (metadata-only by default) instead of "
+            "human-readable text. Carries the wire-stable 'reason' on rejection "
+            "so scripts never parse prose."
+        ),
+    )
+    parser.add_argument(
+        "--include-content",
+        action="store_true",
+        help=(
+            "Include the retained body in the output (bytes are base64-encoded "
+            "with a content_encoding field; str is emitted as-is). OFF by "
+            "default: this is the first surface piping retained bytes outside "
+            "the 0600 store — keep secrets out of terminals/CI logs/history."
+        ),
+    )
+    parser.add_argument(
+        "--output-file",
+        type=Path,
+        default=None,
+        help=(
+            "Write the RAW retained bytes to this path (created at 0o600). The "
+            "metadata still goes to stdout. Use this instead of "
+            "--include-content when piping binary content."
+        ),
+    )
+    parser.add_argument(
+        "--expected-epoch",
+        default=None,
+        help=(
+            "If given, the resolve rejects epoch_mismatch (exit 9) unless this "
+            "equals the store's coordinator_epoch. MANUAL flag — epoch-at-"
+            "capture in the recorder is a separate deferred task."
+        ),
+    )
+    parser.add_argument(
+        "--instance-id",
+        default=None,
+        help=(
+            "Optional identity cross-check: verify this equals the store's "
+            "persisted instance_id (from a trace manifest) before serving any "
+            "bytes. A mismatch fails (exit 11) — the resolve is pointed at the "
+            "wrong store."
+        ),
+    )
+    return parser
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Entry point — returns the exit code; never calls ``sys.exit``.
 
-    Three guards in order of specificity:
+    Mode dispatch (the byte-compat hinge): if the FIRST positional token in
+    ``argv`` is the literal ``resolve``, route to the resolve subcommand;
+    otherwise run the default invariant-replay path with the unchanged parser.
+    Peeking at ``argv`` (rather than wiring ``add_subparsers`` onto the default
+    parser) is what keeps a plain ``agent-coherence-replay <session_dir>``
+    parsing identical to the pre-Unit-6 CLI — a subparser would otherwise
+    consume ``<session_dir>`` as an (invalid) subcommand name.
 
-    - ``_TRACE_ERRORS + OSError`` (exit 3): the documented corrupted-
-      trace family + general read-time IO errors. The full guard wraps
-      load + walk + emit because the loader's iterator is lazy:
-      MultiInstance / TraceCorruption raise mid-walk, not at ``load()``
-      time. Catching only ``load()`` would leak a traceback when the
-      corruption hides past the manifest.
-    - ``BrokenPipeError`` (exit 0): consumer closed the pipe (e.g.
-      ``| head -5``). Not a failure; exit cleanly so CI scripts that
-      compose us with pagers / line-limiters don't accumulate false
-      positives. The ``__main__`` wrapper also guards a residual
-      BrokenPipeError during interpreter shutdown when Python tries to
-      flush stdout to the already-torn-down pipe.
-    - ``Exception`` (exit 4): anything else uncaught. Surfaces the
-      exception type + message on stderr; the traceback is swallowed
-      so partners get an actionable signal instead of Python internals.
-      Distinct from exit 1 (CONFIRMED breach) so agents triage cleanly.
+    Default-mode guards in order of specificity:
+
+    - ``_TRACE_ERRORS + OSError`` (exit 3): the documented corrupted-trace
+      family + general read-time IO errors. The full guard wraps load + walk +
+      emit because the loader's iterator is lazy: MultiInstance / TraceCorruption
+      raise mid-walk, not at ``load()`` time. Catching only ``load()`` would leak
+      a traceback when the corruption hides past the manifest.
+    - ``BrokenPipeError`` (exit 0): consumer closed the pipe (e.g. ``| head -5``).
+      Not a failure; exit cleanly so CI scripts that compose us with pagers /
+      line-limiters don't accumulate false positives. The ``__main__`` wrapper
+      also guards a residual BrokenPipeError during interpreter shutdown.
+    - ``Exception`` (exit 4): anything else uncaught. Surfaces the exception type
+      + message on stderr; the traceback is swallowed so partners get an
+      actionable signal instead of Python internals. Distinct from exit 1
+      (CONFIRMED breach) so agents triage cleanly.
     """
-    args = build_parser().parse_args(argv)
+    argv_list = list(sys.argv[1:] if argv is None else argv)
+    if argv_list and argv_list[0] == "resolve":
+        return _run_resolve_guarded(argv_list[1:])
+
+    args = build_parser().parse_args(argv_list)
     try:
         return _run(args)
     except BrokenPipeError:
@@ -264,6 +478,275 @@ def _exit_code(
     if has_unannounced_skip:
         return 2
     return 0
+
+
+# ---------------------------------------------------------------------------
+# resolve subcommand (Unit 6 / R5b) — read-at-version against a read-only store
+# ---------------------------------------------------------------------------
+
+
+def _run_resolve_guarded(resolve_argv: Sequence[str]) -> int:
+    """Parse + dispatch the resolve subcommand under the same guard discipline.
+
+    ``BrokenPipeError`` → exit 0 (pipe closed). Resolver errors and rejections
+    are handled INSIDE ``_run_resolve`` (each mapped to its own 5+ exit code);
+    anything else uncaught → exit 4 with the type/message on stderr (no
+    traceback), matching the default mode's internal-error contract. A
+    ``ValueError`` (``--version < 1``) is caller misuse → exit 4 as a usage
+    error.
+    """
+    args = build_resolve_parser().parse_args(list(resolve_argv))
+    try:
+        return _run_resolve(args)
+    except BrokenPipeError:
+        return 0
+    except ValueError as exc:
+        # --version < 1 reaches here from the service; a usage error, not a
+        # resolver reason. Surface on stderr (+ JSON envelope) and exit 4.
+        _emit_resolve_error_envelope(args, reason="usage_error", exit_code=4, exc=exc)
+        return 4
+    except Exception as exc:  # noqa: BLE001 — intentional translate-and-return
+        print(
+            f"agent-coherence-replay resolve: internal error: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 4
+
+
+def _run_resolve(args: argparse.Namespace) -> int:
+    """Resolve one version and render the content-safe output. Returns exit code.
+
+    Lazy imports (optional-extra discipline): the resolver + reason constants are
+    imported HERE, not at module top, so ``import ccs.cli.coherence_replay`` does
+    not pull the coordinator surface.
+    """
+    from ccs.core.exceptions import (
+        CURRENT_VERSION_REASON,
+        EPOCH_MISMATCH_REASON,
+        FUTURE_VERSION_REASON,
+        NOT_RETAINED_REASON,
+        RETENTION_OFF_REASON,
+        UNKNOWN_ARTIFACT_REASON,
+    )
+    from ccs.core.types import VersionedContent, VersionedReadRejection
+    from ccs.replay.resolver import (
+        ResolverError,
+        ResolverInstanceMismatchError,
+        ResolverMissingDatabaseError,
+        ResolverRequest,
+        ResolverUnknownArtifactPathError,
+        resolve_version,
+    )
+
+    # Per-rejection exit code, keyed on the wire-stable reason so it cannot drift.
+    rejection_exit_codes = {
+        CURRENT_VERSION_REASON: 5,
+        NOT_RETAINED_REASON: 6,
+        UNKNOWN_ARTIFACT_REASON: 7,
+        RETENTION_OFF_REASON: 8,
+        EPOCH_MISMATCH_REASON: 9,
+        FUTURE_VERSION_REASON: 10,
+    }
+
+    request = ResolverRequest(
+        db_path=args.db,
+        selector=args.artifact,
+        version=args.version,
+        expected_epoch=args.expected_epoch,
+        expected_instance_id=args.instance_id,
+    )
+
+    try:
+        outcome = resolve_version(request)
+    except (ResolverMissingDatabaseError, ResolverInstanceMismatchError) as exc:
+        # Config/caller misuse: missing db (no store) or identity mismatch.
+        _emit_resolve_error_envelope(args, reason=exc.reason, exit_code=11, exc=exc)
+        return 11
+    except ResolverUnknownArtifactPathError as exc:
+        # A by-PATH miss — distinct from the by-id unknown_artifact rejection.
+        _emit_resolve_error_envelope(args, reason=exc.reason, exit_code=13, exc=exc)
+        return 13
+    except ResolverError as exc:
+        # All remaining store-level open failures (needs_recovery / db_busy /
+        # db_corrupt / schema_version_mismatch). The slug distinguishes them.
+        _emit_resolve_error_envelope(args, reason=exc.reason, exit_code=12, exc=exc)
+        return 12
+
+    if isinstance(outcome, VersionedReadRejection):
+        exit_code = rejection_exit_codes[outcome.reason]
+        _emit_resolve_rejection(args, outcome)
+        return exit_code
+
+    assert isinstance(outcome, VersionedContent)
+    _emit_resolve_content(args, outcome)
+    return 0
+
+
+def _content_metadata(content: str | bytes) -> tuple[str, int]:
+    """Return ``(sha256_hex, length)`` over the body — the content-safe fields.
+
+    The hash is computed over the raw bytes (utf-8 for a ``str``) so a consumer
+    can verify integrity / dedup WITHOUT the bytes themselves reaching stdout.
+    ``length`` is the byte length (utf-8-encoded for str), matching the hash
+    input so the two describe the same payload.
+    """
+    raw = content.encode("utf-8") if isinstance(content, str) else content
+    return hashlib.sha256(raw).hexdigest(), len(raw)
+
+
+def _write_output_file(path: Path, content: str | bytes) -> None:
+    """Write RAW bytes to ``path`` at mode 0o600 (race-free at creation).
+
+    Pre-creates the file via ``os.open(O_CREAT, 0o600)`` BEFORE writing so the
+    bytes never land in a file that briefly existed world-readable (the
+    audit_log / state.db 0600-at-creation pattern). A ``str`` body is written as
+    utf-8; ``bytes`` verbatim.
+    """
+    import os
+
+    raw = content.encode("utf-8") if isinstance(content, str) else content
+    fd = os.open(str(path), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(raw)
+    except BaseException:
+        # If fdopen failed before taking ownership, close the raw fd.
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        raise
+    # Tighten in case an operator-broadened pre-existing file kept a wider mode
+    # (O_CREAT does not chmod an existing file).
+    try:
+        os.chmod(str(path), 0o600)
+    except OSError:
+        pass
+
+
+def _emit_resolve_content(args: argparse.Namespace, outcome) -> None:
+    """Render a WIN — metadata always; bytes only via --include-content/--output-file."""
+    content = outcome.content
+    content_hash, content_length = _content_metadata(content)
+    is_bytes = isinstance(content, bytes)
+
+    if args.output_file is not None:
+        _write_output_file(args.output_file, content)
+
+    payload: dict[str, object] = {
+        "kind": "resolved",
+        "exit_code": 0,
+        "artifact_id": str(outcome.artifact_id),
+        "version": outcome.version,
+        "coordinator_epoch": outcome.coordinator_epoch,
+        "captured_at": outcome.captured_at,
+        "content_hash": content_hash,
+        "content_length": content_length,
+    }
+    if args.output_file is not None:
+        payload["output_file"] = str(args.output_file)
+
+    if args.include_content:
+        # str as-is; bytes base64 with a content_encoding field so a JSON
+        # consumer can round-trip the exact bytes. Mirrored in human mode.
+        if is_bytes:
+            payload["content_encoding"] = "base64"
+            payload["content"] = base64.b64encode(content).decode("ascii")
+        else:
+            payload["content_encoding"] = "utf-8"
+            payload["content"] = content
+
+    if args.json:
+        _emit_json_line(payload)
+        return
+
+    # Human: metadata block; the body (when opted-in) printed last so a reader
+    # sees the metadata even if the body is large/binary.
+    lines = [
+        "resolved retained version",
+        f"  artifact_id:       {outcome.artifact_id}",
+        f"  version:           {outcome.version}",
+        f"  coordinator_epoch: {outcome.coordinator_epoch}",
+        f"  captured_at:       {outcome.captured_at}",
+        f"  content_hash:      sha256:{content_hash}",
+        f"  content_length:    {content_length}",
+    ]
+    if args.output_file is not None:
+        lines.append(f"  output_file:       {args.output_file} (0600)")
+    if args.include_content:
+        encoding = "base64" if is_bytes else "utf-8"
+        lines.append(f"  content_encoding:  {encoding}")
+        body = (
+            base64.b64encode(content).decode("ascii") if is_bytes else content
+        )
+        lines.append(f"  content:           {body}")
+    _write_human_block("\n".join(lines))
+
+
+def _emit_resolve_rejection(args: argparse.Namespace, rejection) -> None:
+    """Render a typed rejection — reason slug + version metadata, NO body."""
+    payload = {
+        "kind": "rejected",
+        "exit_code": None,  # filled by the caller's exit-code map; informational
+        "reason": rejection.reason,
+        "artifact_id": str(rejection.artifact_id),
+        "requested_version": rejection.requested_version,
+        "current_version": rejection.current_version,
+        "coordinator_epoch": rejection.coordinator_epoch,
+    }
+    if args.json:
+        # Drop the placeholder exit_code (the process exit code is authoritative;
+        # keeping a null here would mislead a scripted consumer).
+        payload.pop("exit_code")
+        _emit_json_line(payload)
+        return
+    lines = [
+        f"read-at-version rejected: {rejection.reason}",
+        f"  artifact_id:       {rejection.artifact_id}",
+        f"  requested_version: {rejection.requested_version}",
+        f"  current_version:   {rejection.current_version}",
+        f"  coordinator_epoch: {rejection.coordinator_epoch}",
+    ]
+    _write_human_block("\n".join(lines))
+
+
+def _emit_resolve_error_envelope(
+    args: argparse.Namespace, *, reason: str, exit_code: int, exc: Exception
+) -> None:
+    """Emit a resolver open/lookup error: JSON envelope (if --json) + stderr prose.
+
+    Keeps stdout self-contained for ``--json`` consumers (one JSON object) and
+    always writes the human message to stderr for log tailing — the same
+    split-stream discipline the default mode's exit-3 envelope uses.
+    """
+    if getattr(args, "json", False):
+        _emit_json_line(
+            {
+                "kind": "error",
+                "exit_code": exit_code,
+                "reason": reason,
+                "exception": type(exc).__name__,
+                "message": str(exc),
+            }
+        )
+    print(f"agent-coherence-replay resolve: {exc}", file=sys.stderr)
+
+
+def _emit_json_line(payload: dict) -> None:
+    """Write one JSON object + newline to stdout with an explicit flush.
+
+    write+flush (not ``print``) so a downstream ``BrokenPipeError`` surfaces
+    cleanly to the guard rather than being buffered past the close.
+    """
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def _write_human_block(text: str) -> None:
+    """Write a human-readable block + newline to stdout with an explicit flush."""
+    sys.stdout.write(text + "\n")
+    sys.stdout.flush()
 
 
 if __name__ == "__main__":

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -194,6 +194,17 @@ class ArtifactRegistry:
         parity and for the same-process ``expected_epoch`` guard."""
         return self._coordinator_epoch
 
+    @property
+    def instance_id(self) -> str:
+        """The registry's instance identity (minted per construction unless the
+        caller supplied one).
+
+        Public read-only accessor mirroring
+        :attr:`SqliteArtifactRegistry.instance_id` so the two registries share
+        one identity duck-type and consumers never reach into the private
+        field."""
+        return self._instance_id
+
     def retention_meta(self) -> tuple[bool, RetentionPolicy | None]:
         """Return ``(retention_enabled, policy_or_None)`` (Unit 4 / R5 duck-type).
 
@@ -275,20 +286,28 @@ class ArtifactRegistry:
         Single-scope (R5 atomicity): ``version_history`` and
         ``version_captured_at`` are always mutated together (capture and GC), so
         their key sets match; reading the body first and missing means the row is
-        absent. The pair of dict reads is GIL-atomic per access, and a concurrent
-        capture/GC of a *different* version cannot make a present row's two halves
-        disagree (the body and timestamp for one version are written before the
-        next statement and dropped together). ``None`` when the artifact or the
-        version is absent (never captured, K-evicted, or T-expired-then-swept)."""
+        absent. Each dict read is GIL-atomic, but the PAIR is not: a concurrent
+        inline GC can drop THIS version between the two reads, so the stamp is
+        read defensively (``.get``) and an absent stamp after a present body is
+        reported as absent — the row was collected mid-read. ``None`` when the
+        artifact or the version is absent (never captured, K-evicted, or
+        T-expired-then-swept)."""
         record = self._records.get(artifact_id)
         if record is None:
             return None
         content = record.version_history.get(version)
         if content is None:
             return None
-        # captured_at is written in the same _capture_version step as the body
-        # and dropped in the same GC step; a present body implies a present stamp.
-        return content, record.version_captured_at[version]
+        # One .get() per dict, no bare getitem: the GIL makes each dict access
+        # atomic but NOT the pair — a concurrent inline GC (a peer thread's
+        # capture under a bounded policy) can drop THIS version between the two
+        # reads, and a getitem here would KeyError out of read_at_version's
+        # never-raise contract. An absent stamp after a present body simply
+        # means the row was GC'd mid-read ⇒ report it as not retained.
+        captured_at = record.version_captured_at.get(version)
+        if captured_at is None:
+            return None
+        return content, captured_at
 
     def get_state_map(self, artifact_id: UUID) -> dict[UUID, MESIState]:
         """Return copy of per-agent MESI states for an artifact."""

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Optional, TypeAlias
 from uuid import UUID, uuid4
@@ -12,6 +13,8 @@ from uuid import UUID, uuid4
 from ccs.core.exceptions import STALE_READ_GENERATION_REASON, StaleReadGeneration
 from ccs.core.states import MESIState, TransientState
 from ccs.core.types import Artifact, CasCorruption, ConflictDetail
+
+from .retention import RetentionPolicy, collectible_versions
 
 CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
 
@@ -55,7 +58,19 @@ class ArtifactRecord:
     transient_by_agent: dict[UUID, TransientState] = field(default_factory=dict)
     transient_tick_by_agent: dict[UUID, int] = field(default_factory=dict)
     last_writer: Optional[UUID] = None
-    version_history: dict[int, str] = field(default_factory=dict)
+    # Retained version snapshots, keyed by artifact version. The value is the
+    # captured BODY. The annotation admits ``bytes`` because the ``commit_cas``
+    # WIN path stores ``record.content``, which is ``bytes`` on the in-process
+    # library path (``AgentRuntime.write_cas`` threads bytes through). The old
+    # ``dict[int, str]`` annotation was wrong (a ``type: ignore`` papered over
+    # it at the WIN site); corrected here as part of the value-shape change for
+    # bounded retention. ``version_captured_at`` is a PARALLEL dict of capture
+    # wall-clock timestamps (``time.time()``), one per retained version — kept
+    # separate (rather than tupling the value) so the v0.5 pinned suites that
+    # read ``version_history[v]`` as the body stay valid byte-for-byte. The two
+    # dicts are always mutated together (capture and GC) so their key sets match.
+    version_history: dict[int, bytes | str] = field(default_factory=dict)
+    version_captured_at: dict[int, float] = field(default_factory=dict)
     granted_at_tick_by_agent: dict[UUID, int] = field(default_factory=dict)
     last_reclamation_by_agent: dict[UUID, ReclamationSlot] = field(default_factory=dict)
     # Read-generation fence (single-host Piece #2). owner_generation is the
@@ -78,6 +93,7 @@ class ArtifactRegistry:
         agent_names: dict[UUID, str] | None = None,
         instance_id: str | None = None,
         retain_versions: bool = False,
+        retention_policy: RetentionPolicy | None = None,
     ) -> None:
         if state_log is not None and instance_id is None:
             raise ValueError(
@@ -97,13 +113,53 @@ class ArtifactRegistry:
         # store identity exists from day one.
         self._coordinator_epoch: str = uuid4().hex
         self._seq: int = 0
+        # Retention is active iff ``retain_versions`` is True. The attribute is
+        # kept TRUTHY and named ``_retain_versions`` because the recorder test
+        # (tests/test_replay_recorder.py) asserts on this private name.
         self._retain_versions = retain_versions
+        # ``retention_policy=None`` with ``retain_versions=True`` == today's
+        # UNBOUNDED semantics (no GC) — this is the back-compat contract that
+        # keeps the four pinned v0.5/recorder suites green. A policy is an
+        # explicit opt-in to BOUNDED retention: GC runs only when this is set.
+        self._retention_policy = retention_policy
+
+    def _capture_version(
+        self, record: ArtifactRecord, version: int, content: bytes | str
+    ) -> None:
+        """Snapshot ``content`` under ``version`` and run inline GC (R1, R3, R4).
+
+        The single retention apply path shared by all three capture points
+        (``register_artifact``, ``set_artifact_and_content``, the ``commit_cas``
+        WIN). Stores the body and its capture timestamp, then — ONLY when a
+        bounded policy is set — drops the versions :func:`collectible_versions`
+        marks (the current version always survives; unbounded mode skips GC
+        entirely, preserving today's semantics).
+
+        Lock-free posture (registry contract): this is plain GIL-atomic dict
+        mutation. The store-then-drop is a sequence of individual dict ops, each
+        atomic under the GIL; a concurrent reader of ``get_content_at_version``
+        sees a consistent value at any single dict access. No locks, no
+        ``BEGIN IMMEDIATE``.
+        """
+        captured_at = time.time()  # one wall-clock read: stamp == GC reference.
+        record.version_history[version] = content
+        record.version_captured_at[version] = captured_at
+        if self._retention_policy is None:
+            return  # unbounded mode (retain_versions=True, no policy): no GC.
+        for dropped in collectible_versions(
+            record.version_captured_at,
+            current_version=version,
+            policy=self._retention_policy,
+            now=captured_at,
+        ):
+            record.version_history.pop(dropped, None)
+            record.version_captured_at.pop(dropped, None)
 
     def register_artifact(self, artifact: Artifact, content: str) -> None:
         """Insert artifact record into registry."""
         record = ArtifactRecord(artifact=artifact, content=content)
         if self._retain_versions:
-            record.version_history[artifact.version] = content
+            self._capture_version(record, artifact.version, content)
         self._records[artifact.id] = record
 
     def has_artifact(self, artifact_id: UUID) -> bool:
@@ -161,7 +217,7 @@ class ArtifactRegistry:
                     f"owner_gen={record.owner_generation}"
                 )
         if self._retain_versions:
-            record.version_history[artifact.version] = content
+            self._capture_version(record, artifact.version, content)
         record.artifact = artifact
         record.content = content
         record.last_writer = last_writer
@@ -298,11 +354,14 @@ class ArtifactRegistry:
 
         ``content`` is the winning body. When provided (the in-process library
         path threads it from ``AgentRuntime.write_cas``) the WIN updates
-        ``record.content`` (and ``version_history[next_version]`` when versions
-        are retained) to the NEW body, so a peer re-fetching after the win reads
-        the winner's content at the new version — not the stale pre-CAS body.
-        ``None`` (the cross-process / sqlite path, which stores no content)
-        leaves the prior content-coherence behaviour unchanged.
+        ``record.content`` to the NEW body, so a peer re-fetching after the win
+        reads the winner's content at the new version — not the stale pre-CAS
+        body, and (when versions are retained) captures that NEW body under
+        ``next_version``. ``None`` (the cross-process / sqlite path, which stores
+        no content) leaves the prior content-coherence behaviour unchanged AND
+        skips the version capture (it is not retained under ``next_version``);
+        previously the None path retained the stale OLD body under the new
+        version, a latent history-poisoning bug now fixed.
         """
         record = self._records.get(artifact_id)
         if record is None:
@@ -385,13 +444,20 @@ class ArtifactRegistry:
         # Content coherence: when the caller threaded the winning body, advance
         # record.content to it so a peer re-fetch reads the NEW content at the new
         # version (without this, version + content_hash bump but the body stays
-        # stale). The retained version snapshot stores the SAME new body. content
-        # is None on the cross-process / sqlite path (no content stored) — keep
-        # the prior body unchanged there.
+        # stale). content is None on the cross-process / sqlite path (no content
+        # stored) — keep the prior body unchanged there.
         if content is not None:
-            record.content = content  # type: ignore[assignment]
-        if self._retain_versions:
-            record.version_history[next_version] = record.content
+            record.content = content
+        # Retention capture joins this APPLIED block (after every state_log emit
+        # succeeded) so a callback raise above cannot leave phantom history —
+        # parity with the stage-then-apply discipline for the MESI mutations.
+        # content=None SKIPS capture entirely (R-fix): the old code retained the
+        # OLD body under the NEW version when content was None — a latent
+        # history-poisoning bug only observable through retention reads. Now an
+        # unsupplied body simply means "no snapshot for this version"; a later
+        # read of next_version misses (None), rather than returning stale bytes.
+        if self._retain_versions and content is not None:
+            self._capture_version(record, next_version, content)
         record.artifact = updated
         record.last_writer = agent_id
 

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -180,6 +180,33 @@ class ArtifactRegistry:
         record = self._records.get(artifact_id)
         return record.content if record else None
 
+    @property
+    def coordinator_epoch(self) -> str:
+        """The registry's coordinator epoch (read-generation fence follow-on).
+
+        Public accessor mirroring :attr:`SqliteArtifactRegistry.coordinator_epoch`
+        so the two registries satisfy ONE duck-type (Unit 4 / R5): every
+        ``read_at_version`` answer and rejection stamps this, and an optional
+        ``expected_epoch`` is compared against it. The in-memory epoch is
+        **per-construction** (minted fresh in ``__init__``, NOT persisted) — a
+        new ``ArtifactRegistry`` gets a new epoch, so it cannot mismatch across a
+        restart the way the durable sqlite epoch can; it exists for surface
+        parity and for the same-process ``expected_epoch`` guard."""
+        return self._coordinator_epoch
+
+    def retention_meta(self) -> tuple[bool, RetentionPolicy | None]:
+        """Return ``(retention_enabled, policy_or_None)`` (Unit 4 / R5 duck-type).
+
+        Mirrors :meth:`SqliteArtifactRegistry.retention_meta` so ``read_at_version``
+        derives ``retention_off`` and the T-expiry axis identically on both
+        registries. In-memory there is no persisted meta — the answer is the
+        live constructor state: ``_retain_versions`` is the enabled marker and
+        ``_retention_policy`` the bound (``None`` ⇒ unbounded when enabled).
+        ``retain_versions=False`` ⇒ ``(False, None)`` (retention never on)."""
+        if not self._retain_versions:
+            return False, None
+        return True, self._retention_policy
+
     def get_owner_generation(self, artifact_id: UUID) -> int:
         """Return the artifact's ownership epoch (read-generation fence)."""
         return self._records[artifact_id].owner_generation
@@ -222,12 +249,46 @@ class ArtifactRegistry:
         record.content = content
         record.last_writer = last_writer
 
-    def get_content_at_version(self, artifact_id: UUID, version: int) -> str | None:
-        """Return content for a specific version, if retained."""
+    def get_content_at_version(self, artifact_id: UUID, version: int) -> str | bytes | None:
+        """Return content for a specific version, if retained.
+
+        Returns the body with its original Python type (``bytes`` when the
+        ``commit_cas`` WIN threaded bytes — matching the corrected
+        ``version_history`` annotation); ``None`` when not retained. Mirrors
+        :meth:`SqliteArtifactRegistry.get_content_at_version`'s widened type."""
         record = self._records.get(artifact_id)
         if record is None:
             return None
         return record.version_history.get(version)
+
+    def get_version_record(
+        self, artifact_id: UUID, version: int
+    ) -> tuple[str | bytes, float] | None:
+        """Return ``(content, captured_at)`` for a retained version, or ``None``.
+
+        The single accessor Unit 4's ``read_at_version`` needs: the body AND its
+        wall-clock capture timestamp (for ``VersionedContent.captured_at`` and the
+        T-expiry check) in ONE call. Mirrors
+        :meth:`SqliteArtifactRegistry.get_version_record` so the two registries
+        share one duck-type.
+
+        Single-scope (R5 atomicity): ``version_history`` and
+        ``version_captured_at`` are always mutated together (capture and GC), so
+        their key sets match; reading the body first and missing means the row is
+        absent. The pair of dict reads is GIL-atomic per access, and a concurrent
+        capture/GC of a *different* version cannot make a present row's two halves
+        disagree (the body and timestamp for one version are written before the
+        next statement and dropped together). ``None`` when the artifact or the
+        version is absent (never captured, K-evicted, or T-expired-then-swept)."""
+        record = self._records.get(artifact_id)
+        if record is None:
+            return None
+        content = record.version_history.get(version)
+        if content is None:
+            return None
+        # captured_at is written in the same _capture_version step as the body
+        # and dropped in the same GC step; a present body implies a present stamp.
+        return content, record.version_captured_at[version]
 
     def get_state_map(self, artifact_id: UUID) -> dict[UUID, MESIState]:
         """Return copy of per-agent MESI states for an artifact."""

--- a/src/ccs/coordinator/retention.py
+++ b/src/ccs/coordinator/retention.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Bounded version-retention policy and the single GC seam (plan item N v1).
+
+This module owns the *policy* (a frozen :class:`RetentionPolicy` modelled on
+``CrashRecoveryConfig``) and the *one* pure GC decision function
+(:func:`collectible_versions`) that every retention capture point routes
+through. Both registries (in-memory ``ArtifactRegistry`` and the durable
+``SqliteArtifactRegistry`` in Unit 3) import these — same ``coordinator``
+(application) layer, so there is no duplication to pin equal.
+
+Layer discipline (R-arch): ``coordinator`` may import ``core`` only. This module
+imports nothing above ``core`` — it depends on no other ccs module at all — so
+``tools/check_architecture.py`` stays green.
+
+Requirement trace:
+
+- **R1** — bounded retention (K versions / age T), amortized GC, no unbounded
+  write-path pause. K and T are the two axes here; a ``None`` axis disables it.
+- **R4** — GC is invisible to the protocol, the current version is never
+  collectible, and the seam is exemption-extensible (the SB-17 pin-hold seam:
+  :func:`collectible_versions` accepts an ``exemptions`` set today and honors it,
+  with no other v1 use).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+__all__ = ["RetentionPolicy", "collectible_versions"]
+
+
+@dataclass(frozen=True)
+class RetentionPolicy:
+    """Per-registry bound on how many / how old retained versions are kept.
+
+    Modelled on ``CrashRecoveryConfig`` (``service.py``): a frozen dataclass that
+    validates in ``__post_init__`` and is otherwise an inert value object. The
+    registry that owns it decides *when* GC runs (inline at each capture point);
+    this object only describes the *bound*.
+
+    Retention is active iff the registry was constructed with
+    ``retain_versions=True``. A registry with ``retain_versions=True`` and
+    ``retention_policy=None`` keeps **today's unbounded** semantics (no GC at
+    all) — that is the back-compat contract for the v0.5 audit auto-wiring.
+    A policy is therefore an explicit opt-in to *bounded* retention.
+
+    The two axes are independent and either may be disabled with ``None``:
+
+    Attributes:
+        max_versions: **K axis.** Keep at most this many of the most-recent
+            versions, *including the current version's row* (so the effective
+            floor is the current row, which is never collectible regardless of
+            K). Versions older than the K newest are collectible. ``None``
+            disables the K axis (no count bound). Must be ``>= 1`` when set;
+            ``max_versions < 1`` raises :class:`ValueError` (a zero/negative
+            bound would try to collect the current row — caller misuse).
+        max_age_seconds: **T axis.** A version whose capture timestamp is older
+            than ``now - max_age_seconds`` is collectible. ``None`` disables the
+            T axis (no age bound). Must be ``> 0`` when set; ``max_age_seconds
+            <= 0`` raises :class:`ValueError`. **T is WALL-CLOCK seconds**
+            (``time.time()``), matching the sqlite ``captured_at`` / artifact
+            ``updated_at`` columns (also ``time.time()``); a backward clock jump
+            can misfire logical expiry — documented, accepted (monotonic clocks
+            do not survive a process restart, so they cannot back a durable
+            store). T is the secrets-rotation knob: a lowered T expires rotated
+            secrets from retained history sooner (logical-at-read; physical
+            deletion piggybacks on the next capture).
+    """
+
+    max_versions: int | None = 16
+    max_age_seconds: float | None = None
+
+    def __post_init__(self) -> None:
+        """Reject nonsensical bounds at construction (house style: fail fast).
+
+        A ``max_versions`` below 1 would mark the current row collectible (the
+        current row is the floor); a non-positive ``max_age_seconds`` would
+        expire everything including the just-captured current version. Both are
+        caller misuse, so both raise rather than silently clamping.
+        """
+        if self.max_versions is not None and self.max_versions < 1:
+            raise ValueError(
+                f"RetentionPolicy.max_versions must be >= 1 when set "
+                f"(got {self.max_versions}); the current version's row is "
+                f"never collectible, so a K below 1 is meaningless. Use "
+                f"max_versions=None to disable the count bound."
+            )
+        if self.max_age_seconds is not None and self.max_age_seconds <= 0:
+            raise ValueError(
+                f"RetentionPolicy.max_age_seconds must be > 0 when set "
+                f"(got {self.max_age_seconds}); a non-positive age would "
+                f"expire the just-captured version. Use max_age_seconds=None "
+                f"to disable the age bound."
+            )
+
+
+def collectible_versions(
+    versions: Iterable[int] | Mapping[int, float],
+    current_version: int,
+    policy: RetentionPolicy,
+    now: float,
+    exemptions: Iterable[int] = (),
+) -> set[int]:
+    """Return the set of versions that GC may drop under ``policy`` (R1, R4).
+
+    The **single** GC seam: every retention capture point (in-memory and, in
+    Unit 3, sqlite) computes the drop set with this one pure, fully-unit-testable
+    function so the eviction rule lives in exactly one place.
+
+    Rules:
+
+    - The **current version is never collectible**, regardless of policy (R4).
+    - Versions in **``exemptions`` are never collectible** (R4 — the SB-17
+      pin-hold seam: a future pinned-snapshot set plugs in here, no redesign).
+    - **K axis** (``policy.max_versions``): keep at most K of the most-recent
+      versions *including the current one*; mark the oldest beyond K collectible.
+      ``None`` disables the axis.
+    - **T axis** (``policy.max_age_seconds``): a version whose capture timestamp
+      is older than ``now - max_age_seconds`` is collectible. ``None`` disables
+      the axis. The T axis needs per-version timestamps, so ``versions`` must be
+      a mapping ``{version: captured_at}`` for T to apply; when ``versions`` is a
+      bare iterable (no timestamps) the T axis is a no-op for that call.
+
+    Args:
+        versions: The retained versions. Either a bare iterable of version ints
+            (K axis only) or a ``{version: captured_at}`` mapping (enables T).
+        current_version: The artifact's current version — always exempt.
+        policy: The bound to apply.
+        now: Wall-clock reference time (``time.time()``) for the T axis.
+        exemptions: Versions the caller pins (never collected). Honored now;
+            v1 callers pass the default empty set.
+
+    Returns:
+        The set of versions to drop. Empty when both axes are ``None`` (the
+        unbounded case never reaches here — the registry only calls this with a
+        policy set — but the function is total regardless).
+    """
+    timestamps: Mapping[int, float] | None = (
+        versions if isinstance(versions, Mapping) else None
+    )
+    all_versions = set(versions)
+    exempt = set(exemptions)
+    exempt.add(current_version)
+
+    collectible: set[int] = set()
+
+    # K axis: keep the K most-recent versions (descending), drop the older tail.
+    # The current version is exempt below, so a survivor that is "kept by K" but
+    # also exempt is simply not collected; the floor is preserved by the final
+    # exempt-difference, not by special-casing the current version inside the
+    # ranking.
+    if policy.max_versions is not None:
+        kept_by_k = set(sorted(all_versions, reverse=True)[: policy.max_versions])
+        collectible |= all_versions - kept_by_k
+
+    # T axis: logical expiry by capture timestamp. Requires per-version
+    # timestamps; a bare-iterable call (no timestamps) cannot age anything.
+    if policy.max_age_seconds is not None and timestamps is not None:
+        cutoff = now - policy.max_age_seconds
+        collectible |= {
+            v for v, captured_at in timestamps.items() if captured_at < cutoff
+        }
+
+    # Exemptions (incl. the current version) always survive — applied last so
+    # neither axis can ever mark the floor or a pinned version collectible (R4).
+    return collectible - exempt

--- a/src/ccs/coordinator/retention.py
+++ b/src/ccs/coordinator/retention.py
@@ -26,7 +26,7 @@ Requirement trace:
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Collection, Iterable, Mapping
 from dataclasses import dataclass
 
 __all__ = ["RetentionPolicy", "collectible_versions"]
@@ -57,6 +57,15 @@ class RetentionPolicy:
             disables the K axis (no count bound). Must be ``>= 1`` when set;
             ``max_versions < 1`` raises :class:`ValueError` (a zero/negative
             bound would try to collect the current row — caller misuse).
+
+            **The K=1 cliff:** ``max_versions=1`` is legal but sharp — only the
+            current version's row survives each capture, so EVERY historical
+            ``read_at_version`` rejects ``not_retained`` (and the current
+            version is rejected ``current_version`` by design: the history
+            surface serves history only). K=1 therefore retains rows the read
+            surface can never serve. Use ``max_versions >= 2`` for any actual
+            history use; K=1 is only meaningful as a deliberate
+            "current-snapshot-on-disk, no readable history" posture.
         max_age_seconds: **T axis.** A version whose capture timestamp is older
             than ``now - max_age_seconds`` is collectible. ``None`` disables the
             T axis (no age bound). Must be ``> 0`` when set; ``max_age_seconds
@@ -102,7 +111,7 @@ def collectible_versions(
     current_version: int,
     policy: RetentionPolicy,
     now: float,
-    exemptions: Iterable[int] = (),
+    exemptions: Collection[int] = (),
 ) -> set[int]:
     """Return the set of versions that GC may drop under ``policy`` (R1, R4).
 

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from typing import Callable, Optional
 from uuid import UUID
 
+from ccs.coordinator.retention import collectible_versions
 from ccs.core.exceptions import (
     CURRENT_VERSION_REASON,
     EPOCH_MISMATCH_REASON,
@@ -38,7 +39,6 @@ from ccs.core.types import (
     VersionedContent,
     VersionedReadRejection,
 )
-from ccs.coordinator.retention import collectible_versions
 
 from .registry import ArtifactRegistry
 
@@ -415,7 +415,7 @@ class CoordinatorService:
         artifact_id: UUID,
         requested_version: int,
         current_version: int | None,
-        epoch: str | None,
+        epoch: str,
     ) -> VersionedReadRejection:
         """Build a :class:`VersionedReadRejection` (no body material, by type)."""
         return VersionedReadRejection(

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -7,13 +7,20 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 import warnings
 from dataclasses import dataclass
 from typing import Callable, Optional
 from uuid import UUID
 
 from ccs.core.exceptions import (
+    CURRENT_VERSION_REASON,
+    EPOCH_MISMATCH_REASON,
+    FUTURE_VERSION_REASON,
+    NOT_RETAINED_REASON,
     OCC_CALLER_TRANSIENT_REASON,
+    RETENTION_OFF_REASON,
+    UNKNOWN_ARTIFACT_REASON,
     CoherenceError,
     OccCallerTransientError,
     StaleReadGeneration,
@@ -28,7 +35,10 @@ from ccs.core.types import (
     FetchRequest,
     FetchResponse,
     InvalidationSignal,
+    VersionedContent,
+    VersionedReadRejection,
 )
+from ccs.coordinator.retention import collectible_versions
 
 from .registry import ArtifactRegistry
 
@@ -238,6 +248,182 @@ class CoordinatorService:
             version=artifact.version,
             content=content,
             state_grant=grant,
+        )
+
+    def read_at_version(
+        self,
+        artifact_id: UUID,
+        version: int,
+        expected_epoch: str | None = None,
+    ) -> VersionedContent | VersionedReadRejection:
+        """Read a specific RETAINED version off-protocol (plan item N v1 / R5–R7).
+
+        The first-class read-at-version surface: returns the body the registry
+        committed at ``version`` as a :class:`~ccs.core.types.VersionedContent`,
+        or a typed :class:`~ccs.core.types.VersionedReadRejection` carrying one of
+        the six wire-stable reasons in :data:`ccs.core.exceptions.READ_AT_VERSION_REASONS`.
+        It is a typed RETURN, never an exception (the ``ConflictDetail``
+        discipline) — except ``version < 1``, which is caller misuse and raises
+        ``ValueError`` (house style; not a wire reason).
+
+        **Protocol non-interaction by construction (R6, R7):** this method calls
+        NONE of ``set_agent_state`` / ``set_agent_transient`` / grant / transient
+        / invalidation code. Read-generation capture lives ONLY inside
+        ``set_agent_state`` (``registry.py`` ``CLAIM_CAPTURE_TRIGGERS``), so not
+        calling it means the read CANNOT touch ``read_generation`` (R6 fence
+        non-capture) or any MESI state / invalidation membership (R7). The whole
+        point is verifiable by reading this body: it only ever READS the registry
+        (``get_artifact`` / ``retention_meta`` / ``coordinator_epoch`` /
+        ``get_version_record``) and constructs frozen return values.
+
+        Discrimination order (first match wins), computed against ONE snapshot of
+        the current version so a racing commit cannot mislabel a reason:
+
+        1. ``version < 1`` → ``ValueError`` (caller misuse).
+        2. artifact unknown → ``unknown_artifact`` (``current_version=None``).
+        3. retention not enabled for the store → ``retention_off``.
+        4. ``expected_epoch`` supplied and != the store epoch → ``epoch_mismatch``.
+        5. ``version == current`` → ``current_version`` (history surface serves
+           history only; current bytes are read via the protocol fetch path).
+        6. ``version > current`` → ``future_version`` (hints at a 2nd coordinator).
+        7. ``1 <= version < current`` → fetch the row. Present AND not T-expired →
+           ``VersionedContent``; absent OR T-expired → ``not_retained``.
+
+        Single-scope atomicity: ``current`` is read ONCE (the linearization
+        point) and every reason is decided relative to that snapshot. History
+        rows below ``current`` are immutable (a version is captured once and only
+        ever DROPPED by GC, never rewritten), so the step-7 row fetch is safe
+        against a commit that races in after the ``current`` read — that commit
+        only captures the NEW (higher) version and never touches the requested
+        ``version < current`` row. The worst a race yields is the old-current
+        served as history (correct bytes) or ``current_version`` (the value that
+        WAS current at the read point) — never wrong bytes or a mislabeled reason.
+
+        T-expiry is LOGICAL at read (R-fix: a read is non-mutating, so an
+        age-collectible row is reported ``not_retained`` but NOT physically
+        deleted here — physical deletion piggybacks on the next capture). It
+        reuses the one GC seam :func:`collectible_versions` against the persisted
+        policy so the read-side expiry rule matches the write-side eviction rule.
+
+        Args:
+            artifact_id: The artifact to read.
+            version: The 1-based version to read (``< 1`` raises ``ValueError``).
+            expected_epoch: If given, the read rejects ``epoch_mismatch`` unless
+                it equals the store's ``coordinator_epoch`` (the store was reset
+                since the caller captured the epoch).
+
+        Returns:
+            :class:`VersionedContent` on a hit, else :class:`VersionedReadRejection`.
+
+        Raises:
+            ValueError: ``version < 1`` (caller misuse — not a wire reason).
+        """
+        if version < 1:
+            raise ValueError(
+                f"read_at_version: version must be >= 1 (got {version}); "
+                f"versions are 1-based. A sub-1 version is caller misuse, not a "
+                f"retained-history miss (which is the not_retained reason)."
+            )
+
+        epoch = self.registry.coordinator_epoch
+
+        # (2) Unknown artifact — no current version exists for it. Read the
+        # artifact ONCE; ``current`` from this same metadata object is the
+        # linearization snapshot every reason below is decided against.
+        artifact = self.registry.get_artifact(artifact_id)
+        if artifact is None:
+            return VersionedReadRejection(
+                reason=UNKNOWN_ARTIFACT_REASON,
+                artifact_id=artifact_id,
+                requested_version=version,
+                current_version=None,
+                coordinator_epoch=epoch,
+            )
+        current = artifact.version
+
+        # (3) Retention never enabled for this store (store-derived: persisted
+        # meta on sqlite, live ctor state in-memory). The artifact_versions
+        # surface exists on every v2 db, so this marker — not table presence —
+        # distinguishes retention-off from a mere history gap.
+        retention_enabled, policy = self.registry.retention_meta()
+        if not retention_enabled:
+            return self._reject(
+                RETENTION_OFF_REASON, artifact_id, version, current, epoch
+            )
+
+        # (4) Epoch guard — a stale expected_epoch means the store was reset
+        # (delete-and-recreate) since the caller captured it, so its retained
+        # history is from a different incarnation.
+        if expected_epoch is not None and expected_epoch != epoch:
+            return self._reject(
+                EPOCH_MISMATCH_REASON, artifact_id, version, current, epoch
+            )
+
+        # (5) Current version — history surface serves HISTORY ONLY. Current
+        # content is read via the protocol fetch path (artifacts store hashes,
+        # not bodies), never here, by design.
+        if version == current:
+            return self._reject(
+                CURRENT_VERSION_REASON, artifact_id, version, current, epoch
+            )
+
+        # (6) Future version — above current suggests a second coordinator
+        # writing the same store (the diagnostic commit_cas keeps via CasCorruption).
+        if version > current:
+            return self._reject(
+                FUTURE_VERSION_REASON, artifact_id, version, current, epoch
+            )
+
+        # (7) 1 <= version < current: a genuine history request. Fetch body +
+        # capture timestamp in ONE scoped accessor (single SELECT/sqlite, GIL-
+        # atomic pair/in-memory). Absent ⇒ not_retained (never captured, K-
+        # evicted, or already T-swept).
+        record = self.registry.get_version_record(artifact_id, version)
+        if record is None:
+            return self._reject(
+                NOT_RETAINED_REASON, artifact_id, version, current, epoch
+            )
+        content, captured_at = record
+
+        # Logical T-expiry (R-fix: non-mutating read). Reuse the single GC seam
+        # against the persisted policy: an age-collectible row reports
+        # not_retained without being physically deleted (deletion piggybacks on
+        # the next capture). ``current`` is exempt in collectible_versions, but
+        # we already excluded version==current above, so this only ages the
+        # requested historical row. ``policy is None`` ⇒ unbounded ⇒ no T axis.
+        if policy is not None and version in collectible_versions(
+            {version: captured_at},
+            current_version=current,
+            policy=policy,
+            now=time.time(),
+        ):
+            return self._reject(
+                NOT_RETAINED_REASON, artifact_id, version, current, epoch
+            )
+
+        return VersionedContent(
+            artifact_id=artifact_id,
+            version=version,
+            content=content,
+            captured_at=captured_at,
+            coordinator_epoch=epoch,
+        )
+
+    @staticmethod
+    def _reject(
+        reason: str,
+        artifact_id: UUID,
+        requested_version: int,
+        current_version: int | None,
+        epoch: str | None,
+    ) -> VersionedReadRejection:
+        """Build a :class:`VersionedReadRejection` (no body material, by type)."""
+        return VersionedReadRejection(
+            reason=reason,
+            artifact_id=artifact_id,
+            requested_version=requested_version,
+            current_version=current_version,
+            coordinator_epoch=epoch,
         )
 
     def write(

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -85,7 +85,13 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Optional, TypeAlias
 from uuid import UUID, uuid4
 
-from ccs.core.exceptions import STALE_READ_GENERATION_REASON, StaleReadGeneration
+from ccs.core.exceptions import (
+    STALE_READ_GENERATION_REASON,
+    STORE_SIGNAL_BUSY,
+    STORE_SIGNAL_UNREADABLE,
+    STORE_SIGNAL_WAL_RECOVERY,
+    StaleReadGeneration,
+)
 from ccs.core.states import MESIState, TransientState
 from ccs.core.types import Artifact, CasCorruption, ConflictDetail
 
@@ -212,15 +218,49 @@ class ReadOnlyMutationError(ReadOnlyRegistryError):
 
 
 class StoreNeedsRecoveryError(ReadOnlyRegistryError):
-    """The store has an unclean WAL that a read-only connection cannot replay.
+    """The read-only connection could not read the store (recovery/busy/other).
 
     After an embedder crash SQLite leaves a hot WAL whose recovery requires a
     *write* lock; a ``mode=ro`` connection raises ``SQLITE_READONLY_RECOVERY``.
-    This is distinct from missing / corrupt / busy — the remedy is to re-open
+    This is distinct from missing / corrupt — the remedy is to re-open
     the store once with the embedder (read-write) so it checkpoints the WAL,
     then retry the read-only resolve. The forensic population over-represents
     crashed writers, so this is the resolver's most on-brand failure mode.
+
+    ``reason`` is the machine-readable classification signal (one of
+    ``ccs.core.exceptions.STORE_OPEN_SIGNALS``: ``wal_recovery`` / ``busy`` /
+    ``unreadable``), set at the SINGLE classification point
+    (:func:`classify_sqlite_operational_signal`). Consumers (the replay
+    resolver) branch on ``exc.reason == CONSTANT`` — never on the human
+    message — per the typed-signal house rule.
     """
+
+    def __init__(self, message: str, *, reason: str = STORE_SIGNAL_WAL_RECOVERY) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+def classify_sqlite_operational_signal(exc: sqlite3.OperationalError) -> str:
+    """Classify an ``OperationalError`` from a read-only connection into one of
+    the ``STORE_OPEN_SIGNALS`` (``busy`` / ``wal_recovery`` / ``unreadable``).
+
+    The ONE place sqlite's rendered error text is substring-matched: Python's
+    ``sqlite3`` exposes no stable error code on every path/version, so the
+    classification is unavoidably text-based and therefore FRAGILE against
+    sqlite message rewording — which is exactly why it must not be duplicated
+    (the typed-signal-not-substring house rule,
+    ``docs/solutions/best-practices/typed-signal-not-substring-...``). Every
+    downstream consumer matches the returned constant with ``==``, never the
+    message. Order matters: a locked store is checked FIRST because a busy
+    signal has a different remedy (retry) than a recovery one (re-open with
+    the embedder).
+    """
+    text = str(exc).lower()
+    if "busy" in text or "locked" in text:
+        return STORE_SIGNAL_BUSY
+    if "readonly" in text or "recovery" in text or "wal" in text:
+        return STORE_SIGNAL_WAL_RECOVERY
+    return STORE_SIGNAL_UNREADABLE
 
 
 @dataclass(frozen=True)
@@ -289,6 +329,16 @@ class SqliteArtifactRegistry:
         # (O_CREAT without O_EXCL); the migration re-applies the mode to a
         # pre-existing, possibly operator-broadened db and warns once.
         self._precreate_file_0600(self._db_path)
+        # The -wal/-shm sidecars are pre-created at 0600 BEFORE the connect
+        # too: sidecar-creation timing inside sqlite is platform-dependent
+        # (some kernels materialize -shm at connection open, not at the
+        # journal_mode=WAL switch), so touching them only after the connect
+        # would leave a window in which sqlite materializes them under the
+        # process umask. With both pre-touches ahead of the connect, no
+        # sidecar is ever created by sqlite itself; the tighten-after pass
+        # below stays as belt-and-suspenders.
+        self._precreate_file_0600(self._wal_path())
+        self._precreate_file_0600(self._shm_path())
 
         # check_same_thread=False because ThreadingHTTPServer handler threads
         # all share one registry instance. Coupled with the RLock on every
@@ -298,15 +348,6 @@ class SqliteArtifactRegistry:
             check_same_thread=False,
             isolation_level=None,  # autocommit; we manage transactions explicitly
         )
-        # The -wal/-shm sidecars materialize lazily on the first write
-        # (PRAGMA journal_mode=WAL is itself the first write). Pre-create/chmod
-        # them to 0600 immediately around the WAL switch so the window in which
-        # they could exist world-readable is closed BEFORE the migration's first
-        # content-bearing transaction. They may be created by SQLite at any of:
-        # the journal_mode switch, the first WAL frame; pre-touching them here
-        # at 0600 plus a tighten-after pass covers both orderings.
-        self._precreate_file_0600(self._wal_path())
-        self._precreate_file_0600(self._shm_path())
         # WAL for concurrent readers + bounded busy_timeout for write contention.
         # synchronous=NORMAL is durable enough for non-financial use.
         #
@@ -339,6 +380,8 @@ class SqliteArtifactRegistry:
         # unbounded marker) so a read-only resolver can derive T-expiry + the
         # retention_off reason from the store, not a process-local object.
         self._persist_retention_policy()
+        # Policy is immutable per handle (see retention_meta) — cache once.
+        self._retention_meta_cache = self._load_retention_meta()
 
     # ------------------------------------------------------------------
     # File-mode helpers (race-free 0600 — audit_log.py pattern)
@@ -599,14 +642,26 @@ class SqliteArtifactRegistry:
         commits the pending BEGIN IMMEDIATE and varies by Python version);
         ``except BaseException`` ROLLBACK so a SIGKILL/Ctrl-C mid-migration
         leaves the v1 db intact (the next open re-migrates cleanly, never hits
-        "table already exists"). The introspection runs INSIDE the txn: two
-        processes racing the same v1 db serialize on the write lock; the loser
-        re-reads post-commit, sees user_version already 2, and dispatches to the
-        write-free rehydrate path instead of double-migrating.
+        "table already exists"). Concurrent-loser path: two processes can BOTH
+        read ``user_version == 1`` in the dispatch (a bare read, outside any
+        txn) and both land here; they serialize on the ``BEGIN IMMEDIATE``
+        write lock. The loser re-reads ``user_version`` INSIDE its txn, sees
+        the winner already stamped v2, and no-ops (COMMIT immediately, zero
+        DDL) before rehydrating — it does NOT re-run the migration body, so a
+        future non-idempotent v3 step cannot be double-applied by the race.
         """
         c = self._conn
         c.execute("BEGIN IMMEDIATE")
         try:
+            # Concurrent-loser guard: re-check the stamp now that the write
+            # lock is held. The dispatch decision was made from a pre-lock
+            # read; if a racing winner migrated in between, there is nothing
+            # left to do — COMMIT the empty txn and rehydrate like a normal
+            # v2 open. (The winner already ran the mode-tighten pass.)
+            if c.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION:
+                c.execute("COMMIT")
+                self._rehydrate_meta(instance_id)
+                return
             art_cols = {
                 row[1] for row in c.execute("PRAGMA table_info(artifacts)").fetchall()
             }
@@ -711,49 +766,72 @@ class SqliteArtifactRegistry:
             check_same_thread=False,
             isolation_level=None,
         )
-        # foreign_keys is a no-op for a read-only conn (no writes); set for
-        # parity. Do NOT touch journal_mode (that is a write) — opening ro
-        # against a WAL db is fine for reads. busy_timeout helps a reader wait
-        # out a concurrent writer's lock.
-        self._conn.execute("PRAGMA busy_timeout=1500")
+        # Everything past the connect is validation that can raise a TYPED
+        # error; without the close-on-raise the construction failure would leak
+        # the open handle (the caller never gets a registry to .close()). The
+        # BaseException breadth mirrors the transaction-rollback idiom: a
+        # Ctrl-C mid-open must not orphan the connection either.
         try:
-            current = self._conn.execute("PRAGMA user_version").fetchone()[0]
-        except sqlite3.OperationalError as exc:
-            raise self._classify_readonly_operational_error(exc) from exc
-        if current != SCHEMA_USER_VERSION:
-            raise SchemaVersionError(
-                f"read-only open: database at {self._db_path} is schema "
-                f"v{current}, this build serves v{SCHEMA_USER_VERSION}. Read-only "
-                f"mode performs NO migration — re-open the store once with the "
-                f"embedder (read-write) to migrate it, then retry."
-            )
-        try:
-            self._rehydrate_meta(instance_id)
-        except sqlite3.OperationalError as exc:
-            raise self._classify_readonly_operational_error(exc) from exc
+            # foreign_keys is a no-op for a read-only conn (no writes); set for
+            # parity. Do NOT touch journal_mode (that is a write) — opening ro
+            # against a WAL db is fine for reads. busy_timeout helps a reader
+            # wait out a concurrent writer's lock.
+            self._conn.execute("PRAGMA busy_timeout=1500")
+            try:
+                current = self._conn.execute("PRAGMA user_version").fetchone()[0]
+            except sqlite3.OperationalError as exc:
+                raise self._classify_readonly_operational_error(exc) from exc
+            if current != SCHEMA_USER_VERSION:
+                raise SchemaVersionError(
+                    f"read-only open: database at {self._db_path} is schema "
+                    f"v{current}, this build serves v{SCHEMA_USER_VERSION}. Read-only "
+                    f"mode performs NO migration — re-open the store once with the "
+                    f"embedder (read-write) to migrate it, then retry."
+                )
+            try:
+                self._rehydrate_meta(instance_id)
+            except sqlite3.OperationalError as exc:
+                raise self._classify_readonly_operational_error(exc) from exc
+            # Policy is immutable per handle (see retention_meta) — cache once.
+            self._retention_meta_cache = self._load_retention_meta()
+        except BaseException:
+            self._conn.close()
+            raise
 
     def _classify_readonly_operational_error(
         self, exc: sqlite3.OperationalError
     ) -> ReadOnlyRegistryError:
         """Map an OperationalError on a read-only connection to a typed error.
 
-        The needs-recovery case (an unclean hot WAL a ro conn cannot replay)
-        surfaces SQLITE_READONLY_RECOVERY; SQLite renders it with a recognizable
-        substring. Anything else is reported as a generic recovery-or-corruption
-        signal so the CLI never leaks a raw OperationalError to a script.
+        Classification routes through the single
+        :func:`classify_sqlite_operational_signal` seam; the signal rides on
+        ``StoreNeedsRecoveryError.reason`` so consumers (the replay resolver)
+        branch on the attribute, never re-parse the message. All three signals
+        stay ONE exception type — a locked store and a hot WAL are both
+        "cannot read right now" from the registry's perspective; the reason
+        carries the operator remedy.
         """
-        text = str(exc).lower()
-        if "readonly" in text or "recovery" in text or "wal" in text:
+        signal = classify_sqlite_operational_signal(exc)
+        if signal == STORE_SIGNAL_BUSY:
+            return StoreNeedsRecoveryError(
+                f"the store at {self._db_path} is locked by a concurrent writer "
+                f"(SQLITE_BUSY) and the read-only open timed out waiting for the "
+                f"lock. Retry shortly. Underlying: {exc}",
+                reason=signal,
+            )
+        if signal == STORE_SIGNAL_WAL_RECOVERY:
             return StoreNeedsRecoveryError(
                 f"the store at {self._db_path} has an unclean write-ahead log that "
                 f"a read-only connection cannot replay (SQLITE_READONLY_RECOVERY). "
                 f"Re-open it once with the embedder (read-write) so it checkpoints "
-                f"the WAL, then retry the read-only resolve. Underlying: {exc}"
+                f"the WAL, then retry the read-only resolve. Underlying: {exc}",
+                reason=signal,
             )
         return StoreNeedsRecoveryError(
             f"the read-only store at {self._db_path} could not be read "
             f"({exc}); it may need recovery (re-open once with the embedder) or "
-            f"be corrupt."
+            f"be corrupt.",
+            reason=signal,
         )
 
     def _persist_retention_policy(self) -> None:
@@ -766,30 +844,45 @@ class SqliteArtifactRegistry:
         retention semantics are STORE-derived, not process-local. No open-time GC
         pass (dropped per plan): each writer's inline GC trusts its CONSTRUCTOR
         policy; the v1 one-writer-per-store assumption means the last writer
-        open's persisted policy is what readers see. Idempotent UPSERT.
+        open's persisted policy is what readers see.
+
+        Write-free steady-state: the three keys are READ first and the UPSERT is
+        skipped when the persisted values already match — a same-policy reopen
+        issues no write at all (the property the write-free v2 open path
+        documents, and what keeps a reopen from dirtying the WAL).
         """
         if self._read_only:
             return
-        enabled = "1" if self._retain_versions else "0"
         policy = self._retention_policy
-        max_versions = (
-            str(policy.max_versions)
-            if policy is not None and policy.max_versions is not None
-            else None
-        )
-        max_age = (
-            str(policy.max_age_seconds)
-            if policy is not None and policy.max_age_seconds is not None
-            else None
-        )
+        desired: dict[str, str | None] = {
+            _META_RETENTION_ENABLED: "1" if self._retain_versions else "0",
+            _META_RETENTION_MAX_VERSIONS: (
+                str(policy.max_versions)
+                if policy is not None and policy.max_versions is not None
+                else None
+            ),
+            _META_RETENTION_MAX_AGE_SECONDS: (
+                str(policy.max_age_seconds)
+                if policy is not None and policy.max_age_seconds is not None
+                else None
+            ),
+        }
         with self._lock:
+            persisted = dict(
+                self._conn.execute(
+                    "SELECT key, value FROM registry_meta WHERE key IN (?, ?, ?)",
+                    tuple(desired),
+                ).fetchall()
+            )
+            # All three keys present AND equal (incl. NULL axes) ⇒ no write.
+            # len() distinguishes an absent key from a present-NULL value.
+            if len(persisted) == len(desired) and all(
+                persisted[key] == value for key, value in desired.items()
+            ):
+                return
             self._conn.execute("BEGIN IMMEDIATE")
             try:
-                for key, value in (
-                    (_META_RETENTION_ENABLED, enabled),
-                    (_META_RETENTION_MAX_VERSIONS, max_versions),
-                    (_META_RETENTION_MAX_AGE_SECONDS, max_age),
-                ):
+                for key, value in desired.items():
                     self._conn.execute(
                         """
                         INSERT INTO registry_meta (key, value) VALUES (?, ?)
@@ -799,15 +892,20 @@ class SqliteArtifactRegistry:
                     )
                 self._conn.execute("COMMIT")
             except BaseException:
-                self._conn.execute("ROLLBACK")
+                # Guarded ROLLBACK (the schema-init idiom): a COMMIT that failed
+                # mid-promote may have already auto-rolled-back, in which case
+                # the explicit ROLLBACK raises "no transaction is active" and
+                # would mask the original error.
+                try:
+                    self._conn.execute("ROLLBACK")
+                except (sqlite3.Error, OSError):
+                    pass
                 raise
 
-    def retention_meta(self) -> tuple[bool, RetentionPolicy | None]:
-        """Return ``(retention_enabled, persisted_policy_or_None)`` read from
-        registry_meta. Used by Unit 4's ``read_at_version`` (store-derived
-        ``retention_off`` + T-expiry) on both the writer and the read-only
-        resolver. ``retention_enabled=False`` ⇒ retention was never turned on for
-        this store; ``True`` with a ``None`` policy ⇒ unbounded (NULL axes)."""
+    def _load_retention_meta(self) -> tuple[bool, RetentionPolicy | None]:
+        """Read ``(retention_enabled, persisted_policy_or_None)`` from
+        registry_meta — the construction-time loader behind the
+        :meth:`retention_meta` cache. One SELECT under the lock."""
         with self._lock:
             rows = dict(
                 self._conn.execute(
@@ -830,6 +928,22 @@ class SqliteArtifactRegistry:
             max_versions=int(max_v) if max_v is not None else None,
             max_age_seconds=float(max_a) if max_a is not None else None,
         )
+
+    def retention_meta(self) -> tuple[bool, RetentionPolicy | None]:
+        """Return ``(retention_enabled, persisted_policy_or_None)``. Used by
+        Unit 4's ``read_at_version`` (store-derived ``retention_off`` +
+        T-expiry) on both the writer and the read-only resolver.
+        ``retention_enabled=False`` ⇒ retention was never turned on for this
+        store; ``True`` with a ``None`` policy ⇒ unbounded (NULL axes).
+
+        Served from a construction-time cache, not a per-call SELECT: the
+        policy is immutable per handle (a writer persists its constructor
+        policy exactly once at open; nothing rewrites the keys while the handle
+        lives), readers are short-lived, and the documented single-writer
+        assumption means a peer writer changing the persisted policy mid-handle
+        is outside the contract — so caching at construction is correct and
+        keeps ``read_at_version`` loops off the DB for this lookup."""
+        return self._retention_meta_cache
 
     def _guard_writable(self) -> None:
         """Raise if a mutator was called on a read-only registry."""
@@ -902,6 +1016,16 @@ class SqliteArtifactRegistry:
         per-construction epoch). Epoch reset = delete-and-recreate the db, which
         also drops ``artifact_versions``."""
         return self._coordinator_epoch
+
+    @property
+    def instance_id(self) -> str:
+        """The store's persisted instance identity (``registry_meta.instance_id``).
+
+        Public read-only accessor mirroring :attr:`ArtifactRegistry.instance_id`
+        so identity consumers (the replay resolver's ``--instance-id``
+        cross-check, trace-manifest comparisons) never reach into the private
+        field. Seeded at first create, stable across reopens."""
+        return self._instance_id
 
     def get_owner_generation(self, artifact_id: UUID) -> int:
         """Return the artifact's ownership epoch (read-generation fence)."""

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -11,14 +11,23 @@ that survives process restarts and is safe for multi-threaded access from
 
 Contract divergence from in-memory ``ArtifactRegistry`` (per plan KTD-13):
 
-  This registry does NOT persist artifact content. Only ``content_hash`` is
-  stored. ``get_content(artifact_id)`` returns ``b""`` (empty bytes) for
-  known artifacts and ``None`` for unknown. This is deliberate — the plugin's
-  hot path (Unit 4 HTTP hook handlers) never calls
+  By default this registry does NOT persist artifact content. Only
+  ``content_hash`` is stored. ``get_content(artifact_id)`` returns ``b""``
+  (empty bytes) for known artifacts and ``None`` for unknown. This is
+  deliberate — the plugin's hot path (Unit 4 HTTP hook handlers) never calls
   ``CoordinatorService.fetch``; it uses ``resolve_or_register`` / ``write`` /
   ``commit`` / ``invalidate`` directly. Avoiding content storage shrinks the
   disclosure surface if ``.coherence/state.db`` is accidentally committed to
   git (KTD-13 defense-in-depth).
+
+  EXCEPTION — durable version retention (plan item N v1, Unit 3): when
+  constructed with ``retain_versions=True`` (in-process embedders only; the
+  HTTP coordinator-server constructor leaves it off), the BODY of each captured
+  version is stored durably in the ``artifact_versions`` table (KTD-13 reversed
+  for retained rows only). This is opt-in and reachable through
+  ``get_content_at_version``, not ``get_content``. The file is held at mode 0600
+  (race-free at creation) precisely because this puts content on disk; see the
+  ``_DB_FILE_MODE`` note and ``docs/security.md``.
 
   The duck-typing parity test scoped for v0.1 covers the methods the plugin
   actually exercises; ``tests/test_coordinator.py`` patterns that exercise
@@ -65,7 +74,10 @@ IMMEDIATE transactions).
 
 from __future__ import annotations
 
+import logging
+import os
 import sqlite3
+import stat
 import threading
 import time
 from dataclasses import dataclass
@@ -77,16 +89,60 @@ from ccs.core.exceptions import STALE_READ_GENERATION_REASON, StaleReadGeneratio
 from ccs.core.states import MESIState, TransientState
 from ccs.core.types import Artifact, CasCorruption, ConflictDetail
 
+from .retention import RetentionPolicy, collectible_versions
+
+logger = logging.getLogger(__name__)
+
 CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
 """Reuses the same schema version as in-memory registry (state_log emissions
 are interchangeable from a downstream consumer's perspective)."""
 
-SCHEMA_USER_VERSION = 1
-"""Single-version guard per simplified migration framework (plan KTD-3 update).
-v0.1 raises on mismatch; v0.2 will add real migration dispatch when needed."""
+SCHEMA_USER_VERSION = 2
+"""Schema version stamped via ``PRAGMA user_version`` on init.
+
+**v1 -> v2 is the repo's FIRST real schema bump** (plan item N v1, Unit 3): it
+adds the durable ``artifact_versions`` table and — because the fence columns +
+``coordinator_epoch`` seed AND the ``pending_notices`` table both shipped as
+additive no-version-bump shims — idempotently subsumes BOTH shims so that
+``user_version=2`` GUARANTEES the complete schema from every wild v1 variant.
+After migration the normal open path performs **no writes** (no shim ALTERs,
+no IF-NOT-EXISTS), which is the prerequisite that makes the read-only open mode
+implementable. See ``_migrate_v1_to_v2`` and
+``docs/solutions/runtime-errors/sqlite-schema-init-non-atomic-leaves-unbootable-db-2026-05-18.md``."""
+
+_DB_FILE_MODE = 0o600
+"""state.db (and its -wal/-shm sidecars) must be owner-read/write only.
+
+Durable retention puts artifact *content* on disk (v1->v2), so the disclosure
+posture of state.db now matches the audit log's: 0600, race-free at creation.
+Pre-created via ``os.open(..., 0o600)`` BEFORE ``sqlite3.connect`` so the file
+never exists at a broader umask mode; the migration re-applies it (and warns
+once) to an operator-broadened pre-existing db. Mirrors
+``adapters/claude_code/audit_log.py:_REQUIRED_MODE``."""
 
 ReclamationSlot: TypeAlias = tuple[str, int]
 _M_OR_E_STATES: frozenset[MESIState] = frozenset({MESIState.MODIFIED, MESIState.EXCLUSIVE})
+
+# Durable version-retention table (plan item N v1, Unit 3). One row per
+# (artifact, version) retained snapshot. The ``content`` column is declared with
+# NO type name on purpose: SQLite then gives it BLOB affinity (affinity NONE),
+# which stores each value with its own storage class — a Python ``str`` binds as
+# TEXT and a ``bytes`` binds as BLOB, and both round-trip back to the SAME Python
+# type (``str``/``bytes``). A typed column (e.g. ``TEXT``/``BLOB``) would coerce
+# one of them; affinity NONE is what makes the str-vs-bytes round-trip hold.
+# ``captured_at`` is wall-clock ``time.time()`` (matches ``artifacts.updated_at``
+# + the in-memory ``version_captured_at`` parallel dict). FK ON DELETE CASCADE
+# (foreign_keys=ON) drops history when the artifact is removed.
+_ARTIFACT_VERSIONS_DDL = """
+CREATE TABLE artifact_versions (
+    artifact_id TEXT NOT NULL,
+    version     INTEGER NOT NULL,
+    content,
+    captured_at REAL NOT NULL,
+    PRIMARY KEY (artifact_id, version),
+    FOREIGN KEY (artifact_id) REFERENCES artifacts(id) ON DELETE CASCADE
+)
+"""
 
 # Coordinator-side eviction triggers (the stable-grant sweep's two reclaim
 # triggers + the transient-timeout fail-safe) — an M/E -> INVALID carrying one
@@ -102,6 +158,16 @@ RECLAIM_TRIGGERS: frozenset[str] = frozenset(
 # registry.py; pinned equal by the parity test). Service.fetch() emits "fetch".
 CLAIM_CAPTURE_TRIGGERS: frozenset[str] = frozenset({"fetch"})
 
+# registry_meta keys persisting the retention policy on writer open (plan item
+# N v1, Unit 3). ``retention_enabled`` is the explicit marker set even in the
+# unbounded mode (retain_versions=True + policy=None → enabled with NULL axes):
+# the artifact_versions table exists on EVERY v2 db, so table-presence alone
+# cannot tell retention-on-unbounded from retention-never-enabled — a read-only
+# resolver reads these keys to derive ``retention_off`` and the T-expiry axis.
+_META_RETENTION_ENABLED = "retention_enabled"
+_META_RETENTION_MAX_VERSIONS = "retention_max_versions"
+_META_RETENTION_MAX_AGE_SECONDS = "retention_max_age_seconds"
+
 # OCC commit-CAS result (plan Unit 2). A WIN is ``(updated_artifact,
 # invalidated_agent_ids)`` — the service layer turns the id list into
 # ``InvalidationSignal``s. A loss is a typed ``ConflictDetail`` (retry-eligible,
@@ -113,10 +179,47 @@ CasResult: TypeAlias = "tuple[Artifact, list[UUID]] | ConflictDetail | CasCorrup
 class SchemaVersionError(RuntimeError):
     """Raised when an existing ``state.db`` carries an unexpected user_version.
 
-    v0.1 ships a single-version guard rather than a full migration framework
-    (per plan KTD-3 simplification). When v0.2 adds schema columns for
-    strict-mode retry counters, a real migration dispatch lands here and
-    this exception graduates to the not-yet-migrated branch.
+    The message deliberately does **not** recommend deleting the database:
+    as of v2 the store holds durable retained content + read-generation fence
+    state, so a delete is destructive (it drops retained history AND the fence
+    epoch). The forward path is upgrading the embedder binary to one that
+    understands the schema, never ``rm state.db``.
+    """
+
+
+class ReadOnlyRegistryError(RuntimeError):
+    """Base for read-only-open failures (the resolver / SB-17 inherit this).
+
+    A read-only :class:`SqliteArtifactRegistry` (``mode=ro`` URI) never creates,
+    migrates, or mutates the store. The subclasses below give the CLI a typed,
+    prose-free way to distinguish *why* a read-only open or call failed; they
+    are exceptions (not the ``ConflictDetail`` typed-return discipline) because
+    an open that cannot proceed has no value to return.
+    """
+
+
+class MissingDatabaseError(ReadOnlyRegistryError):
+    """A read-only open was asked for a path that does not exist.
+
+    A read-write open would *create* the file; read-only must NOT — a resolver
+    pointed at the wrong path should fail loudly, never materialize a fresh
+    empty ``.coherence/state.db``.
+    """
+
+
+class ReadOnlyMutationError(ReadOnlyRegistryError):
+    """A mutating method was called on a read-only registry."""
+
+
+class StoreNeedsRecoveryError(ReadOnlyRegistryError):
+    """The store has an unclean WAL that a read-only connection cannot replay.
+
+    After an embedder crash SQLite leaves a hot WAL whose recovery requires a
+    *write* lock; a ``mode=ro`` connection raises ``SQLITE_READONLY_RECOVERY``.
+    This is distinct from missing / corrupt / busy — the remedy is to re-open
+    the store once with the embedder (read-write) so it checkpoints the WAL,
+    then retry the read-only resolve. The forensic population over-represents
+    crashed writers, so this is the resolver's most on-brand failure mode.
     """
 
 
@@ -146,6 +249,8 @@ class SqliteArtifactRegistry:
         agent_names: dict[UUID, str] | None = None,
         instance_id: str | None = None,
         retain_versions: bool = False,
+        retention_policy: RetentionPolicy | None = None,
+        read_only: bool = False,
     ) -> None:
         if state_log is not None and instance_id is None:
             raise ValueError(
@@ -153,25 +258,37 @@ class SqliteArtifactRegistry:
                 "pass instance_id=str(uuid4()) or route through the plugin coordinator "
                 "which manages instance_id persistence in registry_meta"
             )
-
-        # P2 ce-review fix #5 (maintainability): retain_versions=True was
-        # silently ignored, diverging from ArtifactRegistry's contract
-        # where True enables version-history queries. Raising here makes
-        # the divergence loud — callers expecting history get a clear
-        # error rather than silent None returns from get_content_at_version().
-        # retain_versions=False (the default) is the only supported value
-        # in v0.1; full version history is a v0.2 audit-trail feature.
-        if retain_versions:
-            raise NotImplementedError(
-                "SqliteArtifactRegistry does not yet support retain_versions=True. "
-                "Version history is a v0.2 audit feature; v0.1 only stores the "
-                "latest version per artifact. Use the in-memory ArtifactRegistry "
-                "if you need version history, or wait for v0.2."
+        if read_only and state_log is not None:
+            raise ValueError(
+                "read_only=True is incompatible with state_log: a read-only "
+                "registry never mutates, so it emits no state_log entries"
             )
 
         self._db_path = Path(db_path)
-        self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         self._lock = threading.RLock()
+        self._read_only = read_only
+        # Retention is active iff retain_versions=True. ``retention_policy=None``
+        # with retain_versions=True == today's UNBOUNDED semantics (no GC) — the
+        # back-compat contract for the v0.5 audit auto-wiring. A policy is an
+        # explicit opt-in to BOUNDED retention. ``_retain_versions`` stays the
+        # private name the recorder test pins. (Mirrors ArtifactRegistry.)
+        self._retain_versions = retain_versions
+        self._retention_policy = retention_policy
+        self._state_log = state_log
+        self._agent_names = agent_names
+
+        if read_only:
+            self._open_read_only(instance_id)
+            return
+
+        self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # Race-free 0600: pre-create state.db at 0o600 via os.open BEFORE
+        # sqlite3.connect, so the file never exists at a broader umask mode in
+        # the window between creation and an explicit chmod (the audit_log
+        # pattern). os.open is a no-op-ish touch when the file already exists
+        # (O_CREAT without O_EXCL); the migration re-applies the mode to a
+        # pre-existing, possibly operator-broadened db and warns once.
+        self._precreate_file_0600(self._db_path)
 
         # check_same_thread=False because ThreadingHTTPServer handler threads
         # all share one registry instance. Coupled with the RLock on every
@@ -181,6 +298,15 @@ class SqliteArtifactRegistry:
             check_same_thread=False,
             isolation_level=None,  # autocommit; we manage transactions explicitly
         )
+        # The -wal/-shm sidecars materialize lazily on the first write
+        # (PRAGMA journal_mode=WAL is itself the first write). Pre-create/chmod
+        # them to 0600 immediately around the WAL switch so the window in which
+        # they could exist world-readable is closed BEFORE the migration's first
+        # content-bearing transaction. They may be created by SQLite at any of:
+        # the journal_mode switch, the first WAL frame; pre-touching them here
+        # at 0600 plus a tighten-after pass covers both orderings.
+        self._precreate_file_0600(self._wal_path())
+        self._precreate_file_0600(self._shm_path())
         # WAL for concurrent readers + bounded busy_timeout for write contention.
         # synchronous=NORMAL is durable enough for non-financial use.
         #
@@ -202,37 +328,101 @@ class SqliteArtifactRegistry:
         self._conn.execute("PRAGMA busy_timeout=1500")
         self._conn.execute("PRAGMA synchronous=NORMAL")
         self._conn.execute("PRAGMA foreign_keys=ON")
+        # Tighten the sidecars again post-WAL-enable: if SQLite created them at
+        # the journal_mode switch above (before our pre-touch could win the
+        # race on some platforms), this chmod brings them to 0600.
+        self._chmod_if_exists(self._wal_path())
+        self._chmod_if_exists(self._shm_path())
 
         self._initialize_schema(instance_id)
-        self._state_log = state_log
-        self._agent_names = agent_names
-        self._retain_versions = retain_versions
-        # In-memory tracking only; not persisted across restarts.
-        # version_history-by-tick is a v0.2 audit feature, not v0.1.
+        # Persist the retention policy on writer open (incl. the explicit
+        # unbounded marker) so a read-only resolver can derive T-expiry + the
+        # retention_off reason from the store, not a process-local object.
+        self._persist_retention_policy()
+
+    # ------------------------------------------------------------------
+    # File-mode helpers (race-free 0600 — audit_log.py pattern)
+    # ------------------------------------------------------------------
+
+    def _wal_path(self) -> Path:
+        return self._db_path.with_name(self._db_path.name + "-wal")
+
+    def _shm_path(self) -> Path:
+        return self._db_path.with_name(self._db_path.name + "-shm")
+
+    @staticmethod
+    def _precreate_file_0600(path: Path) -> None:
+        """Create ``path`` at mode 0o600 if absent; leave an existing file as-is.
+
+        ``os.open(O_CREAT|O_WRONLY, 0o600)`` applies the mode atomically at
+        creation (subject to umask) so the file never exists at a broader mode
+        in a creation->chmod window. We do NOT pass O_EXCL: a benign double-call
+        (e.g. the file already there from a prior run) must not raise. The mode
+        argument is ignored by the kernel when the file already exists — an
+        operator-broadened existing db is re-tightened by the migration's chmod,
+        not here.
+        """
+        try:
+            fd = os.open(str(path), os.O_CREAT | os.O_WRONLY, _DB_FILE_MODE)
+        except OSError:
+            # Parent missing / permission — let sqlite3.connect surface the real
+            # error rather than masking it here.
+            return
+        os.close(fd)
+
+    @staticmethod
+    def _chmod_if_exists(path: Path) -> None:
+        """Best-effort tighten ``path`` to 0o600 if it exists."""
+        try:
+            os.chmod(str(path), _DB_FILE_MODE)
+        except OSError:
+            pass
 
     # ------------------------------------------------------------------
     # Schema lifecycle
     # ------------------------------------------------------------------
 
     def _initialize_schema(self, instance_id: str | None) -> None:
-        """Apply schema or verify existing user_version; seed registry_meta."""
+        """Apply schema, migrate, or verify user_version; seed registry_meta.
+
+        The migration DISPATCH (the repo's first real one):
+
+        - ``user_version == 0`` (brand-new file) → ``_apply_v2_schema``: the
+          COMPLETE v2 schema in one atomic transaction (no shim ever runs on a
+          fresh db).
+        - ``user_version == 1`` (any wild v1 variant) → ``_migrate_v1_to_v2``:
+          idempotently subsumes BOTH additive shims (fence columns + epoch seed,
+          and ``pending_notices``) AND adds ``artifact_versions``, then stamps
+          ``user_version=2`` — all in ONE ``BEGIN IMMEDIATE``. The wild v1
+          population is a 2x2 matrix ({±fence columns} x {±pending_notices})
+          because both shims shipped with no version bump; ``PRAGMA table_info``
+          / ``IF NOT EXISTS`` guards make each piece apply only when missing.
+        - ``user_version == 2`` → ``_rehydrate_meta``: the WRITE-FREE open path
+          (no ALTER, no IF-NOT-EXISTS) — the prerequisite for read-only mode.
+        - anything else → :class:`SchemaVersionError` (no destructive advice).
+        """
         with self._lock:
             current = self._conn.execute("PRAGMA user_version").fetchone()[0]
             if current == 0:
-                # Fresh database — apply v1 schema.
-                self._apply_v1_schema(instance_id)
+                self._apply_v2_schema(instance_id)
+            elif current == 1:
+                self._migrate_v1_to_v2(instance_id)
             elif current == SCHEMA_USER_VERSION:
-                # Existing v1 database — rehydrate _instance_id and _seq.
+                # Existing v2 database — rehydrate; NO writes on this path.
                 self._rehydrate_meta(instance_id)
             else:
                 raise SchemaVersionError(
-                    f"unexpected schema version {current}; v0.1 expects {SCHEMA_USER_VERSION}. "
-                    f"Delete {self._db_path} and restart, or upgrade to a plugin version "
-                    f"that supports this schema."
+                    f"unexpected schema version {current}; this build expects "
+                    f"{SCHEMA_USER_VERSION}. The database at {self._db_path} was "
+                    f"written by a newer coordinator build. Upgrade this embedder "
+                    f"to a build that understands schema v{current} rather than "
+                    f"removing the store — as of v2 it holds durable retained "
+                    f"content and read-generation fence state that a delete would "
+                    f"destroy."
                 )
 
-    def _apply_v1_schema(self, instance_id: str | None) -> None:
-        """Create tables, indexes, and seed registry_meta. Caller holds lock.
+    def _apply_v2_schema(self, instance_id: str | None) -> None:
+        """Create the COMPLETE v2 schema + seed registry_meta. Caller holds lock.
 
         P1 ce-review fix (correctness): schema init must be atomic against
         SIGKILL. Earlier version ran executescript() THEN a separate PRAGMA
@@ -245,6 +435,12 @@ class SqliteArtifactRegistry:
         The truly atomic fix is an explicit BEGIN IMMEDIATE / COMMIT wrapping
         all DDL + meta seed + PRAGMA user_version (which IS transactional
         when issued inside an explicit transaction per SQLite docs).
+
+        A fresh db is created at v2 directly: the fence columns are inline in the
+        ``artifacts``/``agent_states`` DDL, ``coordinator_epoch`` is seeded, and
+        ``pending_notices`` + ``artifact_versions`` are created here — so NO shim
+        (``_ensure_fence_columns`` / the ``pending_notices`` IF-NOT-EXISTS) ever
+        runs against a fresh db, and the open path that follows is write-free.
         """
         c = self._conn
         seed_id = instance_id if instance_id is not None else str(uuid4())
@@ -320,6 +516,7 @@ class SqliteArtifactRegistry:
                 )
                 """
             )
+            c.execute(_ARTIFACT_VERSIONS_DDL)
             seed_epoch = uuid4().hex
             c.execute(
                 "INSERT INTO registry_meta (key, value) VALUES (?, ?), (?, ?), (?, ?)",
@@ -347,7 +544,14 @@ class SqliteArtifactRegistry:
         self._coordinator_epoch = seed_epoch
 
     def _rehydrate_meta(self, instance_id_override: str | None) -> None:
-        """Load _instance_id + _seq from registry_meta. Caller holds lock."""
+        """Load _instance_id + _seq + epoch from registry_meta. Caller holds lock.
+
+        WRITE-FREE: a v2 db carries the complete schema (the migration subsumed
+        every shim), so this open path issues NO DDL/DML — exactly what lets the
+        same code be reused read-only. Earlier versions ran the
+        ``pending_notices`` IF-NOT-EXISTS and the fence-column ALTERs here on
+        EVERY open; those moved into ``_migrate_v1_to_v2`` and run once.
+        """
         rows = dict(
             self._conn.execute(
                 "SELECT key, value FROM registry_meta WHERE key IN ('instance_id', 'sequence_number')"
@@ -356,51 +560,50 @@ class SqliteArtifactRegistry:
         if "instance_id" not in rows or "sequence_number" not in rows:
             raise SchemaVersionError(
                 f"registry_meta is missing required keys at {self._db_path}; "
-                f"the database may be corrupted. Delete and restart to rehydrate."
+                f"the database may be corrupted (a v2 store always carries these). "
+                f"Restore from a backup rather than deleting — the store may hold "
+                f"durable retained content."
             )
         # Caller's explicit instance_id wins (rare; typically used in tests).
         self._instance_id = instance_id_override or rows["instance_id"]
         self._seq = int(rows["sequence_number"])
-        # A1 forward-compat: ensure pending_notices exists even on dbs
-        # initialized before this table was added. PRAGMA user_version stays
-        # at 1; this is an additive change that doesn't warrant a migration.
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS pending_notices (
-                agent_id              TEXT NOT NULL,
-                artifact_id           TEXT NOT NULL,
-                preempter_agent_id    TEXT NOT NULL,
-                preempted_at_unix_ts  REAL NOT NULL,
-                PRIMARY KEY (agent_id, artifact_id),
-                FOREIGN KEY (artifact_id) REFERENCES artifacts(id) ON DELETE CASCADE
-            )
-            """
-        )
-        # Read-generation fence (Piece #2) forward-compat: additively add the
-        # fence columns + coordinator_epoch to dbs created before the fence.
-        # user_version stays unchanged (additive, plan option (a); same posture
-        # as pending_notices above) so an older binary can still open the db.
-        self._ensure_fence_columns()
         epoch_row = self._conn.execute(
             "SELECT value FROM registry_meta WHERE key = 'coordinator_epoch'"
         ).fetchone()
         if epoch_row is None:
             raise SchemaVersionError(
                 f"coordinator_epoch missing from registry_meta at {self._db_path}; "
-                f"the database may be partially upgraded or corrupted. "
-                f"Delete and restart to rehydrate."
+                f"the database may be corrupted (a v2 store always seeds the epoch). "
+                f"Restore from a backup rather than deleting — the store may hold "
+                f"durable retained content and fence state."
             )
         self._coordinator_epoch = epoch_row[0]
 
-    def _ensure_fence_columns(self) -> None:
-        """Additively add the read-generation fence columns + coordinator_epoch
-        to a pre-fence database. Idempotent; user_version stays unchanged.
-        Caller holds the lock; runs in one explicit transaction so a SIGKILL
-        mid-add cannot leave a half-applied column set. The PRAGMA introspection
-        runs INSIDE the BEGIN IMMEDIATE: two processes opening the same
-        pre-fence db serialize on the write lock, and the loser re-reads the
-        schema after the winner's commit — so it sees the columns as present
-        and no-ops instead of crashing on a duplicate-column ALTER."""
+    def _migrate_v1_to_v2(self, instance_id: str | None) -> None:
+        """Migrate any wild v1 db to v2 in ONE atomic transaction. Caller holds lock.
+
+        Correctness-required (not housekeeping): v1 dbs in the wild form a 2x2
+        matrix because BOTH the fence columns + ``coordinator_epoch`` seed AND
+        the ``pending_notices`` table shipped as additive shims with no version
+        bump. This migration idempotently subsumes BOTH shims and adds the new
+        ``artifact_versions`` table, so after it ``user_version=2`` GUARANTEES
+        the complete schema from EVERY v1 variant. Each piece is guarded
+        (``PRAGMA table_info`` for columns, ``IF NOT EXISTS`` for tables,
+        ``INSERT OR IGNORE`` for the epoch) so it applies only when missing.
+
+        Atomicity discipline (learnings skeleton —
+        sqlite-schema-init-non-atomic-leaves-unbootable-db): ONE explicit
+        ``BEGIN IMMEDIATE`` wrapping all DDL + seed + the ``PRAGMA user_version``
+        stamp (which IS transactional inside an explicit txn); individual
+        ``execute()`` calls (NEVER ``executescript`` — its autocommit silently
+        commits the pending BEGIN IMMEDIATE and varies by Python version);
+        ``except BaseException`` ROLLBACK so a SIGKILL/Ctrl-C mid-migration
+        leaves the v1 db intact (the next open re-migrates cleanly, never hits
+        "table already exists"). The introspection runs INSIDE the txn: two
+        processes racing the same v1 db serialize on the write lock; the loser
+        re-reads post-commit, sees user_version already 2, and dispatches to the
+        write-free rehydrate path instead of double-migrating.
+        """
         c = self._conn
         c.execute("BEGIN IMMEDIATE")
         try:
@@ -410,6 +613,7 @@ class SqliteArtifactRegistry:
             state_cols = {
                 row[1] for row in c.execute("PRAGMA table_info(agent_states)").fetchall()
             }
+            # --- Subsume the fence-column shim (was _ensure_fence_columns) ---
             if "owner_generation" not in art_cols:
                 c.execute(
                     "ALTER TABLE artifacts ADD COLUMN owner_generation "
@@ -423,6 +627,27 @@ class SqliteArtifactRegistry:
                 "INSERT OR IGNORE INTO registry_meta (key, value) VALUES (?, ?)",
                 ("coordinator_epoch", uuid4().hex),
             )
+            # --- Subsume the pending_notices shim (was the IF-NOT-EXISTS) ---
+            c.execute(
+                """
+                CREATE TABLE IF NOT EXISTS pending_notices (
+                    agent_id              TEXT NOT NULL,
+                    artifact_id           TEXT NOT NULL,
+                    preempter_agent_id    TEXT NOT NULL,
+                    preempted_at_unix_ts  REAL NOT NULL,
+                    PRIMARY KEY (agent_id, artifact_id),
+                    FOREIGN KEY (artifact_id) REFERENCES artifacts(id) ON DELETE CASCADE
+                )
+                """
+            )
+            # --- The new v2 surface: durable retention table ---
+            # IF NOT EXISTS guards the half-migrated-db case (table created by a
+            # prior crashed migration whose user_version stamp never committed).
+            c.execute(_ARTIFACT_VERSIONS_DDL.replace("CREATE TABLE", "CREATE TABLE IF NOT EXISTS", 1))
+            # In-txn stamp: PRAGMA user_version is transactional inside an explicit
+            # BEGIN; commits atomically with the DDL above. Cannot take bindings,
+            # so the int constant is interpolated.
+            c.execute(f"PRAGMA user_version = {SCHEMA_USER_VERSION}")
             c.execute("COMMIT")
         except BaseException:
             try:
@@ -430,6 +655,253 @@ class SqliteArtifactRegistry:
             except Exception:
                 pass
             raise
+        # Load meta from the now-migrated db (write-free).
+        self._rehydrate_meta(instance_id)
+        # A v1 db predates durable content storage; v2 may now persist content,
+        # so re-apply 0600 to a possibly operator-broadened file and warn ONCE
+        # that the content-storage posture changed (audit_log drift pattern).
+        self._tighten_existing_db_mode_and_warn()
+
+    def _tighten_existing_db_mode_and_warn(self) -> None:
+        """Re-apply 0600 to a pre-existing db whose mode an operator may have
+        broadened, emitting a one-time stderr warning that the content-storage
+        posture changed at v1->v2. Mirrors audit_log's mode-drift warning."""
+        try:
+            actual = stat.S_IMODE(self._db_path.stat().st_mode)
+        except OSError:
+            return
+        if actual != _DB_FILE_MODE:
+            logger.warning(
+                "state.db at %s had mode %o (expected %o). The v1->v2 migration "
+                "tightened it to %o: as of schema v2 this store persists durable "
+                "retained artifact content, so it is now as sensitive as the "
+                "content itself. Copies of state.db do NOT inherit 0600 and carry "
+                "the same content — treat them accordingly.",
+                self._db_path, actual, _DB_FILE_MODE, _DB_FILE_MODE,
+            )
+            self._chmod_if_exists(self._db_path)
+        self._chmod_if_exists(self._wal_path())
+        self._chmod_if_exists(self._shm_path())
+
+    def _open_read_only(self, instance_id: str | None) -> None:
+        """Open the store read-only: never creates, migrates, ALTERs, or mutates.
+
+        Used by the replay resolver (Unit 6) and SB-17 later. The
+        ``file:...?mode=ro`` URI requires ``uri=True`` to be passed EXPLICITLY —
+        without it sqlite3 treats the whole string as a literal filename and can
+        silently fall back to read-write (and create the file). A missing path is
+        a typed :class:`MissingDatabaseError` (a read-write open would create it;
+        read-only must not materialize a fresh empty store). A v1 (un-migrated)
+        db is a typed :class:`SchemaVersionError` with NO migration attempted. A
+        post-crash hot WAL that needs replay raises
+        :class:`StoreNeedsRecoveryError` (a read-only connection cannot run WAL
+        recovery — SQLITE_READONLY_RECOVERY).
+        """
+        if not self._db_path.exists():
+            raise MissingDatabaseError(
+                f"read-only open: no database at {self._db_path}. A read-only "
+                f"registry never creates the file (that would materialize a fresh "
+                f"empty store); point it at an existing coordinator state.db."
+            )
+        # mode=ro + uri=True (explicit) — see docstring on the silent-rw hazard.
+        uri = f"file:{self._db_path}?mode=ro"
+        self._conn = sqlite3.connect(
+            uri,
+            uri=True,
+            check_same_thread=False,
+            isolation_level=None,
+        )
+        # foreign_keys is a no-op for a read-only conn (no writes); set for
+        # parity. Do NOT touch journal_mode (that is a write) — opening ro
+        # against a WAL db is fine for reads. busy_timeout helps a reader wait
+        # out a concurrent writer's lock.
+        self._conn.execute("PRAGMA busy_timeout=1500")
+        try:
+            current = self._conn.execute("PRAGMA user_version").fetchone()[0]
+        except sqlite3.OperationalError as exc:
+            raise self._classify_readonly_operational_error(exc) from exc
+        if current != SCHEMA_USER_VERSION:
+            raise SchemaVersionError(
+                f"read-only open: database at {self._db_path} is schema "
+                f"v{current}, this build serves v{SCHEMA_USER_VERSION}. Read-only "
+                f"mode performs NO migration — re-open the store once with the "
+                f"embedder (read-write) to migrate it, then retry."
+            )
+        try:
+            self._rehydrate_meta(instance_id)
+        except sqlite3.OperationalError as exc:
+            raise self._classify_readonly_operational_error(exc) from exc
+
+    def _classify_readonly_operational_error(
+        self, exc: sqlite3.OperationalError
+    ) -> ReadOnlyRegistryError:
+        """Map an OperationalError on a read-only connection to a typed error.
+
+        The needs-recovery case (an unclean hot WAL a ro conn cannot replay)
+        surfaces SQLITE_READONLY_RECOVERY; SQLite renders it with a recognizable
+        substring. Anything else is reported as a generic recovery-or-corruption
+        signal so the CLI never leaks a raw OperationalError to a script.
+        """
+        text = str(exc).lower()
+        if "readonly" in text or "recovery" in text or "wal" in text:
+            return StoreNeedsRecoveryError(
+                f"the store at {self._db_path} has an unclean write-ahead log that "
+                f"a read-only connection cannot replay (SQLITE_READONLY_RECOVERY). "
+                f"Re-open it once with the embedder (read-write) so it checkpoints "
+                f"the WAL, then retry the read-only resolve. Underlying: {exc}"
+            )
+        return StoreNeedsRecoveryError(
+            f"the read-only store at {self._db_path} could not be read "
+            f"({exc}); it may need recovery (re-open once with the embedder) or "
+            f"be corrupt."
+        )
+
+    def _persist_retention_policy(self) -> None:
+        """Persist the constructor retention policy to registry_meta (writer open).
+
+        Stores ``retention_enabled`` (the explicit marker — set even in unbounded
+        mode) plus the two axes (NULL when an axis is disabled or unbounded). A
+        read-only resolver derives ``retention_off`` from the absence/0 of the
+        marker and the T-expiry axis from the persisted ``max_age_seconds`` — so
+        retention semantics are STORE-derived, not process-local. No open-time GC
+        pass (dropped per plan): each writer's inline GC trusts its CONSTRUCTOR
+        policy; the v1 one-writer-per-store assumption means the last writer
+        open's persisted policy is what readers see. Idempotent UPSERT.
+        """
+        if self._read_only:
+            return
+        enabled = "1" if self._retain_versions else "0"
+        policy = self._retention_policy
+        max_versions = (
+            str(policy.max_versions)
+            if policy is not None and policy.max_versions is not None
+            else None
+        )
+        max_age = (
+            str(policy.max_age_seconds)
+            if policy is not None and policy.max_age_seconds is not None
+            else None
+        )
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                for key, value in (
+                    (_META_RETENTION_ENABLED, enabled),
+                    (_META_RETENTION_MAX_VERSIONS, max_versions),
+                    (_META_RETENTION_MAX_AGE_SECONDS, max_age),
+                ):
+                    self._conn.execute(
+                        """
+                        INSERT INTO registry_meta (key, value) VALUES (?, ?)
+                        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                        """,
+                        (key, value),
+                    )
+                self._conn.execute("COMMIT")
+            except BaseException:
+                self._conn.execute("ROLLBACK")
+                raise
+
+    def retention_meta(self) -> tuple[bool, RetentionPolicy | None]:
+        """Return ``(retention_enabled, persisted_policy_or_None)`` read from
+        registry_meta. Used by Unit 4's ``read_at_version`` (store-derived
+        ``retention_off`` + T-expiry) on both the writer and the read-only
+        resolver. ``retention_enabled=False`` ⇒ retention was never turned on for
+        this store; ``True`` with a ``None`` policy ⇒ unbounded (NULL axes)."""
+        with self._lock:
+            rows = dict(
+                self._conn.execute(
+                    "SELECT key, value FROM registry_meta WHERE key IN (?, ?, ?)",
+                    (
+                        _META_RETENTION_ENABLED,
+                        _META_RETENTION_MAX_VERSIONS,
+                        _META_RETENTION_MAX_AGE_SECONDS,
+                    ),
+                ).fetchall()
+            )
+        enabled = rows.get(_META_RETENTION_ENABLED) == "1"
+        if not enabled:
+            return False, None
+        max_v = rows.get(_META_RETENTION_MAX_VERSIONS)
+        max_a = rows.get(_META_RETENTION_MAX_AGE_SECONDS)
+        if max_v is None and max_a is None:
+            return True, None  # unbounded (NULL axes)
+        return True, RetentionPolicy(
+            max_versions=int(max_v) if max_v is not None else None,
+            max_age_seconds=float(max_a) if max_a is not None else None,
+        )
+
+    def _guard_writable(self) -> None:
+        """Raise if a mutator was called on a read-only registry."""
+        if self._read_only:
+            raise ReadOnlyMutationError(
+                f"this SqliteArtifactRegistry was opened read-only "
+                f"(mode=ro) against {self._db_path}; mutating methods are "
+                f"rejected. Open it read-write (the embedder) to mutate."
+            )
+
+    def _capture_version_sql(
+        self, artifact_id: UUID, version: int, content: bytes | str
+    ) -> None:
+        """Snapshot ``content`` under ``version`` + run inline K/T GC, INSIDE the
+        caller's already-open ``BEGIN IMMEDIATE`` (crash-atomic with the commit /
+        version-bump it captures — a rollback leaves neither phantom history nor
+        a version move). Caller holds the lock and an open transaction; this adds
+        NO new lock acquisition (busy_timeout derivation untouched).
+
+        Mirrors the in-memory ``ArtifactRegistry._capture_version``: store body +
+        wall-clock ``captured_at``, then (only when a bounded policy is set) drop
+        the versions :func:`collectible_versions` marks — the current version is
+        always exempt; unbounded mode (policy=None) skips GC entirely, preserving
+        today's semantics. Decisions route through the persisted authoritative
+        rows (this txn), never an in-memory mirror.
+
+        ``content`` is stored against the affinity-NONE ``content`` column so a
+        ``str`` round-trips TEXT and ``bytes`` round-trips BLOB by value. The
+        single ``time.time()`` read is both the stamp and the GC reference.
+        """
+        c = self._conn
+        captured_at = time.time()
+        # REPLACE (not INSERT): re-capturing the same version (e.g. a retried
+        # commit at the same version on the in-memory parity path) overwrites
+        # rather than raising on the (artifact_id, version) PK.
+        c.execute(
+            "INSERT OR REPLACE INTO artifact_versions "
+            "(artifact_id, version, content, captured_at) VALUES (?, ?, ?, ?)",
+            (artifact_id.hex, version, content, captured_at),
+        )
+        if self._retention_policy is None:
+            return  # unbounded mode (retain_versions=True, no policy): no GC.
+        # Read the authoritative retained set for this artifact (this txn) and
+        # compute the drop set with the SAME pure seam the in-memory path uses.
+        rows = c.execute(
+            "SELECT version, captured_at FROM artifact_versions WHERE artifact_id = ?",
+            (artifact_id.hex,),
+        ).fetchall()
+        timestamps = {int(v): float(ts) for v, ts in rows}
+        for dropped in collectible_versions(
+            timestamps,
+            current_version=version,
+            policy=self._retention_policy,
+            now=captured_at,
+        ):
+            c.execute(
+                "DELETE FROM artifact_versions WHERE artifact_id = ? AND version = ?",
+                (artifact_id.hex, dropped),
+            )
+
+    @property
+    def coordinator_epoch(self) -> str:
+        """The store's coordinator epoch (persisted in registry_meta).
+
+        Read from ``registry_meta.coordinator_epoch`` at open (writer OR
+        read-only), so a resolver opening the durable store read-only sees the
+        same epoch the writer minted. Unit 4's ``read_at_version`` stamps this on
+        every response/rejection and compares an optional ``expected_epoch``
+        against it. Survives restart (unlike the in-memory registry's
+        per-construction epoch). Epoch reset = delete-and-recreate the db, which
+        also drops ``artifact_versions``."""
+        return self._coordinator_epoch
 
     def get_owner_generation(self, artifact_id: UUID) -> int:
         """Return the artifact's ownership epoch (read-generation fence)."""
@@ -476,10 +948,13 @@ class SqliteArtifactRegistry:
     # ------------------------------------------------------------------
 
     def register_artifact(self, artifact: Artifact, content: str) -> None:
-        """Insert artifact record. Content is hashed by the caller and stored
-        only as ``content_hash`` (KTD-13); the ``content`` parameter is
-        accepted for signature compatibility but its bytes are discarded."""
-        del content  # KTD-13: not persisted. caller must pre-compute content_hash on artifact.
+        """Insert artifact record. ``content_hash`` (KTD-13) is always stored;
+        the ``content`` BODY is stored in ``artifact_versions`` ONLY when
+        retention is active (``retain_versions=True``) — otherwise discarded.
+
+        Threat-model note: with retention on, ``register_artifact`` puts the v1
+        body of a merely-OBSERVED artifact on disk (per plan R2 + docs/security)."""
+        self._guard_writable()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
@@ -497,6 +972,9 @@ class SqliteArtifactRegistry:
                         time.time(),
                     ),
                 )
+                # Durable capture INSIDE this txn (crash-atomic with the insert).
+                if self._retain_versions:
+                    self._capture_version_sql(artifact.id, artifact.version, content)
                 self._conn.execute("COMMIT")
             except BaseException:
                 # P2 ce-review fix #14 (kieran-python): BaseException catches
@@ -549,8 +1027,13 @@ class SqliteArtifactRegistry:
         ``fence_agent_id`` is given, reject -- atomically with the version
         persist in this BEGIN IMMEDIATE -- if that committer's captured
         read_generation was superseded by a sweep reclamation. A ``None``
-        fence_agent_id (source-churn) is unguarded."""
-        del content  # KTD-13: not persisted
+        fence_agent_id (source-churn) is unguarded.
+
+        With retention active, the NEW ``content`` body is captured under the
+        NEW version in ``artifact_versions``, atomically inside this txn (a fence
+        reject raises before the capture, so no phantom history). Otherwise the
+        body is discarded (KTD-13)."""
+        self._guard_writable()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
@@ -593,6 +1076,10 @@ class SqliteArtifactRegistry:
                         artifact_id.hex,
                     ),
                 )
+                # Durable capture of the NEW body under the NEW version, INSIDE
+                # this txn (the fence reject above raises before we reach here).
+                if self._retain_versions:
+                    self._capture_version_sql(artifact_id, artifact.version, content)
                 self._conn.execute("COMMIT")
             except BaseException:
                 # P2 ce-review fix #14 (kieran-python): BaseException catches
@@ -602,13 +1089,34 @@ class SqliteArtifactRegistry:
                 self._conn.execute("ROLLBACK")
                 raise
 
-    def get_content_at_version(self, artifact_id: UUID, version: int) -> str | None:
-        """v0.1 returns None — content history is not persisted (KTD-13)."""
-        del version
-        return None
+    def get_content_at_version(
+        self, artifact_id: UUID, version: int
+    ) -> str | bytes | None:
+        """Return the retained body for ``(artifact_id, version)``, or ``None``.
+
+        Durable as of v2 (plan item N v1, Unit 3): reads the ``artifact_versions``
+        table and returns the value with its original Python type — ``str`` for a
+        TEXT row, ``bytes`` for a BLOB row (the affinity-NONE column round-trips
+        by value). ``None`` when retention was never on, the row was K-evicted /
+        T-expired, or it was never captured (e.g. ``commit_cas(content=None)``).
+        Unit 4 builds the typed-reason surface (``not_retained`` vs ``retention_off``)
+        above this raw getter.
+        """
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT content FROM artifact_versions "
+                "WHERE artifact_id = ? AND version = ?",
+                (artifact_id.hex, version),
+            ).fetchone()
+        return row[0] if row is not None else None
 
     def remove_artifact(self, artifact_id: UUID) -> None:
-        """Remove artifact and cascade-delete agent_states for it."""
+        """Remove artifact and cascade-delete agent_states + retained history.
+
+        ``artifact_versions`` carries ``FOREIGN KEY ... ON DELETE CASCADE`` and
+        ``PRAGMA foreign_keys=ON`` is set on the connection, so the retained
+        history rows drop with the artifact (deleted ≡ never-existed)."""
+        self._guard_writable()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
@@ -705,6 +1213,7 @@ class SqliteArtifactRegistry:
         rolled back AND _seq is decremented so the next successful emission
         does not create a phantom gap.
         """
+        self._guard_writable()
         with self._lock:
             # COR-02: initialised outside the try so the except handler can
             # check it even if BEGIN IMMEDIATE or any pre-_seq SQL raises.
@@ -882,6 +1391,7 @@ class SqliteArtifactRegistry:
         entered_tick: int,
     ) -> None:
         """Set transient state and entry tick for one agent/artifact pair."""
+        self._guard_writable()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
@@ -909,6 +1419,7 @@ class SqliteArtifactRegistry:
 
     def clear_agent_transient(self, artifact_id: UUID, agent_id: UUID) -> None:
         """Clear transient state and timestamp for one agent/artifact pair."""
+        self._guard_writable()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
@@ -956,6 +1467,7 @@ class SqliteArtifactRegistry:
 
     def record_heartbeat(self, agent_id: UUID, now_tick: int) -> None:
         """Record an agent's heartbeat tick using max(prev, incoming) (R12 monotonicity)."""
+        self._guard_writable()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
@@ -988,6 +1500,7 @@ class SqliteArtifactRegistry:
         self, agent_id: UUID, artifact_id: UUID, trigger: str, tick: int
     ) -> None:
         """Record the most recent reclamation slot for an (agent, artifact) pair."""
+        self._guard_writable()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
@@ -1074,6 +1587,7 @@ class SqliteArtifactRegistry:
         pre-read handler then calls ``set_agent_state(..., SHARED, ...)``).
         """
         del initial_owner  # parameter symmetry only; plugin handler sets state explicitly
+        self._guard_writable()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
@@ -1179,12 +1693,20 @@ class SqliteArtifactRegistry:
         invariant and the ``state_log`` emit per transition (KTD-13: compare on
         version, never content bytes).
 
-        ``content`` is accepted for signature parity with the in-memory registry
-        but IGNORED (KTD-13: this registry persists no content body —
-        :meth:`get_content` returns ``b""``). The content-hash on the artifact is
-        the source of truth for staleness comparison.
+        ``content`` is the winning body. KTD-13 still governs ``get_content``
+        (the ``artifacts`` table persists no body; ``get_content`` returns
+        ``b""``) and the content-hash remains the staleness source of truth —
+        but with retention active the WIN captures ``content`` under
+        ``next_version`` in ``artifact_versions``, atomically in this txn.
+        ``content=None`` SKIPS the capture (mirror of the in-memory fix: the old
+        path would have stored the stale OLD body under the NEW version — a
+        latent history-poisoning bug; now an unsupplied body means no snapshot,
+        and a later read of ``next_version`` misses). An embedder following the
+        KTD-13 cross-process discipline (``content=None`` on every OCC commit)
+        therefore gets NO durable capture — retention is inert for that workload
+        by design.
         """
-        del content  # KTD-13: not persisted (signature parity only)
+        self._guard_writable()
         with self._lock:
             # Track every _seq increment in this call so the outer
             # BaseException handler can roll them ALL back if COMMIT (or any
@@ -1376,6 +1898,16 @@ class SqliteArtifactRegistry:
                     content_hash=content_hash,
                 )
 
+                # Durable capture of the WINNING body under next_version, INSIDE
+                # this txn (crash-atomic with the version bump). content=None
+                # SKIPS capture (the in-memory parity fix): an unsupplied body
+                # leaves next_version with no snapshot rather than poisoning it
+                # with the stale OLD body. The non-OSError escape window (binding
+                # a large bytes/str into the INSERT) is covered by the outer
+                # BaseException ROLLBACK below.
+                if self._retain_versions and content is not None:
+                    self._capture_version_sql(artifact_id, next_version, content)
+
                 self._conn.execute("COMMIT")
                 # COMMIT succeeded — _seq durably persisted; suppress rollback.
                 seq_incremented_count = 0
@@ -1549,6 +2081,7 @@ class SqliteArtifactRegistry:
         update conditional on excluded.preempted_at_unix_ts being strictly
         greater than the existing row's.
         """
+        self._guard_writable()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
@@ -1584,6 +2117,7 @@ class SqliteArtifactRegistry:
         """Atomically SELECT and DELETE all pending notices for ``agent_id``.
         Returns list of ``(artifact_id, preempter_agent_id, preempted_at_unix_ts)``.
         Empty list if no pending notices."""
+        self._guard_writable()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
@@ -1654,6 +2188,7 @@ class SqliteArtifactRegistry:
         None. Used by the post-edit failure path so the notice is consumed
         at the point it surfaces in the error reason, preventing the next
         pre-event from re-emitting the same preemption prose."""
+        self._guard_writable()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
@@ -1698,6 +2233,7 @@ class SqliteArtifactRegistry:
             # import and confused readers).
             now_unix = time.time()
         cutoff = now_unix - max_age_sec
+        self._guard_writable()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -80,12 +80,14 @@ import sqlite3
 import stat
 import threading
 import time
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterable, Optional, TypeAlias
+from typing import Any, Callable, Iterable, NoReturn, Optional, TypeAlias
 from uuid import UUID, uuid4
 
 from ccs.core.exceptions import (
+    CROSS_RUNTIME_SCHEMA_REASON,
     STALE_READ_GENERATION_REASON,
     STORE_SIGNAL_BUSY,
     STORE_SIGNAL_UNREADABLE,
@@ -174,6 +176,19 @@ _META_RETENTION_ENABLED = "retention_enabled"
 _META_RETENTION_MAX_VERSIONS = "retention_max_versions"
 _META_RETENTION_MAX_AGE_SECONDS = "retention_max_age_seconds"
 
+# Cross-runtime lineage stamp (registry_meta). The sibling Node coordinator
+# shares the SAME ``<workspace>/.coherence/state.db`` path but keeps its OWN
+# migration ledger (its v2/v3 mean different schemas than this repo's v2), so
+# ``PRAGMA user_version`` alone cannot say WHOSE ledger a file belongs to.
+# This side stamps ``schema_runtime=python`` at fresh-create and at the v1->v2
+# migration (inside those existing transactions — the v2 steady-state open
+# stays write-free); the Node side mirrors with ``node`` (alignment issue).
+# A present-and-foreign stamp is the STRONGEST cross-runtime marker — checked
+# before any structural probing. Absence is NOT foreign: every db stamped
+# before this marker shipped lacks the key.
+_META_SCHEMA_RUNTIME = "schema_runtime"
+_SCHEMA_RUNTIME_STAMP = "python"
+
 # OCC commit-CAS result (plan Unit 2). A WIN is ``(updated_artifact,
 # invalidated_agent_ids)`` — the service layer turns the id list into
 # ``InvalidationSignal``s. A loss is a typed ``ConflictDetail`` (retry-eligible,
@@ -191,6 +206,32 @@ class SchemaVersionError(RuntimeError):
     epoch). The forward path is upgrading the embedder binary to one that
     understands the schema, never ``rm state.db``.
     """
+
+
+class CrossRuntimeSchemaError(SchemaVersionError):
+    """The ``state.db`` was written under the sibling Node coordinator's ledger.
+
+    The Node coordinator (agent-coherence-plugin) shares the same db path but
+    assigns DIFFERENT meanings to ``user_version`` 2 and 3 (its v2 adds no
+    schema objects; its v3 adds ``agent_states.deadline_tick``), so this
+    Python coordinator fails CLOSED at open — it will neither read nor migrate
+    a foreign-ledger db (migrating would corrupt the Node side's live state;
+    reading would misinterpret its schema). Detection is in
+    :meth:`SqliteArtifactRegistry._reject_foreign_ledger_db`.
+
+    Subclasses :class:`SchemaVersionError` so every existing catch-site (the
+    replay resolver's ``except SchemaVersionError`` mapping, CLI exit-code
+    plumbing) handles it without change. ``reason`` is always
+    :data:`ccs.core.exceptions.CROSS_RUNTIME_SCHEMA_REASON`; consumers match
+    ``exc.reason == CONSTANT``, never a substring of the message (the
+    typed-signal-not-substring house rule). Same anti-delete wording rule as
+    the parent: the message must never advise removing the db — it holds the
+    sibling runtime's live coordination state.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.reason = CROSS_RUNTIME_SCHEMA_REASON
 
 
 class ReadOnlyRegistryError(RuntimeError):
@@ -443,9 +484,17 @@ class SqliteArtifactRegistry:
         - ``user_version == 2`` → ``_rehydrate_meta``: the WRITE-FREE open path
           (no ALTER, no IF-NOT-EXISTS) — the prerequisite for read-only mode.
         - anything else → :class:`SchemaVersionError` (no destructive advice).
+
+        A :class:`CrossRuntimeSchemaError` pre-empts ALL of the above when the
+        db carries sibling-Node-ledger markers (``_reject_foreign_ledger_db``,
+        called BEFORE any migration or rehydrate write).
         """
         with self._lock:
             current = self._conn.execute("PRAGMA user_version").fetchone()[0]
+            # Cross-runtime fail-closed guard: read-only probes, BEFORE the
+            # dispatch can migrate (v1 branch) or write anything — migrating a
+            # Node-ledger db would corrupt the sibling coordinator's live state.
+            self._reject_foreign_ledger_db(current)
             if current == 0:
                 self._apply_v2_schema(instance_id)
             elif current == 1:
@@ -457,12 +506,125 @@ class SqliteArtifactRegistry:
                 raise SchemaVersionError(
                     f"unexpected schema version {current}; this build expects "
                     f"{SCHEMA_USER_VERSION}. The database at {self._db_path} was "
-                    f"written by a newer coordinator build. Upgrade this embedder "
+                    f"written by a newer coordinator build — either a newer "
+                    f"Python coordinator, or a sibling-runtime coordinator whose "
+                    f"ledger this build does not recognize. Upgrade this embedder "
                     f"to a build that understands schema v{current} rather than "
                     f"removing the store — as of v2 it holds durable retained "
                     f"content and read-generation fence state that a delete would "
                     f"destroy."
                 )
+
+    # ------------------------------------------------------------------
+    # Cross-runtime fail-closed guard (sibling Node coordinator hazard)
+    # ------------------------------------------------------------------
+
+    def _has_table(self, name: str) -> bool:
+        """Read-only probe: does a table exist? (sqlite_master, no writes)."""
+        row = self._conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (name,),
+        ).fetchone()
+        return row is not None
+
+    def _has_column(self, table: str, column: str) -> bool:
+        """Read-only probe: does ``table`` carry ``column``? PRAGMA table_info
+        takes no bindings (callers pass internal literals only) and returns
+        zero rows for a missing table — absent table reads as absent column."""
+        return any(
+            row[1] == column
+            for row in self._conn.execute(f"PRAGMA table_info({table})").fetchall()
+        )
+
+    def _read_schema_runtime_stamp(self) -> str | None:
+        """Return ``registry_meta.schema_runtime``, or None when the table or
+        key is absent (a fresh file, or any db stamped before the marker
+        shipped — absence is NOT foreign)."""
+        if not self._has_table("registry_meta"):
+            return None
+        row = self._conn.execute(
+            "SELECT value FROM registry_meta WHERE key = ?",
+            (_META_SCHEMA_RUNTIME,),
+        ).fetchone()
+        return row[0] if row is not None else None
+
+    def _reject_foreign_ledger_db(self, current: int) -> None:
+        """Fail closed when the db carries sibling-Node-coordinator markers.
+
+        Called by BOTH open paths (writer ``_initialize_schema`` and
+        ``_open_read_only``) right after reading ``user_version`` and BEFORE
+        any migration or rehydrate write; every probe is a plain read
+        (SELECT / PRAGMA table_info), so the guard itself can never dirty a
+        foreign db.
+
+        WHY structural markers and not the version number: the Node
+        coordinator shares this db path but its ledger's v2 adds NO schema
+        objects (pending_notices validation) and its v3 ALTERs
+        ``agent_states ADD COLUMN deadline_tick``, while THIS repo's v2 adds
+        ``artifact_versions`` — the same user_version means different schemas
+        depending on the writer. Detection order (strongest marker first):
+
+        1. ``registry_meta.schema_runtime`` present and foreign — the explicit
+           lineage stamp, checked regardless of version (this side stamps
+           ``python``; the Node side mirrors with ``node``).
+        2. ``user_version >= 3`` with ``agent_states.deadline_tick`` — the
+           Node ledger's v3 ALTER. ``>= 3``, not ``== 3``: a future Node v4+
+           still carries the column (columns are never dropped), and a future
+           Python v3 db is unreadable by this v2 build either way — both
+           classifications stay fail-closed and :class:`CrossRuntimeSchemaError`
+           IS a :class:`SchemaVersionError` for catch-sites. Literal ``3``
+           (the Node ledger's version), deliberately not SCHEMA_USER_VERSION.
+        3. ``user_version == 2`` WITHOUT ``artifact_versions`` — a Python-v2
+           db ALWAYS has the table (the v1->v2 migration creates it atomically
+           with the version stamp); a Node-v2 db never does. Literal ``2``:
+           the check pins user_version-2 semantics even after a future Python
+           v3 bump.
+
+        ``user_version == 1`` is deliberately NOT blocked: the Node ledger's
+        v1 is a byte-for-byte mirror of this repo's v1 schema, so the two are
+        indistinguishable by design — the normal v1->v2 migration proceeds
+        (documented residual risk).
+        """
+        runtime = self._read_schema_runtime_stamp()
+        if runtime is not None and runtime != _SCHEMA_RUNTIME_STAMP:
+            self._raise_cross_runtime(
+                f"is stamped registry_meta.schema_runtime={runtime!r} "
+                f"(this build stamps {_SCHEMA_RUNTIME_STAMP!r})"
+            )
+        if current >= 3 and self._has_column("agent_states", "deadline_tick"):
+            self._raise_cross_runtime(
+                f"is user_version={current} and carries the "
+                f"agent_states.deadline_tick column (the Node ledger's v3 "
+                f"watchdog marker; no Python schema has it)"
+            )
+        if current == 2 and not self._has_table("artifact_versions"):
+            self._raise_cross_runtime(
+                "is user_version=2 without the artifact_versions table (a "
+                "Python-v2 store always has it; the Node ledger's v2 adds no "
+                "schema objects)"
+            )
+
+    def _raise_cross_runtime(self, detail: str) -> NoReturn:
+        """Compose the single :class:`CrossRuntimeSchemaError` message shape.
+
+        Wording rules: name the sibling Node coordinator as the likely writer,
+        state the fail-closed posture, and point at the Node CLI's
+        ``--prepare-for-migration`` as the supported backend-switch path. Per
+        the :class:`SchemaVersionError` rule, NEVER advise deleting the db —
+        it holds the sibling runtime's live coordination state (and possibly
+        retained content), which a delete destroys.
+        """
+        raise CrossRuntimeSchemaError(
+            f"the database at {self._db_path} {detail}. The likely writer is "
+            f"the sibling Node coordinator (agent-coherence-coordinator), "
+            f"which shares this path but keeps its own migration ledger — the "
+            f"two ledgers assign different meanings to the same user_version "
+            f"numbers. This Python coordinator will not read or migrate a "
+            f"foreign-ledger db. To switch the store to this backend, run "
+            f"`agent-coherence-coordinator --prepare-for-migration` (the "
+            f"supported backend-switch path, which preserves the live "
+            f"coordination state the file holds)."
+        )
 
     def _apply_v2_schema(self, instance_id: str | None) -> None:
         """Create the COMPLETE v2 schema + seed registry_meta. Caller holds lock.
@@ -561,12 +723,18 @@ class SqliteArtifactRegistry:
             )
             c.execute(_ARTIFACT_VERSIONS_DDL)
             seed_epoch = uuid4().hex
+            # schema_runtime: the cross-runtime lineage stamp, seeded inside
+            # THIS creation transaction (no extra txn) so the sibling Node
+            # coordinator's mirror check can fail closed on an explicit marker
+            # instead of structural probing.
             c.execute(
-                "INSERT INTO registry_meta (key, value) VALUES (?, ?), (?, ?), (?, ?)",
+                "INSERT INTO registry_meta (key, value) "
+                "VALUES (?, ?), (?, ?), (?, ?), (?, ?)",
                 (
                     "instance_id", seed_id,
                     "sequence_number", "0",
                     "coordinator_epoch", seed_epoch,
+                    _META_SCHEMA_RUNTIME, _SCHEMA_RUNTIME_STAMP,
                 ),
             )
             # PRAGMA is transactional inside an explicit BEGIN; cannot take
@@ -682,6 +850,16 @@ class SqliteArtifactRegistry:
                 "INSERT OR IGNORE INTO registry_meta (key, value) VALUES (?, ?)",
                 ("coordinator_epoch", uuid4().hex),
             )
+            # Cross-runtime lineage stamp, atomic with the v1->v2 stamp in
+            # THIS transaction (no extra txn). A genuine v1 db never carries
+            # the key (the marker postdates v1), but OR IGNORE keeps the step
+            # idempotent alongside the other half-migrated-db guards. The
+            # foreign-stamp case was already rejected at dispatch
+            # (_reject_foreign_ledger_db runs before the migration).
+            c.execute(
+                "INSERT OR IGNORE INTO registry_meta (key, value) VALUES (?, ?)",
+                (_META_SCHEMA_RUNTIME, _SCHEMA_RUNTIME_STAMP),
+            )
             # --- Subsume the pending_notices shim (was the IF-NOT-EXISTS) ---
             c.execute(
                 """
@@ -779,8 +957,25 @@ class SqliteArtifactRegistry:
             self._conn.execute("PRAGMA busy_timeout=1500")
             try:
                 current = self._conn.execute("PRAGMA user_version").fetchone()[0]
+                # Cross-runtime fail-closed guard (same classification as the
+                # writer path): the probes are plain reads, so a busy/hot-WAL
+                # store surfaces the SAME typed signal as the version read.
+                self._reject_foreign_ledger_db(current)
             except sqlite3.OperationalError as exc:
                 raise self._classify_readonly_operational_error(exc) from exc
+            if current > SCHEMA_USER_VERSION:
+                # No Node marker matched above, so this is the future-Python
+                # posture — but a sibling-runtime ledger is also a possible
+                # writer, and the embedder cannot migrate DOWN, so the v1
+                # remedy below would be wrong advice here.
+                raise SchemaVersionError(
+                    f"read-only open: database at {self._db_path} is schema "
+                    f"v{current}, this build serves v{SCHEMA_USER_VERSION}. Either "
+                    f"a newer Python coordinator or a sibling-runtime coordinator "
+                    f"whose ledger this build does not recognize may have written "
+                    f"it. Read-only mode performs NO migration — use a build that "
+                    f"understands schema v{current}, then retry."
+                )
             if current != SCHEMA_USER_VERSION:
                 raise SchemaVersionError(
                     f"read-only open: database at {self._db_path} is schema "
@@ -880,6 +1075,10 @@ class SqliteArtifactRegistry:
                 persisted[key] == value for key, value in desired.items()
             ):
                 return
+            # About to OVERWRITE a different persisted policy — warn first
+            # (the operator-visible half of the single-writer-embedder
+            # assumption; see _warn_on_policy_mismatch for the scope rules).
+            self._warn_on_policy_mismatch(persisted, desired)
             self._conn.execute("BEGIN IMMEDIATE")
             try:
                 for key, value in desired.items():
@@ -901,6 +1100,52 @@ class SqliteArtifactRegistry:
                 except (sqlite3.Error, OSError):
                     pass
                 raise
+
+    def _warn_on_policy_mismatch(
+        self, persisted: dict[str, str | None], desired: dict[str, str | None]
+    ) -> None:
+        """Emit ONE RuntimeWarning when this writer's constructor retention
+        policy is about to overwrite a DIFFERENT previously persisted one.
+
+        WHY: the durable store's contract is one writer-embedder per store
+        (see :meth:`retention_meta`); each writer's inline GC trusts its
+        CONSTRUCTOR policy, so two embedders alternating with different
+        policies flip-flop the persisted policy AND the GC behaviour readers
+        derive from it — silently, unless surfaced here BEFORE the overwrite.
+
+        Scope: both sides retention-ENABLED with differing K/T axes. A first
+        persist (no keys yet) is setup, not a conflict; a matching reopen was
+        already short-circuited by the caller; the enable/disable toggles stay
+        silent (deliberate acts with their own documented semantics — see
+        ``test_disable_retention_preserves_existing_rows``); read-only mode
+        never reaches the caller at all.
+        """
+        if not self._retain_versions:
+            return
+        if persisted.get(_META_RETENTION_ENABLED) != "1":
+            return  # nothing previously persisted with retention enabled
+        # .get() folds absent-key and present-NULL to None — both mean "axis
+        # unbounded/disabled", which is exactly the comparison we want here.
+        p_k = persisted.get(_META_RETENTION_MAX_VERSIONS)
+        p_t = persisted.get(_META_RETENTION_MAX_AGE_SECONDS)
+        c_k = desired[_META_RETENTION_MAX_VERSIONS]
+        c_t = desired[_META_RETENTION_MAX_AGE_SECONDS]
+        if (p_k, p_t) == (c_k, c_t):
+            return
+        # stacklevel=4: warn() -> this helper -> _persist_retention_policy ->
+        # __init__ -> the embedder's constructor call site (the actionable
+        # frame: that is where the divergent policy is passed).
+        warnings.warn(
+            f"retention policy mismatch at {self._db_path}: the store persists "
+            f"max_versions={p_k} / max_age_seconds={p_t}, but this writer was "
+            f"constructed with max_versions={c_k} / max_age_seconds={c_t}; "
+            f"overwriting with the constructor policy. The durable store "
+            f"assumes a SINGLE writer-embedder per store — alternating "
+            f"embedders with different policies flip-flop the persisted "
+            f"policy and its GC behaviour.",
+            RuntimeWarning,
+            stacklevel=4,
+        )
 
     def _load_retention_meta(self) -> tuple[bool, RetentionPolicy | None]:
         """Read ``(retention_enabled, persisted_policy_or_None)`` from

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -1110,6 +1110,35 @@ class SqliteArtifactRegistry:
             ).fetchone()
         return row[0] if row is not None else None
 
+    def get_version_record(
+        self, artifact_id: UUID, version: int
+    ) -> tuple[str | bytes, float] | None:
+        """Return ``(content, captured_at)`` for a retained version, or ``None``.
+
+        The single accessor Unit 4's ``read_at_version`` needs: the body AND its
+        wall-clock ``captured_at`` (for ``VersionedContent.captured_at`` and the
+        T-expiry check) in ONE call. Mirrors
+        :meth:`ArtifactRegistry.get_version_record` so the two registries share
+        one duck-type.
+
+        Single-scope (R5 atomicity): the body and timestamp come from ONE row of
+        ONE ``SELECT`` under ONE lock, so a racing writer's ``BEGIN IMMEDIATE``
+        commit cannot interleave between reading the content and reading its
+        stamp — they are consistent by construction (no separate-statement
+        window two getters would have). Returns the body with its original Python
+        type (TEXT→``str``, BLOB→``bytes``; affinity-NONE column). ``None`` when
+        retention was never on, the row was K-evicted / T-expired, or it was
+        never captured (e.g. ``commit_cas(content=None)``)."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT content, captured_at FROM artifact_versions "
+                "WHERE artifact_id = ? AND version = ?",
+                (artifact_id.hex, version),
+            ).fetchone()
+        if row is None:
+            return None
+        return row[0], float(row[1])
+
     def remove_artifact(self, artifact_id: UUID) -> None:
         """Remove artifact and cascade-delete agent_states + retained history.
 

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -87,6 +87,36 @@ READ_AT_VERSION_REASONS: frozenset[str] = frozenset(
     }
 )
 
+# ---------------------------------------------------------------------------
+# read-only store-open classification signals (Unit 6 hardening)
+# ---------------------------------------------------------------------------
+#
+# Machine-readable signals carried by ``StoreNeedsRecoveryError.reason``
+# (``ccs.coordinator.sqlite_registry``). INTERNAL routing values, not the wire
+# contract: the CLI's JSON ``reason`` slugs (``needs_recovery`` / ``db_busy`` /
+# ``db_corrupt``) stay owned by the resolver error classes. sqlite renders its
+# operational errors as prose, so SOME substring matching is unavoidable — it
+# happens in exactly ONE place (``classify_sqlite_operational_signal``), and
+# every consumer branches on ``exc.reason == CONSTANT`` from here, never on a
+# substring of the human message (the typed-signal-not-substring house rule,
+# ``docs/solutions/best-practices/typed-signal-not-substring-...``).
+STORE_SIGNAL_WAL_RECOVERY = "wal_recovery"
+"""A hot WAL a read-only connection cannot replay (SQLITE_READONLY_RECOVERY).
+Remedy: re-open once with the embedder (read-write) to checkpoint the WAL."""
+
+STORE_SIGNAL_BUSY = "busy"
+"""The store is locked by a concurrent writer (SQLITE_BUSY); retry shortly."""
+
+STORE_SIGNAL_UNREADABLE = "unreadable"
+"""The catch-all: the read-only connection could not read the store for a
+reason that is neither a recognized recovery state nor a lock. The operator
+remedy matches ``wal_recovery`` (re-open with the embedder), so consumers may
+fold this into their needs-recovery surface."""
+
+STORE_OPEN_SIGNALS: frozenset[str] = frozenset(
+    {STORE_SIGNAL_WAL_RECOVERY, STORE_SIGNAL_BUSY, STORE_SIGNAL_UNREADABLE}
+)
+
 
 class CoherenceError(Exception):
     """Base error for coherence domain failures."""

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -21,6 +21,72 @@ OCC_CALLER_TRANSIENT_REASON = "caller_in_transient_state"
 # (pessimistic path) so the two surfaces cannot drift.
 STALE_READ_GENERATION_REASON = "stale_read_generation"
 
+# ---------------------------------------------------------------------------
+# read-at-version rejection vocabulary (plan item N v1, Unit 4 / R5)
+# ---------------------------------------------------------------------------
+#
+# The EXACT string values below are the WIRE CONTRACT: ``read_at_version``
+# returns a :class:`~ccs.core.types.VersionedReadRejection` whose ``reason`` is
+# ONE of these, and every consumer (the Unit 6 replay resolver, SB-17 later)
+# matches with ``reason == CONSTANT`` against :data:`READ_AT_VERSION_REASONS` —
+# NEVER a substring of any human message (the typed-signal-not-substring house
+# rule, ``docs/solutions/best-practices/typed-signal-not-substring-...``).
+# Renaming a value here is a wire break; add, do not mutate.
+#
+# Six reasons, not seven: ``never_retained`` and ``beyond_horizon`` deliberately
+# COLLAPSE into a single ``not_retained``. Once a retained history carries gaps
+# (a T-expiry cleanup, or an off->on retention toggle), "never captured" and
+# "captured then collected/expired" are UNDECIDABLE from persisted state, so a
+# wire-stable constant must not encode a forensic distinction the store cannot
+# honestly make (plan Key Decisions: "Rejection vocabulary (6 reasons ...)").
+RETENTION_OFF_REASON = "retention_off"
+"""Retention was never enabled for this store (``retention_meta()[0]`` False).
+
+Distinct from ``not_retained``: the artifact_versions surface exists on every
+v2 sqlite db, so table-presence cannot tell retention-on-unbounded from
+retention-never-enabled — the persisted ``retention_enabled`` marker does."""
+
+UNKNOWN_ARTIFACT_REASON = "unknown_artifact"
+"""The artifact id is unknown to the registry (``get_artifact`` is None).
+
+Deleted == never-existed: a post-delete read also lands here (delete cascades
+the history rows), per the plan's deliberate collapse."""
+
+NOT_RETAINED_REASON = "not_retained"
+"""``1 <= version < current`` but no servable retained row exists — it was
+never captured (e.g. ``commit_cas(content=None)``), K-evicted, or T-expired.
+The single, deliberately-merged reason (see the module note above)."""
+
+EPOCH_MISMATCH_REASON = "epoch_mismatch"
+"""An ``expected_epoch`` was supplied and != the registry's
+``coordinator_epoch`` — the store was reset (delete-and-recreate) since the
+caller captured the epoch, so its retained history is from a different epoch."""
+
+CURRENT_VERSION_REASON = "current_version"
+"""``version == current``. The history surface serves HISTORY ONLY; current
+content is read via the protocol fetch path (``artifacts`` stores hashes, not
+bodies). A read-only consumer cannot obtain current bytes through any surface —
+by design (plan Key Decisions: consequence of ``current_version``)."""
+
+FUTURE_VERSION_REASON = "future_version"
+"""``version > current``. Preserves the diagnostic ``commit_cas`` keeps via
+:class:`~ccs.core.types.CasCorruption`: a requested version ABOVE the current
+one suggests a second coordinator writing the same store."""
+
+# The closed set every consumer matches against (``reason in
+# READ_AT_VERSION_REASONS``). ``version < 1`` is NOT here — it is a ``ValueError``
+# (caller misuse, house style), never a rejection reason.
+READ_AT_VERSION_REASONS: frozenset[str] = frozenset(
+    {
+        RETENTION_OFF_REASON,
+        UNKNOWN_ARTIFACT_REASON,
+        NOT_RETAINED_REASON,
+        EPOCH_MISMATCH_REASON,
+        CURRENT_VERSION_REASON,
+        FUTURE_VERSION_REASON,
+    }
+)
+
 
 class CoherenceError(Exception):
     """Base error for coherence domain failures."""

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -117,6 +117,26 @@ STORE_OPEN_SIGNALS: frozenset[str] = frozenset(
     {STORE_SIGNAL_WAL_RECOVERY, STORE_SIGNAL_BUSY, STORE_SIGNAL_UNREADABLE}
 )
 
+# ---------------------------------------------------------------------------
+# cross-runtime store-open guard (sibling Node coordinator hazard)
+# ---------------------------------------------------------------------------
+#
+# The sibling Node coordinator (the agent-coherence-plugin repo) shares the
+# SAME ``<workspace>/.coherence/state.db`` path but maintains its OWN migration
+# ledger: its v2 adds no schema objects (pending_notices validation) and its v3
+# is ``ALTER TABLE agent_states ADD COLUMN deadline_tick`` — so the two ledgers
+# assign DIFFERENT meanings to ``PRAGMA user_version`` 2 and 3 on the same
+# file. ``CrossRuntimeSchemaError`` (defined in
+# ``ccs.coordinator.sqlite_registry`` because it subclasses the
+# coordinator-layer ``SchemaVersionError`` to keep existing catch-sites
+# compatible; core must not import upward) carries THIS wire-stable reason so
+# every consumer — and the Node side's mirror check — matches
+# ``exc.reason == CONSTANT``, never a substring of the human message (the
+# typed-signal-not-substring house rule,
+# ``docs/solutions/best-practices/typed-signal-not-substring-...``).
+# Renaming the value is a wire break; add, do not mutate.
+CROSS_RUNTIME_SCHEMA_REASON = "cross_runtime_schema"
+
 
 class CoherenceError(Exception):
     """Base error for coherence domain failures."""

--- a/src/ccs/core/types.py
+++ b/src/ccs/core/types.py
@@ -89,6 +89,72 @@ class CasCorruption:
 
 
 @dataclass(frozen=True)
+class VersionedContent:
+    """A successfully resolved retained version (plan item N v1, Unit 4 / R5).
+
+    The WIN return of :meth:`CoordinatorService.read_at_version` — a typed
+    return (the ``ConflictDetail`` discipline), never an exception. Carries the
+    exact retained body and the forensic metadata a consumer needs:
+
+    - ``content`` is the registry-committed body with its ORIGINAL Python type
+      (``str`` for a TEXT row, ``bytes`` for a BLOB row — the sqlite
+      affinity-NONE column round-trips by value; the in-memory record stores the
+      body as-supplied). It is "the content the registry committed", not what
+      reached any client's disk (the watchdog-ack honesty boundary).
+    - ``captured_at`` is the wall-clock ``time.time()`` capture timestamp — kept
+      on the success surface because forensic consumers need it (omitting it
+      would bake a surface change into the first consumer's contract) and it is
+      also the T-expiry reference.
+    - ``coordinator_epoch`` is the store's epoch, stamped on every answer so a
+      consumer can pin which store-incarnation served the bytes.
+
+    The current version is never served here (``read_at_version`` rejects
+    ``version == current`` with ``current_version``): this is a HISTORY surface.
+    """
+
+    artifact_id: UUID
+    version: int
+    content: str | bytes
+    captured_at: float
+    coordinator_epoch: str
+
+
+@dataclass(frozen=True)
+class VersionedReadRejection:
+    """A typed read-at-version rejection (plan item N v1, Unit 4 / R5).
+
+    The non-WIN return of :meth:`CoordinatorService.read_at_version` — a typed
+    return (the ``ConflictDetail`` discipline), never an exception. ``reason`` is
+    exactly one of the six wire-stable constants in
+    :mod:`ccs.core.exceptions` (:data:`~ccs.core.exceptions.READ_AT_VERSION_REASONS`);
+    consumers match with ``==`` against that set, never on a human message.
+
+    **Carries NO content, NO content hash, NO body material** — only the reason,
+    the requested/current versions, and the epoch. This is enforced by a test
+    that pins the exact field set: a rejection is the one surface that must never
+    leak bytes (e.g. an ``epoch_mismatch`` from a different store-incarnation, or
+    a ``future_version`` that hints at a second coordinator), so the dataclass
+    structurally cannot.
+
+    Field semantics:
+
+    - ``current_version`` is the registry's authoritative current version at the
+      point the reason was decided, or ``None`` when it genuinely cannot be known
+      (``unknown_artifact`` — there is no current version for a missing
+      artifact). The single-scope read means a racing commit cannot mislabel it.
+    - ``coordinator_epoch`` is the store's epoch (always populated — the registry
+      always has one), so even a rejection tells the consumer which store
+      answered.
+    """
+
+    reason: str
+    artifact_id: UUID
+    requested_version: int
+    current_version: int | None
+    coordinator_epoch: str | None
+
+
+@dataclass(frozen=True)
 class InvalidationSignal:
     """Lightweight invalidation signal sent to agents."""
 

--- a/src/ccs/core/types.py
+++ b/src/ccs/core/types.py
@@ -142,16 +142,17 @@ class VersionedReadRejection:
       point the reason was decided, or ``None`` when it genuinely cannot be known
       (``unknown_artifact`` — there is no current version for a missing
       artifact). The single-scope read means a racing commit cannot mislabel it.
-    - ``coordinator_epoch`` is the store's epoch (always populated — the registry
-      always has one), so even a rejection tells the consumer which store
-      answered.
+    - ``coordinator_epoch`` is the store's epoch — ALWAYS populated (``str``,
+      never ``None``): the registry always has one, even for ``unknown_artifact``
+      (the artifact may be missing; the store is not), so every rejection tells
+      the consumer which store answered.
     """
 
     reason: str
     artifact_id: UUID
     requested_version: int
     current_version: int | None
-    coordinator_epoch: str | None
+    coordinator_epoch: str
 
 
 @dataclass(frozen=True)

--- a/src/ccs/replay/__init__.py
+++ b/src/ccs/replay/__init__.py
@@ -77,6 +77,18 @@ from ccs.replay.recorder import (
     UnverifiedAdapterCaptureError,
     record_callbacks,
 )
+from ccs.replay.resolver import (
+    ResolverBusyError,
+    ResolverCorruptDatabaseError,
+    ResolverError,
+    ResolverInstanceMismatchError,
+    ResolverMissingDatabaseError,
+    ResolverNeedsRecoveryError,
+    ResolverRequest,
+    ResolverSchemaVersionError,
+    ResolverUnknownArtifactPathError,
+    resolve_version,
+)
 
 __all__ = [
     "CORE_PREDICATES",
@@ -91,6 +103,15 @@ __all__ = [
     "ReplayConfigurationError",
     "ReplayError",
     "ReplayTraceError",
+    "ResolverBusyError",
+    "ResolverCorruptDatabaseError",
+    "ResolverError",
+    "ResolverInstanceMismatchError",
+    "ResolverMissingDatabaseError",
+    "ResolverNeedsRecoveryError",
+    "ResolverRequest",
+    "ResolverSchemaVersionError",
+    "ResolverUnknownArtifactPathError",
     "SessionDirectoryNotEmptyError",
     "SessionDirectoryNotFoundError",
     "SingleWriterPredicate",
@@ -102,5 +123,6 @@ __all__ = [
     "emit_json",
     "load",
     "record_callbacks",
+    "resolve_version",
     "run_predicates",
 ]

--- a/src/ccs/replay/resolver.py
+++ b/src/ccs/replay/resolver.py
@@ -1,0 +1,369 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Read-at-version resolver — the wired ``read_at_version`` consumer (Unit 6 / R5b).
+
+This module is the bridge between the replay CLI and the durable retention
+surface Units 3-4 shipped: given a ``.coherence/state.db`` path, an artifact
+selector (workspace path OR raw UUID), and a version, it opens the store
+**read-only** (never migrating, never materializing a fresh db), constructs a
+:class:`~ccs.coordinator.service.CoordinatorService` over it, and calls
+``read_at_version`` — the SAME surface SB-17 will consume later. It is the
+restart-survival proof: a process can exit and a separate resolver process can
+recover the exact bytes a prior writer committed at version k.
+
+Layer note: ``replay`` is the ``interface`` layer; ``coordinator`` is
+``application``. interface→application is a LEGAL downward import
+(``src/ccs/hardening/architecture.py``). The coordinator must NOT import
+replay — this dependency only goes one way.
+
+Typed outcomes (no raw stack traces ever reach a script):
+
+  ``resolve_version`` returns a :class:`ResolverResult` — one of:
+
+  - :class:`~ccs.core.types.VersionedContent` (the WIN, retained body + metadata)
+  - :class:`~ccs.core.types.VersionedReadRejection` (a service-level rejection
+    carrying one of the six wire-stable reasons in
+    :data:`ccs.core.exceptions.READ_AT_VERSION_REASONS`)
+
+  …or RAISES a :class:`ResolverError` for an open/lookup failure that has no
+  servable value:
+
+  - :class:`ResolverMissingDatabaseError` — path does not exist (and the
+    registry is NEVER constructed — see the pre-existence check below)
+  - :class:`ResolverSchemaVersionError` — wrong ``user_version`` (a v1 db; the
+    resolver performs NO migration)
+  - :class:`ResolverNeedsRecoveryError` — post-crash hot WAL a read-only
+    connection cannot replay
+  - :class:`ResolverCorruptDatabaseError` — the file is not a SQLite database
+  - :class:`ResolverBusyError` — the store is locked (SQLITE_BUSY)
+  - :class:`ResolverUnknownArtifactPathError` — a workspace-path selector that
+    matches no ``artifacts.name`` row (NOT a raw lookup stack trace)
+  - :class:`ResolverInstanceMismatchError` — an ``--instance-id`` cross-check
+    that disagrees with the store's persisted ``instance_id``
+
+Import discipline (the optional-extra learning,
+``docs/solutions/test-failures/pytest-collect-error-missing-optional-extra``):
+the coordinator import lives INSIDE :func:`resolve_version`, not at module top —
+nothing the replay CLI transitively loads eagerly imports anything beyond the
+``[dev]`` surface. (``coordinator`` is not itself an optional extra, but keeping
+the import surface lazy honors the discipline and keeps ``import
+ccs.cli.coherence_replay`` cheap.)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from uuid import UUID
+
+from ccs.core.types import VersionedContent, VersionedReadRejection
+from ccs.replay.errors import ReplayConfigurationError, ReplayTraceError
+
+# The union ``resolve_version`` RETURNS (a typed result, never an exception).
+# Errors that have no value to return are RAISED as ResolverError subclasses.
+ResolverResult = "VersionedContent | VersionedReadRejection"
+
+
+# ---------------------------------------------------------------------------
+# Resolver error taxonomy
+# ---------------------------------------------------------------------------
+#
+# These are RAISED (not returned) because an open/lookup that cannot proceed has
+# no servable value — mirroring the read-only registry's own exception choice
+# (``ReadOnlyRegistryError`` family). Each maps to a DISTINCT CLI exit code so a
+# script can branch on the failure class without parsing prose; the CLI renders
+# the exact ``reason`` slug from ``.reason`` below, never a substring match.
+#
+# All inherit ``ReplayTraceError`` (the "fix the data / the store" category)
+# EXCEPT ``ResolverInstanceMismatchError`` and the missing-path case, which are
+# closer to caller misconfiguration. We keep the hierarchy aligned with the
+# existing replay split so a caller can still ``except ReplayError`` to catch
+# everything, but the CLI matches the concrete classes for its exit-code map.
+
+
+class ResolverError(ReplayTraceError):
+    """Base for read-at-version resolver open/lookup failures (Unit 6 / R5b).
+
+    A subclass of :class:`~ccs.replay.errors.ReplayTraceError` so a caller that
+    already does ``except ReplayError`` (or ``ReplayTraceError``) keeps catching
+    resolver failures, but the CLI matches the concrete subclasses below to map
+    each to its own exit code. Every subclass carries a stable ``reason`` slug
+    (class attribute) the JSON envelope emits so scripts never parse the human
+    message.
+    """
+
+    #: Stable, prose-free slug the CLI emits in the JSON envelope's ``reason``.
+    reason: str = "resolver_error"
+
+
+class ResolverMissingDatabaseError(ResolverError):
+    """The ``--db`` path does not exist; the resolver constructed NO registry.
+
+    Belt-and-suspenders against materializing a fresh empty
+    ``.coherence/state.db``: :func:`resolve_version` checks ``path.exists()``
+    BEFORE touching ``SqliteArtifactRegistry`` at all, so this is raised without
+    any side effect (read-only mode would also refuse to create, but the
+    pre-check guarantees zero filesystem touch and a clean message)."""
+
+    reason = "db_missing"
+
+
+class ResolverSchemaVersionError(ResolverError):
+    """The store's ``user_version`` is not the version this build serves.
+
+    A v1 (un-migrated) db lands here. Read-only mode performs NO migration —
+    the remedy is to re-open the store once with the embedder (read-write).
+    Distinct slug so the CLI never confuses "needs an upgrade" with "corrupt"."""
+
+    reason = "schema_version_mismatch"
+
+
+class ResolverNeedsRecoveryError(ResolverError):
+    """The store has an unclean hot WAL a read-only connection cannot replay.
+
+    After an embedder crash, SQLite forbids a ``mode=ro`` connection from
+    running WAL recovery (SQLITE_READONLY_RECOVERY). The forensic population
+    over-represents crashed writers, so this is the resolver's most on-brand
+    failure: the remedy is to re-open once with the embedder (read-write) so it
+    checkpoints the WAL, then retry the resolve."""
+
+    reason = "needs_recovery"
+
+
+class ResolverCorruptDatabaseError(ResolverError):
+    """The ``--db`` path exists but is not a readable SQLite database.
+
+    A non-sqlite file (truncated, wrong format, or random bytes) surfaces
+    ``sqlite3.DatabaseError`` on first access; the resolver maps it to this
+    distinct typed error so the CLI renders a clean ``db_corrupt`` reason rather
+    than leaking a raw ``DatabaseError`` to a script."""
+
+    reason = "db_corrupt"
+
+
+class ResolverBusyError(ResolverError):
+    """The store is locked by a concurrent writer (SQLITE_BUSY).
+
+    A read-only resolve that times out waiting for a writer's lock surfaces
+    here. Distinct from needs-recovery (a hot WAL) and corruption (bad bytes):
+    the store is fine, just busy — retry shortly."""
+
+    reason = "db_busy"
+
+
+class ResolverUnknownArtifactPathError(ResolverError):
+    """A workspace-path selector matched no ``artifacts.name`` row.
+
+    ``artifacts.name`` is UNIQUE (the parent-repo-relative path), so a path
+    selector resolves to at most one id; a miss is this typed error NAMING the
+    failed path lookup — never a raw stack trace. (A raw-UUID selector that is
+    simply unknown to the registry is NOT this error: it flows through to
+    ``read_at_version`` and returns the ``unknown_artifact`` rejection, so a
+    by-id miss and a by-path miss stay distinguishable.)"""
+
+    reason = "unknown_artifact_path"
+
+
+class ResolverInstanceMismatchError(ReplayConfigurationError):
+    """The ``--instance-id`` cross-check disagreed with the store's identity.
+
+    An identity guard available today (epoch-at-capture is the deferred recorder
+    task): if the caller passes the ``instance_id`` from a trace manifest, the
+    resolver verifies it equals the store's persisted ``instance_id`` before
+    serving any bytes — catching a resolve pointed at the WRONG store. This is
+    caller/config misuse (a :class:`~ccs.replay.errors.ReplayConfigurationError`,
+    not a store/trace defect), so it sits in that arm of the hierarchy."""
+
+    reason = "instance_id_mismatch"
+
+
+@dataclass(frozen=True)
+class ResolverRequest:
+    """Inputs for one read-at-version resolve (Unit 6).
+
+    ``selector`` is either a raw UUID (hex, with or without dashes) or a
+    workspace path (``artifacts.name``); :func:`resolve_version` discriminates by
+    attempting a UUID parse first. ``expected_epoch`` is a MANUAL passthrough
+    (the recorder does not yet derive it — that is the deferred epoch-provenance
+    task); ``expected_instance_id`` is the optional identity cross-check.
+    """
+
+    db_path: Path
+    selector: str
+    version: int
+    expected_epoch: str | None = None
+    expected_instance_id: str | None = None
+
+
+def _coerce_selector_to_uuid(selector: str) -> UUID | None:
+    """Return a UUID if ``selector`` parses as one, else ``None`` (a path).
+
+    Tries the strict ``UUID(...)`` parse (accepts dashed and bare 32-hex forms).
+    A non-UUID string is treated as a workspace path for the ``artifacts.name``
+    lookup — there is no ambiguity in practice because workspace paths contain
+    ``/`` or ``.`` and never parse as a UUID.
+    """
+    try:
+        return UUID(selector)
+    except (ValueError, AttributeError):
+        return None
+
+
+def resolve_version(request: ResolverRequest) -> "ResolverResult":
+    """Resolve "bytes at version k" against a read-only coordinator store (R5b).
+
+    Steps (each failure is a typed error or typed rejection — never a raw trace):
+
+    1. **Pre-existence check.** If ``request.db_path`` does not exist, raise
+       :class:`ResolverMissingDatabaseError` and NEVER construct the registry
+       (no fresh ``.coherence/state.db`` is ever materialized).
+    2. **Read-only open.** Construct ``SqliteArtifactRegistry(path,
+       read_only=True)`` — the Unit 3 mode that never creates/migrates/ALTERs and
+       rejects mutators. Map its typed open failures
+       (``MissingDatabaseError`` / ``SchemaVersionError`` /
+       ``StoreNeedsRecoveryError``) plus raw ``sqlite3.DatabaseError`` (non-sqlite
+       file) and SQLITE_BUSY to the resolver error taxonomy.
+    3. **Instance cross-check** (optional). If ``expected_instance_id`` is given
+       and != the store's persisted ``instance_id``, raise
+       :class:`ResolverInstanceMismatchError`.
+    4. **Selector → id.** A raw-UUID selector is used directly (an unknown id
+       flows to ``read_at_version`` → ``unknown_artifact`` rejection). A path
+       selector is looked up via ``artifacts.name`` (UNIQUE); a miss raises
+       :class:`ResolverUnknownArtifactPathError`.
+    5. **read_at_version.** Construct ``CoordinatorService`` over the read-only
+       registry and return its ``VersionedContent | VersionedReadRejection``
+       (``version < 1`` raises ``ValueError`` from the service — caller misuse,
+       surfaced by the CLI as a usage error, not a resolver reason).
+
+    The coordinator/sqlite imports are LAZY (inside this function) per the
+    no-eager-optional-import discipline.
+    """
+    # (1) Pre-existence check — BEFORE any registry construction so a wrong path
+    # never materializes a fresh empty store (zero filesystem side effect).
+    if not request.db_path.exists():
+        raise ResolverMissingDatabaseError(
+            f"read-at-version resolve: no coordinator store at "
+            f"{request.db_path}. The resolver opens the store read-only and "
+            f"never creates it — point --db at an existing .coherence/state.db."
+        )
+
+    # Lazy imports (optional-extra discipline): keep ``import
+    # ccs.cli.coherence_replay`` from pulling the coordinator + sqlite surface
+    # at module-load time.
+    import sqlite3
+
+    from ccs.coordinator.service import CoordinatorService
+    from ccs.coordinator.sqlite_registry import (
+        MissingDatabaseError,
+        SchemaVersionError,
+        SqliteArtifactRegistry,
+        StoreNeedsRecoveryError,
+    )
+
+    # (2) Read-only open with typed-failure mapping.
+    try:
+        registry = SqliteArtifactRegistry(request.db_path, read_only=True)
+    except MissingDatabaseError as exc:
+        # Defense in depth: the pre-check above already covers a missing path,
+        # but a TOCTOU delete between the check and the open lands here too.
+        raise ResolverMissingDatabaseError(str(exc)) from exc
+    except SchemaVersionError as exc:
+        raise ResolverSchemaVersionError(str(exc)) from exc
+    except StoreNeedsRecoveryError as exc:
+        raise _classify_recovery_or_corruption(exc) from exc
+    except sqlite3.DatabaseError as exc:
+        # A non-sqlite / corrupt file surfaces sqlite3.DatabaseError on the first
+        # access inside the open. ``OperationalError`` is a DatabaseError
+        # subclass; the read-only open already maps the recovery/locked
+        # OperationalError cases to StoreNeedsRecoveryError, so reaching here
+        # means a genuine corrupt-format signal.
+        raise ResolverCorruptDatabaseError(
+            f"read-at-version resolve: the file at {request.db_path} is not a "
+            f"readable SQLite database (it may be truncated, the wrong format, "
+            f"or not a coordinator store). Underlying: {exc}"
+        ) from exc
+
+    try:
+        # (3) Optional instance-id identity guard.
+        if request.expected_instance_id is not None:
+            actual = registry._instance_id  # noqa: SLF001 — read-only identity read
+            if actual != request.expected_instance_id:
+                raise ResolverInstanceMismatchError(
+                    f"read-at-version resolve: --instance-id "
+                    f"{request.expected_instance_id!r} does not match the store's "
+                    f"persisted instance_id {actual!r} at {request.db_path}. The "
+                    f"resolve is pointed at a different store than the trace "
+                    f"manifest describes; check --db."
+                )
+
+        # (4) Selector → artifact id.
+        artifact_id = _resolve_artifact_id(registry, request.selector)
+
+        # (5) read_at_version via the service over the read-only registry. A
+        # SQLITE_BUSY/locked store can surface OperationalError at QUERY time
+        # (after a clean open) — distinct from the open-time mapping above — so
+        # we map it to the resolver taxonomy here too rather than leaking a raw
+        # OperationalError. A genuine query-time corruption signal
+        # (DatabaseError that is not Operational) maps to the corrupt bucket.
+        service = CoordinatorService(registry)
+        try:
+            return service.read_at_version(
+                artifact_id, request.version, expected_epoch=request.expected_epoch
+            )
+        except sqlite3.OperationalError as exc:
+            raise _classify_recovery_or_corruption(exc) from exc
+        except sqlite3.DatabaseError as exc:
+            raise ResolverCorruptDatabaseError(
+                f"read-at-version resolve: a query against {request.db_path} "
+                f"failed — the store may be corrupt. Underlying: {exc}"
+            ) from exc
+    finally:
+        registry.close()
+
+
+def _resolve_artifact_id(registry: object, selector: str) -> UUID:
+    """Map a selector (raw UUID or ``artifacts.name`` path) to an artifact id.
+
+    A UUID selector is returned as-is (an id unknown to the registry flows to
+    ``read_at_version`` and becomes ``unknown_artifact`` — keeping a by-id miss
+    distinct from a by-path miss). A path selector is looked up via the UNIQUE
+    ``artifacts.name`` column; a miss raises
+    :class:`ResolverUnknownArtifactPathError` (the named lookup, not a trace).
+    """
+    as_uuid = _coerce_selector_to_uuid(selector)
+    if as_uuid is not None:
+        return as_uuid
+    looked_up = registry.lookup_artifact_id_by_name(selector)  # type: ignore[attr-defined]
+    if looked_up is None:
+        raise ResolverUnknownArtifactPathError(
+            f"read-at-version resolve: no artifact registered at workspace path "
+            f"{selector!r} (artifacts.name lookup miss). Pass a path that the "
+            f"coordinator has observed, or a raw artifact UUID."
+        )
+    return looked_up
+
+
+def _classify_recovery_or_corruption(exc: Exception) -> ResolverError:
+    """Split the read-only registry's ``StoreNeedsRecoveryError`` into the
+    resolver's needs-recovery vs corrupt vs busy buckets.
+
+    Unit 3's ``_classify_readonly_operational_error`` already folds every
+    OperationalError on the read-only connection into ``StoreNeedsRecoveryError``
+    (recovery, corruption, or busy). The resolver re-splits on the rendered text
+    so the CLI can show distinct reasons: a hot-WAL recovery state, a locked
+    store (SQLITE_BUSY), and a generic could-not-read all carry different
+    operator remedies.
+    """
+    text = str(exc).lower()
+    if "busy" in text or "locked" in text:
+        return ResolverBusyError(
+            f"read-at-version resolve: the store is locked by a concurrent "
+            f"writer (SQLITE_BUSY) and the read-only resolve timed out waiting "
+            f"for the lock. Retry shortly. Underlying: {exc}"
+        )
+    if "recovery" in text or "readonly" in text or "wal" in text:
+        return ResolverNeedsRecoveryError(str(exc))
+    # Generic could-not-read (the registry's catch-all branch) — surface as
+    # needs-recovery since the remedy (re-open with the embedder) is the same.
+    return ResolverNeedsRecoveryError(str(exc))

--- a/src/ccs/replay/resolver.py
+++ b/src/ccs/replay/resolver.py
@@ -55,14 +55,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING, TypeAlias
 from uuid import UUID
 
+from ccs.core.exceptions import STORE_SIGNAL_BUSY
 from ccs.core.types import VersionedContent, VersionedReadRejection
 from ccs.replay.errors import ReplayConfigurationError, ReplayTraceError
 
+if TYPE_CHECKING:  # pragma: no cover — typing only; the runtime import is lazy
+    from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+
 # The union ``resolve_version`` RETURNS (a typed result, never an exception).
 # Errors that have no value to return are RAISED as ResolverError subclasses.
-ResolverResult = "VersionedContent | VersionedReadRejection"
+ResolverResult: TypeAlias = VersionedContent | VersionedReadRejection
 
 
 # ---------------------------------------------------------------------------
@@ -210,7 +215,7 @@ def _coerce_selector_to_uuid(selector: str) -> UUID | None:
         return None
 
 
-def resolve_version(request: ResolverRequest) -> "ResolverResult":
+def resolve_version(request: ResolverRequest) -> ResolverResult:
     """Resolve "bytes at version k" against a read-only coordinator store (R5b).
 
     Steps (each failure is a typed error or typed rejection — never a raw trace):
@@ -271,7 +276,9 @@ def resolve_version(request: ResolverRequest) -> "ResolverResult":
     except SchemaVersionError as exc:
         raise ResolverSchemaVersionError(str(exc)) from exc
     except StoreNeedsRecoveryError as exc:
-        raise _classify_recovery_or_corruption(exc) from exc
+        # Branch on the typed signal the registry classified at ITS single
+        # classification point — never on str(exc) content.
+        raise _resolver_error_for_store_signal(exc.reason, exc) from exc
     except sqlite3.DatabaseError as exc:
         # A non-sqlite / corrupt file surfaces sqlite3.DatabaseError on the first
         # access inside the open. ``OperationalError`` is a DatabaseError
@@ -287,7 +294,7 @@ def resolve_version(request: ResolverRequest) -> "ResolverResult":
     try:
         # (3) Optional instance-id identity guard.
         if request.expected_instance_id is not None:
-            actual = registry._instance_id  # noqa: SLF001 — read-only identity read
+            actual = registry.instance_id
             if actual != request.expected_instance_id:
                 raise ResolverInstanceMismatchError(
                     f"read-at-version resolve: --instance-id "
@@ -304,15 +311,23 @@ def resolve_version(request: ResolverRequest) -> "ResolverResult":
         # SQLITE_BUSY/locked store can surface OperationalError at QUERY time
         # (after a clean open) — distinct from the open-time mapping above — so
         # we map it to the resolver taxonomy here too rather than leaking a raw
-        # OperationalError. A genuine query-time corruption signal
-        # (DatabaseError that is not Operational) maps to the corrupt bucket.
+        # OperationalError. Classification routes through the registry's ONE
+        # classification seam (typed-signal house rule). A genuine query-time
+        # corruption signal (DatabaseError that is not Operational) maps to the
+        # corrupt bucket.
         service = CoordinatorService(registry)
         try:
             return service.read_at_version(
                 artifact_id, request.version, expected_epoch=request.expected_epoch
             )
         except sqlite3.OperationalError as exc:
-            raise _classify_recovery_or_corruption(exc) from exc
+            from ccs.coordinator.sqlite_registry import (
+                classify_sqlite_operational_signal,
+            )
+
+            raise _resolver_error_for_store_signal(
+                classify_sqlite_operational_signal(exc), exc
+            ) from exc
         except sqlite3.DatabaseError as exc:
             raise ResolverCorruptDatabaseError(
                 f"read-at-version resolve: a query against {request.db_path} "
@@ -322,7 +337,7 @@ def resolve_version(request: ResolverRequest) -> "ResolverResult":
         registry.close()
 
 
-def _resolve_artifact_id(registry: object, selector: str) -> UUID:
+def _resolve_artifact_id(registry: "SqliteArtifactRegistry", selector: str) -> UUID:
     """Map a selector (raw UUID or ``artifacts.name`` path) to an artifact id.
 
     A UUID selector is returned as-is (an id unknown to the registry flows to
@@ -334,7 +349,7 @@ def _resolve_artifact_id(registry: object, selector: str) -> UUID:
     as_uuid = _coerce_selector_to_uuid(selector)
     if as_uuid is not None:
         return as_uuid
-    looked_up = registry.lookup_artifact_id_by_name(selector)  # type: ignore[attr-defined]
+    looked_up = registry.lookup_artifact_id_by_name(selector)
     if looked_up is None:
         raise ResolverUnknownArtifactPathError(
             f"read-at-version resolve: no artifact registered at workspace path "
@@ -344,26 +359,22 @@ def _resolve_artifact_id(registry: object, selector: str) -> UUID:
     return looked_up
 
 
-def _classify_recovery_or_corruption(exc: Exception) -> ResolverError:
-    """Split the read-only registry's ``StoreNeedsRecoveryError`` into the
-    resolver's needs-recovery vs corrupt vs busy buckets.
+def _resolver_error_for_store_signal(signal: str, exc: Exception) -> ResolverError:
+    """Map a typed store-open signal (``StoreNeedsRecoveryError.reason`` /
+    ``classify_sqlite_operational_signal``) to the resolver error taxonomy.
 
-    Unit 3's ``_classify_readonly_operational_error`` already folds every
-    OperationalError on the read-only connection into ``StoreNeedsRecoveryError``
-    (recovery, corruption, or busy). The resolver re-splits on the rendered text
-    so the CLI can show distinct reasons: a hot-WAL recovery state, a locked
-    store (SQLITE_BUSY), and a generic could-not-read all carry different
-    operator remedies.
+    No message parsing happens here — the signal was classified ONCE at the
+    registry seam and is matched with ``==`` against the constants in
+    ``ccs.core.exceptions`` (the typed-signal house rule). ``busy`` keeps its
+    own class (retry shortly); ``wal_recovery`` and the ``unreadable``
+    catch-all share :class:`ResolverNeedsRecoveryError` because they share the
+    operator remedy (re-open once with the embedder) — preserving the
+    wire-visible JSON reasons / exit codes exactly.
     """
-    text = str(exc).lower()
-    if "busy" in text or "locked" in text:
+    if signal == STORE_SIGNAL_BUSY:
         return ResolverBusyError(
             f"read-at-version resolve: the store is locked by a concurrent "
             f"writer (SQLITE_BUSY) and the read-only resolve timed out waiting "
             f"for the lock. Retry shortly. Underlying: {exc}"
         )
-    if "recovery" in text or "readonly" in text or "wal" in text:
-        return ResolverNeedsRecoveryError(str(exc))
-    # Generic could-not-read (the registry's catch-all branch) — surface as
-    # needs-recovery since the remedy (re-open with the embedder) is the same.
     return ResolverNeedsRecoveryError(str(exc))

--- a/tests/test_cli_coherence_replay.py
+++ b/tests/test_cli_coherence_replay.py
@@ -738,6 +738,47 @@ class TestExceptionEnvelope:
         assert rc != 1
         assert rc == 4
 
+    def test_internal_error_with_json_emits_error_envelope(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # --json consumers get a self-contained stdout on EVERY exit path,
+        # including the exit-4 internal-error one (mirrors the exit-3 trace
+        # error envelope). stderr keeps the human prose.
+        session = _clean_session(tmp_path)
+
+        def raise_internal(*_args: Any, **_kwargs: Any) -> int:
+            raise RuntimeError("simulated CLI internal error")
+
+        monkeypatch.setattr("ccs.cli.coherence_replay._run", raise_internal)
+        rc = main([str(session), "--json"])
+        captured = capsys.readouterr()
+        assert rc == 4
+        envelope = json.loads(captured.out.strip())
+        assert envelope["kind"] == "error"
+        assert envelope["exit_code"] == 4
+        assert envelope["exception"] == "RuntimeError"
+        assert "internal error" in captured.err
+
+    def test_internal_error_without_json_keeps_stdout_empty(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        session = _clean_session(tmp_path)
+
+        def raise_internal(*_args: Any, **_kwargs: Any) -> int:
+            raise RuntimeError("simulated CLI internal error")
+
+        monkeypatch.setattr("ccs.cli.coherence_replay._run", raise_internal)
+        rc = main([str(session)])
+        captured = capsys.readouterr()
+        assert rc == 4
+        assert captured.out == ""
+
 
 # ---------------------------------------------------------------------------
 # JSON schema conformance

--- a/tests/test_read_at_version.py
+++ b/tests/test_read_at_version.py
@@ -1,0 +1,604 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""read-at-version service surface — typed outcomes, epoch stability, and
+PROVABLE protocol non-interaction (plan item N v1, Unit 4).
+
+Requirement trace: **R5** (service-level read-at-version; typed, distinguishable
+rejections; responses carry ``coordinator_epoch``; ``version==current``
+rejected), **R6** (fence non-capture — versioned reads never touch
+``read_generation``), **R7** (off-protocol read — no MESI state, no invalidation
+membership, no write rights at any version).
+
+Both registry arms run via the parametrized ``rav_registry`` fixture (the
+``tests/test_retention.py`` ``retention_registry`` pattern, here parameterized
+per-test so the policy can vary). Reason matching is ALWAYS ``reason ==
+CONSTANT`` against the imported wire-stable constants — never a substring of a
+human message (the typed-signal-not-substring house rule).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.retention import RetentionPolicy
+from ccs.coordinator.service import CoordinatorService
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.exceptions import (
+    CURRENT_VERSION_REASON,
+    EPOCH_MISMATCH_REASON,
+    FUTURE_VERSION_REASON,
+    NOT_RETAINED_REASON,
+    READ_AT_VERSION_REASONS,
+    RETENTION_OFF_REASON,
+    UNKNOWN_ARTIFACT_REASON,
+)
+from ccs.core.states import MESIState, TransientState
+from ccs.core.types import (
+    Artifact,
+    FetchRequest,
+    VersionedContent,
+    VersionedReadRejection,
+)
+
+# ---------------------------------------------------------------------------
+# Registry factories — a fixture cannot take a per-test policy arg, so the
+# parametrization yields a FACTORY ``make(policy=..., retain_versions=...)``
+# that each test calls. Both arms are exercised by every test that uses it.
+# ---------------------------------------------------------------------------
+
+
+class _RegistryFactory:
+    """Builds a registry of one arm; tracks instances to close at teardown."""
+
+    def __init__(self, arm: str, tmp_path: Path) -> None:
+        self._arm = arm
+        self._tmp_path = tmp_path
+        self._open: list[SqliteArtifactRegistry] = []
+        self._n = 0
+
+    def __call__(
+        self,
+        *,
+        retain_versions: bool = True,
+        retention_policy: RetentionPolicy | None = None,
+    ):
+        if self._arm == "in_memory":
+            return ArtifactRegistry(
+                retain_versions=retain_versions, retention_policy=retention_policy
+            )
+        self._n += 1
+        reg = SqliteArtifactRegistry(
+            self._tmp_path / f"state-{self._n}.db",
+            retain_versions=retain_versions,
+            retention_policy=retention_policy,
+        )
+        self._open.append(reg)
+        return reg
+
+    def close(self) -> None:
+        for reg in self._open:
+            reg.close()
+
+
+@pytest.fixture(params=["in_memory", "sqlite"])
+def make_registry(request, tmp_path: Path):
+    """Yield a per-arm registry factory (closes any sqlite handles at teardown)."""
+    factory = _RegistryFactory(request.param, tmp_path)
+    try:
+        yield factory
+    finally:
+        factory.close()
+
+
+# ---------------------------------------------------------------------------
+# Scenario builders
+# ---------------------------------------------------------------------------
+
+
+def _register(reg, *, content: str = "c1") -> Artifact:
+    art = Artifact(id=uuid4(), name="plan.md", version=1, content_hash="h")
+    reg.register_artifact(art, content=content)
+    return art
+
+
+def _commit_pessimistic(reg, art: Artifact, version: int, body: str | bytes) -> None:
+    nxt = Artifact(id=art.id, name="plan.md", version=version, content_hash="h")
+    reg.set_artifact_and_content(art.id, nxt, body)
+
+
+def _chain(reg, bodies: tuple[str, ...]) -> Artifact:
+    """register v1=bodies[0], then pessimistic-commit bodies[1:] as v2.., returns the artifact."""
+    art = _register(reg, content=bodies[0])
+    for i, body in enumerate(bodies[1:], start=2):
+        _commit_pessimistic(reg, art, i, body)
+    return art
+
+
+def _read_generation_snapshot(reg, artifact_id: UUID, agents: list[UUID]) -> dict:
+    """Snapshot the fence state both registries expose publicly (R6).
+
+    Captures every agent's ``read_generation`` plus the artifact's
+    ``owner_generation`` — the exact state a versioned read must NOT mutate.
+    """
+    snap = {
+        "owner_generation": reg.get_owner_generation(artifact_id),
+        "read_generation": {
+            ag: reg.get_read_generation(artifact_id, ag) for ag in agents
+        },
+    }
+    return snap
+
+
+def _mesi_snapshot(reg, artifact_id: UUID) -> dict:
+    """Snapshot the MESI state map + transient map + valid-holder membership (R7)."""
+    return {
+        "state_map": reg.get_state_map(artifact_id),
+        "transient_map": reg.get_transient_map(artifact_id),
+        "valid_holders": sorted(reg.valid_holders(artifact_id), key=str),
+    }
+
+
+# ===========================================================================
+# Happy path — retained version served exactly (both registries, str + bytes)
+# ===========================================================================
+
+
+class TestHappyPath:
+    def test_retained_str_version_served_exactly(self, make_registry):
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=4))
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2", "c3"))  # current = 3
+        out = svc.read_at_version(art.id, 2)
+        assert isinstance(out, VersionedContent)
+        assert out.artifact_id == art.id
+        assert out.version == 2
+        assert out.content == "c2"
+        assert isinstance(out.captured_at, float)
+        assert out.coordinator_epoch == reg.coordinator_epoch
+
+    def test_retained_bytes_version_served_exactly(self, make_registry):
+        # The in-process library path threads bytes through commit_cas; the
+        # versioned read returns the EXACT bytes (affinity-NONE round-trip).
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=4))
+        svc = CoordinatorService(reg)
+        art = _register(reg, content="seed")
+        writer = uuid4()
+        reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
+        reg.commit_cas(
+            art.id, writer, expected_version=1,
+            content_hash="h2", content=b"\x00\x01bytes-v2", tick=2,
+        )
+        # commit_cas WIN advanced current to 2 and captured bytes under v2; do
+        # one more commit so v2 is HISTORY (read_at_version serves history only).
+        reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=3)
+        reg.commit_cas(
+            art.id, writer, expected_version=2,
+            content_hash="h3", content=b"v3", tick=4,
+        )
+        out = svc.read_at_version(art.id, 2)
+        assert isinstance(out, VersionedContent)
+        assert out.content == b"\x00\x01bytes-v2"
+        assert isinstance(out.content, bytes)
+
+    def test_captured_at_matches_a_monkeypatched_clock(self, make_registry, monkeypatch):
+        # captured_at on the success surface is the wall-clock capture time.
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(time, "time", lambda: clock["now"])
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=4))
+        svc = CoordinatorService(reg)
+        art = _register(reg, content="c1")
+        clock["now"] = 1234.5
+        _commit_pessimistic(reg, art, 2, "c2")  # captured at 1234.5
+        clock["now"] = 2000.0
+        _commit_pessimistic(reg, art, 3, "c3")  # current = 3
+        out = svc.read_at_version(art.id, 2)
+        assert isinstance(out, VersionedContent)
+        assert out.captured_at == 1234.5
+
+
+# ===========================================================================
+# Per-reason matrix — every reason on both registries, matched by == CONSTANT
+# ===========================================================================
+
+
+class TestReasonMatrix:
+    def test_retention_never_enabled_is_retention_off(self, make_registry):
+        # retain_versions=False ⇒ retention never on ⇒ retention_off (NOT
+        # not_retained), even though the artifact exists and the version is
+        # otherwise in range.
+        reg = make_registry(retain_versions=False, retention_policy=None)
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2", "c3"))
+        out = svc.read_at_version(art.id, 2)
+        assert isinstance(out, VersionedReadRejection)
+        assert out.reason == RETENTION_OFF_REASON
+        assert out.reason in READ_AT_VERSION_REASONS
+        assert out.current_version == 3
+        assert out.coordinator_epoch == reg.coordinator_epoch
+
+    def test_retention_on_unbounded_with_row_present_is_served(self, make_registry):
+        # retain_versions=True + policy=None (NULL axes / unbounded) with the row
+        # present ⇒ SERVED, not rejected. This is the v0.5 audit auto-wiring mode.
+        reg = make_registry(retention_policy=None)
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2", "c3"))  # unbounded → v1,v2 both retained
+        out = svc.read_at_version(art.id, 1)
+        assert isinstance(out, VersionedContent)
+        assert out.content == "c1"
+
+    def test_unknown_uuid_is_unknown_artifact(self, make_registry):
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=4))
+        svc = CoordinatorService(reg)
+        out = svc.read_at_version(uuid4(), 1)
+        assert isinstance(out, VersionedReadRejection)
+        assert out.reason == UNKNOWN_ARTIFACT_REASON
+        # No current version exists for a missing artifact.
+        assert out.current_version is None
+        # Epoch is still known (the store has one even if the artifact doesn't).
+        assert out.coordinator_epoch == reg.coordinator_epoch
+
+    def test_stale_expected_epoch_is_epoch_mismatch(self, make_registry):
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=4))
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2", "c3"))
+        out = svc.read_at_version(art.id, 2, expected_epoch="not-the-epoch")
+        assert isinstance(out, VersionedReadRejection)
+        assert out.reason == EPOCH_MISMATCH_REASON
+        # The response still carries the REAL store epoch (so the caller learns it).
+        assert out.coordinator_epoch == reg.coordinator_epoch
+
+    def test_matching_expected_epoch_is_served(self, make_registry):
+        # The epoch guard passes when expected_epoch == the store epoch.
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=4))
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2", "c3"))
+        out = svc.read_at_version(art.id, 2, expected_epoch=reg.coordinator_epoch)
+        assert isinstance(out, VersionedContent)
+        assert out.content == "c2"
+
+    def test_version_equals_current_is_current_version(self, make_registry):
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=4))
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2", "c3"))  # current = 3
+        out = svc.read_at_version(art.id, 3)
+        assert isinstance(out, VersionedReadRejection)
+        assert out.reason == CURRENT_VERSION_REASON
+        assert out.current_version == 3
+
+    def test_version_above_current_is_future_version(self, make_registry):
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=4))
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2", "c3"))  # current = 3
+        out = svc.read_at_version(art.id, 4)
+        assert isinstance(out, VersionedReadRejection)
+        assert out.reason == FUTURE_VERSION_REASON
+        assert out.current_version == 3
+
+    def test_version_zero_raises_value_error(self, make_registry):
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=4))
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2"))
+        with pytest.raises(ValueError, match="version must be >= 1"):
+            svc.read_at_version(art.id, 0)
+
+    def test_version_negative_raises_value_error(self, make_registry):
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=4))
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2"))
+        with pytest.raises(ValueError, match="version must be >= 1"):
+            svc.read_at_version(art.id, -1)
+
+
+class TestNotRetainedThreeConstructions:
+    """An absent row while retention is ON must reject ``not_retained`` no matter
+    HOW the gap arose — the deliberately-merged reason (plan Key Decisions)."""
+
+    def test_committed_during_off_then_enabled(self, make_registry):
+        # Construct: v1 committed while retention OFF (no row), then a retention-ON
+        # registry over the SAME store reads v1. Only the sqlite arm can carry
+        # state across registry instances on one store; the in-memory arm models
+        # the same gap by capturing under a policy that never stored v1 (a
+        # commit_cas(content=None) win — the canonical "row never captured" case).
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=8))
+        svc = CoordinatorService(reg)
+        art = _register(reg, content="seed-v1")
+        writer = uuid4()
+        reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
+        # content=None WIN advances to v2 but captures NO row for v2.
+        reg.commit_cas(
+            art.id, writer, expected_version=1, content_hash="h2", content=None, tick=2
+        )
+        # One more real commit so v2 is history (current = 3).
+        reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=3)
+        reg.commit_cas(
+            art.id, writer, expected_version=2, content_hash="h3", content="c3", tick=4
+        )
+        out = svc.read_at_version(art.id, 2)  # v2 never captured
+        assert isinstance(out, VersionedReadRejection)
+        assert out.reason == NOT_RETAINED_REASON
+
+    def test_k_collected_row(self, make_registry):
+        # K=2 over three commits drops v1; reading v1 ⇒ not_retained.
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=2))
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2", "c3"))  # K=2 → v1 evicted, current=3
+        out = svc.read_at_version(art.id, 1)
+        assert isinstance(out, VersionedReadRejection)
+        assert out.reason == NOT_RETAINED_REASON
+
+    def test_t_expired_row_is_logically_not_retained(self, make_registry, monkeypatch):
+        # T-axis logical-at-read: a row present on disk but older than max_age
+        # reports not_retained WITHOUT being physically deleted by the read.
+        clock = {"now": 0.0}
+        monkeypatch.setattr(time, "time", lambda: clock["now"])
+        # Large K so K never evicts; T=10s is the only axis that can age v2.
+        reg = make_registry(
+            retention_policy=RetentionPolicy(max_versions=100, max_age_seconds=10.0)
+        )
+        svc = CoordinatorService(reg)
+        art = _register(reg, content="c1")
+        clock["now"] = 5.0
+        _commit_pessimistic(reg, art, 2, "c2")  # v2 captured at t=5
+        clock["now"] = 6.0
+        _commit_pessimistic(reg, art, 3, "c3")  # current=3 at t=6; v2 still fresh
+        # v2 is present and fresh now.
+        assert isinstance(svc.read_at_version(art.id, 2), VersionedContent)
+        # Advance the clock past v2's horizon WITHOUT a new capture (no physical
+        # cleanup runs) → the read must logically expire v2.
+        clock["now"] = 100.0  # v2@5 now older than now-10=90
+        out = svc.read_at_version(art.id, 2)
+        assert isinstance(out, VersionedReadRejection)
+        assert out.reason == NOT_RETAINED_REASON
+        # Read is non-mutating: the row is still physically present (proven by
+        # the raw getter still returning it — deletion only piggybacks on the
+        # next capture, which has not happened).
+        assert reg.get_content_at_version(art.id, 2) == "c2"
+
+
+# ===========================================================================
+# R6 — fence non-capture (LOAD-BEARING): versioned reads never touch the fence
+# ===========================================================================
+
+
+class TestFenceNonCaptureR6:
+    def test_reads_do_not_mutate_read_generation(self, make_registry):
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=8))
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2", "c3"))  # current = 3
+        # An agent with an established fence claim (E acquire captures read_gen).
+        agent = uuid4()
+        reg.set_agent_state(art.id, agent, MESIState.EXCLUSIVE, trigger="write", tick=1)
+        before = _read_generation_snapshot(reg, art.id, [agent])
+        # A whole sequence of versioned reads spanning every reason branch.
+        svc.read_at_version(art.id, 2)            # served history
+        svc.read_at_version(art.id, 3)            # current_version
+        svc.read_at_version(art.id, 4)            # future_version
+        svc.read_at_version(art.id, 1)            # not_retained (K-evicted)
+        svc.read_at_version(uuid4(), 1)           # unknown_artifact
+        svc.read_at_version(art.id, 2, expected_epoch="x")  # epoch_mismatch
+        after = _read_generation_snapshot(reg, art.id, [agent])
+        assert after == before, "versioned reads mutated fence state (R6 violated)"
+
+    def test_read_by_invalid_stale_agent_does_not_capture(self, make_registry):
+        # The EXACT hazard R6 closes: a read performed in the context of an
+        # INVALID/stale agent must NOT mint or refresh a fence claim for it. The
+        # service read takes no agent arg, but we assert the agent's fence state
+        # is byte-identical across reads regardless of its MESI state.
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=8))
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2", "c3"))
+        stale = uuid4()
+        # Drive the agent to INVALID via a sweep reclamation so it is a genuine
+        # unfenced zombie (owner_generation bumped past any claim it had).
+        reg.set_agent_state(art.id, stale, MESIState.EXCLUSIVE, trigger="write", tick=1)
+        reg.set_agent_state(art.id, stale, MESIState.INVALID, trigger="reclaim_heartbeat", tick=2)
+        assert reg.get_agent_state(art.id, stale) == MESIState.INVALID
+        before = _read_generation_snapshot(reg, art.id, [stale])
+        for _ in range(3):
+            svc.read_at_version(art.id, 2)
+        after = _read_generation_snapshot(reg, art.id, [stale])
+        assert after == before
+        # And the agent gained NO read_generation it didn't already have.
+        assert reg.get_read_generation(art.id, stale) == before["read_generation"][stale]
+
+
+# ===========================================================================
+# R7 — MESI non-interaction: state, transients, membership unchanged; a real
+# fetch afterward behaves as if the reads never happened
+# ===========================================================================
+
+
+class TestMesiNonInteractionR7:
+    def test_state_maps_transients_membership_unchanged(self, make_registry):
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=8))
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2", "c3"))
+        a, b = uuid4(), uuid4()
+        reg.set_agent_state(art.id, a, MESIState.SHARED, trigger="fetch", tick=1)
+        reg.set_agent_state(art.id, b, MESIState.SHARED, trigger="fetch", tick=1)
+        reg.set_agent_transient(art.id, b, TransientState.ISG, entered_tick=1)
+        before = _mesi_snapshot(reg, art.id)
+        for v in (1, 2, 3, 4):
+            svc.read_at_version(art.id, v)
+        after = _mesi_snapshot(reg, art.id)
+        assert after == before, "versioned reads mutated MESI/transient/membership (R7)"
+
+    def test_subsequent_fetch_behaves_as_if_reads_never_happened(self, make_registry):
+        # Two parallel runs: one interleaves versioned reads before a fetch, one
+        # does not. The fetch grant + version + content must be identical.
+        def run(with_reads: bool):
+            reg = make_registry(retention_policy=RetentionPolicy(max_versions=8))
+            svc = CoordinatorService(reg)
+            art = _chain(reg, ("c1", "c2", "c3"))
+            requester = uuid4()
+            if with_reads:
+                svc.read_at_version(art.id, 2)
+                svc.read_at_version(art.id, 1)
+                svc.read_at_version(art.id, 3)
+            resp = svc.fetch(
+                FetchRequest(artifact_id=art.id, requesting_agent_id=requester, requested_at_tick=10)
+            )
+            grant = resp.state_grant
+            state = reg.get_agent_state(art.id, requester)
+            owner_gen = reg.get_owner_generation(art.id)
+            read_gen = reg.get_read_generation(art.id, requester)
+            return resp.version, grant, state, owner_gen, read_gen
+
+        assert run(with_reads=True) == run(with_reads=False)
+
+
+# ===========================================================================
+# Racing-commit atomicity — a commit interleaved with the read never mislabels
+# (test_occ_commit_cas.py discipline: correctness HARD, realism as warnings)
+# ===========================================================================
+
+
+class TestRacingCommitAtomicity:
+    def test_read_of_old_current_during_commit_is_history_or_current_never_wrong(
+        self, make_registry
+    ):
+        # A "race" we can assert deterministically: read version N while N is the
+        # current version, then commit to N+1, then read N again. The first read
+        # must be current_version (N was current); the second must serve N as
+        # exact history bytes — never wrong bytes, never a mislabeled reason.
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=8))
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2"))  # current = 2, body "c2"
+        # Before the commit: v2 is current.
+        pre = svc.read_at_version(art.id, 2)
+        assert isinstance(pre, VersionedReadRejection)
+        assert pre.reason == CURRENT_VERSION_REASON
+        # Commit to v3 — v2 becomes history.
+        _commit_pessimistic(reg, art, 3, "c3")
+        post = svc.read_at_version(art.id, 2)
+        assert isinstance(post, VersionedContent), (
+            "v2 must serve as history after the commit; got a rejection — a racing "
+            "commit mislabeled the reason"
+        )
+        assert post.content == "c2"  # exact old-current bytes, never v3's body
+
+    def test_outcome_is_always_one_of_two_allowed(self, make_registry):
+        # Property-style assertion over the allowed outcome set for reading the
+        # version that is current-at-entry: it is EITHER current_version (the
+        # value that was current) OR — if a commit landed first — that version
+        # served as history. Never wrong bytes, never another reason.
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=8))
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2", "c3"))  # current = 3
+        out = svc.read_at_version(art.id, 3)
+        if isinstance(out, VersionedContent):
+            assert out.content == "c3"  # would only happen if v3 became history
+        else:
+            assert out.reason == CURRENT_VERSION_REASON
+
+
+# ===========================================================================
+# Rejection-payload pin — NO content / hash / body material on a rejection
+# ===========================================================================
+
+
+class TestRejectionPayloadPin:
+    # The exact, complete field set a VersionedReadRejection is allowed to carry.
+    # No content, no content_hash, no body bytes — a rejection must never leak.
+    _ALLOWED_FIELDS = frozenset(
+        {"reason", "artifact_id", "requested_version", "current_version", "coordinator_epoch"}
+    )
+    _FORBIDDEN_SUBSTRINGS = ("content", "hash", "body", "bytes", "payload", "data")
+
+    def test_dataclass_has_no_body_carrying_field(self):
+        import dataclasses
+
+        names = {f.name for f in dataclasses.fields(VersionedReadRejection)}
+        assert names == self._ALLOWED_FIELDS, (
+            f"VersionedReadRejection field set drifted to {names}; a rejection "
+            f"must carry ONLY {self._ALLOWED_FIELDS} (no body material)."
+        )
+        for name in names:
+            for bad in self._FORBIDDEN_SUBSTRINGS:
+                assert bad not in name, f"field {name!r} hints at body material"
+
+    def test_every_reason_rejection_instance_has_only_allowed_fields(self, make_registry):
+        # Construct one rejection of each reason and assert the live instance's
+        # __dict__ carries no extra (body-bearing) attribute.
+        import dataclasses
+
+        reg = make_registry(retention_policy=RetentionPolicy(max_versions=2))
+        svc = CoordinatorService(reg)
+        art = _chain(reg, ("c1", "c2", "c3"))  # K=2 → v1 evicted, current=3
+        rejections = [
+            svc.read_at_version(art.id, 1),                          # not_retained
+            svc.read_at_version(art.id, 3),                          # current_version
+            svc.read_at_version(art.id, 9),                          # future_version
+            svc.read_at_version(uuid4(), 1),                         # unknown_artifact
+            svc.read_at_version(art.id, 2, expected_epoch="x"),      # epoch_mismatch
+        ]
+        for rej in rejections:
+            assert isinstance(rej, VersionedReadRejection)
+            assert rej.reason in READ_AT_VERSION_REASONS
+            assert {f.name for f in dataclasses.fields(rej)} == self._ALLOWED_FIELDS
+
+
+# ===========================================================================
+# Route-guard — the HTTP coordinator server exposes NO read-at-version /
+# content-serving route (locks the v1 no-HTTP-exposure boundary). Modeled on
+# tests/test_fence_signature_guard.py.
+# ===========================================================================
+
+
+class TestNoHttpReadAtVersionRoute:
+    """v1 boundary: read-at-version is service-level + in-process CLI only. The
+    hash-only HTTP topology has nothing to serve, so the route table must expose
+    no content-serving / read-at-version route. The day one is added is a named
+    follow-on gated on its own threat-model review (plan R5) — and it must fail
+    this test until then. Same discipline as the fence signature guard."""
+
+    # Path substrings that would indicate a content / version-history-serving
+    # HTTP route crossed into the coordinator server.
+    _FORBIDDEN_ROUTE_SUBSTRINGS = (
+        "read-at-version",
+        "read_at_version",
+        "version",
+        "content",
+        "history",
+        "retain",
+        "snapshot",
+    )
+
+    def test_route_table_exposes_no_content_or_version_route(self):
+        from ccs.adapters.claude_code.coordinator_server import _ROUTES
+
+        offending = [
+            (method, path)
+            for (method, path) in _ROUTES
+            for bad in self._FORBIDDEN_ROUTE_SUBSTRINGS
+            if bad in path.lower()
+        ]
+        assert not offending, (
+            f"coordinator server route table exposes a content/version route "
+            f"{offending}; read-at-version must stay OFF the hash-only HTTP "
+            f"topology in v1 (plan R5). Adding an HTTP content route is a named "
+            f"follow-on behind its own threat-model review — remove the route or "
+            f"open that work."
+        )
+
+    def test_handler_module_defines_no_read_at_version_handler(self):
+        # Defense in depth: no ``_handle_*`` function whose name implies it serves
+        # versioned content (a route could be wired later from such a handler).
+        from ccs.adapters.claude_code import coordinator_server as srv
+
+        suspects = [
+            name
+            for name in dir(srv)
+            if name.startswith("_handle_")
+            and any(b in name.lower() for b in ("read_at_version", "content", "version", "history"))
+        ]
+        assert not suspects, (
+            f"coordinator server defines handler(s) {suspects} implying versioned "
+            f"content service; the v1 HTTP topology serves no content (plan R5)."
+        )

--- a/tests/test_replay_resolver.py
+++ b/tests/test_replay_resolver.py
@@ -32,8 +32,9 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import sqlite3
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from uuid import uuid4
 
@@ -50,7 +51,7 @@ from ccs.core.exceptions import (
     RETENTION_OFF_REASON,
     UNKNOWN_ARTIFACT_REASON,
 )
-from ccs.core.types import Artifact
+from ccs.core.types import Artifact, VersionedContent, VersionedReadRejection
 from ccs.replay import (
     ResolverCorruptDatabaseError,
     ResolverInstanceMismatchError,
@@ -61,7 +62,6 @@ from ccs.replay import (
     ResolverUnknownArtifactPathError,
     resolve_version,
 )
-from ccs.core.types import VersionedContent, VersionedReadRejection
 
 _K8 = RetentionPolicy(max_versions=8)
 
@@ -505,6 +505,119 @@ class TestErrorPaths:
         assert rc == 4
         assert obj["reason"] == "usage_error"
 
+    def test_query_time_busy_maps_to_db_busy(self, tmp_path: Path, monkeypatch) -> None:
+        # SQLITE_BUSY surfacing at QUERY time (after a clean read-only open)
+        # must classify identically to the open-time path: db_busy, exit 12.
+        # Inject on the artifact_versions SELECT — past every open-time read.
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+
+        from ccs.coordinator import sqlite_registry as sr
+
+        class _QueryBusyProxy:
+            def __init__(self, real):
+                self._real = real
+
+            def execute(self, sql, *a, **k):
+                if "artifact_versions" in sql:
+                    raise sqlite3.OperationalError("database is locked")
+                return self._real.execute(sql, *a, **k)
+
+            def __getattr__(self, n):
+                return getattr(self._real, n)
+
+        real_connect = sqlite3.connect
+
+        def fake_connect(*a, **k):
+            conn = real_connect(*a, **k)
+            if a and "mode=ro" in str(a[0]):
+                return _QueryBusyProxy(conn)
+            return conn
+
+        monkeypatch.setattr(sr.sqlite3, "connect", fake_connect)
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2", "--json"]
+        )
+        assert rc == 12
+        assert obj["reason"] == "db_busy"
+
+    def test_query_time_recovery_maps_to_needs_recovery(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # The wal_recovery signal at query time folds into needs_recovery —
+        # same wire outcome as the open-time classification.
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+
+        from ccs.coordinator import sqlite_registry as sr
+
+        class _QueryRecoveryProxy:
+            def __init__(self, real):
+                self._real = real
+
+            def execute(self, sql, *a, **k):
+                if "artifact_versions" in sql:
+                    raise sqlite3.OperationalError(
+                        "attempt to write a readonly database (SQLITE_READONLY_RECOVERY)"
+                    )
+                return self._real.execute(sql, *a, **k)
+
+            def __getattr__(self, n):
+                return getattr(self._real, n)
+
+        real_connect = sqlite3.connect
+
+        def fake_connect(*a, **k):
+            conn = real_connect(*a, **k)
+            if a and "mode=ro" in str(a[0]):
+                return _QueryRecoveryProxy(conn)
+            return conn
+
+        monkeypatch.setattr(sr.sqlite3, "connect", fake_connect)
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2", "--json"]
+        )
+        assert rc == 12
+        assert obj["reason"] == "needs_recovery"
+
+    def test_open_time_unreadable_signal_maps_to_needs_recovery(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # The catch-all "unreadable" signal (an OperationalError that is
+        # neither busy nor a recognized recovery state) keeps today's wire
+        # outcome: needs_recovery, exit 12 (same operator remedy).
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+
+        from ccs.coordinator import sqlite_registry as sr
+
+        class _UnreadableProxy:
+            def __init__(self, real):
+                self._real = real
+
+            def execute(self, sql, *a, **k):
+                if "user_version" in sql:
+                    raise sqlite3.OperationalError("no such table: sqlite_master_oops")
+                return self._real.execute(sql, *a, **k)
+
+            def __getattr__(self, n):
+                return getattr(self._real, n)
+
+        real_connect = sqlite3.connect
+
+        def fake_connect(*a, **k):
+            conn = real_connect(*a, **k)
+            if a and "mode=ro" in str(a[0]):
+                return _UnreadableProxy(conn)
+            return conn
+
+        monkeypatch.setattr(sr.sqlite3, "connect", fake_connect)
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2", "--json"]
+        )
+        assert rc == 12
+        assert obj["reason"] == "needs_recovery"
+
     def test_no_output_file_written_on_rejection(self, tmp_path: Path) -> None:
         # A rejection must not produce a partial output file even if --output-file
         # was requested (no bytes to write).
@@ -572,7 +685,7 @@ class TestInstanceIdCrossCheck:
         _write_store(db, ("c1", "c2", "c3"))
         # Read the store's persisted instance_id via a read-only registry.
         with SqliteArtifactRegistry(db, read_only=True) as ro:
-            inst = ro._instance_id
+            inst = ro.instance_id
         rc, obj = _resolve_json(
             ["--db", str(db), "--artifact", "plan.md", "--version", "2",
              "--instance-id", inst, "--include-content", "--json"]
@@ -655,6 +768,416 @@ class TestResolverLibrarySurface:
                     expected_instance_id="nope",
                 )
             )
+
+    def test_resolve_version_below_one_raises_value_error(self, tmp_path: Path) -> None:
+        # The LIBRARY contract (not just the CLI's exit-4 translation): a sub-1
+        # version propagates the service's ValueError out of resolve_version —
+        # caller misuse, never a typed rejection and never a ResolverError.
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        for bad_version in (0, -1):
+            with pytest.raises(ValueError, match="version must be >= 1"):
+                resolve_version(
+                    ResolverRequest(db_path=db, selector="plan.md", version=bad_version)
+                )
+
+
+# ===========================================================================
+# NO LEAKED CONNECTION — every typed-raise path closes the read-only handle
+# ===========================================================================
+
+
+class _ConnectionCloseTracker:
+    """Wrap ``sqlite3.connect`` for ``mode=ro`` URIs and track close() calls."""
+
+    def __init__(self, monkeypatch, *, fault_sql: str | None = None,
+                 fault_message: str | None = None) -> None:
+        self.opened: list[object] = []
+        self.closed: list[object] = []
+        tracker = self
+
+        class _Proxy:
+            def __init__(self, real):
+                self._real = real
+
+            def close(self):
+                tracker.closed.append(self)
+                return self._real.close()
+
+            def execute(self, sql, *a, **k):
+                if fault_sql is not None and fault_sql in sql:
+                    raise sqlite3.OperationalError(fault_message)
+                return self._real.execute(sql, *a, **k)
+
+            def __getattr__(self, n):
+                return getattr(self._real, n)
+
+        from ccs.coordinator import sqlite_registry as sr
+
+        real_connect = sqlite3.connect
+
+        def fake_connect(*a, **k):
+            conn = real_connect(*a, **k)
+            if a and "mode=ro" in str(a[0]):
+                proxy = _Proxy(conn)
+                tracker.opened.append(proxy)
+                return proxy
+            return conn
+
+        monkeypatch.setattr(sr.sqlite3, "connect", fake_connect)
+
+    def assert_all_closed(self) -> None:
+        assert self.opened, "the fault never exercised a read-only open"
+        assert len(self.closed) == len(self.opened), (
+            f"{len(self.opened) - len(self.closed)} read-only sqlite "
+            f"connection(s) leaked on the typed-raise path"
+        )
+
+
+class TestNoLeakedConnectionOnTypedRaise:
+    """A typed open/lookup failure must never orphan the read-only handle —
+    the post-connect validation closes the connection before raising."""
+
+    def test_schema_version_mismatch_closes_connection(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        db = tmp_path / "state.db"
+        _build_raw_v1_db(db)
+        tracker = _ConnectionCloseTracker(monkeypatch)
+        with pytest.raises(ResolverSchemaVersionError):
+            resolve_version(ResolverRequest(db_path=db, selector="plan.md", version=1))
+        tracker.assert_all_closed()
+
+    def test_needs_recovery_closes_connection(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        tracker = _ConnectionCloseTracker(
+            monkeypatch,
+            fault_sql="user_version",
+            fault_message=(
+                "attempt to write a readonly database (SQLITE_READONLY_RECOVERY)"
+            ),
+        )
+        with pytest.raises(ResolverNeedsRecoveryError):
+            resolve_version(ResolverRequest(db_path=db, selector="plan.md", version=2))
+        tracker.assert_all_closed()
+
+    def test_instance_mismatch_closes_connection(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # The mismatch raises AFTER a successful open; the resolver's finally
+        # must close the handle (pinned here so a refactor cannot drop it).
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        tracker = _ConnectionCloseTracker(monkeypatch)
+        with pytest.raises(ResolverInstanceMismatchError):
+            resolve_version(
+                ResolverRequest(
+                    db_path=db, selector="plan.md", version=2,
+                    expected_instance_id="nope",
+                )
+            )
+        tracker.assert_all_closed()
+
+
+# ===========================================================================
+# CLI CONTRACT HARDENING — argparse exit 2, envelopes, mapping pin, output file
+# ===========================================================================
+
+
+class TestArgparseExit2Contract:
+    """argparse usage errors exit 2; with --json among argv a JSON error
+    envelope reaches stdout first (stderr keeps the usage prose)."""
+
+    def test_resolve_missing_required_arg_with_json_emits_envelope(self) -> None:
+        buf, err = io.StringIO(), io.StringIO()
+        with pytest.raises(SystemExit) as excinfo:
+            with redirect_stdout(buf), redirect_stderr(err):
+                main(["resolve", "--db", "/tmp/x", "--artifact", "a", "--json"])
+        assert excinfo.value.code == 2
+        obj = json.loads(buf.getvalue().strip())
+        assert obj["kind"] == "error"
+        assert obj["exit_code"] == 2
+        assert obj["reason"] == "argument_error"
+        assert "usage:" in err.getvalue()  # stderr prose preserved
+
+    def test_resolve_missing_required_arg_without_json_keeps_stdout_empty(
+        self,
+    ) -> None:
+        buf, err = io.StringIO(), io.StringIO()
+        with pytest.raises(SystemExit) as excinfo:
+            with redirect_stdout(buf), redirect_stderr(err):
+                main(["resolve", "--db", "/tmp/x", "--artifact", "a"])
+        assert excinfo.value.code == 2
+        assert buf.getvalue() == ""  # no envelope without --json
+        assert "usage:" in err.getvalue()
+
+    def test_default_mode_bad_flag_with_json_emits_envelope(self) -> None:
+        buf, err = io.StringIO(), io.StringIO()
+        with pytest.raises(SystemExit) as excinfo:
+            with redirect_stdout(buf), redirect_stderr(err):
+                main(["--json", "--definitely-not-a-flag", "/tmp/session"])
+        assert excinfo.value.code == 2
+        obj = json.loads(buf.getvalue().strip())
+        assert obj["exit_code"] == 2
+        assert obj["reason"] == "argument_error"
+
+    def test_default_mode_bad_flag_without_json_keeps_stdout_empty(self) -> None:
+        buf, err = io.StringIO(), io.StringIO()
+        with pytest.raises(SystemExit) as excinfo:
+            with redirect_stdout(buf), redirect_stderr(err):
+                main(["--definitely-not-a-flag", "/tmp/session"])
+        assert excinfo.value.code == 2
+        assert buf.getvalue() == ""
+
+
+class TestResolveTokenDispatch:
+    """The bare literal 'resolve' selects the subcommand; a path spelling of a
+    session dir literally named resolve routes to the default replay mode."""
+
+    def test_dot_slash_resolve_routes_to_replay_mode(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # A session dir literally named "resolve": invoking it as ./resolve
+        # must hit the DEFAULT replay mode (here: exit 3, manifest missing —
+        # a replay-mode outcome, not a resolve-mode argparse error).
+        session = tmp_path / "resolve"
+        session.mkdir()
+        monkeypatch.chdir(tmp_path)
+        rc = main(["./resolve"])
+        assert rc == 3  # replay-mode trace error (manifest missing)
+
+    def test_bare_resolve_token_still_selects_subcommand(self) -> None:
+        # The bare word stays the subcommand selector (missing required args
+        # → argparse exit 2), regardless of cwd contents.
+        with pytest.raises(SystemExit) as excinfo:
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                main(["resolve"])
+        assert excinfo.value.code == 2
+
+
+class TestResolveInternalErrorEnvelope:
+    """An unexpected exception in resolve mode exits 4 AND emits the JSON error
+    envelope under --json (stdout stays self-contained on every exit path)."""
+
+    def test_unexpected_raise_with_json_emits_envelope(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+
+        def boom(request):
+            raise RuntimeError("simulated resolver bug")
+
+        monkeypatch.setattr("ccs.replay.resolver.resolve_version", boom)
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2", "--json"]
+        )
+        assert rc == 4
+        assert obj["kind"] == "error"
+        assert obj["exit_code"] == 4
+        assert obj["reason"] == "internal_error"
+        assert obj["exception"] == "RuntimeError"
+
+    def test_unexpected_raise_without_json_keeps_stdout_empty(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+
+        def boom(request):
+            raise RuntimeError("simulated resolver bug")
+
+        monkeypatch.setattr("ccs.replay.resolver.resolve_version", boom)
+        rc = main(["resolve", "--db", str(db), "--artifact", "plan.md", "--version", "2"])
+        captured = capsys.readouterr()
+        assert rc == 4
+        assert captured.out == ""
+        assert "internal error" in captured.err
+        assert "RuntimeError" in captured.err
+        assert "Traceback" not in captured.err
+
+
+class TestRejectionEnvelopeExitCode:
+    """The rejection JSON envelope carries the REAL numeric exit code (the
+    misleading exit_code: None placeholder is gone)."""
+
+    def test_rejection_envelope_exit_code_matches_process_exit(
+        self, tmp_path: Path
+    ) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))  # current = 3
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "3", "--json"]
+        )
+        assert rc == 5
+        assert obj["kind"] == "rejected"
+        assert obj["exit_code"] == 5  # the real code, not None / absent
+
+    def test_every_rejection_reason_envelope_carries_its_code(
+        self, tmp_path: Path
+    ) -> None:
+        from ccs.cli.coherence_replay import _RESOLVE_REJECTION_EXIT_CODES
+
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"), policy=RetentionPolicy(max_versions=2))
+        scenarios = {
+            CURRENT_VERSION_REASON: ["--artifact", "plan.md", "--version", "3"],
+            NOT_RETAINED_REASON: ["--artifact", "plan.md", "--version", "1"],
+            UNKNOWN_ARTIFACT_REASON: ["--artifact", str(uuid4()), "--version", "1"],
+            EPOCH_MISMATCH_REASON: [
+                "--artifact", "plan.md", "--version", "2",
+                "--expected-epoch", "not-the-epoch",
+            ],
+            FUTURE_VERSION_REASON: ["--artifact", "plan.md", "--version", "9"],
+        }
+        for reason, argv in scenarios.items():
+            rc, obj = _resolve_json(["--db", str(db), *argv, "--json"])
+            assert obj["reason"] == reason
+            assert rc == _RESOLVE_REJECTION_EXIT_CODES[reason]
+            assert obj["exit_code"] == rc
+
+
+class TestRejectionExitCodeMappingPin:
+    """The mapping is exhaustively pinned against READ_AT_VERSION_REASONS and
+    the rendered --help is generated from it (no hand-drift possible)."""
+
+    def test_mapping_covers_reason_set_exactly(self) -> None:
+        from ccs.cli.coherence_replay import _RESOLVE_REJECTION_EXIT_CODES
+        from ccs.core.exceptions import READ_AT_VERSION_REASONS
+
+        assert set(_RESOLVE_REJECTION_EXIT_CODES) == set(READ_AT_VERSION_REASONS)
+        # Pin the exact reason -> code assignments (the wire contract).
+        assert _RESOLVE_REJECTION_EXIT_CODES == {
+            CURRENT_VERSION_REASON: 5,
+            NOT_RETAINED_REASON: 6,
+            UNKNOWN_ARTIFACT_REASON: 7,
+            RETENTION_OFF_REASON: 8,
+            EPOCH_MISMATCH_REASON: 9,
+            FUTURE_VERSION_REASON: 10,
+        }
+
+    def test_resolve_epilog_mentions_every_reason_with_its_code(self) -> None:
+        from ccs.cli.coherence_replay import (
+            _RESOLVE_REJECTION_EXIT_CODES,
+            build_resolve_parser,
+        )
+
+        help_text = build_resolve_parser().format_help()
+        for reason, code in _RESOLVE_REJECTION_EXIT_CODES.items():
+            assert f"{code:<3} {reason}" in help_text, (
+                f"resolve --help is missing the '{code} {reason}' row"
+            )
+        # And the table is numerically ordered (0/2/4 precede the 5+ rows).
+        positions = [help_text.index(f"{code:<3} {reason}")
+                     for reason, code in _RESOLVE_REJECTION_EXIT_CODES.items()]
+        assert positions == sorted(positions)
+        for shared in ("  0 ", "  2 ", "  4 "):
+            assert help_text.index(shared) < min(positions)
+
+    def test_resolve_epilog_documents_exit_2(self) -> None:
+        from ccs.cli.coherence_replay import build_resolve_parser
+
+        help_text = build_resolve_parser().format_help()
+        assert "argument/usage error" in help_text
+
+    def test_default_epilog_documents_exit_2_collision_and_escape(self) -> None:
+        help_text = build_parser().format_help()
+        assert "argparse" in help_text  # exit-2 usage-error note
+        assert "./resolve" in help_text  # the named-dir escape hatch
+
+
+class TestOutputFileHardening:
+    """_write_output_file: symlink refusal, atomic publish, 0600 preserved."""
+
+    def test_symlink_target_refused_no_write_through(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        real_target = tmp_path / "real-destination.bin"
+        real_target.write_bytes(b"untouched")
+        link = tmp_path / "planted-link.bin"
+        link.symlink_to(real_target)
+        buf, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(buf), redirect_stderr(err):
+            rc = main([
+                "resolve", "--db", str(db), "--artifact", "plan.md",
+                "--version", "2", "--output-file", str(link), "--json",
+            ])
+        assert rc == 4  # usage error (typed config error), not a silent follow
+        obj = json.loads(buf.getvalue().strip())
+        assert obj["reason"] == "usage_error"
+        assert "symlink" in obj["message"]
+        # The bytes never reached the link's destination; the link survives.
+        assert real_target.read_bytes() == b"untouched"
+        assert link.is_symlink()
+
+    def test_mid_write_failure_leaves_prior_content_intact(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        import os as os_module
+
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        out = tmp_path / "out.bin"
+        out.write_bytes(b"prior-content")
+
+        def exploding_replace(src, dst):
+            raise OSError("simulated mid-write failure")
+
+        monkeypatch.setattr(os_module, "replace", exploding_replace)
+        buf, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(buf), redirect_stderr(err):
+            rc = main([
+                "resolve", "--db", str(db), "--artifact", "plan.md",
+                "--version", "2", "--output-file", str(out),
+            ])
+        assert rc == 4
+        # Prior content intact — never truncated/partial.
+        assert out.read_bytes() == b"prior-content"
+        # No leftover temp files in the directory.
+        leftovers = [p for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+        assert leftovers == []
+
+    def test_mid_write_failure_fresh_target_never_materializes(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        import os as os_module
+
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        out = tmp_path / "never-created.bin"
+
+        def exploding_replace(src, dst):
+            raise OSError("simulated mid-write failure")
+
+        monkeypatch.setattr(os_module, "replace", exploding_replace)
+        buf, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(buf), redirect_stderr(err):
+            rc = main([
+                "resolve", "--db", str(db), "--artifact", "plan.md",
+                "--version", "2", "--output-file", str(out),
+            ])
+        assert rc == 4
+        assert not out.exists()  # no partial/empty target
+
+    def test_success_path_still_0600_and_exact_bytes(self, tmp_path: Path) -> None:
+        # Unchanged success contract after the atomic-write rework (the
+        # original 0600 test lives in TestContentSafeDefault; this re-pins it
+        # against the temp+replace implementation alongside an existing file).
+        db = tmp_path / "state.db"
+        _write_store(db, ("seed", b"\x00\x01raw-v2", "c3"))
+        out = tmp_path / "extracted.bin"
+        out.write_bytes(b"old")  # pre-existing target gets atomically replaced
+        os.chmod(out, 0o644)
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2",
+             "--output-file", str(out), "--json"]
+        )
+        assert rc == 0
+        assert out.read_bytes() == b"\x00\x01raw-v2"
+        assert (out.stat().st_mode & 0o777) == 0o600  # replace swaps to 0600
 
 
 # ===========================================================================

--- a/tests/test_replay_resolver.py
+++ b/tests/test_replay_resolver.py
@@ -1,0 +1,796 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Replay CLI resolve mode — the wired ``read_at_version`` consumer (Unit 6 / R5b).
+
+Requirement trace: **R5b** — one wired consumer (``agent-coherence-replay``
+resolve mode), restart-survival proof. This is the test that makes the whole
+feature's value story real: an embedder writes versions with retention on, the
+process exits, and a SEPARATE read-only resolver recovers the exact bytes.
+
+Coverage map (plan §Unit 6 Test scenarios):
+
+- The consumer proof (happy path): cross-process restart → exact bytes, exit 0.
+- Content-safe default: metadata only (no raw bytes) without ``--include-content``;
+  ``--include-content`` yields base64 + ``content_encoding`` for bytes;
+  ``--output-file`` writes raw bytes at ``0o600``.
+- Per-rejection mapping: each of the 6 reasons → distinct exit code + JSON
+  ``reason`` (``not_retained`` vs ``unknown_artifact`` distinguishable).
+- Error paths: missing db (NO file created), corrupt/non-sqlite, v1-schema (no
+  migration), needs-recovery (fault-injected), SQLITE_BUSY (fault-injected) —
+  each a distinct typed error, non-zero exit, no partial output.
+- name→id lookup: by workspace path works; a miss → typed error naming the lookup.
+- Backward-compat: the existing ``agent-coherence-replay <session_dir>``
+  invocation behaves byte-identically; ``--help`` documents the new mode.
+
+Reason matching is ALWAYS ``== CONSTANT`` against the imported wire-stable
+constants (the typed-signal-not-substring house rule). Runs against a bare
+``[dev]`` import surface — no test here requires langgraph/etc.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sqlite3
+from contextlib import redirect_stdout
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from ccs.cli.coherence_replay import build_parser, main
+from ccs.coordinator.retention import RetentionPolicy
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.exceptions import (
+    CURRENT_VERSION_REASON,
+    EPOCH_MISMATCH_REASON,
+    FUTURE_VERSION_REASON,
+    NOT_RETAINED_REASON,
+    RETENTION_OFF_REASON,
+    UNKNOWN_ARTIFACT_REASON,
+)
+from ccs.core.types import Artifact
+from ccs.replay import (
+    ResolverCorruptDatabaseError,
+    ResolverInstanceMismatchError,
+    ResolverMissingDatabaseError,
+    ResolverNeedsRecoveryError,
+    ResolverRequest,
+    ResolverSchemaVersionError,
+    ResolverUnknownArtifactPathError,
+    resolve_version,
+)
+from ccs.core.types import VersionedContent, VersionedReadRejection
+
+_K8 = RetentionPolicy(max_versions=8)
+
+
+# ---------------------------------------------------------------------------
+# Store builders — write with one registry, CLOSE (= process exit), then the
+# resolver reopens the SAME path read-only. This is the restart boundary.
+# ---------------------------------------------------------------------------
+
+
+def _write_store(
+    db_path: Path,
+    bodies: tuple[str | bytes, ...],
+    *,
+    policy: RetentionPolicy | None = _K8,
+    retain_versions: bool = True,
+) -> Artifact:
+    """Populate ``db_path`` then CLOSE the writer (simulating process exit).
+
+    Registers v1=bodies[0] and pessimistic/CAS-commits bodies[1:] as v2.. The
+    writer is fully closed before returning so the resolver opens a cold store
+    over the same file — the cross-process restart the proof depends on.
+    """
+    writer = SqliteArtifactRegistry(
+        db_path, retain_versions=retain_versions, retention_policy=policy
+    )
+    try:
+        # register_artifact takes str content; a bytes v1 is seeded as a string
+        # placeholder (tests that assert on bytes always do so for v2+ via CAS).
+        first = bodies[0]
+        art = Artifact(id=uuid4(), name="plan.md", version=1, content_hash="h")
+        writer.register_artifact(
+            art, content=first if isinstance(first, str) else "seed"
+        )
+        agent = uuid4()
+        version = 1
+        for body in bodies[1:]:
+            version += 1
+            if isinstance(body, bytes):
+                writer.set_agent_state(art.id, agent, _SHARED, tick=version)
+                writer.commit_cas(
+                    art.id, agent, expected_version=version - 1,
+                    content_hash="h", content=body, tick=version,
+                )
+            else:
+                nx = Artifact(id=art.id, name="plan.md", version=version, content_hash="h")
+                writer.set_artifact_and_content(art.id, nx, body)
+        return art
+    finally:
+        writer.close()
+
+
+# Imported lazily-ish to keep the builder readable; MESIState is core, cheap.
+from ccs.core.states import MESIState as _MESI  # noqa: E402
+
+_SHARED = _MESI.SHARED
+
+
+def _resolve_json(args: list[str]) -> tuple[int, dict | None]:
+    """Run ``main(['resolve', ...])`` capturing stdout; parse the JSON object.
+
+    Returns ``(exit_code, parsed_json_or_None)``. ``--json`` must be in ``args``
+    for the second element to be populated.
+    """
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(["resolve", *args])
+    text = buf.getvalue().strip()
+    obj = json.loads(text) if text else None
+    return rc, obj
+
+
+# ===========================================================================
+# THE CONSUMER PROOF — restart-survival: write, exit, resolve exact bytes
+# ===========================================================================
+
+
+class TestConsumerProofRestartSurvival:
+    """The R5b proof: a closed-then-reopened store yields the exact retained
+    bytes at version k. This is the test that proves the feature's value."""
+
+    def test_resolve_exact_bytes_after_writer_closed(self, tmp_path: Path) -> None:
+        db = tmp_path / ".coherence" / "state.db"
+        art = _write_store(db, ("body-v1", "body-v2", "body-v3"))  # current = 3
+        # Writer is closed (process "exited"). Resolve v2 from the cold store.
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2",
+             "--include-content", "--json"]
+        )
+        assert rc == 0
+        assert obj["kind"] == "resolved"
+        assert obj["version"] == 2
+        assert obj["content"] == "body-v2"  # EXACT bytes survived the restart
+        assert obj["artifact_id"] == str(art.id)
+
+    def test_resolve_by_raw_uuid_after_restart(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        art = _write_store(db, ("body-v1", "body-v2", "body-v3"))
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", str(art.id), "--version", "1",
+             "--include-content", "--json"]
+        )
+        assert rc == 0
+        assert obj["content"] == "body-v1"
+
+    def test_resolve_bytes_body_round_trips_base64(self, tmp_path: Path) -> None:
+        # A BLOB-stored bytes version survives and is base64 in --include-content.
+        db = tmp_path / "state.db"
+        art = _write_store(db, ("seed", b"\x00\x01bytes-v2", "body-v3"))
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2",
+             "--include-content", "--json"]
+        )
+        import base64
+
+        assert rc == 0
+        assert obj["content_encoding"] == "base64"
+        assert base64.b64decode(obj["content"]) == b"\x00\x01bytes-v2"
+
+
+# ===========================================================================
+# CONTENT-SAFE DEFAULT — metadata only unless explicitly asked
+# ===========================================================================
+
+
+class TestContentSafeDefault:
+    def test_default_output_is_metadata_only_no_bytes(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("secret-v1", "secret-v2", "secret-v3"))
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2", "--json"]
+        )
+        assert rc == 0
+        # The DEFAULT carries metadata only — no raw bytes anywhere.
+        assert "content" not in obj
+        assert "content_encoding" not in obj
+        assert set(obj) >= {
+            "version", "coordinator_epoch", "captured_at",
+            "content_hash", "content_length",
+        }
+        assert obj["content_length"] == len("secret-v2")
+        # And the secret literal must not appear in the serialized output.
+        assert "secret-v2" not in json.dumps(obj)
+
+    def test_default_human_output_omits_body(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("secret-v1", "secret-v2", "secret-v3"))
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main(["resolve", "--db", str(db), "--artifact", "plan.md", "--version", "2"])
+        out = buf.getvalue()
+        assert rc == 0
+        assert "content_hash" in out and "content_length" in out
+        assert "secret-v2" not in out  # body never printed without the flag
+
+    def test_content_hash_is_sha256_over_bytes(self, tmp_path: Path) -> None:
+        import hashlib
+
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "hash-me-v2", "c3"))
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2", "--json"]
+        )
+        assert rc == 0
+        assert obj["content_hash"] == hashlib.sha256(b"hash-me-v2").hexdigest()
+
+    def test_include_content_str_is_utf8_as_is(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "plain-v2", "c3"))
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2",
+             "--include-content", "--json"]
+        )
+        assert rc == 0
+        assert obj["content_encoding"] == "utf-8"
+        assert obj["content"] == "plain-v2"
+
+    def test_output_file_writes_raw_bytes_at_0600(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("seed", b"\x00\x01raw-v2", "c3"))
+        out = tmp_path / "extracted.bin"
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2",
+             "--output-file", str(out), "--json"]
+        )
+        assert rc == 0
+        # Raw bytes on disk, no base64; metadata (incl. output_file) on stdout.
+        assert out.read_bytes() == b"\x00\x01raw-v2"
+        assert (out.stat().st_mode & 0o777) == 0o600
+        assert obj["output_file"] == str(out)
+        # Default (no --include-content) still keeps bytes out of stdout.
+        assert "content" not in obj
+
+    def test_output_file_str_body_written_utf8(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "str-body-v2", "c3"))
+        out = tmp_path / "out.txt"
+        rc, _ = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2",
+             "--output-file", str(out), "--json"]
+        )
+        assert rc == 0
+        assert out.read_bytes() == b"str-body-v2"
+
+
+# ===========================================================================
+# PER-REJECTION MAPPING — every reason a distinct exit code + JSON reason
+# ===========================================================================
+
+
+class TestPerRejectionMapping:
+    """Each of the six read_at_version reasons surfaces distinguishably: a
+    distinct exit code AND a wire-stable JSON ``reason`` (no prose parsing)."""
+
+    def test_current_version_exit_5(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))  # current = 3
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "3", "--json"]
+        )
+        assert rc == 5
+        assert obj["reason"] == CURRENT_VERSION_REASON
+
+    def test_not_retained_exit_6(self, tmp_path: Path) -> None:
+        # K=2 over three commits drops v1 → reading v1 is not_retained.
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"), policy=RetentionPolicy(max_versions=2))
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "1", "--json"]
+        )
+        assert rc == 6
+        assert obj["reason"] == NOT_RETAINED_REASON
+
+    def test_unknown_artifact_exit_7(self, tmp_path: Path) -> None:
+        # A raw UUID unknown to the registry flows to read_at_version →
+        # unknown_artifact (NOT the by-path lookup error — that is exit 13).
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", str(uuid4()), "--version", "1", "--json"]
+        )
+        assert rc == 7
+        assert obj["reason"] == UNKNOWN_ARTIFACT_REASON
+
+    def test_retention_off_exit_8(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"), retain_versions=False, policy=None)
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2", "--json"]
+        )
+        assert rc == 8
+        assert obj["reason"] == RETENTION_OFF_REASON
+
+    def test_epoch_mismatch_exit_9(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2",
+             "--expected-epoch", "not-the-epoch", "--json"]
+        )
+        assert rc == 9
+        assert obj["reason"] == EPOCH_MISMATCH_REASON
+
+    def test_future_version_exit_10(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))  # current = 3
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "9", "--json"]
+        )
+        assert rc == 10
+        assert obj["reason"] == FUTURE_VERSION_REASON
+
+    def test_not_retained_and_unknown_artifact_are_distinct(self, tmp_path: Path) -> None:
+        # The plan calls this out explicitly: a script must tell not_retained from
+        # unknown_artifact WITHOUT parsing prose — distinct exit codes + reasons.
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"), policy=RetentionPolicy(max_versions=2))
+        rc_nr, obj_nr = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "1", "--json"]
+        )
+        rc_uk, obj_uk = _resolve_json(
+            ["--db", str(db), "--artifact", str(uuid4()), "--version", "1", "--json"]
+        )
+        assert (rc_nr, obj_nr["reason"]) == (6, NOT_RETAINED_REASON)
+        assert (rc_uk, obj_uk["reason"]) == (7, UNKNOWN_ARTIFACT_REASON)
+        assert rc_nr != rc_uk
+
+    def test_rejection_carries_no_body_material(self, tmp_path: Path) -> None:
+        # A rejection envelope must never leak content/hash/body fields.
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "3", "--json"]
+        )
+        assert rc == 5
+        for forbidden in ("content", "content_hash", "content_length", "content_encoding"):
+            assert forbidden not in obj
+
+    def test_rejection_human_output_names_reason(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"), policy=RetentionPolicy(max_versions=2))
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main(["resolve", "--db", str(db), "--artifact", "plan.md", "--version", "1"])
+        out = buf.getvalue()
+        assert rc == 6
+        assert NOT_RETAINED_REASON in out
+
+
+# ===========================================================================
+# ERROR PATHS — open/lookup failures: distinct typed errors, no partial output
+# ===========================================================================
+
+
+class TestErrorPaths:
+    def test_missing_db_exit_11_no_file_created(self, tmp_path: Path) -> None:
+        absent = tmp_path / "nope" / "state.db"
+        rc, obj = _resolve_json(
+            ["--db", str(absent), "--artifact", "plan.md", "--version", "1", "--json"]
+        )
+        assert rc == 11
+        assert obj["reason"] == "db_missing"
+        # The defining assertion: NO db materialized at the absent path.
+        assert not absent.exists()
+        assert not absent.parent.exists()
+
+    def test_corrupt_non_sqlite_file_exit_12_db_corrupt(self, tmp_path: Path) -> None:
+        bad = tmp_path / "garbage.db"
+        bad.write_bytes(b"this is definitely not a sqlite database header\x00\x01")
+        rc, obj = _resolve_json(
+            ["--db", str(bad), "--artifact", "plan.md", "--version", "1", "--json"]
+        )
+        assert rc == 12
+        assert obj["reason"] == "db_corrupt"
+
+    def test_v1_schema_db_exit_12_no_migration(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _build_raw_v1_db(db)
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "1", "--json"]
+        )
+        assert rc == 12
+        assert obj["reason"] == "schema_version_mismatch"
+        # No migration ran: user_version is STILL 1 after the read-only resolve.
+        conn = sqlite3.connect(str(db))
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+        finally:
+            conn.close()
+
+    def test_needs_recovery_exit_12_fault_injected(self, tmp_path: Path, monkeypatch) -> None:
+        # A real post-crash hot-WAL state cannot be created deterministically in
+        # pytest; inject SQLITE_READONLY_RECOVERY on the ro connection's first
+        # user_version read (the Unit 3 fault-injection approach).
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+
+        from ccs.coordinator import sqlite_registry as sr
+
+        class _RecoveryProxy:
+            def __init__(self, real):
+                self._real = real
+
+            def execute(self, sql, *a, **k):
+                if "user_version" in sql:
+                    raise sqlite3.OperationalError(
+                        "attempt to write a readonly database (SQLITE_READONLY_RECOVERY)"
+                    )
+                return self._real.execute(sql, *a, **k)
+
+            def __getattr__(self, n):
+                return getattr(self._real, n)
+
+        real_connect = sqlite3.connect
+
+        def fake_connect(*a, **k):
+            conn = real_connect(*a, **k)
+            if a and "mode=ro" in str(a[0]):
+                return _RecoveryProxy(conn)
+            return conn
+
+        monkeypatch.setattr(sr.sqlite3, "connect", fake_connect)
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2", "--json"]
+        )
+        assert rc == 12
+        assert obj["reason"] == "needs_recovery"
+
+    def test_sqlite_busy_exit_12_db_busy_no_partial_output(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # Under WAL a read-only resolver cannot deterministically hit real
+        # reader-side contention; inject SQLITE_BUSY ("database is locked") on the
+        # ro connection's first read (per the feasibility review).
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+
+        from ccs.coordinator import sqlite_registry as sr
+
+        class _BusyProxy:
+            def __init__(self, real):
+                self._real = real
+
+            def execute(self, sql, *a, **k):
+                if "user_version" in sql:
+                    raise sqlite3.OperationalError("database is locked")
+                return self._real.execute(sql, *a, **k)
+
+            def __getattr__(self, n):
+                return getattr(self._real, n)
+
+        real_connect = sqlite3.connect
+
+        def fake_connect(*a, **k):
+            conn = real_connect(*a, **k)
+            if a and "mode=ro" in str(a[0]):
+                return _BusyProxy(conn)
+            return conn
+
+        monkeypatch.setattr(sr.sqlite3, "connect", fake_connect)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main(["resolve", "--db", str(db), "--artifact", "plan.md", "--version", "2", "--json"])
+        out = buf.getvalue().strip()
+        obj = json.loads(out)
+        assert rc == 12
+        assert obj["reason"] == "db_busy"
+        # No PARTIAL content output — the single object is an error envelope, not
+        # a resolved/rejected payload, and carries no body material.
+        assert obj["kind"] == "error"
+        assert "content" not in obj
+
+    def test_version_below_one_is_usage_error_exit_4(self, tmp_path: Path) -> None:
+        # --version 0 is caller misuse (ValueError from the service), NOT a
+        # resolver reason — surfaced as exit 4.
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "0", "--json"]
+        )
+        assert rc == 4
+        assert obj["reason"] == "usage_error"
+
+    def test_no_output_file_written_on_rejection(self, tmp_path: Path) -> None:
+        # A rejection must not produce a partial output file even if --output-file
+        # was requested (no bytes to write).
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))  # current = 3
+        out = tmp_path / "should-not-exist.bin"
+        rc, _ = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "3",
+             "--output-file", str(out), "--json"]
+        )
+        assert rc == 5  # current_version rejection
+        assert not out.exists()
+
+
+# ===========================================================================
+# NAME → ID LOOKUP — by workspace path, and a typed miss
+# ===========================================================================
+
+
+class TestNameToIdLookup:
+    def test_resolve_by_workspace_path_works(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2",
+             "--include-content", "--json"]
+        )
+        assert rc == 0
+        assert obj["content"] == "c2"
+
+    def test_unknown_path_exit_13_names_the_lookup(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "docs/never-observed.md", "--version", "1", "--json"]
+        )
+        assert rc == 13
+        assert obj["reason"] == "unknown_artifact_path"
+        # The message names the failed path lookup (not a raw stack trace).
+        assert "docs/never-observed.md" in obj["message"]
+
+    def test_unknown_path_human_no_traceback(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        buf = io.StringIO()
+        err = io.StringIO()
+        import contextlib
+
+        with redirect_stdout(buf), contextlib.redirect_stderr(err):
+            rc = main(["resolve", "--db", str(db), "--artifact", "no/such/path.md", "--version", "1"])
+        assert rc == 13
+        # A clean message, never a Python traceback.
+        assert "Traceback" not in err.getvalue()
+        assert "no/such/path.md" in err.getvalue()
+
+
+# ===========================================================================
+# INSTANCE-ID CROSS-CHECK — identity guard before serving any bytes
+# ===========================================================================
+
+
+class TestInstanceIdCrossCheck:
+    def test_matching_instance_id_serves(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        # Read the store's persisted instance_id via a read-only registry.
+        with SqliteArtifactRegistry(db, read_only=True) as ro:
+            inst = ro._instance_id
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2",
+             "--instance-id", inst, "--include-content", "--json"]
+        )
+        assert rc == 0
+        assert obj["content"] == "c2"
+
+    def test_mismatched_instance_id_exit_11(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        rc, obj = _resolve_json(
+            ["--db", str(db), "--artifact", "plan.md", "--version", "2",
+             "--instance-id", "wrong-instance", "--json"]
+        )
+        assert rc == 11
+        assert obj["reason"] == "instance_id_mismatch"
+        # Identity guard fires BEFORE any bytes are served — no content leaked.
+        assert "content" not in obj
+
+
+# ===========================================================================
+# RESOLVER LIBRARY SURFACE — resolve_version returns typed results / raises
+# typed errors (the CLI is a thin shell over this; pin the library too)
+# ===========================================================================
+
+
+class TestResolverLibrarySurface:
+    def test_resolve_version_returns_versioned_content(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        art = _write_store(db, ("c1", "c2", "c3"))
+        out = resolve_version(
+            ResolverRequest(db_path=db, selector="plan.md", version=2)
+        )
+        assert isinstance(out, VersionedContent)
+        assert out.content == "c2"
+        assert out.artifact_id == art.id
+
+    def test_resolve_version_returns_rejection(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        out = resolve_version(
+            ResolverRequest(db_path=db, selector="plan.md", version=3)
+        )
+        assert isinstance(out, VersionedReadRejection)
+        assert out.reason == CURRENT_VERSION_REASON
+
+    def test_resolve_version_missing_db_raises_and_creates_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        absent = tmp_path / "void" / "state.db"
+        with pytest.raises(ResolverMissingDatabaseError):
+            resolve_version(ResolverRequest(db_path=absent, selector="plan.md", version=1))
+        assert not absent.exists()
+
+    def test_resolve_version_v1_db_raises_schema_error(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _build_raw_v1_db(db)
+        with pytest.raises(ResolverSchemaVersionError):
+            resolve_version(ResolverRequest(db_path=db, selector="plan.md", version=1))
+
+    def test_resolve_version_corrupt_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.db"
+        bad.write_bytes(b"not-a-db" * 10)
+        with pytest.raises(ResolverCorruptDatabaseError):
+            resolve_version(ResolverRequest(db_path=bad, selector="plan.md", version=1))
+
+    def test_resolve_version_unknown_path_raises_named(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        with pytest.raises(ResolverUnknownArtifactPathError, match="missing.md"):
+            resolve_version(ResolverRequest(db_path=db, selector="missing.md", version=1))
+
+    def test_resolve_version_instance_mismatch_raises(self, tmp_path: Path) -> None:
+        db = tmp_path / "state.db"
+        _write_store(db, ("c1", "c2", "c3"))
+        with pytest.raises(ResolverInstanceMismatchError):
+            resolve_version(
+                ResolverRequest(
+                    db_path=db, selector="plan.md", version=2,
+                    expected_instance_id="nope",
+                )
+            )
+
+
+# ===========================================================================
+# BACKWARD-COMPAT — the existing positional invocation is byte-identical
+# ===========================================================================
+
+
+class TestBackwardCompat:
+    """Adding the resolve mode must not change the default invariant-replay
+    behavior at all. These mirror tests/test_cli_coherence_replay.py."""
+
+    def _clean_session(self, tmp_path: Path) -> Path:
+        session = tmp_path / "clean"
+        session.mkdir(parents=True, exist_ok=True)
+        manifest = {
+            "schema_version": 0,
+            "schema_note": "test fixture",
+            "adapter_type": "test-fixture",
+            "start_tick": 0,
+            "end_tick": 10,
+            "instance_id": "instance-A",
+            "streams": ["state_log"],
+            "agents": {},
+            "artifacts": {},
+        }
+        (session / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+        entries = [
+            {
+                "tick": 0, "artifact_id": "art-1", "agent_id": "agent-1",
+                "agent_name": "agent-1", "from_state": "INVALID",
+                "to_state": "EXCLUSIVE", "trigger": "write", "version": 1,
+                "content_hash": "abc", "sequence_number": 1,
+                "instance_id": "instance-A", "schema_version": "ccs.state_log.v2",
+            },
+        ]
+        with (session / "state_log.jsonl").open("w", encoding="utf-8") as fh:
+            for e in entries:
+                fh.write(json.dumps(e) + "\n")
+        return session
+
+    def test_bare_positional_clean_trace_exits_zero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        session = self._clean_session(tmp_path)
+        rc = main([str(session)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "0 CONFIRMED" in out
+
+    def test_bare_positional_missing_dir_exit_3(self, tmp_path: Path) -> None:
+        rc = main([str(tmp_path / "does-not-exist")])
+        assert rc == 3
+
+    def test_bare_positional_parser_unchanged_shape(self) -> None:
+        # The default parser still accepts a single positional + the original
+        # flag set, and nothing about resolve leaked into it.
+        ns = build_parser().parse_args(["/tmp/session", "--json", "--quiet"])
+        assert ns.session_dir == Path("/tmp/session")
+        assert ns.json is True and ns.quiet is True
+        # No resolve-only attribute exists on the default namespace.
+        for resolve_only in ("db", "artifact", "version", "include_content"):
+            assert not hasattr(ns, resolve_only)
+
+    def test_help_documents_the_resolve_mode(self) -> None:
+        help_text = build_parser().format_help()
+        assert "agent-coherence-replay" in help_text
+        assert "replay_trace_format.md" in help_text  # original content intact
+        assert "resolve" in help_text  # new mode advertised
+
+    def test_resolve_help_documents_content_safety(self) -> None:
+        from ccs.cli.coherence_replay import build_resolve_parser
+
+        help_text = build_resolve_parser().format_help()
+        assert "--include-content" in help_text
+        assert "--output-file" in help_text
+        assert "--db" in help_text and "--artifact" in help_text and "--version" in help_text
+
+
+# ---------------------------------------------------------------------------
+# Raw v1 db builder (mirrors tests/test_sqlite_registry.py::_build_raw_v1_db)
+# ---------------------------------------------------------------------------
+
+
+def _build_raw_v1_db(db_path: Path) -> str:
+    """Construct a RAW v1 ``state.db`` BY HAND (full-shim variant) for the
+    read-only-resolver schema-error path. Returns the artifact id hex.
+
+    The resolver must reject a v1 db with a typed schema error and perform NO
+    migration; this builds a complete v1 (fence columns + pending_notices +
+    epoch seed) at ``user_version=1`` so the resolver's read-only open hits the
+    version mismatch, not a missing-column error.
+    """
+    art_id, ag_id = uuid4().hex, uuid4().hex
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            "CREATE TABLE artifacts (id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE, "
+            "version INTEGER NOT NULL, owner_generation INTEGER NOT NULL DEFAULT 0, "
+            "content_hash TEXT NOT NULL, size_tokens INTEGER, last_writer_id TEXT, "
+            "updated_at REAL NOT NULL)"
+        )
+        conn.execute("CREATE INDEX idx_artifacts_name ON artifacts(name)")
+        conn.execute(
+            "CREATE TABLE agent_states (artifact_id TEXT NOT NULL, agent_id TEXT NOT NULL, "
+            "state TEXT NOT NULL, transient_state TEXT, transient_tick INTEGER, "
+            "granted_at_tick INTEGER, last_reclaim_trigger TEXT, last_reclaim_tick INTEGER, "
+            "read_generation INTEGER, PRIMARY KEY (artifact_id, agent_id), "
+            "FOREIGN KEY (artifact_id) REFERENCES artifacts(id) ON DELETE CASCADE)"
+        )
+        conn.execute(
+            "CREATE TABLE heartbeats (agent_id TEXT PRIMARY KEY, last_tick INTEGER NOT NULL)"
+        )
+        conn.execute("CREATE TABLE registry_meta (key TEXT PRIMARY KEY, value TEXT)")
+        conn.executemany(
+            "INSERT INTO registry_meta (key, value) VALUES (?, ?)",
+            [("instance_id", "wild-v1"), ("sequence_number", "0"),
+             ("coordinator_epoch", "epoch-pre-migration")],
+        )
+        conn.execute(
+            "CREATE TABLE pending_notices (agent_id TEXT NOT NULL, artifact_id TEXT NOT NULL, "
+            "preempter_agent_id TEXT NOT NULL, preempted_at_unix_ts REAL NOT NULL, "
+            "PRIMARY KEY (agent_id, artifact_id), "
+            "FOREIGN KEY (artifact_id) REFERENCES artifacts(id) ON DELETE CASCADE)"
+        )
+        conn.execute(
+            "INSERT INTO artifacts (id, name, version, owner_generation, content_hash, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (art_id, "plan.md", 3, 0, "deadbeef", 1.0),
+        )
+        conn.execute(
+            "INSERT INTO agent_states (artifact_id, agent_id, state) VALUES (?, ?, ?)",
+            (art_id, ag_id, "M"),
+        )
+        conn.execute("PRAGMA user_version = 1")
+        conn.execute("COMMIT")
+    finally:
+        conn.close()
+    return art_id

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -58,6 +58,19 @@ def _register(reg, *, version: int = 1, content: str = "v1") -> Artifact:
     return art
 
 
+def _history_snapshot(reg, artifact_id, max_version: int = 8) -> dict[int, object]:
+    """Retained-history snapshot via the PUBLIC accessor only.
+
+    ``{version: body_or_None}`` over a fixed version range — the
+    no-mutation assertions compare two of these instead of reaching into
+    ``reg._records`` (the test_retention_parity.py ``_content_map`` pattern).
+    """
+    return {
+        v: reg.get_content_at_version(artifact_id, v)
+        for v in range(1, max_version + 1)
+    }
+
+
 # ===========================================================================
 # Part A — collectible_versions: the single pure GC seam (R1, R4)
 # ===========================================================================
@@ -310,10 +323,10 @@ class TestNoCaptureOnRejectedWrites:
         art = _register(reg, version=5, content="seed")
         writer = uuid4()
         reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
-        before = dict(reg._records[art.id].version_history)
+        before = _history_snapshot(reg, art.id)
         res = reg.commit_cas(art.id, writer, expected_version=3, content_hash="h", content="should-not-store", tick=2)
         assert isinstance(res, ConflictDetail)
-        assert reg._records[art.id].version_history == before
+        assert _history_snapshot(reg, art.id) == before
 
     def test_commit_cas_other_holder_no_capture(self):
         # ConflictDetail("other_holder") — a peer holds EXCLUSIVE → no mutation.
@@ -322,10 +335,10 @@ class TestNoCaptureOnRejectedWrites:
         writer, peer = uuid4(), uuid4()
         reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
         reg.set_agent_state(art.id, peer, MESIState.EXCLUSIVE, tick=2)
-        before = dict(reg._records[art.id].version_history)
+        before = _history_snapshot(reg, art.id)
         res = reg.commit_cas(art.id, writer, expected_version=5, content_hash="h", content="should-not-store", tick=3)
         assert isinstance(res, ConflictDetail)
-        assert reg._records[art.id].version_history == before
+        assert _history_snapshot(reg, art.id) == before
 
     def test_commit_cas_corruption_no_capture(self):
         # CasCorruption — expected > current → no mutation.
@@ -333,10 +346,10 @@ class TestNoCaptureOnRejectedWrites:
         art = _register(reg, version=5, content="seed")
         writer = uuid4()
         reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
-        before = dict(reg._records[art.id].version_history)
+        before = _history_snapshot(reg, art.id)
         res = reg.commit_cas(art.id, writer, expected_version=99, content_hash="h", content="should-not-store", tick=2)
         assert isinstance(res, CasCorruption)
-        assert reg._records[art.id].version_history == before
+        assert _history_snapshot(reg, art.id) == before
 
     def test_set_artifact_and_content_fence_reject_no_capture(self):
         # StaleReadGeneration — the pessimistic-commit fence rejects a committer
@@ -350,11 +363,34 @@ class TestNoCaptureOnRejectedWrites:
         # A sweep reclamation bumps owner_generation past the captured read_gen.
         reg.set_agent_state(art.id, committer, MESIState.INVALID, trigger="reclaim_heartbeat", tick=2)
         assert reg.get_owner_generation(art.id) == 1
-        before = dict(reg._records[art.id].version_history)
+        before = _history_snapshot(reg, art.id)
         nxt = Artifact(id=art.id, name="plan.md", version=2, content_hash="h")
         with pytest.raises(StaleReadGeneration):
             reg.set_artifact_and_content(art.id, nxt, "should-not-store", fence_agent_id=committer)
-        assert reg._records[art.id].version_history == before
+        assert _history_snapshot(reg, art.id) == before
+
+
+class TestGetVersionRecordGcWindow:
+    """get_version_record under a mid-read inline GC: absent ⇒ None, never
+    KeyError (the read_at_version never-raise contract)."""
+
+    def test_half_collected_row_returns_none_not_keyerror(self):
+        # Deterministic stand-in for the GIL window: a peer thread's inline GC
+        # pops version_history[v] then version_captured_at[v]; a reader that
+        # saw the body before the pop can find the STAMP already gone. Freeze
+        # that exact intermediate state (private-attr setup is the only way to
+        # hold the window open — the test_fencing.py race-setup precedent) and
+        # pin the contract: the row reads as absent, no KeyError escapes.
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=RetentionPolicy(max_versions=8))
+        art = _register(reg, version=1, content="c1")
+        nxt = Artifact(id=art.id, name="plan.md", version=2, content_hash="h")
+        reg.set_artifact_and_content(art.id, nxt, "c2")
+        # Window: the stamp for v1 is collected; the body briefly survives.
+        del reg._records[art.id].version_captured_at[1]
+        assert reg.get_version_record(art.id, 1) is None  # not KeyError
+        # An intact row still reads normally.
+        record = reg.get_version_record(art.id, 2)
+        assert record is not None and record[0] == "c2"
 
 
 class TestRemoveArtifactDropsHistory:

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -9,10 +9,11 @@ amortized GC), **R3** (all three capture points retain), **R4** (GC invisible to
 the protocol, current never collected, exemption-extensible).
 
 This file ESTABLISHES the parametrized dual-registry fixture (the
-``tests/test_fencing.py:27-35`` pattern). The ``sqlite`` arm is xfail-marked for
-retention specifics until Unit 3 lands durable retention — Unit 3 flips it on by
-deleting the xfail marker. Units 3-5 extend/consolidate this fixture; per-reason
-service scenarios arrive with Unit 4's ``read_at_version``.
+``tests/test_fencing.py:27-35`` pattern). Unit 3 landed durable sqlite retention,
+so the ``sqlite`` arm is now ACTIVE (the xfail marker was removed and the ctor
+takes ``retention_policy``); the parity scenarios run against both registries.
+Units 4-5 extend/consolidate this fixture; per-reason service scenarios arrive
+with Unit 4's ``read_at_version``.
 """
 
 from __future__ import annotations
@@ -31,44 +32,23 @@ from ccs.core.states import MESIState
 from ccs.core.types import Artifact, CasCorruption, ConflictDetail
 
 # ---------------------------------------------------------------------------
-# Dual-registry fixture (established here; Unit 3 enables the sqlite arm)
+# Dual-registry fixture (both arms ACTIVE as of Unit 3)
 # ---------------------------------------------------------------------------
 
-# Durable retention lands in Unit 3. Until then the sqlite registry raises
-# NotImplementedError on retain_versions=True, so retention-specific scenarios
-# cannot run against it. The fixture is structured exactly like
-# test_fencing.py's so Unit 3 only has to drop this xfail marker — the parity
-# scenarios are already written against `registry` and will light up for free.
-_SQLITE_RETENTION_PENDING = pytest.param(
-    "sqlite",
-    marks=pytest.mark.xfail(
-        reason="durable retention lands in Unit 3; sqlite retain_versions "
-        "raises NotImplementedError today",
-        raises=NotImplementedError,
-        strict=False,
-    ),
-)
 
-
-@pytest.fixture(params=["in_memory", _SQLITE_RETENTION_PENDING])
+@pytest.fixture(params=["in_memory", "sqlite"])
 def retention_registry(request, tmp_path: Path):
     """Yield each registry with a bounded policy (K=2) so the SAME retention
-    scenarios run against both. The sqlite arm is xfail until Unit 3.
-
-    NOTE for Unit 3: ``SqliteArtifactRegistry.__init__`` does not accept
-    ``retention_policy`` yet — it raises ``NotImplementedError`` on
-    ``retain_versions=True`` before any policy kwarg would bind. The sqlite arm
-    therefore constructs WITHOUT a policy today (the xfail catches that raise).
-    Unit 3 adds the ``retention_policy`` parameter to the sqlite ctor, drops the
-    xfail marker, and passes ``retention_policy=policy`` here — the parity
-    scenarios below already run against ``retention_registry`` and light up
-    automatically."""
+    scenarios run against both. Unit 3 enabled the sqlite arm (durable
+    ``artifact_versions`` table + ``retention_policy`` ctor param); the parity
+    scenarios below run identically on both registries."""
     policy = RetentionPolicy(max_versions=2)
     if request.param == "in_memory":
         yield ArtifactRegistry(retain_versions=True, retention_policy=policy)
     else:
-        # Unit 3: add retention_policy=policy once the sqlite ctor accepts it.
-        with SqliteArtifactRegistry(tmp_path / "state.db", retain_versions=True) as reg:
+        with SqliteArtifactRegistry(
+            tmp_path / "state.db", retain_versions=True, retention_policy=policy
+        ) as reg:
             yield reg
 
 

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,410 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Bounded version retention — policy unit tests + in-memory registry behavior.
+
+Plan item N v1, Unit 2 (``docs/plans/2026-06-10-001-feat-version-retention-
+read-at-version-plan.md``). Requirement trace: **R1** (bounded K/T retention,
+amortized GC), **R3** (all three capture points retain), **R4** (GC invisible to
+the protocol, current never collected, exemption-extensible).
+
+This file ESTABLISHES the parametrized dual-registry fixture (the
+``tests/test_fencing.py:27-35`` pattern). The ``sqlite`` arm is xfail-marked for
+retention specifics until Unit 3 lands durable retention — Unit 3 flips it on by
+deleting the xfail marker. Units 3-5 extend/consolidate this fixture; per-reason
+service scenarios arrive with Unit 4's ``read_at_version``.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.retention import RetentionPolicy, collectible_versions
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.exceptions import StaleReadGeneration
+from ccs.core.states import MESIState
+from ccs.core.types import Artifact, CasCorruption, ConflictDetail
+
+# ---------------------------------------------------------------------------
+# Dual-registry fixture (established here; Unit 3 enables the sqlite arm)
+# ---------------------------------------------------------------------------
+
+# Durable retention lands in Unit 3. Until then the sqlite registry raises
+# NotImplementedError on retain_versions=True, so retention-specific scenarios
+# cannot run against it. The fixture is structured exactly like
+# test_fencing.py's so Unit 3 only has to drop this xfail marker — the parity
+# scenarios are already written against `registry` and will light up for free.
+_SQLITE_RETENTION_PENDING = pytest.param(
+    "sqlite",
+    marks=pytest.mark.xfail(
+        reason="durable retention lands in Unit 3; sqlite retain_versions "
+        "raises NotImplementedError today",
+        raises=NotImplementedError,
+        strict=False,
+    ),
+)
+
+
+@pytest.fixture(params=["in_memory", _SQLITE_RETENTION_PENDING])
+def retention_registry(request, tmp_path: Path):
+    """Yield each registry with a bounded policy (K=2) so the SAME retention
+    scenarios run against both. The sqlite arm is xfail until Unit 3.
+
+    NOTE for Unit 3: ``SqliteArtifactRegistry.__init__`` does not accept
+    ``retention_policy`` yet — it raises ``NotImplementedError`` on
+    ``retain_versions=True`` before any policy kwarg would bind. The sqlite arm
+    therefore constructs WITHOUT a policy today (the xfail catches that raise).
+    Unit 3 adds the ``retention_policy`` parameter to the sqlite ctor, drops the
+    xfail marker, and passes ``retention_policy=policy`` here — the parity
+    scenarios below already run against ``retention_registry`` and light up
+    automatically."""
+    policy = RetentionPolicy(max_versions=2)
+    if request.param == "in_memory":
+        yield ArtifactRegistry(retain_versions=True, retention_policy=policy)
+    else:
+        # Unit 3: add retention_policy=policy once the sqlite ctor accepts it.
+        with SqliteArtifactRegistry(tmp_path / "state.db", retain_versions=True) as reg:
+            yield reg
+
+
+def _register(reg, *, version: int = 1, content: str = "v1") -> Artifact:
+    art = Artifact(id=uuid4(), name="plan.md", version=version, content_hash="h")
+    reg.register_artifact(art, content=content)
+    return art
+
+
+# ===========================================================================
+# Part A — collectible_versions: the single pure GC seam (R1, R4)
+# ===========================================================================
+
+
+class TestCollectibleVersions:
+    """The pure GC decision function — exhaustively unit-tested in isolation so
+    the eviction rule is pinned independent of either registry."""
+
+    def test_empty_history_collects_nothing(self):
+        # R4: nothing to collect, including the current version itself.
+        assert collectible_versions([], current_version=1, policy=RetentionPolicy(max_versions=2), now=0.0) == set()
+
+    def test_k_only_drops_oldest_beyond_k(self):
+        # R1 K-axis: keep the K=2 most-recent (incl. current=3) → drop {1}.
+        assert collectible_versions(
+            [1, 2, 3], current_version=3, policy=RetentionPolicy(max_versions=2), now=0.0
+        ) == {1}
+
+    def test_k_one_keeps_only_current(self):
+        # K=1 → only the current row survives; all older versions drop.
+        assert collectible_versions(
+            [1, 2, 3], current_version=3, policy=RetentionPolicy(max_versions=1), now=0.0
+        ) == {1, 2}
+
+    def test_current_never_collected_even_if_oldest(self):
+        # R4: the current version is exempt regardless of K ranking. Here
+        # current=1 is the OLDEST of {1,2,3}; K=2 would rank it out, but the
+        # exempt floor keeps it — {2,3} kept by K, 1 kept as current → drop none.
+        assert collectible_versions(
+            [1, 2, 3], current_version=1, policy=RetentionPolicy(max_versions=2), now=0.0
+        ) == set()
+
+    def test_none_k_axis_disables_count_bound(self):
+        # max_versions=None → K axis off; with T also None, nothing collects.
+        assert collectible_versions(
+            [1, 2, 3, 4, 5], current_version=5,
+            policy=RetentionPolicy(max_versions=None, max_age_seconds=None), now=0.0,
+        ) == set()
+
+    def test_t_only_drops_versions_older_than_cutoff(self):
+        # R1 T-axis: a version captured before now - max_age is collectible.
+        # now=100, max_age=10 → cutoff=90; v1@50 and v2@80 expired, v3@95 fresh.
+        ts = {1: 50.0, 2: 80.0, 3: 95.0}
+        assert collectible_versions(
+            ts, current_version=3, policy=RetentionPolicy(max_versions=None, max_age_seconds=10.0), now=100.0
+        ) == {1, 2}
+
+    def test_t_axis_current_never_expires(self):
+        # R4: even an "old" current version is exempt from T expiry.
+        ts = {1: 0.0, 2: 0.0}
+        assert collectible_versions(
+            ts, current_version=2, policy=RetentionPolicy(max_versions=None, max_age_seconds=1.0), now=1000.0
+        ) == {1}  # v2 is current → exempt; v1 expired.
+
+    def test_t_axis_noop_without_timestamps(self):
+        # A bare-iterable call (no timestamps) cannot age anything — T is a
+        # no-op; only the K axis can act on a plain list.
+        assert collectible_versions(
+            [1, 2, 3], current_version=3,
+            policy=RetentionPolicy(max_versions=None, max_age_seconds=1.0), now=1e9,
+        ) == set()
+
+    def test_k_and_t_union(self):
+        # Both axes active → drop set is the union. K=2 would drop {1}; T
+        # (cutoff 90) also expires v2@80 → union {1, 2}.
+        ts = {1: 50.0, 2: 80.0, 3: 95.0}
+        assert collectible_versions(
+            ts, current_version=3, policy=RetentionPolicy(max_versions=2, max_age_seconds=10.0), now=100.0
+        ) == {1, 2}
+
+    def test_exemptions_honored(self):
+        # R4 SB-17 seam: a pinned version is never collected even when both
+        # axes would drop it. K=1 + old timestamps would drop {1,2}; pinning 1
+        # rescues it → only {2} drops.
+        ts = {1: 0.0, 2: 0.0, 3: 100.0}
+        assert collectible_versions(
+            ts, current_version=3,
+            policy=RetentionPolicy(max_versions=1, max_age_seconds=1.0), now=1000.0,
+            exemptions={1},
+        ) == {2}
+
+
+class TestRetentionPolicyValidation:
+    """__post_init__ rejects nonsensical bounds (house fail-fast style)."""
+
+    def test_max_versions_zero_raises(self):
+        with pytest.raises(ValueError, match="max_versions must be >= 1"):
+            RetentionPolicy(max_versions=0)
+
+    def test_max_versions_negative_raises(self):
+        with pytest.raises(ValueError, match="max_versions must be >= 1"):
+            RetentionPolicy(max_versions=-3)
+
+    def test_max_age_zero_raises(self):
+        with pytest.raises(ValueError, match="max_age_seconds must be > 0"):
+            RetentionPolicy(max_age_seconds=0)
+
+    def test_max_age_negative_raises(self):
+        with pytest.raises(ValueError, match="max_age_seconds must be > 0"):
+            RetentionPolicy(max_age_seconds=-1.0)
+
+    def test_none_axes_are_valid(self):
+        # Both axes disabled is a legal (unbounded) policy object.
+        policy = RetentionPolicy(max_versions=None, max_age_seconds=None)
+        assert policy.max_versions is None
+        assert policy.max_age_seconds is None
+
+    def test_defaults(self):
+        # Documented defaults: K=16, T off.
+        policy = RetentionPolicy()
+        assert policy.max_versions == 16
+        assert policy.max_age_seconds is None
+
+
+# ===========================================================================
+# Part B — in-memory ArtifactRegistry bounded retention (R1, R3, R4)
+# ===========================================================================
+
+
+class TestBoundedRetentionInMemory:
+    """K-eviction across the capture points on the in-memory registry."""
+
+    def test_k2_over_three_commits_keeps_two_drops_oldest(self):
+        # R1: policy K=2 over 3 commits keeps {2,3}, drops 1 (current=3).
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=RetentionPolicy(max_versions=2))
+        art = _register(reg, version=1, content="c1")
+        for v, body in ((2, "c2"), (3, "c3")):
+            nxt = Artifact(id=art.id, name="plan.md", version=v, content_hash="h")
+            reg.set_artifact_and_content(art.id, nxt, body)
+        assert reg.get_content_at_version(art.id, 1) is None  # collected
+        assert reg.get_content_at_version(art.id, 2) == "c2"
+        assert reg.get_content_at_version(art.id, 3) == "c3"
+
+    def test_k1_keeps_only_current(self):
+        # R4 floor: K=1 → only the current row survives each commit.
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=RetentionPolicy(max_versions=1))
+        art = _register(reg, version=1, content="c1")
+        nxt = Artifact(id=art.id, name="plan.md", version=2, content_hash="h")
+        reg.set_artifact_and_content(art.id, nxt, "c2")
+        assert reg.get_content_at_version(art.id, 1) is None
+        assert reg.get_content_at_version(art.id, 2) == "c2"
+
+    def test_unbounded_policy_none_keeps_all(self):
+        # Back-compat: retain_versions=True + policy=None == today's unbounded
+        # semantics. GC never runs; every version survives.
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=None)
+        art = _register(reg, version=1, content="c1")
+        for v, body in ((2, "c2"), (3, "c3"), (4, "c4")):
+            nxt = Artifact(id=art.id, name="plan.md", version=v, content_hash="h")
+            reg.set_artifact_and_content(art.id, nxt, body)
+        assert reg.get_content_at_version(art.id, 1) == "c1"
+        assert reg.get_content_at_version(art.id, 4) == "c4"
+
+    def test_retain_versions_false_ignores_policy(self):
+        # Retention only activates on retain_versions=True; a policy alone does
+        # nothing when retain_versions is False (the active-iff contract).
+        reg = ArtifactRegistry(retain_versions=False, retention_policy=RetentionPolicy(max_versions=2))
+        art = _register(reg, version=1, content="c1")
+        assert reg.get_content_at_version(art.id, 1) is None
+
+    def test_t_expiry_via_monkeypatched_clock(self, monkeypatch):
+        # R1 T-axis end-to-end: capture v1 at t=0, advance the clock past
+        # max_age, capture v2 → v1 is physically dropped at the next capture.
+        clock = {"now": 0.0}
+        monkeypatch.setattr(time, "time", lambda: clock["now"])
+        reg = ArtifactRegistry(
+            retain_versions=True,
+            retention_policy=RetentionPolicy(max_versions=None, max_age_seconds=10.0),
+        )
+        art = _register(reg, version=1, content="c1")
+        assert reg.get_content_at_version(art.id, 1) == "c1"  # fresh at capture
+        clock["now"] = 100.0  # well past the 10s horizon
+        nxt = Artifact(id=art.id, name="plan.md", version=2, content_hash="h")
+        reg.set_artifact_and_content(art.id, nxt, "c2")
+        assert reg.get_content_at_version(art.id, 1) is None  # T-expired + swept
+        assert reg.get_content_at_version(art.id, 2) == "c2"  # current survives
+
+
+class TestCapturePointsRetain:
+    """R3: all three capture points snapshot under retention (str and bytes)."""
+
+    def test_register_artifact_captures(self):
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=RetentionPolicy(max_versions=4))
+        art = _register(reg, version=1, content="seed")
+        assert reg.get_content_at_version(art.id, 1) == "seed"
+
+    def test_pessimistic_set_artifact_and_content_captures(self):
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=RetentionPolicy(max_versions=4))
+        art = _register(reg, version=1, content="seed")
+        nxt = Artifact(id=art.id, name="plan.md", version=2, content_hash="h")
+        reg.set_artifact_and_content(art.id, nxt, "pessimistic-v2")
+        assert reg.get_content_at_version(art.id, 2) == "pessimistic-v2"
+
+    def test_commit_cas_win_captures_str_body(self):
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=RetentionPolicy(max_versions=4))
+        art = _register(reg, version=1, content="seed")
+        writer = uuid4()
+        reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
+        reg.commit_cas(art.id, writer, expected_version=1, content_hash="h-new", content="cas-v2", tick=2)
+        assert reg.get_content_at_version(art.id, 2) == "cas-v2"
+
+    def test_commit_cas_win_captures_bytes_body(self):
+        # The in-process library path threads bytes; the corrected annotation
+        # admits them and a versioned read returns the exact bytes.
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=RetentionPolicy(max_versions=4))
+        art = _register(reg, version=1, content="seed")
+        writer = uuid4()
+        reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
+        reg.commit_cas(art.id, writer, expected_version=1, content_hash="h-new", content=b"\x00\x01bytes-v2", tick=2)
+        assert reg.get_content_at_version(art.id, 2) == b"\x00\x01bytes-v2"
+
+
+class TestCommitCasContentNoneSkipsCapture:
+    """The history-poisoning fix: content=None WIN retains NO row (R-fix)."""
+
+    def test_content_none_win_skips_capture(self):
+        # Pre-fix bug: the None path retained the OLD body under the NEW
+        # version. Now next_version is simply not captured → read misses.
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=RetentionPolicy(max_versions=8))
+        art = _register(reg, version=1, content="seed-v1")
+        writer = uuid4()
+        reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
+        updated, _ = reg.commit_cas(art.id, writer, expected_version=1, content_hash="h-new", content=None, tick=2)
+        # Version advanced per existing semantics ...
+        assert updated.version == 2
+        assert reg.get_artifact(art.id).version == 2
+        # ... but the NEW version has NO retained snapshot (no stale OLD body).
+        assert reg.get_content_at_version(art.id, 2) is None
+        # The old version's snapshot is untouched (still the original body).
+        assert reg.get_content_at_version(art.id, 1) == "seed-v1"
+
+    def test_content_none_win_unbounded_also_skips(self):
+        # Same fix under the unbounded (policy=None) mode — the v0.5 path.
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=None)
+        art = _register(reg, version=1, content="seed-v1")
+        writer = uuid4()
+        reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
+        reg.commit_cas(art.id, writer, expected_version=1, content_hash="h-new", content=None, tick=2)
+        assert reg.get_content_at_version(art.id, 2) is None
+        assert reg.get_content_at_version(art.id, 1) == "seed-v1"
+
+
+class TestNoCaptureOnRejectedWrites:
+    """R4/R3: a write that does NOT mutate leaves history unchanged."""
+
+    def test_commit_cas_version_mismatch_no_capture(self):
+        # ConflictDetail("version_mismatch") — expected < current → no mutation.
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=RetentionPolicy(max_versions=8))
+        art = _register(reg, version=5, content="seed")
+        writer = uuid4()
+        reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
+        before = dict(reg._records[art.id].version_history)
+        res = reg.commit_cas(art.id, writer, expected_version=3, content_hash="h", content="should-not-store", tick=2)
+        assert isinstance(res, ConflictDetail)
+        assert reg._records[art.id].version_history == before
+
+    def test_commit_cas_other_holder_no_capture(self):
+        # ConflictDetail("other_holder") — a peer holds EXCLUSIVE → no mutation.
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=RetentionPolicy(max_versions=8))
+        art = _register(reg, version=5, content="seed")
+        writer, peer = uuid4(), uuid4()
+        reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
+        reg.set_agent_state(art.id, peer, MESIState.EXCLUSIVE, tick=2)
+        before = dict(reg._records[art.id].version_history)
+        res = reg.commit_cas(art.id, writer, expected_version=5, content_hash="h", content="should-not-store", tick=3)
+        assert isinstance(res, ConflictDetail)
+        assert reg._records[art.id].version_history == before
+
+    def test_commit_cas_corruption_no_capture(self):
+        # CasCorruption — expected > current → no mutation.
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=RetentionPolicy(max_versions=8))
+        art = _register(reg, version=5, content="seed")
+        writer = uuid4()
+        reg.set_agent_state(art.id, writer, MESIState.SHARED, tick=1)
+        before = dict(reg._records[art.id].version_history)
+        res = reg.commit_cas(art.id, writer, expected_version=99, content_hash="h", content="should-not-store", tick=2)
+        assert isinstance(res, CasCorruption)
+        assert reg._records[art.id].version_history == before
+
+    def test_set_artifact_and_content_fence_reject_no_capture(self):
+        # StaleReadGeneration — the pessimistic-commit fence rejects a committer
+        # whose captured read_generation was superseded by a sweep reclamation.
+        # The raise must leave version_history untouched (no phantom snapshot).
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=RetentionPolicy(max_versions=8))
+        art = _register(reg, version=1, content="seed")
+        committer = uuid4()
+        # Establish a fence claim (captures read_generation=0 at owner_gen=0).
+        reg.set_agent_state(art.id, committer, MESIState.EXCLUSIVE, trigger="write", tick=1)
+        # A sweep reclamation bumps owner_generation past the captured read_gen.
+        reg.set_agent_state(art.id, committer, MESIState.INVALID, trigger="reclaim_heartbeat", tick=2)
+        assert reg.get_owner_generation(art.id) == 1
+        before = dict(reg._records[art.id].version_history)
+        nxt = Artifact(id=art.id, name="plan.md", version=2, content_hash="h")
+        with pytest.raises(StaleReadGeneration):
+            reg.set_artifact_and_content(art.id, nxt, "should-not-store", fence_agent_id=committer)
+        assert reg._records[art.id].version_history == before
+
+
+class TestRemoveArtifactDropsHistory:
+    """R4: deleting an artifact drops its retained history with the record."""
+
+    def test_remove_drops_history(self):
+        reg = ArtifactRegistry(retain_versions=True, retention_policy=RetentionPolicy(max_versions=8))
+        art = _register(reg, version=1, content="seed")
+        assert reg.get_content_at_version(art.id, 1) == "seed"
+        reg.remove_artifact(art.id)
+        # Deleted ≡ never-existed: the record (and its history) is gone.
+        assert reg.get_content_at_version(art.id, 1) is None
+
+
+# ===========================================================================
+# Part C — dual-registry parity scaffold (in_memory now; sqlite via Unit 3)
+# ===========================================================================
+
+
+class TestDualRegistryRetentionParity:
+    """The parametrized harness Units 3-5 extend. Runs the K=2 eviction
+    scenario against the `retention_registry` fixture so the sqlite arm lights
+    up the moment Unit 3 drops its xfail marker."""
+
+    def test_k2_eviction_parity(self, retention_registry):
+        reg = retention_registry  # K=2 policy from the fixture
+        art = _register(reg, version=1, content="c1")
+        for v, body in ((2, "c2"), (3, "c3")):
+            nxt = Artifact(id=art.id, name="plan.md", version=v, content_hash="h")
+            reg.set_artifact_and_content(art.id, nxt, body)
+        assert reg.get_content_at_version(art.id, 1) is None  # evicted at K=2
+        assert reg.get_content_at_version(art.id, 2) == "c2"
+        assert reg.get_content_at_version(art.id, 3) == "c3"

--- a/tests/test_retention_parity.py
+++ b/tests/test_retention_parity.py
@@ -1,0 +1,572 @@
+# Copyright (c) 2026 Arbiter contributors.
+# The Coherence Protocol for AI Agents
+
+"""Cross-registry retention parity — the genuinely net-new Unit 5 scenarios.
+
+Plan item N v1, Unit 5 (``docs/plans/2026-06-10-001-feat-version-retention-
+read-at-version-plan.md``). Requirement trace: **R3** (parity), suite-wide
+success criteria.
+
+This file is DELIBERATELY SMALL. Units 2-4 already established extensive
+both-registry coverage:
+
+- ``tests/test_retention.py`` runs a parametrized ``retention_registry`` fixture
+  (in_memory + sqlite) over per-capture-point capture, K-eviction, T-expiry,
+  ``content=None`` skip, no-capture-on-reject, and remove-drops-history.
+- ``tests/test_read_at_version.py`` runs a parametrized ``make_registry`` factory
+  (in_memory + sqlite) over the full per-reason matrix, fence non-capture (R6),
+  MESI non-interaction (R7), and the rejection-payload pin.
+
+Unit 5 adds ONLY the two cross-registry scenarios those per-unit suites do not
+cover, because each runs one closure against one arm at a time rather than
+asserting the two arms agree as a whole:
+
+1. **Whole-sequence equivalence** (``TestWholeSequenceEquivalence``) — one
+   identical operation sequence (register → K-evicting commits → delete-cascade
+   → ``commit_cas(content=None)`` skip → T-expiry via a monkeypatched clock) run
+   against BOTH registries built as a pair (the ``tests/test_registry.py:195``
+   ``_build_pair`` / ``_normalize`` pattern), asserting the observable retention
+   state — retained ``(version → content)`` maps (str AND bytes) and
+   ``read_at_version`` ``(version → outcome)`` maps — is IDENTICAL across
+   registries. This is the test that catches sqlite and in-memory DRIFTING
+   apart; no per-unit test compares the two arms' full state.
+
+2. **Peer-interleaving parity** (``TestPeerInterleavingParity``) — a second
+   writer commits a new version BETWEEN this reader's operations; the reader's
+   next ``read_at_version`` must reflect the AUTHORITATIVE persisted history, not
+   a stale per-instance cached belief. This guards the exact bug class in
+   ``docs/solutions/logic-errors/coherent-volume-write-noop-skip-stale-cache-
+   disk-divergence-2026-06-08.md`` (an optimization that consulted a per-instance
+   cache instead of the authoritative store → silent divergence). The sqlite arm
+   is the REAL two-handle case (two ``SqliteArtifactRegistry`` handles on one db
+   file); the in-memory arm is single-object (two handles is N/A) and instead
+   proves the read path re-derives from the one authoritative store after a peer
+   mutation. Per the ``tests/test_occ_commit_cas.py`` discipline the only HARD
+   assertion is the correctness property; concurrency-realism is a
+   ``RuntimeWarning`` and a ``threading.Barrier`` forces the window.
+
+Reason matching is ALWAYS ``reason == CONSTANT`` against the imported wire-stable
+constants — never a substring of a human message (the
+typed-signal-not-substring house rule).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import warnings
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.retention import RetentionPolicy
+from ccs.coordinator.service import CoordinatorService
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.exceptions import (
+    CURRENT_VERSION_REASON,
+    NOT_RETAINED_REASON,
+    UNKNOWN_ARTIFACT_REASON,
+)
+from ccs.core.states import MESIState
+from ccs.core.types import (
+    Artifact,
+    VersionedContent,
+    VersionedReadRejection,
+)
+
+# ---------------------------------------------------------------------------
+# Pair builders — the tests/test_registry.py:195 `_build_pair` pattern, run the
+# SAME closure against both registries and compare normalized outcomes.
+# ---------------------------------------------------------------------------
+
+
+def _build_pair(
+    tmp_path: Path, policy: RetentionPolicy | None
+) -> tuple[ArtifactRegistry, SqliteArtifactRegistry]:
+    """An in-memory + a sqlite registry, both with retention on under the SAME
+    policy, so one closure's observable retention state can be compared across
+    them. The sqlite handle is closed by the caller (try/finally)."""
+    return (
+        ArtifactRegistry(retain_versions=True, retention_policy=policy),
+        SqliteArtifactRegistry(
+            tmp_path / "parity.db", retain_versions=True, retention_policy=policy
+        ),
+    )
+
+
+def _commit(reg, artifact_id: UUID, version: int, body: str | bytes) -> None:
+    nxt = Artifact(id=artifact_id, name="plan.md", version=version, content_hash="h")
+    reg.set_artifact_and_content(artifact_id, nxt, body)
+
+
+def _content_map(reg, artifact_id: UUID, versions: range) -> dict[int, object]:
+    """The raw retained ``(version → content|None)`` map — the registry-agnostic
+    normal form for "same set of retained versions, same content per version"."""
+    return {v: reg.get_content_at_version(artifact_id, v) for v in versions}
+
+
+def _outcome_map(svc: CoordinatorService, artifact_id: UUID, versions: range) -> dict:
+    """The ``read_at_version`` ``(version → outcome)`` map normalized to a
+    registry-agnostic tuple: a hit → ``("content", body)`` (carries the body so
+    str/bytes type is compared too); a rejection → ``("reject", reason)``."""
+    out: dict[int, tuple] = {}
+    for v in versions:
+        res = svc.read_at_version(artifact_id, v)
+        if isinstance(res, VersionedContent):
+            out[v] = ("content", res.content)
+        else:
+            assert isinstance(res, VersionedReadRejection)
+            out[v] = ("reject", res.reason)
+    return out
+
+
+# ===========================================================================
+# A — Whole-sequence cross-registry equivalence
+# ===========================================================================
+
+
+class TestWholeSequenceEquivalence:
+    """Run ONE identical operation sequence against both registries and assert
+    the observable retention state is byte-for-byte identical. This is the only
+    test that compares the two arms' FULL state — the per-unit suites each run
+    one arm at a time, so a silent sqlite-vs-in-memory drift would pass them all
+    yet fail here."""
+
+    # A FIXED artifact id so the (version → ...) maps are directly comparable
+    # across the two registries (no per-arm uuid divergence in the keys).
+    _FIXED_ID = UUID(int=0xA17FAC7)
+
+    def _run_sequence(self, reg) -> None:
+        """register v1 → K-evicting commits (v2,v3,v4) → commit_cas(content=None)
+        WIN (v5, no capture) — the shared mutation history both arms replay.
+        K=3 so v1 is evicted; v4 carries a bytes body to exercise the
+        str-vs-bytes round trip inside the equivalence comparison."""
+        art = Artifact(
+            id=self._FIXED_ID, name="plan.md", version=1, content_hash="h"
+        )
+        reg.register_artifact(art, content="c1")
+        for v, body in ((2, "c2"), (3, "c3"), (4, b"\x00\x04bytes")):
+            _commit(reg, self._FIXED_ID, v, body)
+        # commit_cas(content=None) WIN: current advances to v5 but NO row is
+        # captured for v5 (the history-poisoning fix) — a versioned read of v5 is
+        # therefore current_version, and there is no stale v5 body to diverge on.
+        writer = uuid4()
+        reg.set_agent_state(self._FIXED_ID, writer, MESIState.SHARED, tick=1)
+        reg.commit_cas(
+            self._FIXED_ID,
+            writer,
+            expected_version=4,
+            content_hash="h5",
+            content=None,
+            tick=2,
+        )
+
+    def test_retained_content_maps_identical(self, tmp_path: Path) -> None:
+        # Same retained-version set AND same content per version (str + bytes).
+        mem, sql = _build_pair(tmp_path, RetentionPolicy(max_versions=3))
+        try:
+            self._run_sequence(mem)
+            self._run_sequence(sql)
+            probe = range(1, 7)
+            mem_map = _content_map(mem, self._FIXED_ID, probe)
+            sql_map = _content_map(sql, self._FIXED_ID, probe)
+            assert mem_map == sql_map, (
+                f"retained content drifted between registries:\n"
+                f"  in-memory: {mem_map}\n  sqlite   : {sql_map}"
+            )
+            # Pin the expected shape too (so a both-arms-equally-wrong regression
+            # is still caught): K=3 evicted v1; v2,v3 are str; v4 is the exact
+            # bytes; v5 never captured (content=None WIN); v6 never existed.
+            assert mem_map == {
+                1: None,
+                2: "c2",
+                3: "c3",
+                4: b"\x00\x04bytes",
+                5: None,
+                6: None,
+            }
+            # Type fidelity is part of "same content": str stays str, bytes stays
+            # bytes, identically on both arms.
+            assert isinstance(mem_map[2], str) and isinstance(sql_map[2], str)
+            assert isinstance(mem_map[4], bytes) and isinstance(sql_map[4], bytes)
+        finally:
+            sql.close()
+
+    def test_read_at_version_outcome_maps_identical(self, tmp_path: Path) -> None:
+        # Same read_at_version outcome (VersionedContent body OR rejection reason)
+        # for a probe set spanning every branch — across both registries.
+        mem, sql = _build_pair(tmp_path, RetentionPolicy(max_versions=3))
+        try:
+            self._run_sequence(mem)
+            self._run_sequence(sql)
+            svc_mem, svc_sql = CoordinatorService(mem), CoordinatorService(sql)
+            probe = range(1, 7)
+            mem_out = _outcome_map(svc_mem, self._FIXED_ID, probe)
+            sql_out = _outcome_map(svc_sql, self._FIXED_ID, probe)
+            assert mem_out == sql_out, (
+                f"read_at_version outcomes drifted between registries:\n"
+                f"  in-memory: {mem_out}\n  sqlite   : {sql_out}"
+            )
+            # Expected shape: v1 K-evicted → not_retained; v2,v3 served; v4 served
+            # (exact bytes); v5 is current (content=None advanced it) →
+            # current_version; v6 > current → future_version.
+            assert mem_out == {
+                1: ("reject", NOT_RETAINED_REASON),
+                2: ("content", "c2"),
+                3: ("content", "c3"),
+                4: ("content", b"\x00\x04bytes"),
+                5: ("reject", CURRENT_VERSION_REASON),
+                6: ("reject", "future_version"),
+            }
+        finally:
+            sql.close()
+
+    def test_delete_cascade_equivalence(self, tmp_path: Path) -> None:
+        # remove_artifact drops history on BOTH registries identically: every
+        # post-delete read is unknown_artifact (deleted ≡ never-existed) and the
+        # raw getter returns None for every prior version on both arms.
+        mem, sql = _build_pair(tmp_path, RetentionPolicy(max_versions=8))
+        try:
+            self._run_sequence(mem)
+            self._run_sequence(sql)
+            for reg in (mem, sql):
+                reg.remove_artifact(self._FIXED_ID)
+            probe = range(1, 6)
+            assert _content_map(mem, self._FIXED_ID, probe) == _content_map(
+                sql, self._FIXED_ID, probe
+            ) == {v: None for v in probe}
+            svc_mem, svc_sql = CoordinatorService(mem), CoordinatorService(sql)
+            mem_out = _outcome_map(svc_mem, self._FIXED_ID, probe)
+            sql_out = _outcome_map(svc_sql, self._FIXED_ID, probe)
+            assert mem_out == sql_out
+            assert all(
+                v == ("reject", UNKNOWN_ARTIFACT_REASON) for v in mem_out.values()
+            )
+        finally:
+            sql.close()
+
+    def test_t_expiry_equivalence_under_monkeypatched_clock(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # T-axis physical-drop parity: capture v1@t=0, v2@t=5, then v3@t=100 (past
+        # the 10s horizon) — the t=100 capture physically drops v1 AND v2 on both
+        # registries; only the current row (v3) survives, identically.
+        clock = {"now": 0.0}
+        monkeypatch.setattr(time, "time", lambda: clock["now"])
+        policy = RetentionPolicy(max_versions=100, max_age_seconds=10.0)
+        mem, sql = _build_pair(tmp_path, policy)
+        try:
+            for reg in (mem, sql):
+                clock["now"] = 0.0
+                art = Artifact(
+                    id=self._FIXED_ID, name="plan.md", version=1, content_hash="h"
+                )
+                reg.register_artifact(art, content="c1")  # captured at t=0
+                clock["now"] = 5.0
+                _commit(reg, self._FIXED_ID, 2, "c2")  # t=5
+                clock["now"] = 100.0  # past horizon → v1,v2 dropped at this capture
+                _commit(reg, self._FIXED_ID, 3, "c3")
+            probe = range(1, 4)
+            mem_map = _content_map(mem, self._FIXED_ID, probe)
+            sql_map = _content_map(sql, self._FIXED_ID, probe)
+            assert mem_map == sql_map == {1: None, 2: None, 3: "c3"}
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# B — Peer-interleaving parity (the CoherentVolume stale-cache bug class)
+# ===========================================================================
+
+
+class TestPeerInterleavingParity:
+    """A peer mutates the store BETWEEN this reader's operations; the reader's
+    next read must reflect the AUTHORITATIVE persisted history, never a stale
+    per-instance cached belief (the
+    ``coherent-volume-write-noop-skip-stale-cache-disk-divergence`` bug class:
+    an optimization consulting a cached belief instead of the authoritative
+    store → silent divergence).
+
+    Discipline per ``tests/test_occ_commit_cas.py``: the ONLY hard assertion is
+    the correctness property (reads reflect the authoritative store); a
+    ``threading.Barrier`` forces the interleaving window, and any "did the
+    interleave actually overlap" check is a ``RuntimeWarning``, never an assert.
+    """
+
+    def test_sqlite_two_handles_reads_reflect_peer_commit(
+        self, tmp_path: Path
+    ) -> None:
+        # The REAL two-handle case: writer A and reader B are two SEPARATE
+        # SqliteArtifactRegistry handles on the SAME db file (WAL allows it; the
+        # second open finds user_version=2 and runs no migration). B holds NO
+        # per-instance cache of A's writes — its read path issues a fresh SELECT
+        # under its own lock, so it MUST observe A's committed bytes.
+        policy = RetentionPolicy(max_versions=8)
+        db = tmp_path / "shared.db"
+        writer_a = SqliteArtifactRegistry(
+            db, retain_versions=True, retention_policy=policy
+        )
+        reader_b = SqliteArtifactRegistry(
+            db, retain_versions=True, retention_policy=policy
+        )
+        svc_b = CoordinatorService(reader_b)
+        try:
+            artifact_id = uuid4()
+            art = Artifact(
+                id=artifact_id, name="plan.md", version=1, content_hash="h"
+            )
+            writer_a.register_artifact(art, content="c1")
+            _commit(writer_a, artifact_id, 2, "c2")  # A: current=2, v1 history
+
+            # B reads v1 BEFORE A's interleaved commit — sees the authoritative
+            # store as it stands now (v1 retained, current=2).
+            assert reader_b.get_artifact(artifact_id).version == 2
+            pre = svc_b.read_at_version(artifact_id, 1)
+            assert isinstance(pre, VersionedContent)
+            assert pre.content == "c1"
+            # v2 is current at this instant → current_version (not history yet).
+            pre_v2 = svc_b.read_at_version(artifact_id, 2)
+            assert isinstance(pre_v2, VersionedReadRejection)
+            assert pre_v2.reason == CURRENT_VERSION_REASON
+
+            # PEER A commits v3 BETWEEN B's operations — v2 becomes history.
+            _commit(writer_a, artifact_id, 3, "c3")
+
+            # B's NEXT reads must reflect A's interleaved commit from the
+            # AUTHORITATIVE store, not a cached belief: v2 is now servable history
+            # with EXACT bytes, and v3 is the new current. A phantom retained
+            # version or a missing one (the bug class) would fail here.
+            post_v2 = svc_b.read_at_version(artifact_id, 2)
+            assert isinstance(post_v2, VersionedContent), (
+                "reader B did not observe peer A's interleaved commit: v2 should "
+                "be servable history after A advanced current to v3 — a stale "
+                "per-instance belief would still call v2 the current version"
+            )
+            assert post_v2.content == "c2"  # exact persisted bytes, never v3's
+            post_v3 = svc_b.read_at_version(artifact_id, 3)
+            assert isinstance(post_v3, VersionedReadRejection)
+            assert post_v3.reason == CURRENT_VERSION_REASON
+            assert post_v3.current_version == 3
+            # v1, K-bounded but K=8 here, is still retained authoritative history.
+            assert reader_b.get_content_at_version(artifact_id, 1) == "c1"
+        finally:
+            reader_b.close()
+            writer_a.close()
+
+    def test_sqlite_two_handles_peer_gc_evicts_from_readers_view(
+        self, tmp_path: Path
+    ) -> None:
+        # The eviction direction of the same property: under a bounded K, peer
+        # A's interleaved commits push an OLD version past the K window. Reader
+        # B — deriving from the authoritative store — must see that version as
+        # not_retained (it was authoritatively GC'd), NOT serve a phantom copy
+        # from any cached belief.
+        policy = RetentionPolicy(max_versions=2)  # keep current + 1
+        db = tmp_path / "shared_gc.db"
+        writer_a = SqliteArtifactRegistry(
+            db, retain_versions=True, retention_policy=policy
+        )
+        reader_b = SqliteArtifactRegistry(
+            db, retain_versions=True, retention_policy=policy
+        )
+        svc_b = CoordinatorService(reader_b)
+        try:
+            artifact_id = uuid4()
+            art = Artifact(
+                id=artifact_id, name="plan.md", version=1, content_hash="h"
+            )
+            writer_a.register_artifact(art, content="c1")
+            _commit(writer_a, artifact_id, 2, "c2")  # K=2 → {1,2}, current=2
+
+            # B sees v1 retained right now.
+            assert isinstance(svc_b.read_at_version(artifact_id, 1), VersionedContent)
+
+            # PEER A commits v3 → K=2 evicts v1 authoritatively ({2,3}).
+            _commit(writer_a, artifact_id, 3, "c3")
+
+            # B's next read of v1 MUST be not_retained — the authoritative GC is
+            # what B derives from; a cached belief would still serve v1.
+            out = svc_b.read_at_version(artifact_id, 1)
+            assert isinstance(out, VersionedReadRejection), (
+                "reader B served a phantom v1 after peer A's commit GC'd it — the "
+                "read consulted a stale belief instead of the authoritative store"
+            )
+            assert out.reason == NOT_RETAINED_REASON
+            # And v2 (now within the K window as history) is still authoritative.
+            assert reader_b.get_content_at_version(artifact_id, 2) == "c2"
+        finally:
+            reader_b.close()
+            writer_a.close()
+
+    def test_sqlite_two_handles_concurrent_interleave_barrier(
+        self, tmp_path: Path
+    ) -> None:
+        # The same property under a genuine threading.Barrier-forced window
+        # (test_occ_commit_cas.py discipline). Writer A commits v3 while reader B
+        # reads around the barrier; the HARD assertion is the correctness
+        # property — B's read of v2 is EITHER current_version (B won the race,
+        # v2 still current) OR exact "c2" history (A won, v2 demoted) — NEVER
+        # wrong bytes and never another reason. "Did the threads overlap" is a
+        # RuntimeWarning only (a constrained runner may serialize them).
+        policy = RetentionPolicy(max_versions=8)
+        db = tmp_path / "shared_barrier.db"
+        writer_a = SqliteArtifactRegistry(
+            db, retain_versions=True, retention_policy=policy
+        )
+        reader_b = SqliteArtifactRegistry(
+            db, retain_versions=True, retention_policy=policy
+        )
+        svc_b = CoordinatorService(reader_b)
+        try:
+            artifact_id = uuid4()
+            art = Artifact(
+                id=artifact_id, name="plan.md", version=1, content_hash="h"
+            )
+            writer_a.register_artifact(art, content="c1")
+            _commit(writer_a, artifact_id, 2, "c2")  # current=2
+
+            barrier = threading.Barrier(2)
+            results: dict[str, object] = {}
+
+            def commit_v3() -> None:
+                barrier.wait()
+                _commit(writer_a, artifact_id, 3, "c3")
+                results["a_done"] = time.perf_counter()
+
+            def read_v2() -> None:
+                barrier.wait()
+                results["b_read"] = svc_b.read_at_version(artifact_id, 2)
+                results["b_done"] = time.perf_counter()
+
+            ta = threading.Thread(target=commit_v3)
+            tb = threading.Thread(target=read_v2)
+            ta.start()
+            tb.start()
+            ta.join(timeout=10.0)
+            tb.join(timeout=10.0)
+            assert not ta.is_alive() and not tb.is_alive(), "threads hung"
+
+            # HARD correctness property — the read is one of exactly two allowed
+            # authoritative outcomes; never wrong bytes, never a mislabeled reason.
+            out = results["b_read"]
+            if isinstance(out, VersionedContent):
+                assert out.content == "c2", (
+                    "v2 served as history with WRONG bytes — a racing peer commit "
+                    "corrupted the authoritative read"
+                )
+            else:
+                assert isinstance(out, VersionedReadRejection)
+                assert out.reason == CURRENT_VERSION_REASON, (
+                    f"v2 read mislabeled under a racing commit: {out.reason}"
+                )
+
+            # After both threads settle, the authoritative store is unambiguous:
+            # current=3, v2 is servable history with exact bytes (B re-derives it,
+            # no phantom / no miss).
+            final = svc_b.read_at_version(artifact_id, 2)
+            assert isinstance(final, VersionedContent)
+            assert final.content == "c2"
+            assert reader_b.get_artifact(artifact_id).version == 3
+
+            # Realism check — warning only, never an assertion (constrained
+            # runners may serialize the two threads).
+            if "a_done" in results and "b_done" in results:
+                if abs(results["a_done"] - results["b_done"]) > 0.5:
+                    warnings.warn(
+                        "peer commit and reader did not overlap within 500ms; the "
+                        "interleave window may not have been exercised on this "
+                        "runner (correctness still asserted)",
+                        RuntimeWarning,
+                        stacklevel=2,
+                    )
+        finally:
+            reader_b.close()
+            writer_a.close()
+
+    def test_in_memory_single_store_reads_reflect_peer_mutation(self) -> None:
+        # In-memory has ONE registry object, so "two handles on one store" is N/A
+        # (a second handle would be a DIFFERENT, empty store). The analogous
+        # property: writer A and reader B share the ONE authoritative object;
+        # after A mutates it between B's operations, B's read path — which always
+        # re-derives from that object, holding no separate cached belief — sees
+        # the mutation. This is the in-memory expression of "reads reflect the
+        # authoritative store after a peer mutation".
+        reg = ArtifactRegistry(
+            retain_versions=True, retention_policy=RetentionPolicy(max_versions=8)
+        )
+        svc = CoordinatorService(reg)
+        artifact_id = uuid4()
+        art = Artifact(id=artifact_id, name="plan.md", version=1, content_hash="h")
+        reg.register_artifact(art, content="c1")
+        _commit(reg, artifact_id, 2, "c2")  # current=2, v1 history
+
+        # B reads v2 → current at this instant.
+        pre = svc.read_at_version(artifact_id, 2)
+        assert isinstance(pre, VersionedReadRejection)
+        assert pre.reason == CURRENT_VERSION_REASON
+
+        # PEER mutation interleaved: A commits v3 → v2 demoted to history.
+        _commit(reg, artifact_id, 3, "c3")
+
+        # B's next read re-derives current from the authoritative store: v2 is now
+        # servable history (exact bytes), v3 is current.
+        post = svc.read_at_version(artifact_id, 2)
+        assert isinstance(post, VersionedContent)
+        assert post.content == "c2"
+        assert svc.read_at_version(artifact_id, 3).reason == CURRENT_VERSION_REASON
+
+
+# ===========================================================================
+# C — str/bytes round-trip pin across BOTH registries (one focused assertion)
+# ===========================================================================
+
+
+class TestStrBytesRoundTripAcrossRegistries:
+    """One focused pin: a str body and a bytes body each round-trip with TYPE
+    preserved through BOTH registries' retention AND read_at_version. (Sections
+    A/B exercise type fidelity inside larger sequences; this isolates it so a
+    type-coercion regression has a single named failure.)"""
+
+    @pytest.mark.parametrize(
+        ("body", "py_type"),
+        [("a-str-body", str), (b"\x00\xff-bytes-body", bytes)],
+        ids=["str", "bytes"],
+    )
+    def test_body_round_trips_with_type_on_both_registries(
+        self, tmp_path: Path, body: str | bytes, py_type: type
+    ) -> None:
+        mem = ArtifactRegistry(
+            retain_versions=True, retention_policy=RetentionPolicy(max_versions=8)
+        )
+        sql = SqliteArtifactRegistry(
+            tmp_path / "roundtrip.db",
+            retain_versions=True,
+            retention_policy=RetentionPolicy(max_versions=8),
+        )
+        try:
+            for reg in (mem, sql):
+                artifact_id = uuid4()
+                art = Artifact(
+                    id=artifact_id, name="plan.md", version=1, content_hash="h"
+                )
+                reg.register_artifact(art, content="seed")
+                _commit(reg, artifact_id, 2, body)  # capture the typed body at v2
+                _commit(reg, artifact_id, 3, "make-v2-history")  # v2 → history
+
+                # Raw getter round-trips the exact value AND type.
+                got = reg.get_content_at_version(artifact_id, 2)
+                assert got == body
+                assert isinstance(got, py_type), (
+                    f"{type(reg).__name__} coerced the retained body type: "
+                    f"expected {py_type.__name__}, got {type(got).__name__}"
+                )
+
+                # read_at_version serves the same value AND type.
+                out = CoordinatorService(reg).read_at_version(artifact_id, 2)
+                assert isinstance(out, VersionedContent)
+                assert out.content == body
+                assert isinstance(out.content, py_type)
+        finally:
+            sql.close()

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -16,6 +16,7 @@ import os
 import sqlite3
 import stat
 import threading
+import warnings
 from pathlib import Path
 from uuid import UUID, uuid4
 
@@ -27,12 +28,14 @@ from ccs.coordinator.sqlite_registry import (
     _DB_FILE_MODE,
     CCS_STATE_LOG_SCHEMA_VERSION,
     SCHEMA_USER_VERSION,
+    CrossRuntimeSchemaError,
     MissingDatabaseError,
     ReadOnlyMutationError,
     SchemaVersionError,
     SqliteArtifactRegistry,
     StoreNeedsRecoveryError,
 )
+from ccs.core.exceptions import CROSS_RUNTIME_SCHEMA_REASON
 from ccs.core.states import MESIState, TransientState
 from ccs.core.types import Artifact, CasCorruption, ConflictDetail
 
@@ -1360,6 +1363,186 @@ class TestWildV1Migration:
         assert ddl == [], f"concurrent loser re-ran DDL: {ddl}"
 
 
+# ----------------------------------------------------------------------
+# Cross-runtime fail-closed guard (sibling Node coordinator ledger)
+# ----------------------------------------------------------------------
+
+
+def _assert_no_delete_advice(message: str) -> None:
+    """The anti-delete wording rule (SchemaVersionError docstring): a store-open
+    failure message must never advise deleting state.db — the file holds
+    durable retained content and, for a foreign-ledger db, the sibling
+    runtime's live state. The Node coordinator's own KTD-D message DOES say
+    ``rm <workspace>/.coherence/state.db``; assert that advice shape never
+    leaks into this side's cross-runtime message. A strict substring ban is
+    safe here because the message is written without the verbs entirely
+    (unlike SchemaVersionError's, which negates them: 'rather than removing').
+    """
+    lowered = message.lower()
+    for fragment in ("rm ", "delet", "remov", "discard", "unlink"):
+        assert fragment not in lowered, (
+            f"cross-runtime message contains {fragment!r} (reads as delete "
+            f"advice): {message}"
+        )
+
+
+def _forge_node_v3_db(db_path: Path) -> None:
+    """Forge what the sibling Node coordinator's ledger produces at ITS v3:
+    Node v1 is a byte-for-byte mirror of this repo's v1 DDL (pending_notices
+    included, no fence columns), Node v2 adds no schema objects, Node v3 is
+    ``ALTER TABLE agent_states ADD COLUMN deadline_tick`` + user_version=3."""
+    _build_raw_v1_db(db_path, fence=False, notices=True)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("ALTER TABLE agent_states ADD COLUMN deadline_tick INTEGER")
+        conn.execute("PRAGMA user_version = 3")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _forge_node_v2_db(db_path: Path) -> None:
+    """Forge a Node-v2 db: this repo's v1 DDL with user_version=2 and NO
+    artifact_versions table (the Node ledger's v2 adds no schema objects; a
+    Python-v2 db ALWAYS has artifact_versions)."""
+    _build_raw_v1_db(db_path, fence=False, notices=True)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("PRAGMA user_version = 2")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _stamp_schema_runtime(db_path: Path, value: str) -> None:
+    """Hand-stamp registry_meta.schema_runtime (forging the Node side's mirror
+    stamp, or clearing ours via DELETE elsewhere)."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO registry_meta (key, value) "
+            "VALUES ('schema_runtime', ?)",
+            (value,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _user_version(db_path: Path) -> int:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute("PRAGMA user_version").fetchone()[0]
+    finally:
+        conn.close()
+
+
+class TestCrossRuntimeGuard:
+    """Fail-closed open against a sibling-Node-ledger state.db (both open
+    paths). The Node coordinator shares the db path but its ledger assigns
+    different meanings to user_version 2/3, so the guard must fire BEFORE any
+    migration or rehydrate write — extends the wild-v1 migration and
+    read-only open coverage above."""
+
+    @pytest.mark.parametrize("read_only", [False, True])
+    def test_node_v3_db_raises_cross_runtime(
+        self, db_path: Path, read_only: bool
+    ) -> None:
+        _forge_node_v3_db(db_path)
+        with pytest.raises(CrossRuntimeSchemaError) as ei:
+            SqliteArtifactRegistry(db_path, read_only=read_only)
+        # Typed signal: match the wire-stable constant with ==, never the text.
+        assert ei.value.reason == CROSS_RUNTIME_SCHEMA_REASON
+        msg = str(ei.value)
+        # The supported backend-switch path is named; deletion never advised.
+        assert "agent-coherence-coordinator --prepare-for-migration" in msg
+        _assert_no_delete_advice(msg)
+        # Fail-closed means NO migration/write happened: still the Node shape.
+        assert _user_version(db_path) == 3
+
+    @pytest.mark.parametrize("read_only", [False, True])
+    def test_foreign_v2_db_raises_cross_runtime(
+        self, db_path: Path, read_only: bool
+    ) -> None:
+        _forge_node_v2_db(db_path)
+        with pytest.raises(CrossRuntimeSchemaError) as ei:
+            SqliteArtifactRegistry(db_path, read_only=read_only)
+        assert ei.value.reason == CROSS_RUNTIME_SCHEMA_REASON
+        _assert_no_delete_advice(str(ei.value))
+        assert _user_version(db_path) == 2
+
+    @pytest.mark.parametrize("read_only", [False, True])
+    @pytest.mark.parametrize("forge_version", [1, 2])
+    def test_schema_runtime_node_stamp_raises_regardless_of_version(
+        self, db_path: Path, read_only: bool, forge_version: int
+    ) -> None:
+        # The explicit stamp is the STRONGEST marker: it must reject even a
+        # db whose structure would otherwise pass — a genuine v1 (normally
+        # migratable) and a structurally perfect Python v2.
+        if forge_version == 1:
+            _build_raw_v1_db(db_path, fence=False, notices=True)
+        else:
+            with SqliteArtifactRegistry(db_path):
+                pass
+        _stamp_schema_runtime(db_path, "node")
+        before = _user_version(db_path)
+        with pytest.raises(CrossRuntimeSchemaError) as ei:
+            SqliteArtifactRegistry(db_path, read_only=read_only)
+        assert ei.value.reason == CROSS_RUNTIME_SCHEMA_REASON
+        _assert_no_delete_advice(str(ei.value))
+        # NO migration ran on the stamped-foreign db (v1 stays v1).
+        assert _user_version(db_path) == before
+
+    def test_genuine_v1_migrates_and_stamps_python(self, db_path: Path) -> None:
+        # The documented residual risk, accepted by design: a v1 db is
+        # byte-identical between the two runtimes, so it is NOT blocked — the
+        # normal v1->v2 migration proceeds and stamps OUR lineage marker.
+        art_id, _ = _build_raw_v1_db(db_path, fence=False, notices=False)
+        with SqliteArtifactRegistry(db_path) as reg:
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+            assert reg.get_artifact(UUID(art_id)) is not None
+            stamp = reg._conn.execute(
+                "SELECT value FROM registry_meta WHERE key = 'schema_runtime'"
+            ).fetchone()
+            assert stamp is not None and stamp[0] == "python"
+
+    def test_fresh_db_stamps_python(self, db_path: Path) -> None:
+        with SqliteArtifactRegistry(db_path) as reg:
+            stamp = reg._conn.execute(
+                "SELECT value FROM registry_meta WHERE key = 'schema_runtime'"
+            ).fetchone()
+            assert stamp is not None and stamp[0] == "python"
+
+    def test_genuine_python_v2_reopens_fine_both_paths(self, db_path: Path) -> None:
+        # A db this build created (stamped python) passes the guard on the
+        # writer AND read-only paths.
+        with SqliteArtifactRegistry(db_path) as reg:
+            _retain_artifact(reg, content="x")
+        with SqliteArtifactRegistry(db_path) as rw:
+            assert rw._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+        with SqliteArtifactRegistry(db_path, read_only=True) as ro:
+            assert ro.instance_id
+
+    def test_pre_stamp_python_v2_opens_fine(self, db_path: Path) -> None:
+        # Back-compat: a Python-v2 db written BEFORE the schema_runtime marker
+        # shipped has no stamp at all. Absence is NOT foreign (the v2 open
+        # path is write-free, so the stamp is never backfilled either).
+        with SqliteArtifactRegistry(db_path):
+            pass
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute("DELETE FROM registry_meta WHERE key = 'schema_runtime'")
+            conn.commit()
+        finally:
+            conn.close()
+        with SqliteArtifactRegistry(db_path) as reg:
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+            # Still un-stamped: the steady-state v2 open performs no writes.
+            assert reg._conn.execute(
+                "SELECT value FROM registry_meta WHERE key = 'schema_runtime'"
+            ).fetchone() is None
+
+
 class TestRetentionPolicyAcrossRuns:
     """R2/R4: K-lowered-between-runs (no open-time GC) + disable != purge."""
 
@@ -1377,10 +1560,13 @@ class TestRetentionPolicyAcrossRuns:
                 reg.set_artifact_and_content(art_id, nx, f"c{v}")
             assert _versions(reg, art_id) == [1, 2, 3, 4, 5]
 
-        # Reopen with a lower K: rows persist (NO open-time GC pass).
-        with SqliteArtifactRegistry(
-            db_path, retain_versions=True, retention_policy=RetentionPolicy(max_versions=2)
-        ) as reg:
+        # Reopen with a lower K: rows persist (NO open-time GC pass). The
+        # policy change is deliberate here — acknowledge the mismatch warning.
+        with pytest.warns(RuntimeWarning, match="retention policy mismatch"):
+            reg = SqliteArtifactRegistry(
+                db_path, retain_versions=True, retention_policy=RetentionPolicy(max_versions=2)
+            )
+        with reg:
             assert _versions(reg, art_id) == [1, 2, 3, 4, 5]
             # Next capture for THIS artifact prunes to the new K.
             nx = Artifact(id=art_id, name="plan.md", version=6, content_hash="h")
@@ -1408,11 +1594,14 @@ class TestRetentionPolicyAcrossRuns:
             # The cached meta still reflects the persisted policy.
             assert reg2.retention_meta() == (True, pol)
 
-        # A CHANGED policy does write (the skip is equality-gated, not blanket).
-        with SqliteArtifactRegistry(
-            db_path, retain_versions=True,
-            retention_policy=RetentionPolicy(max_versions=2),
-        ) as reg3:
+        # A CHANGED policy does write (the skip is equality-gated, not
+        # blanket) — and warns about the mismatch before overwriting.
+        with pytest.warns(RuntimeWarning, match="retention policy mismatch"):
+            reg3 = SqliteArtifactRegistry(
+                db_path, retain_versions=True,
+                retention_policy=RetentionPolicy(max_versions=2),
+            )
+        with reg3:
             assert reg3._conn.total_changes > 0
             assert reg3.retention_meta() == (True, RetentionPolicy(max_versions=2))
 
@@ -1435,6 +1624,65 @@ class TestRetentionPolicyAcrossRuns:
             reg.set_artifact_and_content(art_id, nx, "not-captured")
             assert reg.get_content_at_version(art_id, 2) is None
             assert reg.get_content_at_version(art_id, 1) == "kept"
+
+    def test_policy_mismatch_reopen_warns_naming_both_policies(
+        self, db_path: Path
+    ) -> None:
+        # A writer whose constructor policy differs from the persisted one
+        # warns ONCE before overwriting — the single-writer-embedder
+        # assumption made operator-visible. Both policies appear in the text.
+        with SqliteArtifactRegistry(
+            db_path,
+            retain_versions=True,
+            retention_policy=RetentionPolicy(max_versions=8, max_age_seconds=60.0),
+        ):
+            pass
+        with pytest.warns(
+            RuntimeWarning,
+            match=(
+                r"retention policy mismatch.*"
+                r"max_versions=8 / max_age_seconds=60\.0.*"
+                r"max_versions=2 / max_age_seconds=None.*"
+                r"SINGLE writer-embedder"
+            ),
+        ):
+            reg = SqliteArtifactRegistry(
+                db_path,
+                retain_versions=True,
+                retention_policy=RetentionPolicy(max_versions=2),
+            )
+        try:
+            # Warn-then-overwrite: the constructor policy DID land.
+            assert reg.retention_meta() == (True, RetentionPolicy(max_versions=2))
+        finally:
+            reg.close()
+
+    def test_policy_first_persist_match_and_read_only_stay_silent(
+        self, db_path: Path
+    ) -> None:
+        # No warning on: first persist (nothing persisted yet), a matching
+        # reopen (skip-if-unchanged), and a read-only open (never persists) —
+        # escalate any RuntimeWarning to an error to prove silence.
+        pol = RetentionPolicy(max_versions=4, max_age_seconds=60.0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            with SqliteArtifactRegistry(
+                db_path, retain_versions=True, retention_policy=pol
+            ):
+                pass
+            with SqliteArtifactRegistry(
+                db_path, retain_versions=True, retention_policy=pol
+            ):
+                pass
+            # Read-only with a DIVERGENT constructor policy: still silent —
+            # a reader never persists, so there is no overwrite to warn about.
+            with SqliteArtifactRegistry(
+                db_path,
+                read_only=True,
+                retain_versions=True,
+                retention_policy=RetentionPolicy(max_versions=1),
+            ):
+                pass
 
 
 class TestRetentionCrashAtomicity:

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -23,6 +23,8 @@ import pytest
 
 from ccs.coordinator.retention import RetentionPolicy
 from ccs.coordinator.sqlite_registry import (
+    _ARTIFACT_VERSIONS_DDL,
+    _DB_FILE_MODE,
     CCS_STATE_LOG_SCHEMA_VERSION,
     SCHEMA_USER_VERSION,
     MissingDatabaseError,
@@ -30,8 +32,6 @@ from ccs.coordinator.sqlite_registry import (
     SchemaVersionError,
     SqliteArtifactRegistry,
     StoreNeedsRecoveryError,
-    _ARTIFACT_VERSIONS_DDL,
-    _DB_FILE_MODE,
 )
 from ccs.core.states import MESIState, TransientState
 from ccs.core.types import Artifact, CasCorruption, ConflictDetail
@@ -1174,6 +1174,52 @@ class TestDurableRetentionRoundTrip:
             assert reg.get_content_at_version(art.id, 2) is None
             assert reg.get_content_at_version(art.id, 1) == "seed-v1"
 
+    def test_t_expiry_backdated_row_rejects_then_sweeps(self, db_path: Path) -> None:
+        # Sqlite-arm-isolated T-expiry (the parity suite diagnoses divergence,
+        # not the sqlite SQL mechanics): backdate captured_at DIRECTLY in
+        # artifact_versions, assert read_at_version logically rejects
+        # not_retained, then assert the next capture PHYSICALLY removes the row
+        # (deletion piggybacks on capture-time GC).
+        from ccs.coordinator.service import CoordinatorService
+        from ccs.core.exceptions import NOT_RETAINED_REASON
+        from ccs.core.types import VersionedReadRejection
+
+        pol = RetentionPolicy(max_versions=100, max_age_seconds=600.0)
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=pol
+        ) as reg:
+            art = _retain_artifact(reg, content="c1")
+            for v in (2, 3):
+                nx = Artifact(id=art.id, name="plan.md", version=v, content_hash="h")
+                reg.set_artifact_and_content(art.id, nx, f"c{v}")
+            # Backdate v2 far past the 600s horizon (raw SQL on purpose: this
+            # pins the sqlite captured_at-float comparison path in isolation).
+            reg._conn.execute(
+                "UPDATE artifact_versions SET captured_at = 1.0 "
+                "WHERE artifact_id = ? AND version = 2",
+                (art.id.hex,),
+            )
+            svc = CoordinatorService(reg)
+            out = svc.read_at_version(art.id, 2)
+            assert isinstance(out, VersionedReadRejection)
+            assert out.reason == NOT_RETAINED_REASON
+            # Logical-at-read: the row is still physically present.
+            assert reg._conn.execute(
+                "SELECT COUNT(*) FROM artifact_versions "
+                "WHERE artifact_id = ? AND version = 2",
+                (art.id.hex,),
+            ).fetchone()[0] == 1
+            # The next capture's inline GC physically removes the aged row.
+            nx4 = Artifact(id=art.id, name="plan.md", version=4, content_hash="h")
+            reg.set_artifact_and_content(art.id, nx4, "c4")
+            assert reg._conn.execute(
+                "SELECT COUNT(*) FROM artifact_versions "
+                "WHERE artifact_id = ? AND version = 2",
+                (art.id.hex,),
+            ).fetchone()[0] == 0
+            # Fresh rows are untouched by the sweep.
+            assert reg.get_content_at_version(art.id, 3) == "c3"
+
     def test_unbounded_marker_persisted_when_policy_none(self, db_path: Path) -> None:
         # retain_versions=True + policy=None -> enabled with NULL axes, so a
         # resolver can tell retention-on-unbounded from retention-never-enabled.
@@ -1224,7 +1270,7 @@ class TestWildV1Migration:
             # Pre-existing data intact.
             art = reg.get_artifact(UUID(art_id))
             assert art is not None and art.version == 3
-            assert reg._instance_id == "wild-v1"
+            assert reg.instance_id == "wild-v1"
             assert reg._seq == 4
             # Fence queries work even on a PREVIOUSLY-pre-fence variant.
             assert reg.get_owner_generation(UUID(art_id)) == 0
@@ -1273,6 +1319,46 @@ class TestWildV1Migration:
         finally:
             reg.close()
 
+    def test_concurrent_loser_re_checks_in_txn_and_runs_no_ddl(
+        self, db_path: Path, monkeypatch
+    ) -> None:
+        # Two processes can both read user_version==1 in the dispatch (outside
+        # any txn) and both enter _migrate_v1_to_v2; they serialize on BEGIN
+        # IMMEDIATE. Simulate the LOSER deterministically: the db is already
+        # migrated (the "winner" ran), but the dispatch decision was made from
+        # the stale pre-lock read — force it down the migration path and
+        # assert the in-txn user_version re-check no-ops with ZERO DDL.
+        art_id, _ = _build_raw_v1_db(db_path, fence=True, notices=True)
+        with SqliteArtifactRegistry(db_path) as winner:
+            assert winner._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+
+        statements: list[str] = []
+
+        def loser_initialize(self, instance_id):
+            # The loser's stale dispatch: call the migration directly against
+            # the already-v2 db, tracing every statement it executes.
+            self._conn.set_trace_callback(statements.append)
+            try:
+                self._migrate_v1_to_v2(instance_id)
+            finally:
+                self._conn.set_trace_callback(None)
+
+        monkeypatch.setattr(
+            SqliteArtifactRegistry, "_initialize_schema", loser_initialize
+        )
+        with SqliteArtifactRegistry(db_path) as loser:
+            # The loser rehydrated normally (meta loaded, data intact) ...
+            assert loser.instance_id == "wild-v1"
+            assert loser.get_artifact(UUID(art_id)) is not None
+            assert loser._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+        # ... and performed NO DDL: the in-txn re-check exited before any
+        # ALTER/CREATE could re-run against the migrated schema.
+        ddl = [
+            s for s in statements
+            if s.lstrip().upper().startswith(("ALTER", "CREATE"))
+        ]
+        assert ddl == [], f"concurrent loser re-ran DDL: {ddl}"
+
 
 class TestRetentionPolicyAcrossRuns:
     """R2/R4: K-lowered-between-runs (no open-time GC) + disable != purge."""
@@ -1300,6 +1386,35 @@ class TestRetentionPolicyAcrossRuns:
             nx = Artifact(id=art_id, name="plan.md", version=6, content_hash="h")
             reg.set_artifact_and_content(art_id, nx, "c6")
             assert _versions(reg, art_id) == [5, 6]
+
+    def test_same_policy_reopen_performs_no_write(self, db_path: Path) -> None:
+        # Write-free steady-state: a reopen with the SAME policy must not
+        # UPSERT the (unchanged) retention keys — the v2 open path stays
+        # write-free end-to-end. total_changes counts every row this
+        # connection inserted/updated/deleted; zero == no write happened.
+        pol = RetentionPolicy(max_versions=4, max_age_seconds=60.0)
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=pol
+        ) as reg:
+            _retain_artifact(reg, content="seed")
+
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=pol
+        ) as reg2:
+            assert reg2._conn.total_changes == 0, (
+                "same-policy reopen wrote to the store (the retention-key "
+                "UPSERT must be skipped when persisted values already match)"
+            )
+            # The cached meta still reflects the persisted policy.
+            assert reg2.retention_meta() == (True, pol)
+
+        # A CHANGED policy does write (the skip is equality-gated, not blanket).
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True,
+            retention_policy=RetentionPolicy(max_versions=2),
+        ) as reg3:
+            assert reg3._conn.total_changes > 0
+            assert reg3.retention_meta() == (True, RetentionPolicy(max_versions=2))
 
     def test_disable_retention_preserves_existing_rows(self, db_path: Path) -> None:
         # disable != purge: reopening with retain_versions=False over existing
@@ -1456,6 +1571,105 @@ class TestReadOnlyMode:
         with pytest.raises(StoreNeedsRecoveryError):
             SqliteArtifactRegistry(db_path, read_only=True)
 
+    @pytest.mark.parametrize(
+        ("build_store", "fault_message", "expected_error"),
+        [
+            pytest.param("v1", None, SchemaVersionError, id="schema-version-mismatch"),
+            pytest.param(
+                "v2",
+                "attempt to write a readonly database (SQLITE_READONLY_RECOVERY)",
+                StoreNeedsRecoveryError,
+                id="needs-recovery",
+            ),
+            pytest.param(
+                "v2", "database is locked", StoreNeedsRecoveryError, id="busy"
+            ),
+        ],
+    )
+    def test_read_only_open_failure_closes_connection(
+        self, db_path: Path, monkeypatch, build_store, fault_message, expected_error
+    ) -> None:
+        # A typed failure AFTER sqlite3.connect succeeded must close the
+        # connection before raising — the caller never receives a registry
+        # handle, so a leaked conn would hold the db open for the process
+        # lifetime (and pin the WAL on platforms that block unlink).
+        if build_store == "v1":
+            _build_raw_v1_db(db_path, fence=True, notices=True)
+        else:
+            with SqliteArtifactRegistry(db_path) as reg:
+                _retain_artifact(reg, content="x")
+
+        from ccs.coordinator import sqlite_registry as sr
+
+        closes: list[bool] = []
+
+        class _Proxy:
+            def __init__(self, real):
+                self._real = real
+
+            def close(self):
+                closes.append(True)
+                return self._real.close()
+
+            def execute(self, sql, *a, **k):
+                if fault_message is not None and "user_version" in sql:
+                    raise sqlite3.OperationalError(fault_message)
+                return self._real.execute(sql, *a, **k)
+
+            def __getattr__(self, n):
+                return getattr(self._real, n)
+
+        real_connect = sqlite3.connect
+
+        def fake_connect(*a, **k):
+            conn = real_connect(*a, **k)
+            if a and "mode=ro" in str(a[0]):
+                return _Proxy(conn)
+            return conn
+
+        monkeypatch.setattr(sr.sqlite3, "connect", fake_connect)
+        with pytest.raises(expected_error):
+            SqliteArtifactRegistry(db_path, read_only=True)
+        assert closes == [True], "typed read-only open failure leaked the connection"
+
+    def test_read_only_busy_open_carries_busy_reason(
+        self, db_path: Path, monkeypatch
+    ) -> None:
+        # The typed signal (not the message) is the routing contract: a locked
+        # store classifies reason == STORE_SIGNAL_BUSY at the registry's single
+        # classification point.
+        from ccs.core.exceptions import STORE_SIGNAL_BUSY
+
+        with SqliteArtifactRegistry(db_path) as reg:
+            _retain_artifact(reg, content="x")
+
+        from ccs.coordinator import sqlite_registry as sr
+
+        class _BusyProxy:
+            def __init__(self, real):
+                self._real = real
+
+            def execute(self, sql, *a, **k):
+                if "user_version" in sql:
+                    raise sqlite3.OperationalError("database is locked")
+                return self._real.execute(sql, *a, **k)
+
+            def __getattr__(self, n):
+                return getattr(self._real, n)
+
+        real_connect = sqlite3.connect
+
+        def fake_connect(*a, **k):
+            conn = real_connect(*a, **k)
+            if a and "mode=ro" in str(a[0]):
+                return _BusyProxy(conn)
+            return conn
+
+        monkeypatch.setattr(sr.sqlite3, "connect", fake_connect)
+        with pytest.raises(StoreNeedsRecoveryError) as excinfo:
+            SqliteArtifactRegistry(db_path, read_only=True)
+        assert excinfo.value.reason == STORE_SIGNAL_BUSY
+
 
 class TestRetentionRemoveAndEpoch:
     """R4: delete cascades history; re-register mints new UUID; epoch reset."""
@@ -1538,6 +1752,49 @@ class TestRetentionFileModes:
                         f"{sidecar.name} mode "
                         f"{oct(stat.S_IMODE(sidecar.stat().st_mode))} != 0600"
                     )
+
+    def test_umask_window_db_and_sidecars_0600_from_creation(
+        self, db_path: Path, monkeypatch
+    ) -> None:
+        # The no-umask-window claim, pinned: under a permissive umask (0o022)
+        # all three files (db + -wal + -shm) must ALREADY exist at 0600 when
+        # sqlite3.connect first sees the path — i.e. they were pre-created by
+        # os.open(..., 0o600), never materialized by sqlite under the umask.
+        # A regression to open()+chmod (or to post-connect pre-creation) makes
+        # the at-connect snapshot miss files or show a broader mode.
+        from ccs.coordinator import sqlite_registry as sr
+
+        wal = db_path.with_name(db_path.name + "-wal")
+        shm = db_path.with_name(db_path.name + "-shm")
+        modes_at_connect: dict[str, int] = {}
+        real_connect = sqlite3.connect
+
+        def spying_connect(*a, **k):
+            if not modes_at_connect:  # first (writer) connect only
+                for p in (db_path, wal, shm):
+                    if p.exists():
+                        modes_at_connect[p.name] = stat.S_IMODE(p.stat().st_mode)
+            return real_connect(*a, **k)
+
+        monkeypatch.setattr(sr.sqlite3, "connect", spying_connect)
+        old_umask = os.umask(0o022)
+        try:
+            with SqliteArtifactRegistry(
+                db_path, retain_versions=True, retention_policy=_K8
+            ) as reg:
+                _retain_artifact(reg, content="x")  # force WAL frames
+        finally:
+            os.umask(old_umask)
+        # All three existed at 0600 BEFORE sqlite touched the path ...
+        assert modes_at_connect == {
+            db_path.name: 0o600,
+            wal.name: 0o600,
+            shm.name: 0o600,
+        }, f"files at connect time: {modes_at_connect}"
+        # ... and end at 0600 after real writes under the permissive umask.
+        for p in (db_path, wal, shm):
+            if p.exists():
+                assert stat.S_IMODE(p.stat().st_mode) == _DB_FILE_MODE
 
     def test_migration_tightens_broadened_db_and_warns_once(
         self, db_path: Path, caplog

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -12,17 +12,26 @@ deliberately does not preserve (KTD-13 contract divergence).
 
 from __future__ import annotations
 
+import os
+import sqlite3
+import stat
 import threading
 from pathlib import Path
 from uuid import UUID, uuid4
 
 import pytest
 
+from ccs.coordinator.retention import RetentionPolicy
 from ccs.coordinator.sqlite_registry import (
     CCS_STATE_LOG_SCHEMA_VERSION,
     SCHEMA_USER_VERSION,
+    MissingDatabaseError,
+    ReadOnlyMutationError,
     SchemaVersionError,
     SqliteArtifactRegistry,
+    StoreNeedsRecoveryError,
+    _ARTIFACT_VERSIONS_DDL,
+    _DB_FILE_MODE,
 )
 from ccs.core.states import MESIState, TransientState
 from ccs.core.types import Artifact, CasCorruption, ConflictDetail
@@ -792,8 +801,8 @@ def _build_pre_fence_db(db_path: Path, art_id: str, ag_id: str) -> None:
 
 
 def test_fresh_db_has_fence_schema(db_path: Path) -> None:
-    """A freshly initialized db carries the fence columns + coordinator_epoch,
-    and (option (a)) does NOT advance user_version beyond the existing v1."""
+    """A freshly initialized db carries the fence columns + coordinator_epoch
+    inline in the v2 schema (Unit 3: fresh dbs are created at v2 directly)."""
     with SqliteArtifactRegistry(db_path) as reg:
         art_cols = {r[1] for r in reg._conn.execute("PRAGMA table_info(artifacts)").fetchall()}
         state_cols = {
@@ -802,14 +811,16 @@ def test_fresh_db_has_fence_schema(db_path: Path) -> None:
         assert "owner_generation" in art_cols
         assert "read_generation" in state_cols
         assert reg._coordinator_epoch
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 1
+        # v1->v2 is the repo's first real schema bump (Unit 3): a fresh db is v2.
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
 
 
 def test_pre_fence_db_upgrades_in_place_additively(db_path: Path) -> None:
-    """A v1 db created before the fence gains the columns + coordinator_epoch
-    additively on open, WITHOUT a user_version bump; existing rows backfill to
-    owner_generation = 0 / read_generation = NULL, and prior meta is preserved.
-    Re-open is idempotent and the epoch is stable."""
+    """A pre-fence v1 db migrates to v2 on open (Unit 3): it gains the fence
+    columns + coordinator_epoch (the subsumed fence shim) AND the new
+    artifact_versions table, with user_version stamped 2. Existing rows backfill
+    to owner_generation = 0 / read_generation = NULL, and prior meta is
+    preserved. Re-open is the write-free v2 path; the epoch is stable."""
     art_id, ag_id = str(uuid4()), str(uuid4())
     _build_pre_fence_db(db_path, art_id, ag_id)
 
@@ -820,6 +831,13 @@ def test_pre_fence_db_upgrades_in_place_additively(db_path: Path) -> None:
         }
         assert "owner_generation" in art_cols
         assert "read_generation" in state_cols
+        # The migration also created the v2 retention table.
+        tables = {
+            r[0] for r in reg._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert "artifact_versions" in tables
         # Existing rows backfill: artifact -> 0, grant -> NULL (absent operand).
         assert (
             reg._conn.execute(
@@ -835,9 +853,9 @@ def test_pre_fence_db_upgrades_in_place_additively(db_path: Path) -> None:
             ).fetchone()[0]
             is None
         )
-        # Epoch seeded + loaded; user_version NOT bumped (option (a)).
+        # Epoch seeded + loaded; user_version stamped to 2 by the migration.
         assert reg._coordinator_epoch
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 1
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
         # Prior meta preserved (no clobber of instance_id / sequence_number).
         assert reg._instance_id == "fixed-instance"
         assert reg._seq == 7
@@ -990,9 +1008,10 @@ def test_set_artifact_and_content_fence_rejects_stale_committer(db_path: Path) -
 
 
 def test_fence_columns_present_epoch_absent_recovers(db_path: Path) -> None:
-    """A db whose fence COLUMNS exist but whose coordinator_epoch was never
-    seeded (partial prior upgrade) opens cleanly: _ensure_fence_columns skips
-    the duplicate ALTERs and the INSERT OR IGNORE seeds the missing epoch."""
+    """A v1 db whose fence COLUMNS exist but whose coordinator_epoch was never
+    seeded (one wild v1 variant) migrates to v2 cleanly: the migration's
+    table_info guards skip the duplicate column ALTERs and the INSERT OR IGNORE
+    seeds the missing epoch, while stamping user_version to 2."""
     import sqlite3
 
     # hex ids: the registry's lookups key on UUID.hex (the pre-fence builder
@@ -1009,5 +1028,541 @@ def test_fence_columns_present_epoch_absent_recovers(db_path: Path) -> None:
 
     with SqliteArtifactRegistry(db_path) as reg:
         assert reg._coordinator_epoch  # seeded on this open
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 1
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
         assert reg.get_owner_generation(UUID(art_id)) == 0
+
+
+# ======================================================================
+# Durable version retention (plan item N v1, Unit 3) — R2, R3, R4
+# ======================================================================
+
+
+_K8 = RetentionPolicy(max_versions=8)
+
+
+def _retain_artifact(reg, *, version: int = 1, content: str = "v1") -> Artifact:
+    art = Artifact(id=uuid4(), name="plan.md", version=version, content_hash="h")
+    reg.register_artifact(art, content=content)
+    return art
+
+
+def _build_raw_v1_db(
+    db_path: Path, *, fence: bool, notices: bool
+) -> tuple[str, str]:
+    """Construct a RAW v1 ``state.db`` BY HAND (not via the current code path,
+    which now emits v2) for one cell of the wild-v1 2x2 matrix.
+
+    ``fence`` toggles the read-generation fence columns + the ``coordinator_epoch``
+    seed (the fence shim shipped 2026-06-09 with no version bump, so most wild
+    dbs PRE-DATE it). ``notices`` toggles the ``pending_notices`` table (also a
+    no-bump shim). Seeds one artifact at version 3 + one M-grant so post-migration
+    queries have rows to check. Returns ``(artifact_id_hex, agent_id_hex)``.
+    """
+    art_id, ag_id = uuid4().hex, uuid4().hex
+    fence_art = ", owner_generation INTEGER NOT NULL DEFAULT 0" if fence else ""
+    fence_state = ", read_generation INTEGER" if fence else ""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            f"CREATE TABLE artifacts (id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE, "
+            f"version INTEGER NOT NULL{fence_art}, content_hash TEXT NOT NULL, "
+            f"size_tokens INTEGER, last_writer_id TEXT, updated_at REAL NOT NULL)"
+        )
+        conn.execute("CREATE INDEX idx_artifacts_name ON artifacts(name)")
+        conn.execute(
+            f"CREATE TABLE agent_states (artifact_id TEXT NOT NULL, agent_id TEXT NOT NULL, "
+            f"state TEXT NOT NULL, transient_state TEXT, transient_tick INTEGER, "
+            f"granted_at_tick INTEGER, last_reclaim_trigger TEXT, last_reclaim_tick INTEGER"
+            f"{fence_state}, PRIMARY KEY (artifact_id, agent_id), "
+            f"FOREIGN KEY (artifact_id) REFERENCES artifacts(id) ON DELETE CASCADE)"
+        )
+        conn.execute(
+            "CREATE TABLE heartbeats (agent_id TEXT PRIMARY KEY, last_tick INTEGER NOT NULL)"
+        )
+        conn.execute("CREATE TABLE registry_meta (key TEXT PRIMARY KEY, value TEXT)")
+        meta = [("instance_id", "wild-v1"), ("sequence_number", "4")]
+        if fence:
+            meta.append(("coordinator_epoch", "epoch-pre-migration"))
+        conn.executemany("INSERT INTO registry_meta (key, value) VALUES (?, ?)", meta)
+        if notices:
+            conn.execute(
+                "CREATE TABLE pending_notices (agent_id TEXT NOT NULL, "
+                "artifact_id TEXT NOT NULL, preempter_agent_id TEXT NOT NULL, "
+                "preempted_at_unix_ts REAL NOT NULL, PRIMARY KEY (agent_id, artifact_id), "
+                "FOREIGN KEY (artifact_id) REFERENCES artifacts(id) ON DELETE CASCADE)"
+            )
+        if fence:
+            conn.execute(
+                "INSERT INTO artifacts (id, name, version, owner_generation, "
+                "content_hash, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+                (art_id, "plan.md", 3, 0, "deadbeef", 1.0),
+            )
+        else:
+            conn.execute(
+                "INSERT INTO artifacts (id, name, version, content_hash, updated_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (art_id, "plan.md", 3, "deadbeef", 1.0),
+            )
+        conn.execute(
+            "INSERT INTO agent_states (artifact_id, agent_id, state) VALUES (?, ?, ?)",
+            (art_id, ag_id, "M"),
+        )
+        conn.execute("PRAGMA user_version = 1")
+        conn.execute("COMMIT")
+    finally:
+        conn.close()
+    return art_id, ag_id
+
+
+class TestDurableRetentionRoundTrip:
+    """R2/R3: retained versions survive a fresh process; types preserved."""
+
+    def test_round_trip_across_fresh_instance_str_and_bytes(self, db_path: Path) -> None:
+        # Capture across all three points with both str and bytes, then reopen a
+        # NEW registry instance (= fresh process) and read the durable rows.
+        pol = RetentionPolicy(max_versions=4)
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=pol
+        ) as reg:
+            art = _retain_artifact(reg, version=1, content="str-v1")  # register
+            n2 = Artifact(id=art.id, name="plan.md", version=2, content_hash="h")
+            reg.set_artifact_and_content(art.id, n2, "str-v2")  # pessimistic
+            w = uuid4()
+            reg.set_agent_state(art.id, w, MESIState.SHARED, tick=1)
+            reg.commit_cas(
+                art.id, w, expected_version=2, content_hash="h3",
+                content=b"\x00\x01bytes-v3", tick=2,
+            )  # commit_cas WIN, bytes
+            art_id = art.id
+
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=pol
+        ) as reg2:
+            v1 = reg2.get_content_at_version(art_id, 1)
+            v2 = reg2.get_content_at_version(art_id, 2)
+            v3 = reg2.get_content_at_version(art_id, 3)
+            # str rows round-trip TEXT -> str; bytes row round-trips BLOB -> bytes.
+            assert v1 == "str-v1" and isinstance(v1, str)
+            assert v2 == "str-v2" and isinstance(v2, str)
+            assert v3 == b"\x00\x01bytes-v3" and isinstance(v3, bytes)
+
+    def test_retention_off_returns_none_and_stores_nothing(self, db_path: Path) -> None:
+        # Default (retain_versions=False): no capture, get_content_at_version None.
+        with SqliteArtifactRegistry(db_path) as reg:
+            art = _retain_artifact(reg, content="discarded")
+            assert reg.get_content_at_version(art.id, 1) is None
+            assert reg._conn.execute(
+                "SELECT COUNT(*) FROM artifact_versions"
+            ).fetchone()[0] == 0
+            # The persisted marker says retention was never enabled.
+            assert reg.retention_meta() == (False, None)
+
+    def test_commit_cas_content_none_skips_capture(self, db_path: Path) -> None:
+        # Mirror of the in-memory fix: a content=None WIN retains NO row for the
+        # new version (no stale-old-body poisoning).
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=_K8
+        ) as reg:
+            art = _retain_artifact(reg, content="seed-v1")
+            w = uuid4()
+            reg.set_agent_state(art.id, w, MESIState.SHARED, tick=1)
+            updated, _ = reg.commit_cas(
+                art.id, w, expected_version=1, content_hash="hN", content=None, tick=2
+            )
+            assert updated.version == 2
+            assert reg.get_content_at_version(art.id, 2) is None
+            assert reg.get_content_at_version(art.id, 1) == "seed-v1"
+
+    def test_unbounded_marker_persisted_when_policy_none(self, db_path: Path) -> None:
+        # retain_versions=True + policy=None -> enabled with NULL axes, so a
+        # resolver can tell retention-on-unbounded from retention-never-enabled.
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=None
+        ) as reg:
+            art = _retain_artifact(reg, content="c1")
+            for v in (2, 3, 4):
+                nx = Artifact(id=art.id, name="plan.md", version=v, content_hash="h")
+                reg.set_artifact_and_content(art.id, nx, f"c{v}")
+            # Unbounded: every version retained.
+            assert reg.get_content_at_version(art.id, 1) == "c1"
+            assert reg.get_content_at_version(art.id, 4) == "c4"
+            assert reg.retention_meta() == (True, None)
+
+
+class TestWildV1Migration:
+    """R2: the four wild v1 variants ({±fence cols} x {±pending_notices}) each
+    migrate to v2 in one transaction with data intact + complete schema."""
+
+    @pytest.mark.parametrize("fence", [True, False])
+    @pytest.mark.parametrize("notices", [True, False])
+    def test_wild_variant_migrates_to_v2(
+        self, db_path: Path, fence: bool, notices: bool
+    ) -> None:
+        art_id, ag_id = _build_raw_v1_db(db_path, fence=fence, notices=notices)
+        with SqliteArtifactRegistry(db_path) as reg:
+            # user_version stamped 2; complete schema guaranteed.
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+            tables = {
+                r[0] for r in reg._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert {"artifact_versions", "pending_notices"}.issubset(tables)
+            art_cols = {
+                r[1] for r in reg._conn.execute(
+                    "PRAGMA table_info(artifacts)"
+                ).fetchall()
+            }
+            state_cols = {
+                r[1] for r in reg._conn.execute(
+                    "PRAGMA table_info(agent_states)"
+                ).fetchall()
+            }
+            assert "owner_generation" in art_cols
+            assert "read_generation" in state_cols
+            # Pre-existing data intact.
+            art = reg.get_artifact(UUID(art_id))
+            assert art is not None and art.version == 3
+            assert reg._instance_id == "wild-v1"
+            assert reg._seq == 4
+            # Fence queries work even on a PREVIOUSLY-pre-fence variant.
+            assert reg.get_owner_generation(UUID(art_id)) == 0
+            assert reg.get_read_generation(UUID(art_id), UUID(ag_id)) is None
+            # A fence-present v1 keeps its epoch; a fence-absent one is seeded.
+            if fence:
+                assert reg._coordinator_epoch == "epoch-pre-migration"
+            else:
+                assert reg._coordinator_epoch  # freshly seeded hex
+
+    def test_migrated_v1_supports_durable_capture(self, db_path: Path) -> None:
+        # After migrating a pre-fence v1, retention works on the upgraded store.
+        art_id, _ = _build_raw_v1_db(db_path, fence=False, notices=False)
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=_K8
+        ) as reg:
+            nx = Artifact(id=UUID(art_id), name="plan.md", version=4, content_hash="h")
+            reg.set_artifact_and_content(UUID(art_id), nx, "post-migration-body")
+            assert reg.get_content_at_version(UUID(art_id), 4) == "post-migration-body"
+
+    def test_half_migrated_db_completes_cleanly(self, db_path: Path) -> None:
+        # Characterization: a db with the v2 table already present but
+        # user_version still 1 (a crashed prior migration whose stamp never
+        # committed) must complete to v2, never "table already exists".
+        _build_raw_v1_db(db_path, fence=True, notices=True)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(_ARTIFACT_VERSIONS_DDL)  # table present; user_version still 1
+        conn.commit()
+        conn.close()
+        # Open via the normal path: must not raise OperationalError.
+        with SqliteArtifactRegistry(db_path) as reg:
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+
+    def test_half_migrated_db_missing_stamp_recovers(self, db_path: Path) -> None:
+        # The classic learnings case generalized to v2: all v2 tables present but
+        # user_version left at 1. The migration's IF-NOT-EXISTS / table_info
+        # guards make it idempotent — clean completion, no error.
+        _build_raw_v1_db(db_path, fence=True, notices=True)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(_ARTIFACT_VERSIONS_DDL)
+        conn.commit()
+        conn.close()
+        reg = SqliteArtifactRegistry(db_path)  # must not raise
+        try:
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+        finally:
+            reg.close()
+
+
+class TestRetentionPolicyAcrossRuns:
+    """R2/R4: K-lowered-between-runs (no open-time GC) + disable != purge."""
+
+    def test_k_lowered_between_runs_persists_until_next_capture(
+        self, db_path: Path
+    ) -> None:
+        art_id = None
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=RetentionPolicy(max_versions=10)
+        ) as reg:
+            art = _retain_artifact(reg, content="c1")
+            art_id = art.id
+            for v in range(2, 6):
+                nx = Artifact(id=art_id, name="plan.md", version=v, content_hash="h")
+                reg.set_artifact_and_content(art_id, nx, f"c{v}")
+            assert _versions(reg, art_id) == [1, 2, 3, 4, 5]
+
+        # Reopen with a lower K: rows persist (NO open-time GC pass).
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=RetentionPolicy(max_versions=2)
+        ) as reg:
+            assert _versions(reg, art_id) == [1, 2, 3, 4, 5]
+            # Next capture for THIS artifact prunes to the new K.
+            nx = Artifact(id=art_id, name="plan.md", version=6, content_hash="h")
+            reg.set_artifact_and_content(art_id, nx, "c6")
+            assert _versions(reg, art_id) == [5, 6]
+
+    def test_disable_retention_preserves_existing_rows(self, db_path: Path) -> None:
+        # disable != purge: reopening with retain_versions=False over existing
+        # rows preserves them (capture stops; rows stay readable).
+        art_id = None
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=_K8
+        ) as reg:
+            art = _retain_artifact(reg, content="kept")
+            art_id = art.id
+
+        with SqliteArtifactRegistry(db_path, retain_versions=False) as reg:
+            assert reg.get_content_at_version(art_id, 1) == "kept"
+            # The marker now records retention OFF, but the rows survive.
+            assert reg.retention_meta() == (False, None)
+            # A further write captures NOTHING (retention off).
+            nx = Artifact(id=art_id, name="plan.md", version=2, content_hash="h")
+            reg.set_artifact_and_content(art_id, nx, "not-captured")
+            assert reg.get_content_at_version(art_id, 2) is None
+            assert reg.get_content_at_version(art_id, 1) == "kept"
+
+
+class TestRetentionCrashAtomicity:
+    """R2: a BaseException mid-transaction leaves no phantom history AND no
+    version bump — capture and commit are one atomic unit."""
+
+    def test_commit_cas_win_log_raise_rolls_back_history_and_version(
+        self, db_path: Path
+    ) -> None:
+        # A state_log raise during the committer's WIN log entry must roll back
+        # the whole txn: no version move, no captured next_version row.
+        def boom(entry):
+            if entry["to_state"] == "SHARED" and entry["trigger"] == "commit_cas":
+                raise RuntimeError("boom in committer log")
+
+        iid = str(uuid4())
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=_K8,
+            state_log=boom, instance_id=iid,
+        ) as reg:
+            art = _retain_artifact(reg, content="seed-v1")
+            w = uuid4()
+            reg.set_agent_state(art.id, w, MESIState.SHARED, tick=1)
+            with pytest.raises(RuntimeError):
+                reg.commit_cas(
+                    art.id, w, expected_version=1, content_hash="hN",
+                    content="cas-v2", tick=2,
+                )
+            # No version bump, no phantom history, _seq consistent.
+            assert reg.get_artifact(art.id).version == 1
+            assert reg.get_content_at_version(art.id, 2) is None
+            assert reg.get_content_at_version(art.id, 1) == "seed-v1"
+
+    def test_fence_reject_leaves_no_capture(self, db_path: Path) -> None:
+        # The pessimistic fence rejects a superseded committer BEFORE the
+        # capture, so no phantom history row for the rejected version.
+        from ccs.core.exceptions import StaleReadGeneration
+
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=_K8
+        ) as reg:
+            art = _retain_artifact(reg, content="seed")
+            a = uuid4()
+            reg.set_agent_state(art.id, a, MESIState.EXCLUSIVE, trigger="write", tick=1)
+            reg.set_agent_state(art.id, a, MESIState.INVALID, trigger="reclaim_heartbeat", tick=2)
+            stale = Artifact(id=art.id, name="plan.md", version=2, content_hash="stale")
+            with pytest.raises(StaleReadGeneration):
+                reg.set_artifact_and_content(
+                    art.id, stale, "should-not-store", last_writer=a, fence_agent_id=a
+                )
+            assert reg.get_content_at_version(art.id, 2) is None
+
+
+class TestReadOnlyMode:
+    """R2: read-only open never creates / migrates / mutates; typed failures."""
+
+    def test_missing_path_raises_and_creates_no_file(self, tmp_path: Path) -> None:
+        missing = tmp_path / "absent.db"
+        with pytest.raises(MissingDatabaseError):
+            SqliteArtifactRegistry(missing, read_only=True)
+        assert not missing.exists()  # NO fresh db materialized
+
+    def test_v1_db_raises_version_error_no_migration(self, db_path: Path) -> None:
+        _build_raw_v1_db(db_path, fence=True, notices=True)
+        with pytest.raises(SchemaVersionError):
+            SqliteArtifactRegistry(db_path, read_only=True)
+        # The read-only open performed NO migration.
+        conn = sqlite3.connect(str(db_path))
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+        finally:
+            conn.close()
+
+    def test_read_only_reads_durable_rows(self, db_path: Path) -> None:
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=_K8
+        ) as reg:
+            art = _retain_artifact(reg, content="ro-body")
+            art_id = art.id
+            epoch = reg.coordinator_epoch
+        with SqliteArtifactRegistry(db_path, read_only=True) as ro:
+            assert ro.get_content_at_version(art_id, 1) == "ro-body"
+            assert ro.coordinator_epoch == epoch  # same epoch the writer minted
+            assert ro.retention_meta()[0] is True
+
+    def test_read_only_mutator_raises(self, db_path: Path) -> None:
+        with SqliteArtifactRegistry(db_path) as reg:
+            _retain_artifact(reg, content="x")
+        with SqliteArtifactRegistry(db_path, read_only=True) as ro:
+            with pytest.raises(ReadOnlyMutationError):
+                ro.register_artifact(
+                    Artifact(id=uuid4(), name="y", version=1, content_hash="h"), content="x"
+                )
+            with pytest.raises(ReadOnlyMutationError):
+                ro.set_agent_state(uuid4(), uuid4(), MESIState.SHARED)
+            with pytest.raises(ReadOnlyMutationError):
+                ro.remove_artifact(uuid4())
+
+    def test_read_only_needs_recovery_fault_injected(
+        self, db_path: Path, monkeypatch
+    ) -> None:
+        # A real post-crash hot-WAL state cannot be deterministically created in
+        # pytest, so inject SQLITE_READONLY_RECOVERY on the ro connection's first
+        # user_version read (the point a hot-WAL ro open fails).
+        with SqliteArtifactRegistry(db_path) as reg:
+            _retain_artifact(reg, content="x")
+
+        from ccs.coordinator import sqlite_registry as sr
+
+        class _RecoveryProxy:
+            def __init__(self, real):
+                self._real = real
+
+            def execute(self, sql, *a, **k):
+                if "user_version" in sql:
+                    raise sqlite3.OperationalError(
+                        "attempt to write a readonly database "
+                        "(SQLITE_READONLY_RECOVERY)"
+                    )
+                return self._real.execute(sql, *a, **k)
+
+            def __getattr__(self, n):
+                return getattr(self._real, n)
+
+        real_connect = sqlite3.connect
+
+        def fake_connect(*a, **k):
+            conn = real_connect(*a, **k)
+            if a and "mode=ro" in str(a[0]):
+                return _RecoveryProxy(conn)
+            return conn
+
+        monkeypatch.setattr(sr.sqlite3, "connect", fake_connect)
+        with pytest.raises(StoreNeedsRecoveryError):
+            SqliteArtifactRegistry(db_path, read_only=True)
+
+
+class TestRetentionRemoveAndEpoch:
+    """R4: delete cascades history; re-register mints new UUID; epoch reset."""
+
+    def test_remove_artifact_cascades_history(self, db_path: Path) -> None:
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=_K8
+        ) as reg:
+            art = _retain_artifact(reg, content="seed")
+            for v in (2, 3):
+                nx = Artifact(id=art.id, name="plan.md", version=v, content_hash="h")
+                reg.set_artifact_and_content(art.id, nx, f"c{v}")
+            assert reg._conn.execute(
+                "SELECT COUNT(*) FROM artifact_versions WHERE artifact_id = ?",
+                (art.id.hex,),
+            ).fetchone()[0] == 3
+            reg.remove_artifact(art.id)
+            # ON DELETE CASCADE dropped the retained rows.
+            assert reg._conn.execute(
+                "SELECT COUNT(*) FROM artifact_versions WHERE artifact_id = ?",
+                (art.id.hex,),
+            ).fetchone()[0] == 0
+            assert reg.get_content_at_version(art.id, 1) is None
+
+    def test_delete_then_reregister_same_name_fresh_history(self, db_path: Path) -> None:
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=_K8
+        ) as reg:
+            art = _retain_artifact(reg, content="old")
+            old_id = art.id
+            reg.remove_artifact(old_id)
+            # Re-register the SAME name mints a new UUID with fresh history.
+            art2 = Artifact(id=uuid4(), name="plan.md", version=1, content_hash="h")
+            assert art2.id != old_id
+            reg.register_artifact(art2, content="new")
+            assert reg.get_content_at_version(art2.id, 1) == "new"
+            assert reg.get_content_at_version(old_id, 1) is None  # old id gone
+
+    def test_epoch_reset_drops_rows(self, db_path: Path) -> None:
+        # Epoch reset = delete-and-recreate the db; retained rows do not survive.
+        art_id = None
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=_K8
+        ) as reg:
+            art = _retain_artifact(reg, content="pre-reset")
+            art_id = art.id
+            epoch1 = reg.coordinator_epoch
+        # Simulate the operator purge: remove the db (+ sidecars) and recreate.
+        db_path.unlink()
+        for sidecar in (db_path.with_name(db_path.name + "-wal"),
+                        db_path.with_name(db_path.name + "-shm")):
+            if sidecar.exists():
+                sidecar.unlink()
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=_K8
+        ) as reg:
+            assert reg.coordinator_epoch != epoch1  # fresh epoch
+            assert reg.get_content_at_version(art_id, 1) is None  # rows gone
+
+
+class TestRetentionFileModes:
+    """R2: state.db + sidecars are 0600, race-free; migration tightens + warns."""
+
+    def test_fresh_db_is_0600_immediately(self, db_path: Path) -> None:
+        with SqliteArtifactRegistry(db_path) as reg:
+            mode = stat.S_IMODE(db_path.stat().st_mode)
+            assert mode == _DB_FILE_MODE, f"db mode {oct(mode)} != 0600"
+
+    def test_sidecars_are_0600_after_writes(self, db_path: Path) -> None:
+        with SqliteArtifactRegistry(
+            db_path, retain_versions=True, retention_policy=_K8
+        ) as reg:
+            # Force WAL frames so the sidecars materialize.
+            _retain_artifact(reg, content="x")
+            wal = db_path.with_name(db_path.name + "-wal")
+            shm = db_path.with_name(db_path.name + "-shm")
+            for sidecar in (wal, shm):
+                if sidecar.exists():
+                    assert stat.S_IMODE(sidecar.stat().st_mode) == _DB_FILE_MODE, (
+                        f"{sidecar.name} mode "
+                        f"{oct(stat.S_IMODE(sidecar.stat().st_mode))} != 0600"
+                    )
+
+    def test_migration_tightens_broadened_db_and_warns_once(
+        self, db_path: Path, caplog
+    ) -> None:
+        # A pre-existing v1 db whose mode an operator broadened (0644) is
+        # tightened to 0600 by the migration, with a one-time warning.
+        _build_raw_v1_db(db_path, fence=True, notices=True)
+        os.chmod(db_path, 0o644)
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="ccs.coordinator.sqlite_registry"):
+            with SqliteArtifactRegistry(db_path) as reg:
+                pass
+        assert stat.S_IMODE(db_path.stat().st_mode) == _DB_FILE_MODE
+        warnings = [
+            r for r in caplog.records if "v1->v2 migration tightened" in r.message
+        ]
+        assert len(warnings) == 1, "expected exactly one posture-change warning"
+
+
+def _versions(reg, artifact_id) -> list[int]:
+    """Sorted retained versions for an artifact (sqlite test helper)."""
+    return sorted(
+        r[0] for r in reg._conn.execute(
+            "SELECT version FROM artifact_versions WHERE artifact_id = ?",
+            (artifact_id.hex,),
+        ).fetchall()
+    )


### PR DESCRIPTION
## Summary

- **Bounded version retention.** Opt-in `RetentionPolicy(max_versions=K, max_age_seconds=T)` replaces the unbounded in-process `version_history`: inline, amortized GC at every capture point; the current version is never collectible. Existing `retain_versions=True` consumers (the v0.5 content-audit wiring) keep today's unbounded semantics by construction — their suites pass unmodified.
- **Durable retention in `SqliteArtifactRegistry`** (in-process embedders only) behind the store's first real schema-version bump (v1 → v2). The migration runs in one `BEGIN IMMEDIATE`, idempotently subsumes the two prior additive shims (fence columns + epoch seed, `pending_notices`), and is tested against all four wild v1 schema variants; after it the steady-state open path performs no writes. The hook/HTTP coordinator topology is unchanged and stays hash-only (default off).
- **`CoordinatorService.read_at_version(artifact_id, version, expected_epoch=None)`** returning `VersionedContent` or a typed `VersionedReadRejection` over six wire-stable reasons (`retention_off`, `unknown_artifact`, `not_retained`, `epoch_mismatch`, `current_version`, `future_version`). Off-protocol by construction: no MESI state, no invalidation membership, no read-generation fence capture — asserted statically and at runtime, including reads by a sweep-reclaimed agent. Current-version requests are rejected so history never serves fresh content; a route-guard test pins that no HTTP route serves version content.
- **`agent-coherence-replay resolve`** — the wired consumer: opens a stored `.coherence/state.db` read-only (never creates, never migrates; typed errors incl. a distinct post-crash needs-recovery case) and answers "bytes at version k" across a coordinator restart. Content-safe by default: metadata only (version, epoch, captured_at, hash, length); bytes leave the process only via `--include-content` (base64 for binary) or `--output-file` (raw, 0600). Existing `agent-coherence-replay <session_dir>` invocation is byte-compatible.
- **Formal model first:** `formal/tla/Retention.tla` extends `Fencing.tla`; commit+retain+GC is one atomic action; a TLC action property proves a versioned read leaves every protocol variable unchanged; `NoCollectedRead` plus the inherited single-writer / `NoStaleApply` invariants re-checked with retention enabled. Wired into `make tla-check` with four dated mutant recipes in the README.
- Hardening that rode along: race-free `0600` on `state.db` + WAL sidecars (pre-created before connect; migration re-tightens and warns once); `SchemaVersionError` no longer recommends deleting the db; fixed a latent commit-CAS bug where a win with `content=None` retained the prior body under the new version.

## Test plan

- [x] Full suite: **1965 passed** (post-rebase on dev/v0.9.2), architecture check clean
- [x] `make tla-check`: all five specs green (`Retention_CI` ≈ 1m47s, within the CI budget); four mutants verified to violate and reverted
- [x] Four-variant wild-v1 migration matrix + half-migrated-db recovery tests (written before the migration code)
- [x] Dual-registry parity incl. whole-sequence equivalence and a real two-handle sqlite peer-interleaving case
- [x] Restart-survival consumer proof: write versions → close → reopen read-only → resolve exact bytes
- [x] v0.5 content-audit / replay-recorder suites pass **unmodified** (back-compat by construction)

## Notes for review

- Durable content storage is **opt-in twice** (`retain_versions=True` + an explicit policy for bounds); no existing deployment changes what it writes to disk. `docs/security.md` documents the new posture (content bytes, deletion vs WAL residue, backup sensitivity).
- The v1→v2 migration applies automatically and atomically on first open of an older db; rollback is "keep running the old binary" (older binaries refuse v2 cleanly rather than corrupting).