### PR TITLE
fix(coordinator): harden spawn/idle lifecycle (L1/L3/L5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,31 @@ Alpha — APIs may change before `v1.0`.
   both registries — bytes bodies round-trip as `bytes` (they always did on the
   in-process path; the annotation was wrong).
 
+### Fixed
+
+- **Coordinator spawn/idle lifecycle hardening (L1, L3, L5).**
+  - **L1 — `rm -rf .coherence/` during coordinator construction.** The
+    spawn-or-join loop revalidated the `server.pid` inode before acquiring the
+    flock, but an external `rm -rf .coherence/ && recreate` landing during
+    `CoordinatorHTTPServer` construction (SQLite open + TCP bind, >300ms cold)
+    left the winner about to write the port into an orphaned `server.pid` that
+    no concurrent reader could see — losers read the recreated, port-less file
+    and degraded. The winner now re-validates the inode after construction and
+    immediately before writing the port; on mismatch it tears down the
+    just-bound coordinator (freeing the socket) and recovers on a fresh inode.
+  - **L5 — idle/uptime now use a monotonic clock.** `idle_seconds` and
+    `uptime_s` were computed from `time.time()` deltas, so an NTP step or a
+    suspend/resume could misfire idle shutdown early or defer it. Both now use
+    `time.monotonic()`; `time.time()` is reserved for operator-facing absolute
+    timestamps.
+  - **L3 — thundering-herd loser degrade is now observable.** When the loop
+    exhausts its inode/retry budget under a cold-start herd and returns `-1`,
+    a per-reason process-lifetime counter (`get_spawn_join_exhaustion_total()`
+    / `_by_reason()`) records it — surfacing the otherwise-silent degrade and
+    keeping the herd-exhaustion reasons distinct from the dying-coordinator
+    probe failure. The retry budget itself is unchanged (a deterministic retune
+    is deferred pending real-world p99 cold-start data).
+
 ## [0.9.2] — 2026-06-11
 
 ### Fixed

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -311,7 +311,10 @@ class CoordinatorHTTPServer:
     ) -> None:
         self.coordinator_root = Path(coordinator_root).resolve()
         self.bind_host = bind_host
-        self._started_at = time.time()
+        # Monotonic reference points (NOT wall-clock): idle/uptime deltas must
+        # survive NTP steps and suspend/resume (finding L5). time.time() stays
+        # reserved for operator-facing absolute timestamps elsewhere.
+        self._started_at = time.monotonic()
         self._last_request_at = self._started_at
         self._shutting_down = False
         # ADV-001 (fix): "migration draining" is a halfway state between
@@ -652,16 +655,19 @@ class CoordinatorHTTPServer:
     # ------------------------------------------------------------------
 
     def mark_request(self) -> None:
-        self._last_request_at = time.time()
+        # Monotonic — see __init__ (L5). Feeds idle_seconds, not any wire timestamp.
+        self._last_request_at = time.monotonic()
 
     @property
     def uptime_s(self) -> float:
-        return time.time() - self._started_at
+        """Monotonic seconds since server start (NTP-/suspend-safe duration)."""
+        return time.monotonic() - self._started_at
 
     @property
     def last_request_at(self) -> float:
-        """Wall-clock timestamp of the most recent request, or the
-        server start time if no requests have hit it yet.
+        """Monotonic reference point of the most recent request (or server
+        start if none yet). NOT a wall-clock timestamp — do not emit on the
+        wire or convert to ISO (finding L5).
 
         P3 ce-review fix #39 (kieran-python): the idle-shutdown loop in
         lifecycle.py previously reached into the private
@@ -671,8 +677,8 @@ class CoordinatorHTTPServer:
 
     @property
     def idle_seconds(self) -> float:
-        """Wall-clock seconds since the most recent request."""
-        return time.time() - self._last_request_at
+        """Monotonic seconds since the most recent request (NTP-/suspend-safe)."""
+        return time.monotonic() - self._last_request_at
 
     @property
     def migration_draining(self) -> bool:

--- a/src/ccs/adapters/claude_code/lifecycle.py
+++ b/src/ccs/adapters/claude_code/lifecycle.py
@@ -42,6 +42,52 @@ from ccs.adapters.claude_code.coordinator_server import CoordinatorHTTPServer
 logger = logging.getLogger(__name__)
 
 
+# L3 observability (companion to the deferred budget retune): the spawn-or-join
+# loop can exhaust its retry/inode budget under a cold-start thundering herd and
+# return -1, degrading the caller. Each exhaustion already logs a warning, but a
+# per-process, per-reason aggregate lets an operator measure how often — and
+# why — without grepping logs (the real-world p99 data the port_file_retry
+# budget comment is waiting for before any deterministic retune). Telemetry
+# only; never changes control flow. Per-reason (not one total) so herd
+# exhaustion ("inode_budget"/"retry_budget") stays distinguishable from the
+# dying-coordinator probe failure ("loser_probe_failed") — a different failure
+# mode that would otherwise pollute the retune signal.
+_EXHAUSTION_LOCK = threading.Lock()
+_spawn_join_exhaustion_by_reason: dict[str, int] = {}
+
+
+def _record_spawn_join_exhaustion(reason: str) -> None:
+    """Increment the process-lifetime exhaustion counter for ``reason`` (one of
+    ``"inode_budget"``, ``"retry_budget"``, ``"loser_probe_failed"``)."""
+    with _EXHAUSTION_LOCK:
+        _spawn_join_exhaustion_by_reason[reason] = (
+            _spawn_join_exhaustion_by_reason.get(reason, 0) + 1
+        )
+
+
+def get_spawn_join_exhaustion_total() -> int:
+    """Process-lifetime count of spawn/join exhaustion -1 degrades (all reasons).
+
+    Surfaces the otherwise-invisible loser-degrade path (L3). Use
+    :func:`get_spawn_join_exhaustion_by_reason` to separate herd exhaustion
+    (``inode_budget``/``retry_budget``) from the dying-coordinator probe failure
+    (``loser_probe_failed``)."""
+    with _EXHAUSTION_LOCK:
+        return sum(_spawn_join_exhaustion_by_reason.values())
+
+
+def get_spawn_join_exhaustion_by_reason() -> dict[str, int]:
+    """Per-reason snapshot of the spawn/join exhaustion counter (L3)."""
+    with _EXHAUSTION_LOCK:
+        return dict(_spawn_join_exhaustion_by_reason)
+
+
+def _reset_spawn_join_exhaustion() -> None:  # pragma: no cover - test hook
+    """Test-only: clear the counter so tests don't see cross-test bleed."""
+    with _EXHAUSTION_LOCK:
+        _spawn_join_exhaustion_by_reason.clear()
+
+
 # G8 fix (subagent finding #8): fcntl is POSIX-only. On Windows, import-time
 # failure would crash hook handlers with a stack trace on every hook event.
 # Guard the import and provide a stub that degrades gracefully — hook handlers
@@ -211,6 +257,7 @@ def ensure_coordinator(
                     "(%d revalidations); external churn on .coherence/ — giving up",
                     cfg.inode_revalidation_budget,
                 )
+                _record_spawn_join_exhaustion("inode_budget")  # L3 observability
                 _close_quiet(fd)
                 return -1
             revalidations_remaining -= 1
@@ -262,6 +309,31 @@ def ensure_coordinator(
         try:
             coordinator = CoordinatorHTTPServer(coordinator_root, port=0, bind_host=bind_host)
             port = coordinator.port
+            # KTD-H Unit 5 L1: close the construct->write TOCTOU window. The
+            # top-of-loop inode check ran BEFORE this construction, which opens
+            # state.db (+WAL) and binds the TCP socket (>300ms cold). An external
+            # `rm -rf .coherence/ && recreate` landing DURING construction would
+            # leave us about to write the port into an ORPHANED server.pid that no
+            # concurrent reader can see — losers read the recreated, port-less file
+            # and degrade ("spawned a coordinator no one can reach"). Re-validate
+            # the inode now, before committing any bytes. On mismatch: tear down
+            # the just-bound coordinator to free the socket (shutdown() is safe
+            # pre-serve — it skips _server.shutdown when no serve thread exists,
+            # then server_close + registry.close), release the flock, and restart
+            # the loop; the top-of-loop revalidation re-opens on the fresh inode
+            # and consumes one revalidation budget.
+            if not _inode_matches(fd, pid_file):
+                logger.info(
+                    "ensure_coordinator: server.pid inode changed during coordinator "
+                    "construction (rm -rf race in the construct->write window); "
+                    "tearing down and revalidating"
+                )
+                coordinator.shutdown()
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                except OSError:
+                    pass
+                continue
             _write_pidfile(fd, os.getpid(), port)
             coordinator.serve_in_thread()
             entry = _SpawnedEntry(
@@ -310,6 +382,7 @@ def ensure_coordinator(
         "ensure_coordinator: %d attempts exhausted without acquiring lock or reading port",
         cfg.port_file_retry_attempts,
     )
+    _record_spawn_join_exhaustion("retry_budget")  # L3 observability
     return -1
 
 
@@ -342,6 +415,9 @@ def connect_or_spawn(
     # the just-read port may belong to a coordinator mid-shutdown).
     if not tcp_probe(port, cfg, bind_host=bind_host):
         logger.warning("coordinator spawned at port=%d but TCP probe failed", port)
+        # L3 observability: distinct reason — this is a stale/dying coordinator
+        # (re-probe of an already-read port failed), NOT herd budget exhaustion.
+        _record_spawn_join_exhaustion("loser_probe_failed")
         return -1
     return port
 
@@ -722,8 +798,10 @@ def _sweep_loop(entry: _SpawnedEntry, cfg: LifecycleConfig) -> None:
 
 
 def _idle_shutdown_loop(entry: _SpawnedEntry, cfg: LifecycleConfig) -> None:
-    """Wall-clock idle watcher. When ``time.time() - last_request_at >=
-    idle_shutdown_sec``, runs the race-safe shutdown sequence.
+    """Monotonic idle watcher. When ``idle_seconds >= idle_shutdown_sec``,
+    runs the race-safe shutdown sequence. Finding L5: ``idle_seconds`` is now a
+    monotonic delta, so a wall-clock (NTP / suspend-resume) step no longer
+    misfires or defers idle shutdown.
 
     P2 ce-review fix #7 (reliability): retry shutdown on the next tick if
     G4 abort path fired (coordinator.shutdown raised) — previously the

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -3257,3 +3257,35 @@ def test_t01_pre_bash_notices_only_branch_surfaces_preemption(
     else:
         # Notice deferred to next pre-read — handler returned plain fresh.
         assert body.get("status") == "fresh"
+
+
+# ----------------------------------------------------------------------
+# L5 — idle/uptime use a monotonic clock (NTP-/suspend-safe)
+# ----------------------------------------------------------------------
+
+
+def test_l5_idle_and_uptime_use_monotonic_immune_to_wall_clock(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """L5: idle_seconds / uptime_s are monotonic deltas, so a wall-clock
+    (NTP step / suspend-resume) jump does not misfire or defer idle shutdown.
+    Against the old time.time() body the backward-time assertions below fail."""
+    import ccs.adapters.claude_code.coordinator_server as mod
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(mod.time, "monotonic", lambda: clock["t"])
+    with CoordinatorHTTPServer(tmp_path, port=0, instance_id="l5-test") as srv:
+        # _started_at and _last_request_at were seeded at monotonic 1000.0.
+        clock["t"] = 1030.0
+        assert srv.idle_seconds == 30.0
+        assert srv.uptime_s == 30.0
+        # A wild wall-clock step (NTP back an hour / resume) must NOT perturb the
+        # monotonic-based deltas — the core L5 regression assertion.
+        monkeypatch.setattr(mod.time, "time", lambda: 1.0)
+        assert srv.idle_seconds == 30.0
+        assert srv.uptime_s == 30.0
+        # mark_request resets idle on the monotonic clock.
+        clock["t"] = 1100.0
+        srv.mark_request()
+        clock["t"] = 1105.0
+        assert srv.idle_seconds == 5.0

--- a/tests/test_claude_code_lifecycle.py
+++ b/tests/test_claude_code_lifecycle.py
@@ -902,3 +902,118 @@ def test_l2_drain_observable_via_lifecycle_stop(tmp_path, fast_cfg):
         f"shutdown with no in-flight handlers took {elapsed:.2f}s; "
         "drain may not be returning promptly when counter is already 0"
     )
+
+
+# ----------------------------------------------------------------------
+# L1 — construct->write inode TOCTOU sub-window
+# ----------------------------------------------------------------------
+
+
+def test_l1_construct_to_write_window_recheck_recovers(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """L1: the top-of-loop inode check runs BEFORE CoordinatorHTTPServer
+    construction (SQLite open + TCP bind). An external rm -rf landing DURING
+    construction must be caught by the post-construct recheck — the winner must
+    tear down the orphaned coordinator and recover on a fresh inode, NOT write
+    the port into an orphaned server.pid no concurrent reader can see."""
+    cfg = LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0,
+        port_file_retry_attempts=20,
+        port_file_retry_interval_sec=0.02,
+        inode_revalidation_budget=3,
+        spawn_self_probe_attempts=20,
+        spawn_self_probe_interval_sec=0.05,
+    )
+    pid_file = workspace / ".coherence" / "server.pid"
+    real_ctor = lifecycle.CoordinatorHTTPServer
+    state = {"constructs": 0, "teardowns": 0}
+
+    def wiping_ctor(*args, **kwargs):
+        inst = real_ctor(*args, **kwargs)
+        state["constructs"] += 1
+        if state["constructs"] == 1:
+            # Simulate `rm -rf .coherence/` racing in DURING construction:
+            # unlink server.pid so the fd ensure_coordinator holds is orphaned.
+            try:
+                pid_file.unlink()
+            except FileNotFoundError:
+                pass
+            real_shutdown = inst.shutdown
+
+            def tracking_shutdown() -> None:
+                state["teardowns"] += 1
+                real_shutdown()
+
+            inst.shutdown = tracking_shutdown  # type: ignore[method-assign]
+        return inst
+
+    monkeypatch.setattr(lifecycle, "CoordinatorHTTPServer", wiping_ctor)
+    try:
+        port = ensure_coordinator(workspace, config=cfg)
+        assert port > 0, f"expected recovery on a fresh inode; got {port}"
+        live_port = _read_port_from_file(pid_file)
+        assert live_port == port, (
+            f"pid file ({live_port}) != bound port ({port}); the recheck did not "
+            "fire and the port was written to an orphaned inode"
+        )
+        assert state["constructs"] >= 2, (
+            "recheck must have torn down the orphaned coordinator and reconstructed "
+            f"on a fresh inode; constructs={state['constructs']}"
+        )
+        assert state["teardowns"] == 1, (
+            f"the orphaned coordinator must be shut down exactly once; "
+            f"teardowns={state['teardowns']}"
+        )
+    finally:
+        monkeypatch.undo()
+        stop_coordinator(workspace)
+
+
+# ----------------------------------------------------------------------
+# L3 — spawn/join exhaustion observability counter
+# ----------------------------------------------------------------------
+
+
+def test_l3_retry_exhaustion_increments_per_reason_counter(
+    workspace: Path,
+) -> None:
+    """L3: when the spawn-or-join loop exhausts its port-file retry budget and
+    returns -1, the per-reason observability counter records a "retry_budget"
+    exhaustion so the otherwise-silent loser degrade is countable — without
+    conflating it with the dying-coordinator "loser_probe_failed" reason."""
+    import fcntl  # POSIX-only; the surrounding suite is POSIX-gated elsewhere
+
+    lifecycle._reset_spawn_join_exhaustion()
+    coherence_dir = workspace / ".coherence"
+    coherence_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    pid_file = coherence_dir / "server.pid"
+    # Hold the flock from THIS process so ensure_coordinator can never win, and
+    # leave the port line empty so the loser-read never succeeds — deterministic
+    # retry-budget exhaustion with no real coordinator spawned.
+    hold_fd = os.open(str(pid_file), os.O_RDWR | os.O_CREAT, 0o600)
+    fcntl.flock(hold_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    cfg = LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0,
+        port_file_retry_attempts=3,
+        port_file_retry_interval_sec=0.01,
+        inode_revalidation_budget=3,
+        spawn_self_probe_attempts=3,
+        spawn_self_probe_interval_sec=0.01,
+    )
+    try:
+        port = ensure_coordinator(workspace, config=cfg)
+        assert port == -1, f"expected retry-budget exhaustion -> -1; got {port}"
+        by_reason = lifecycle.get_spawn_join_exhaustion_by_reason()
+        assert by_reason.get("retry_budget") == 1, by_reason
+        assert "loser_probe_failed" not in by_reason, (
+            f"must not conflate herd exhaustion with the dying-coordinator probe "
+            f"failure; got {by_reason}"
+        )
+        assert lifecycle.get_spawn_join_exhaustion_total() == 1
+    finally:
+        fcntl.flock(hold_fd, fcntl.LOCK_UN)
+        os.close(hold_fd)
+        lifecycle._reset_spawn_join_exhaustion()


### PR DESCRIPTION
## Summary
Three independent robustness fixes to the coordinator's spawn-or-join and idle-shutdown paths (findings L1, L3, L5), each verified against an adversarial design review.

- **L1** — an external `rm -rf .coherence/` landing *during* `CoordinatorHTTPServer` construction could make the winner write the bound port into an orphaned `server.pid` that no concurrent reader sees, so losers degrade ("spawned a coordinator no one can reach"). The winner now re-validates the `server.pid` inode after construction and immediately before writing the port; on mismatch it tears down the just-bound coordinator and recovers on a fresh inode.
- **L5** — `idle_seconds` / `uptime_s` used `time.time()` deltas, so an NTP step or suspend/resume could misfire or defer idle shutdown. Both now use `time.monotonic()`.
- **L3** — when the spawn loop exhausts its budget and returns `-1` under a cold-start herd, a per-reason counter now records it (surfacing the silent loser-degrade); the retry budget itself is unchanged (deterministic retune deferred pending p99 data).

## Detail
**L1.** The top-of-loop inode revalidation runs *before* the flock; the residual was the construct→write span. `CoordinatorHTTPServer.shutdown()` is safe to call pre-`serve_in_thread()` (it skips `_server.shutdown()` when no serve thread exists, then `server_close()` + `registry.close()`), so on a post-construct inode mismatch the winner cleanly frees the socket and `continue`s into the existing revalidation (which re-opens on the fresh inode and consumes one revalidation budget). Residual (documented): an `rm` during construction also destroys `state.db` / `hook.secret` — broader than L1 and out of scope here.

**L3.** The counter is per-reason (`inode_budget` / `retry_budget` / `loser_probe_failed`) so the herd-exhaustion signal stays uncontaminated by the dying-coordinator re-probe failure (a different failure mode).

## Test Plan
- [x] `test_l1_construct_to_write_window_recheck_recovers`: injects the `rm` *during* construction (wraps `CoordinatorHTTPServer`); asserts the port lands on a fresh inode, the orphaned coordinator is torn down exactly once, and recovery succeeds. Fails against the pre-fix code.
- [x] `test_l3_retry_exhaustion_increments_per_reason_counter`: deterministic retry-budget exhaustion increments only `retry_budget`, not `loser_probe_failed`.
- [x] `test_l5_idle_and_uptime_use_monotonic_immune_to_wall_clock`: a backward wall-clock step leaves `idle_seconds`/`uptime_s` unchanged (fails against the old `time.time()` body).
- [x] Full suite: **2017 passed**, 3 skipped.
