### PR TITLE
fix(coordinator): abort watchdog-late mutations and de-silence degraded reads (A6/A7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,42 @@ Alpha — APIs may change before `v1.0`.
   both registries — bytes bodies round-trip as `bytes` (they always did on the
   in-process path; the annotation was wrong).
 
+### Fixed
+
+- **Watchdog late-completion phantom grant / late grant-revocation (A6).** When
+  a coordinator hook handler exceeded its 4s watchdog and returned
+  `degraded: true`, its work kept running in the pool and its registry mutation
+  could land afterward — the agent could be left holding an `EXCLUSIVE` grant it
+  never saw (and its peers silently invalidated), or a late `session-stop`
+  release could revoke a grant the registry had since handed to the next
+  session. This was detection-only (`watchdog_late_completion_total`). The
+  mutating handlers (`pre-edit`, `post-edit`, `post-edit-cas`, `session-stop`)
+  now thread a per-request abort token into `CoordinatorService.write` /
+  `invalidate` / `commit` / `commit_cas`; the watchdog sets it on timeout, and a
+  new `registry.abort_guard` checks it the instant the late work wins the
+  registry write lock (the reentrant `RLock` that serializes all mutations),
+  raising `WatchdogAbandoned` so the mutation never lands. This closes the
+  dominant case (work blocked on the lock under contention). A new
+  `watchdog_late_aborts_total` counter (in `/status?detail=metrics`) records
+  when the guard fires. Residual (documented): a `BEGIN IMMEDIATE` that begins
+  after the check and then blocks on cross-process SQLite contention is still
+  observed by `watchdog_late_completion_total`; the complete fix
+  (response-and-visibility atomicity) is deferred to a fencing redesign.
+- **Watchdog-degraded reads no longer silently pass as verified-fresh (A7).**
+  When a `pre-read` / `pre-bash` / `pre-grep` handler exceeded its watchdog
+  (e.g. its task burned the budget waiting in the executor queue under SQLite
+  contention), it returned `{status: "fresh", degraded: true}` with no
+  `hookSpecificOutput` — so the staleness check that never ran was
+  indistinguishable from a confirmed-fresh read, and the model saw no warning.
+  The degraded read envelope now carries an advisory `additionalContext` (the
+  hook client passes it straight through) stating that freshness is unverified
+  and the file should be re-read if shared. `status` stays `"fresh"` for wire
+  back-compat. (Unbounded handler concurrency was already bounded by the
+  handler-concurrency semaphore + watchdog queue-depth gate; this addresses the
+  remaining *silent* suppression. Coupling the per-request deadline to dequeue
+  time, so queue wait doesn't consume the work budget, is a separate deferred
+  improvement.)
+
 ## [0.9.2] — 2026-06-11
 
 ### Fixed

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -66,6 +66,7 @@ from ccs.core.exceptions import (
     CoherenceError,
     OccCallerTransientError,
     StaleReadGeneration,
+    WatchdogAbandoned,
 )
 from ccs.core.states import MESIState
 from ccs.core.types import ConflictDetail
@@ -380,6 +381,10 @@ class CoordinatorHTTPServer:
         # cause is rare (4s deadline + 1.5s busy_timeout = real-world
         # only hits with a wedged SQLite or contended drive).
         self._watchdog_late_completion_total: int = 0
+        # A6: a watchdog-timed-out future that aborted cleanly at the registry
+        # write lock (abort_guard) before mutating — the mitigation working.
+        # Distinct from late_completion (which is an UNmitigated phantom).
+        self._watchdog_late_aborts_total: int = 0
 
         # KTD-I (Unit 5 L2) — in-flight handler counter. Incremented at
         # dispatch entry via :meth:`acquire_handler_slot`, decremented in
@@ -833,6 +838,14 @@ class CoordinatorHTTPServer:
         diagnosable from a bug report."""
         self._watchdog_late_completion_total += 1
 
+    def increment_watchdog_late_abort(self) -> None:
+        """A6: a watchdog-timed-out future aborted at the registry write lock
+        (``abort_guard``) before mutating — the late-completion mitigation
+        working as intended. No phantom state landed. Operator-visible via
+        ``/status?detail=metrics`` so the abort rate is distinguishable from
+        the unmitigated ``watchdog_late_completion_total`` residual."""
+        self._watchdog_late_aborts_total += 1
+
     def record_401(self) -> None:
         """P1 #6: bump ``auth_401_total`` and (deduped to once per 60s)
         emit a WARNING log explaining the most common cause — operator
@@ -870,6 +883,7 @@ class CoordinatorHTTPServer:
             "watchdog_timeouts_total": self._watchdog_timeouts_total,
             "watchdog_queue_overflows_total": self._watchdog_queue_overflows_total,
             "watchdog_late_completion_total": self._watchdog_late_completion_total,
+            "watchdog_late_aborts_total": self._watchdog_late_aborts_total,
             "handler_concurrency_overflows_total": (
                 self._server.handler_concurrency_overflows_total
                 if self._server is not None else 0
@@ -907,24 +921,33 @@ class CoordinatorHTTPServer:
                 return True
             return False
 
-    def run_with_watchdog(self, fn: Callable[[], Any]) -> Any:
+    def run_with_watchdog(
+        self, fn: Callable[[], Any], abort: threading.Event | None = None
+    ) -> Any:
         """Run a callable under the 4s handler-side timeout. Raises
         :class:`FuturesTimeout` on timeout (caller decides degradation).
 
-        P1 #5 (detection-only): when the future times out, ``cancel_futures``
-        is not set so the underlying work continues running in the pool.
-        Attach a done_callback that fires when that runaway work
-        eventually finishes — if it completed successfully, the
-        registry now holds state the agent never saw (phantom EXCLUSIVE
-        grant being the canonical worry). The callback bumps
-        ``watchdog_late_completion_total`` and logs CRITICAL so the
-        operator can correlate a phantom-grant cluster in a bug report
-        with the rate at which late completions are firing.
+        A6 mitigation: when the future times out, ``cancel_futures`` is not
+        set so the underlying work keeps running in the pool. If the caller
+        passed an ``abort`` Event (the mutating handlers do, threaded into the
+        ``service.*`` calls inside ``fn``), we SET it here — the work then
+        fails closed via ``registry.abort_guard`` the instant it wins the
+        registry write lock, so its mutation never lands after we returned a
+        degraded response. A ``fn`` that ignores ``abort`` (the read-only
+        handlers) is unaffected.
+
+        Either way we attach a done_callback for the residual: a future that
+        slips past the abort window and completes successfully bumps
+        ``watchdog_late_completion_total`` + logs CRITICAL; one that aborts
+        cleanly bumps ``watchdog_late_aborts_total`` so operators can see the
+        mitigation working.
         """
         future = self._watchdog.submit(fn)
         try:
             return future.result(timeout=HANDLER_TIMEOUT_SEC)
         except FuturesTimeout:
+            if abort is not None:
+                abort.set()
             future.add_done_callback(self._on_watchdog_future_done_after_timeout)
             raise
 
@@ -939,6 +962,13 @@ class CoordinatorHTTPServer:
             return
         try:
             future.result(timeout=0)
+        except WatchdogAbandoned:
+            # A6 mitigation fired: the late work aborted at the registry write
+            # lock before mutating. Clean no-op (no phantom state landed) —
+            # counted separately so operators can see the guard working,
+            # distinct from an unmitigated late completion.
+            self.increment_watchdog_late_abort()
+            return
         except Exception:
             # Late failure — no phantom state landed in the registry.
             return
@@ -1594,7 +1624,7 @@ def _handle_pre_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
 
         # Acquire EXCLUSIVE — this invalidates peers (KTD-1 single-writer).
         try:
-            coordinator.service.write(agent_id=agent_id, artifact_id=artifact_id, issued_at_tick=now)
+            coordinator.service.write(agent_id=agent_id, artifact_id=artifact_id, issued_at_tick=now, abort=abort)
         except CoherenceError as exc:
             return {"ok": False, "reason": str(exc)}
 
@@ -1645,7 +1675,11 @@ def _handle_pre_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
     # AC-05: pre-edit's wire contract is {ok: bool}, not {status: ...}.
     # On watchdog timeout, return the ok-shape degraded envelope so a
     # client doing result.get("ok") sees True rather than None.
-    _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE)
+    # A6: abort threaded into service.write so a late acquire aborts at the
+    # registry lock instead of granting a phantom EXCLUSIVE (and silently
+    # invalidating peers) the agent never saw.
+    abort = threading.Event()
+    _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE, abort=abort)
 
 
 def _handle_post_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
@@ -1697,6 +1731,7 @@ def _handle_post_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer)
                         new_version=artifact.version,
                         issuer_agent_id=agent_id,
                         issued_at_tick=now,
+                        abort=abort,
                     )
                 except CoherenceError as exc:
                     return {"ok": False, "reason": str(exc)}
@@ -1710,6 +1745,7 @@ def _handle_post_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer)
                 content="",  # KTD-13 — registry stores only the hash
                 issued_at_tick=now,
                 content_hash=content_hash,
+                abort=abort,
             )
         except StaleReadGeneration:
             # Read-generation fence: a sweep reclaimed this committer in the race
@@ -1770,7 +1806,10 @@ def _handle_post_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer)
 
     # AC-05: post-edit's wire contract is {ok: bool}; ok-shape degraded
     # envelope keeps clients reading result.get("ok") safe on timeout.
-    _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE)
+    # A6: abort threaded into invalidate/commit so a late post-edit aborts at
+    # the registry lock instead of landing a phantom version bump/invalidation.
+    abort = threading.Event()
+    _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE, abort=abort)
 
 
 def _handle_post_edit_cas(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
@@ -1864,6 +1903,7 @@ def _handle_post_edit_cas(req: _RequestProtocol, coordinator: CoordinatorHTTPSer
                 expected_version=expected_version,
                 content_hash=content_hash,
                 issued_at_tick=now,
+                abort=abort,
             )
         except OccCallerTransientError:
             # Retry-eligible (AC2): a peer invalidated the caller between its
@@ -1903,8 +1943,9 @@ def _handle_post_edit_cas(req: _RequestProtocol, coordinator: CoordinatorHTTPSer
 
     # Fail-closed: the OCC commit degrades to a body that reads as FAILURE.
     # A timed-out commit_cas whose future the watchdog does NOT cancel may
-    # still run to completion later (a pre-existing hazard — detection-only
-    # via watchdog_late_completion_total). For OCC the residual is bounded
+    # still run to completion later. A6: the abort token (below) makes the
+    # dominant case — work blocked on the registry write lock — abort before
+    # it lands (tracked via watchdog_late_aborts_total). The residual is bounded
     # and honest: in the contended case the late CAS sees the advanced
     # version → version_mismatch, no mutation; in the uncontended case it
     # lands N+1 AFTER the client gave up — a phantom/duplicate version bump
@@ -1914,7 +1955,8 @@ def _handle_post_edit_cas(req: _RequestProtocol, coordinator: CoordinatorHTTPSer
     # cross-host follow-on. v1's only obligation: the client must never
     # mistake a degraded CAS for success — hence _OCC_DEGRADED_RESPONSE
     # ({ok: false, …}), never _OK_DEGRADED_RESPONSE.
-    _run_or_degrade(req, coordinator, work, degraded_response=_OCC_DEGRADED_RESPONSE)
+    abort = threading.Event()
+    _run_or_degrade(req, coordinator, work, degraded_response=_OCC_DEGRADED_RESPONSE, abort=abort)
 
 
 def _handle_session_stop(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
@@ -1948,6 +1990,7 @@ def _handle_session_stop(req: _RequestProtocol, coordinator: CoordinatorHTTPServ
                     new_version=artifact.version,
                     issuer_agent_id=agent_id,
                     issued_at_tick=now,
+                    abort=abort,
                 )
                 released.append(artifact.name)
             except CoherenceError as exc:
@@ -1987,7 +2030,10 @@ def _handle_session_stop(req: _RequestProtocol, coordinator: CoordinatorHTTPServ
 
     # AC-05: session-stop's wire contract is {ok: bool}; ok-shape degraded
     # envelope keeps clients reading result.get("ok") safe on timeout.
-    _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE)
+    # A6: abort threaded into the per-artifact invalidate so a late release
+    # aborts before revoking a grant the registry handed to the next session.
+    abort = threading.Event()
+    _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE, abort=abort)
 
 
 def _handle_policy_track(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
@@ -2795,11 +2841,31 @@ _ENDPOINT_COUNTER_NAMES: dict[tuple[str, str], str] = {
 # ----------------------------------------------------------------------
 
 
-_DEFAULT_DEGRADED_RESPONSE: dict = {"status": "fresh", "degraded": True}
-"""AC-05: pre-read / pre-bash / pre-grep degrade to a fresh-shape envelope
-because their wire contract uses ``{status: "fresh"|"stale"}``. Endpoints
-whose contract is ``{ok: bool}`` (pre-edit, post-edit, session-stop) pass
-``OK_DEGRADED_RESPONSE`` instead so the client doesn't see ``None`` from
+_DEFAULT_DEGRADED_RESPONSE: dict = {
+    "status": "fresh",
+    "degraded": True,
+    # A7: a degraded read must NOT silently masquerade as a verified-fresh read.
+    # The handler timed out, so the staleness check never ran — surface an
+    # advisory the model actually sees (the hook client passes hookSpecificOutput
+    # straight through) instead of an empty allow. ``status`` stays "fresh" for
+    # wire back-compat (clients branch on it); the advisory + ``degraded`` flag
+    # are the honest signal that freshness is UNVERIFIED, not confirmed.
+    "hookSpecificOutput": _payloads.emit_allow(
+        source="watchdog_degraded_read",
+        additional_context=(
+            "⚠ Coherence could not verify this file's freshness — the coordinator "
+            "staleness check timed out under load. Proceeding WITHOUT a stale-read "
+            "guarantee: if this file is shared with other agents or sessions, "
+            "re-read it before relying on its contents."
+        ),
+    ),
+}
+"""AC-05 / A7: pre-read / pre-bash / pre-grep degrade to a fresh-shape envelope
+because their wire contract uses ``{status: "fresh"|"stale"}``. A7: the envelope
+now carries a ``hookSpecificOutput`` advisory so a watchdog-degraded read is
+visible to the model rather than silently passing as a confirmed fresh read.
+Endpoints whose contract is ``{ok: bool}`` (pre-edit, post-edit, session-stop)
+pass ``OK_DEGRADED_RESPONSE`` instead so the client doesn't see ``None`` from
 ``result.get("ok")``."""
 
 _OK_DEGRADED_RESPONSE: dict = {"ok": True, "degraded": True}
@@ -2829,6 +2895,7 @@ def _run_or_degrade(
     work: Callable[[], dict],
     *,
     degraded_response: dict | None = None,
+    abort: threading.Event | None = None,
 ) -> None:
     """Run ``work`` under the handler-side watchdog. On timeout, log WARNING
     and return 200 with ``degraded_response`` (or the default fresh-shape
@@ -2872,7 +2939,7 @@ def _run_or_degrade(
         return
 
     try:
-        result = coordinator.run_with_watchdog(work)
+        result = coordinator.run_with_watchdog(work, abort=abort)
     except FuturesTimeout:
         # KTD-G item 3: surface watchdog degradation via /status counter.
         coordinator.increment_watchdog_timeout()  # finding #31

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -5,9 +5,10 @@
 
 from __future__ import annotations
 
+import threading
 import time
-from dataclasses import dataclass, field
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from typing import Any, Callable, Iterator, Optional, TypeAlias
 from uuid import UUID, uuid4
 

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -7,10 +7,15 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, TypeAlias
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Optional, TypeAlias
 from uuid import UUID, uuid4
 
-from ccs.core.exceptions import STALE_READ_GENERATION_REASON, StaleReadGeneration
+from ccs.core.exceptions import (
+    STALE_READ_GENERATION_REASON,
+    StaleReadGeneration,
+    WatchdogAbandoned,
+)
 from ccs.core.states import MESIState, TransientState
 from ccs.core.types import Artifact, CasCorruption, ConflictDetail
 
@@ -89,6 +94,24 @@ class ArtifactRecord:
 
 class ArtifactRegistry:
     """Canonical in-memory artifact directory and payload store."""
+
+    @contextmanager
+    def abort_guard(self, abort: "threading.Event | None" = None) -> Iterator[None]:
+        """In-memory mirror of :meth:`SqliteArtifactRegistry.abort_guard`
+        (finding A6) so :class:`CoordinatorService` can call it uniformly
+        regardless of which registry backs it.
+
+        This registry is single-threaded (no process-level lock), so the guard
+        is a lock-free abort check: if the handler watchdog already timed out
+        and SET ``abort``, fail closed before the caller mutates; otherwise run
+        the mutation. ``abort=None`` (every non-watchdog caller) is a no-op.
+        """
+        if abort is not None and abort.is_set():
+            raise WatchdogAbandoned(
+                "handler watchdog timed out before this mutation ran; aborting "
+                "before it lands (A6)."
+            )
+        yield
 
     def __init__(
         self,

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -432,8 +432,26 @@ class CoordinatorService:
         agent_id: UUID,
         artifact_id: UUID,
         issued_at_tick: int = 0,
+        abort: threading.Event | None = None,
     ) -> list[InvalidationSignal]:
-        """Request write ownership by invalidating peers and granting EXCLUSIVE."""
+        """Request write ownership by invalidating peers and granting EXCLUSIVE.
+
+        Wrapped in :meth:`registry.abort_guard` (finding A6): if the handler
+        watchdog already timed out, the grant aborts before it lands rather than
+        leaving a phantom EXCLUSIVE the agent never saw (and silently
+        invalidating its peers)."""
+        with self.registry.abort_guard(abort):
+            return self._write_impl(
+                agent_id=agent_id, artifact_id=artifact_id, issued_at_tick=issued_at_tick
+            )
+
+    def _write_impl(
+        self,
+        *,
+        agent_id: UUID,
+        artifact_id: UUID,
+        issued_at_tick: int = 0,
+    ) -> list[InvalidationSignal]:
         artifact = self._require_artifact(artifact_id)
         self.registry.set_agent_transient(
             artifact_id,
@@ -479,6 +497,28 @@ class CoordinatorService:
         return self.write(agent_id=agent_id, artifact_id=artifact_id, issued_at_tick=issued_at_tick)
 
     def commit(
+        self,
+        *,
+        agent_id: UUID,
+        artifact_id: UUID,
+        content: str,
+        issued_at_tick: int = 0,
+        content_hash: str | None = None,
+        size_tokens: int | None = None,
+        abort: threading.Event | None = None,
+    ) -> tuple[Artifact, list[InvalidationSignal]]:
+        """Commit modified content under the A6 abort guard (see _commit_impl)."""
+        with self.registry.abort_guard(abort):
+            return self._commit_impl(
+                agent_id=agent_id,
+                artifact_id=artifact_id,
+                content=content,
+                issued_at_tick=issued_at_tick,
+                content_hash=content_hash,
+                size_tokens=size_tokens,
+            )
+
+    def _commit_impl(
         self,
         *,
         agent_id: UUID,
@@ -583,6 +623,30 @@ class CoordinatorService:
         return updated, signals
 
     def commit_cas(
+        self,
+        *,
+        agent_id: UUID,
+        artifact_id: UUID,
+        expected_version: int,
+        content_hash: str,
+        issued_at_tick: int = 0,
+        size_tokens: int | None = None,
+        content: bytes | str | None = None,
+        abort: threading.Event | None = None,
+    ) -> tuple[Artifact, list[InvalidationSignal]] | ConflictDetail:
+        """Optimistic-concurrency commit under the A6 abort guard (see _commit_cas_impl)."""
+        with self.registry.abort_guard(abort):
+            return self._commit_cas_impl(
+                agent_id=agent_id,
+                artifact_id=artifact_id,
+                expected_version=expected_version,
+                content_hash=content_hash,
+                issued_at_tick=issued_at_tick,
+                size_tokens=size_tokens,
+                content=content,
+            )
+
+    def _commit_cas_impl(
         self,
         *,
         agent_id: UUID,
@@ -715,12 +779,32 @@ class CoordinatorService:
         new_version: int,
         issuer_agent_id: UUID,
         issued_at_tick: int,
+        abort: threading.Event | None = None,
     ) -> InvalidationSignal | None:
-        """Apply invalidation for one agent and return corresponding signal object.
+        """Apply invalidation for one agent under the A6 abort guard.
 
-        Returns None when the artifact has already been deleted — callers applying
-        a delete-tombstone invalidation must not crash on a missing artifact.
+        Wrapped in :meth:`registry.abort_guard` (finding A6): a late
+        session-stop release whose handler already timed out aborts here rather
+        than revoking a grant the registry has since handed to another session.
         """
+        with self.registry.abort_guard(abort):
+            return self._invalidate_impl(
+                agent_id=agent_id,
+                artifact_id=artifact_id,
+                new_version=new_version,
+                issuer_agent_id=issuer_agent_id,
+                issued_at_tick=issued_at_tick,
+            )
+
+    def _invalidate_impl(
+        self,
+        *,
+        agent_id: UUID,
+        artifact_id: UUID,
+        new_version: int,
+        issuer_agent_id: UUID,
+        issued_at_tick: int,
+    ) -> InvalidationSignal | None:
         if not self.registry.has_artifact(artifact_id):
             return None
         self.registry.set_agent_state(

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -81,9 +81,10 @@ import stat
 import threading
 import time
 import warnings
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterable, NoReturn, Optional, TypeAlias
+from typing import Any, Callable, Iterable, Iterator, NoReturn, Optional, TypeAlias
 from uuid import UUID, uuid4
 
 from ccs.core.exceptions import (
@@ -93,6 +94,7 @@ from ccs.core.exceptions import (
     STORE_SIGNAL_UNREADABLE,
     STORE_SIGNAL_WAL_RECOVERY,
     StaleReadGeneration,
+    WatchdogAbandoned,
 )
 from ccs.core.states import MESIState, TransientState
 from ccs.core.types import Artifact, CasCorruption, ConflictDetail
@@ -518,6 +520,37 @@ class SqliteArtifactRegistry:
     # ------------------------------------------------------------------
     # Cross-runtime fail-closed guard (sibling Node coordinator hazard)
     # ------------------------------------------------------------------
+
+    @contextmanager
+    def abort_guard(self, abort: "threading.Event | None" = None) -> Iterator[None]:
+        """Acquire the registry write lock, then fail closed if the handler
+        watchdog already timed out (finding A6).
+
+        The dominant reason a mutation handler exceeds its 4s budget is that it
+        is blocked here — on the process-level ``RLock`` that serializes every
+        registry mutation — while a peer handler holds it. By the time this
+        handler wins the lock the watchdog may have already fired, returned
+        ``degraded: true`` to the client, and SET ``abort``. Checking ``abort``
+        the instant we win the lock, and holding the lock across the caller's
+        whole mutation (the RLock is reentrant, so the inner registry calls
+        re-enter freely), makes the late "phantom grant" abort before it lands.
+
+        ``abort=None`` — every non-watchdog caller (CoherentVolume, CCSStore,
+        the CLI) — is a plain lock acquire with no behavioural change.
+
+        Residual (documented, finding A6): a ``BEGIN IMMEDIATE`` that starts
+        AFTER this check and then blocks on CROSS-PROCESS SQLite write
+        contention is not covered. That window is narrow — the coordinator is
+        single-process, so the RLock already serializes in-process writers — and
+        remains observed by ``watchdog_late_completion_total``.
+        """
+        with self._lock:
+            if abort is not None and abort.is_set():
+                raise WatchdogAbandoned(
+                    "handler watchdog timed out while this mutation was blocked "
+                    "on the registry write lock; aborting before it lands (A6)."
+                )
+            yield
 
     def _has_table(self, name: str) -> bool:
         """Read-only probe: does a table exist? (sqlite_master, no writes)."""

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -236,3 +236,22 @@ class ScenarioValidationError(CoherenceError):
     def __init__(self, path: str, message: str):
         super().__init__(f"scenario={path}: {message}")
         self.path = path
+
+
+class WatchdogAbandoned(RuntimeError):
+    """A handler's 4s watchdog fired, so its still-running work was told to abort
+    before it could mutate the registry (finding A6).
+
+    Raised by the registries' ``abort_guard`` when the per-request abort
+    :class:`threading.Event` is already set at the moment the mutation wins the
+    registry write lock — i.e. the handler timed out (and the client already got
+    ``degraded: true``) while this work was blocked on that lock. Aborting there
+    is what stops the late "phantom grant" / grant-revocation from landing.
+
+    Deliberately NOT a :class:`CoherenceError`: it never reaches a client. The
+    only caller that ever sets the abort Event is the handler watchdog, which
+    has already responded; this exception surfaces solely inside the abandoned
+    pool future, where ``_on_watchdog_future_done_after_timeout`` treats it as a
+    clean no-op (no phantom state landed). Every non-watchdog caller
+    (CoherentVolume, CCSStore, the CLI) passes ``abort=None`` and never sees it.
+    """

--- a/tests/integration/test_strict_mode.py
+++ b/tests/integration/test_strict_mode.py
@@ -344,6 +344,7 @@ ALLOW_EMISSION_SOURCES: list[str] = [
     "pre_edit_notice_only",          # coordinator_server._handle_pre_edit
     "pre_bash_stale_warn",           # coordinator_server._handle_pre_bash
     "pre_grep_stale_warn",           # coordinator_server._handle_pre_grep
+    "watchdog_degraded_read",        # coordinator_server._DEFAULT_DEGRADED_RESPONSE (A7)
 ]
 
 

--- a/tests/protocol_corpus/fixtures/warn_mode/08-status-default-tier-empty-workspace.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/08-status-default-tier-empty-workspace.json
@@ -39,6 +39,7 @@
       "strict_mode_routed_around_via_bash_total": 0,
       "audit_log_mode_drift_total": 0,
       "tracked_artifacts": "<IGNORED>",
+      "watchdog_late_aborts_total": 0,
       "watchdog_late_completion_total": 0,
       "watchdog_queue_overflows_total": 0,
       "watchdog_timeouts_total": 0

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -3133,7 +3133,7 @@ def test_ac05_pre_edit_degraded_response_returns_ok_shape(
     result.get('ok') don't see None. AC-05 fix."""
     from concurrent.futures import TimeoutError as FuturesTimeout
 
-    def force_timeout(fn):
+    def force_timeout(fn, abort=None):
         raise FuturesTimeout()
 
     monkeypatch.setattr(coordinator, "run_with_watchdog", force_timeout)
@@ -3155,7 +3155,7 @@ def test_ac05_post_edit_degraded_response_returns_ok_shape(
     include ok=True. AC-05 fix."""
     from concurrent.futures import TimeoutError as FuturesTimeout
 
-    def force_timeout(fn):
+    def force_timeout(fn, abort=None):
         raise FuturesTimeout()
 
     monkeypatch.setattr(coordinator, "run_with_watchdog", force_timeout)
@@ -3180,7 +3180,7 @@ def test_ac05_session_stop_degraded_response_returns_ok_shape(
     must include ok=True. AC-05 fix."""
     from concurrent.futures import TimeoutError as FuturesTimeout
 
-    def force_timeout(fn):
+    def force_timeout(fn, abort=None):
         raise FuturesTimeout()
 
     monkeypatch.setattr(coordinator, "run_with_watchdog", force_timeout)
@@ -3200,7 +3200,7 @@ def test_ac05_pre_read_degraded_response_keeps_status_fresh_shape(
     don't see ok=None. AC-05 contract preservation."""
     from concurrent.futures import TimeoutError as FuturesTimeout
 
-    def force_timeout(fn):
+    def force_timeout(fn, abort=None):
         raise FuturesTimeout()
 
     monkeypatch.setattr(coordinator, "run_with_watchdog", force_timeout)
@@ -3213,6 +3213,33 @@ def test_ac05_pre_read_degraded_response_keeps_status_fresh_shape(
     assert body.get("degraded") is True
     # Crucially, pre-read's degraded envelope does NOT include ok.
     assert "ok" not in body
+
+
+def test_a7_degraded_read_surfaces_advisory_not_silent(
+    coordinator, client: _Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A7: a watchdog-degraded read must NOT silently pass as verified-fresh.
+    The degraded envelope now carries a hookSpecificOutput advisory the model
+    sees (the hook client passes it straight through), so an in-queue/processing
+    timeout cannot masquerade as a confirmed fresh read."""
+    from concurrent.futures import TimeoutError as FuturesTimeout
+
+    def force_timeout(fn, abort=None):
+        raise FuturesTimeout()
+
+    monkeypatch.setattr(coordinator, "run_with_watchdog", force_timeout)
+    status, body = client.post(
+        "/hooks/pre-read",
+        {"session_id": _sid("a7-degraded"), "path": "plan.md"},
+    )
+    assert status == 200
+    assert body.get("status") == "fresh"
+    assert body.get("degraded") is True
+    hso = body.get("hookSpecificOutput")
+    assert isinstance(hso, dict), "degraded read must carry an advisory (non-silent)"
+    assert "timed out" in hso.get("additionalContext", "").lower(), (
+        f"advisory must explain the freshness check did not run; got {hso!r}"
+    )
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_watchdog_abort_a6.py
+++ b/tests/test_watchdog_abort_a6.py
@@ -21,7 +21,6 @@ from ccs.coordinator.service import CoordinatorService
 from ccs.core.exceptions import WatchdogAbandoned
 from ccs.core.states import MESIState
 
-
 # --- guard correctness (deterministic, in-memory; no timing) --------------
 
 

--- a/tests/test_watchdog_abort_a6.py
+++ b/tests/test_watchdog_abort_a6.py
@@ -1,0 +1,144 @@
+"""A6 — watchdog late-completion abort guard.
+
+Before this fix, a handler that exceeded the 4s watchdog returned
+``degraded: true`` but its work kept running in the pool and its mutation
+(``service.write`` phantom grant, late ``service.invalidate`` grant-revocation)
+landed afterward — detection-only via a counter. These tests pin the contained
+mitigation: an abort Event set by the watchdog on timeout makes the late work
+fail closed at the registry write lock (``abort_guard``) before it mutates.
+"""
+
+import threading
+import time
+from concurrent.futures import TimeoutError as FuturesTimeout
+from uuid import uuid4
+
+import pytest
+
+import ccs.adapters.claude_code.coordinator_server as cs
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.service import CoordinatorService
+from ccs.core.exceptions import WatchdogAbandoned
+from ccs.core.states import MESIState
+
+
+# --- guard correctness (deterministic, in-memory; no timing) --------------
+
+
+def _service() -> CoordinatorService:
+    return CoordinatorService(ArtifactRegistry())
+
+
+def test_a6_write_aborts_when_abort_preset() -> None:
+    """A preset abort makes write() fail closed before granting EXCLUSIVE."""
+    svc = _service()
+    art = svc.register_artifact(name="plan.md", content="v1")
+    agent = uuid4()
+    abort = threading.Event()
+    abort.set()
+
+    with pytest.raises(WatchdogAbandoned):
+        svc.write(agent_id=agent, artifact_id=art.id, abort=abort)
+
+    assert svc.registry.get_agent_state(art.id, agent) != MESIState.EXCLUSIVE, (
+        "no phantom EXCLUSIVE grant must land when the watchdog already aborted"
+    )
+
+
+def test_a6_write_applies_when_abort_clear() -> None:
+    """An unset abort (or None) is a no-op — the grant applies normally."""
+    svc = _service()
+    art = svc.register_artifact(name="plan.md", content="v1")
+    agent = uuid4()
+
+    svc.write(agent_id=agent, artifact_id=art.id, abort=threading.Event())
+    assert svc.registry.get_agent_state(art.id, agent) == MESIState.EXCLUSIVE
+
+
+def test_a6_invalidate_aborts_when_abort_preset_does_not_revoke() -> None:
+    """The worst case: a late session-stop release must NOT revoke a grant."""
+    svc = _service()
+    art = svc.register_artifact(name="plan.md", content="v1")
+    agent = uuid4()
+    svc.write(agent_id=agent, artifact_id=art.id)  # agent -> EXCLUSIVE
+    assert svc.registry.get_agent_state(art.id, agent) == MESIState.EXCLUSIVE
+
+    abort = threading.Event()
+    abort.set()
+    with pytest.raises(WatchdogAbandoned):
+        svc.invalidate(
+            agent_id=agent,
+            artifact_id=art.id,
+            new_version=art.version,
+            issuer_agent_id=agent,
+            issued_at_tick=1,
+            abort=abort,
+        )
+
+    assert svc.registry.get_agent_state(art.id, agent) == MESIState.EXCLUSIVE, (
+        "a late, aborted invalidate must not revoke the still-valid grant"
+    )
+
+
+# --- watchdog wiring (timing-bounded, uses the real sqlite coordinator) ----
+
+
+def test_a6_watchdog_timeout_sets_abort_event(tmp_path) -> None:
+    """run_with_watchdog SETS the caller's abort Event on timeout."""
+    with cs.CoordinatorHTTPServer(tmp_path, port=0, instance_id="a6-set") as coordinator:
+        release = threading.Event()
+        abort = threading.Event()
+
+        def slow_work() -> dict:
+            release.wait(timeout=5.0)
+            return {"ok": True}
+
+        original = cs.HANDLER_TIMEOUT_SEC
+        try:
+            cs.HANDLER_TIMEOUT_SEC = 0.05
+            with pytest.raises(FuturesTimeout):
+                coordinator.run_with_watchdog(slow_work, abort=abort)
+            assert abort.is_set(), "watchdog timeout must signal the runaway work to abort"
+        finally:
+            cs.HANDLER_TIMEOUT_SEC = original
+            release.set()
+
+
+def test_a6_late_write_aborts_with_no_phantom_grant(tmp_path) -> None:
+    """End to end: a write whose handler times out aborts at the registry lock
+    when it finally runs — no phantom EXCLUSIVE, and the abort is counted."""
+    with cs.CoordinatorHTTPServer(tmp_path, port=0, instance_id="a6-e2e") as coordinator:
+        art = coordinator.service.register_artifact(name="plan.md", content="v1")
+        agent = uuid4()
+        release = threading.Event()
+        abort = threading.Event()
+
+        def work() -> list:
+            release.wait(timeout=5.0)  # block past the watchdog deadline
+            return coordinator.service.write(
+                agent_id=agent, artifact_id=art.id, abort=abort
+            )
+
+        original = cs.HANDLER_TIMEOUT_SEC
+        try:
+            cs.HANDLER_TIMEOUT_SEC = 0.05
+            before = coordinator._watchdog_late_aborts_total
+            with pytest.raises(FuturesTimeout):
+                coordinator.run_with_watchdog(work, abort=abort)
+            # The watchdog has set `abort`; release the work so it reaches the
+            # guarded write, which must now abort rather than grant.
+            release.set()
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline:
+                if coordinator._watchdog_late_aborts_total > before:
+                    break
+                time.sleep(0.02)
+            assert coordinator._watchdog_late_aborts_total == before + 1, (
+                "the aborted late completion must bump watchdog_late_aborts_total"
+            )
+            assert coordinator.registry.get_agent_state(art.id, agent) != MESIState.EXCLUSIVE, (
+                "the late write must not have granted a phantom EXCLUSIVE"
+            )
+        finally:
+            cs.HANDLER_TIMEOUT_SEC = original
+            release.set()


### PR DESCRIPTION
## Summary
- **A6:** a coordinator hook handler that exceeded its 4s watchdog returned `degraded: true` but kept running and could still mutate the registry — a phantom EXCLUSIVE grant the agent never saw (peers silently invalidated), or a late `session-stop` release revoking the next session's grant. The late mutation now fails closed at the registry write lock instead of landing.
- **A7:** a watchdog-degraded read returned `status: "fresh"` with no advisory, indistinguishable from a verified-fresh read. It now carries a visible advisory that freshness is unverified.

## Detail
**A6.** The mutating handlers thread a per-request abort `Event` into `CoordinatorService.write / invalidate / commit / commit_cas`. `run_with_watchdog` sets it on timeout; the new `registry.abort_guard(abort)` acquires the reentrant registry lock and, if the abort is set, raises `WatchdogAbandoned` before the mutation — so a handler that timed out while blocked on the lock (the dominant cause of >4s under SQLite contention) aborts the instant it wins the lock. A new `watchdog_late_aborts_total` counter (`/status?detail=metrics`) records the guard firing. Residual (documented): a `BEGIN IMMEDIATE` blocking on cross-process contention after the check is still observed by `watchdog_late_completion_total`; the complete fix (response-and-visibility atomicity) is a separate fencing redesign.

**A7.** The degraded read envelope now includes a `hookSpecificOutput` advisory (`status` stays `fresh` for wire back-compat, so existing clients that branch on it are unaffected). Unbounded handler concurrency was already bounded by the handler-concurrency semaphore + watchdog queue-depth gate; this closes the remaining *silent* suppression. Coupling the per-request deadline to dequeue time is a separate deferred improvement.

## Test Plan
- [x] `tests/test_watchdog_abort_a6.py` (5): the guard aborts a preset-abort `write`/`invalidate` with no state change; `run_with_watchdog` sets the abort on timeout; end-to-end, a late write aborts with no phantom grant and bumps `watchdog_late_aborts_total`.
- [x] `test_a7_degraded_read_surfaces_advisory_not_silent`: a degraded pre-read carries the advisory.
- [x] Updated 4 AC-05 stubs for the new `run_with_watchdog(fn, abort=None)` signature.
- [x] Full suite: **2019 passed**, 3 skipped.
