### PR TITLE
docs: emphasize the RAG/memory arm + TC-1 outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,20 @@ Each row is a safety invariant model-checked with TLA+/TLC. `make tla-check` run
 
 *Measured on real LangGraph graphs; see [docs/reproduce.md](docs/reproduce.md) and the [user guide](docs/guide.md#real-workload-benchmarks).*
 
+Those are the **spatial** savings (more agents sharing one artifact). The **temporal** dimension — a single agent whose source drifts between its turns — has its own pre-registered benchmark, **TC-1** (#116): a reproducible savings-regime map of how many re-fetches coherence-gating avoids as the change-rate rises. The metric is *re-fetches-avoided* — a proxy, a regime map, **not** a token/dollar invoice. Reproduce with `python tools/run_cost_sweep.py`; the locked verdict + numbers (PASS at n=50, crossover r≈0.31) live in [`benchmarks/cost_preregistration.md`](benchmarks/cost_preregistration.md). Shipped in `v0.9.3`.
+
+## RAG & shared agent memory
+
+RAG corpora and agent memory are **shared mutable state**, so the stale-read→write lost update lands there too — and *a consistent store doesn't save you*: the staleness is in the **agent's cached view of a record**, not the store. Two agents read a record at v1; one writes v2; the other, still on its v1, writes an edit computed from v1 and clobbers v2. `agent-coherence` keeps the readers honest: `CCSStore` is a drop-in for `langgraph.store` (and composes with Mem0, Letta, LlamaIndex, a vector store, or a plain file via `CoherentVolume`) — it stores no vectors and does no ranking; it's the consistency layer underneath whatever you already use to retrieve and remember.
+
+- **Runnable, deterministic demo** (offline, no keys): `python -m examples.coherent_volume.main` reproduces the documented lost update, then prevents it.
+- **Honest scope:** writes that go through the coordinator are caught. Auto-watching an *unmanaged external source* that changes with no coordinator write (a hand-edited file, an out-of-band re-index) is the source-watcher case — **on the roadmap, demand-gated, not shipped today.**
+- **Positioning + FAQ:** [agent-coherence.dev/rag](https://agent-coherence.dev/rag/).
+
 ---
 
 - 📖 [User guide](docs/guide.md) — installation, namespace convention, strategies, observability, telemetry, examples, full API reference
+- 🔎 [RAG & shared memory](https://agent-coherence.dev/rag/) — coherence for retrieval corpora and agent memory stores, with the runnable lost-update demo
 - 🧮 [Formal verification](formal/tla/README.md) — the five TLA+ specs, invariant ↔ implementation map, mutant recipes
 - 🩺 [`ccs-diagnose` CLI](docs/ccs-diagnose.md) — find divergent reads in your existing LangGraph graph without changing any code
 - 🧩 [Claude Code plugin](https://github.com/hipvlady/agent-coherence-plugin) — cross-session coherence for the prose rules (CLAUDE.md, plan.md) parallel Claude Code sessions share

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -738,6 +738,18 @@ rate). The high-churn workload has 4 writes and 8 reads (50% hit rate).
 For the simulation-based results from the paper (84–95% savings), see
 [REPRODUCE.md](REPRODUCE.md).
 
+### Temporal cost: source drift between turns (TC-1)
+
+The table above is the **spatial** dimension — savings grow with more agents sharing one artifact. The **temporal** dimension is orthogonal: a *single* agent (a RAG/memory reader) whose source drifts between its turns, where coherence-gating avoids re-fetching a chunk that didn't change. TC-1 is the pre-registered benchmark for it — a savings-regime map across change-rate × answer-sensitivity:
+
+```bash
+python tools/run_cost_sweep.py --rates 0,0.05,0.1,0.15,0.2,0.25,0.3,0.35,0.5,0.75,1.0 \
+  --sensitivities 0,0.5,1.0 --runs 50 --output benchmarks/results/cost_sweep_published.json
+python tools/plot_cost_sweep.py    # savings-vs-change-rate curve
+```
+
+PASS at n=50: savings stay ≥ 30% while the source changes fewer than ~3 turns in 10 (`r ≤ 0.30`), crossing below 30% at `r ≈ 0.31` and falling to 0 at constant churn. The metric is **re-fetches-avoided** — a proxy / regime map, not a token-dollar invoice (`tools/cost_to_tokens.py` gives an assumption-parameterized dollar translation). Verdict + distinguisher triage: [`../benchmarks/cost_preregistration.md`](../benchmarks/cost_preregistration.md). **Don't splice these numbers into the spatial table above.** Shipped in `v0.9.3` (#116).
+
 ---
 
 ## Benchmarking your own workload

--- a/docs/reproduce.md
+++ b/docs/reproduce.md
@@ -34,6 +34,21 @@ bash scripts/reproduce.sh
 
 `scripts/reproduce.sh` re-runs all scenarios and verifies output against `SUMMARY.md` within ±0.5% tolerance using `tools/verify_baseline.py`.
 
+## Temporal-cost sweep (TC-1)
+
+A separate, pre-registered benchmark for the **temporal / source-drift** dimension — how many re-fetches coherence-gating avoids as a *single* agent's source changes between turns, versus an always-re-fetch baseline. Distinct from the spatial workloads above (more agents sharing one artifact); do not splice the two.
+
+```bash
+python tools/run_cost_sweep.py \
+  --rates 0,0.05,0.1,0.15,0.2,0.25,0.3,0.35,0.5,0.75,1.0 \
+  --sensitivities 0,0.5,1.0 --runs 50 \
+  --output benchmarks/results/cost_sweep_published.json
+python tools/plot_cost_sweep.py    # → benchmarks/results/cost_sweep_savings_curve.svg
+python tools/cost_to_tokens.py     # token/$ translation, under stated assumptions
+```
+
+The seeded sweep reproduces the committed `benchmarks/results/cost_sweep_published.json` byte-for-byte. The pre-registered verdict (PASS at n=50; savings ≥ 30% across all `r ≤ 0.30`; crossover `r ≈ 0.31`) and the distinguisher triage live in [`../benchmarks/cost_preregistration.md`](../benchmarks/cost_preregistration.md). The metric is **re-fetches-avoided** — a proxy / regime map, **not** a token-dollar invoice; `cost_to_tokens.py`'s dollar figures are explicitly assumption-parameterized. Shipped in `v0.9.3` (#116).
+
 ## Simulation scope
 
 The simulation models token transmission accounting, MESI state transitions, write-frequency effects, and artifact volatility.


### PR DESCRIPTION
Docs-only. Surfaces the **RAG/memory arm** and the **TC-1** temporal-cost benchmark (#116) across end-user docs.

## Changes
- **README** — a dedicated "RAG & shared agent memory" section (RAG/memory records are shared mutable state; the staleness is in the agent's cached view, not the store; `CCSStore` drop-in; runnable lost-update demo; source-watcher roadmap-not-shipped); a TC-1 temporal-benchmark note kept **distinct** from the spatial 29–69% table (provenance wall); a `/rag` link.
- **docs/reproduce.md** — a TC-1 cost-sweep reproduce section.
- **docs/guide.md** — a TC-1 temporal subsection under real-workload benchmarks.

Honest framing throughout: re-fetches-avoided is a proxy / regime map, not a token-dollar invoice; the source-watcher is roadmap, not shipped.

## Release
**No release.** Docs-only — no version bump, no tag. Lands on `main` directly per request; `release.yml` triggers only on a `v*` tag, so this does not publish.