### PR TITLE
docs: CoherentVolume data-plane positioning + RAG/memory framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ RAG corpora and agent memory are **shared mutable state**, so the stale-read→w
 
 - 📖 [User guide](docs/guide.md) — installation, namespace convention, strategies, observability, telemetry, examples, full API reference
 - 🔎 [RAG & shared memory](https://agent-coherence.dev/rag/) — coherence for retrieval corpora and agent memory stores, with the runnable lost-update demo
+- 🗂️ [Coherent workspace](#coherent-workspace-the-data-plane-for-shared-files) — `CoherentVolume`, the data-plane appliance for plain files shared across processes
 - 🧮 [Formal verification](formal/tla/README.md) — the five TLA+ specs, invariant ↔ implementation map, mutant recipes
 - 🩺 [`ccs-diagnose` CLI](docs/ccs-diagnose.md) — find divergent reads in your existing LangGraph graph without changing any code
 - 🧩 [Claude Code plugin](https://github.com/hipvlady/agent-coherence-plugin) — cross-session coherence for the prose rules (CLAUDE.md, plan.md) parallel Claude Code sessions share
@@ -97,21 +98,41 @@ Five synchronization strategies ship out of the box: `lazy` (default), `eager`, 
 
 - **Protocol** (`ccs.core`, `ccs.strategies`) — coherence state machine and synchronization strategies; no framework dependencies.
 - **Coordinator** (`ccs.coordinator`) — authority service tracking directory state, publishing invalidations, arbitrating commit-CAS, and reclaiming stale grants (crash recovery + read-generation fence).
-- **Adapters** (`ccs.adapters`) — framework integrations for LangGraph, CrewAI, and AutoGen (~100 lines each), an experimental OpenAI Agents SDK adapter (`Session`-cache coherence + `RunHooks`), and `CoherentVolume` for plain files shared across processes.
+- **Adapters** (`ccs.adapters`) — framework integrations for LangGraph, CrewAI, and AutoGen (~100 lines each), plus an experimental OpenAI Agents SDK adapter (`Session`-cache coherence + `RunHooks`).
+- **Coherent workspace** (`ccs.adapters.coherent_volume`) — the **data-plane appliance**: an out-of-process coordinator client that brings the same guarantee to plain files on disk, no framework required. See [Coherent workspace](#coherent-workspace-the-data-plane-for-shared-files).
 - **Simulation** (`ccs.simulation`) — deterministic tick-driven engine for scenario benchmarks with failure injection.
 - **Event bus** (`ccs.bus`) — pluggable transport for invalidation signals; in-memory by default, swap in Redis, Kafka, NATS, or gRPC streams for production.
 
 Protocol safety properties — single-writer, monotonic versioning, the crash-recovery sweep invariants, the OCC no-lost-update, the reclamation fence's no-stale-apply, and version retention's no-collected-read — are model-checked with [TLA+/TLC](formal/tla/README.md). The `tla-check` CI job runs all five specs on every push and PR.
 
+## Coherent workspace: the data plane for shared files
+
+The framework adapters wrap a store. `CoherentVolume` is the other half — the **data-plane appliance**, the building block that makes a shared *workspace* coherent for plain files on disk, with no framework in the loop. Architecturally it's an out-of-process coordinator *client*, not an in-process wrapper: it writes the policy, spawns (or attaches to) a local coordinator over SQLite-WAL, and routes reads and writes through it. Your content stays on the real filesystem; the coordinator holds only MESI state, a content hash, and a version per managed file. Point a sibling volume in another process at the same workspace and it attaches to the same coordinator, so a single-host fleet shares one coherent view.
+
+```python
+from ccs.adapters.coherent_volume import CoherentVolume
+
+vol = CoherentVolume(workspace_root, managed=("plans/**", "memory/**"))
+data = vol.read("plans/plan.md")              # bytes — registers a SHARED view
+vol.write("plans/plan.md", revise(data))      # stale view? denied fail-closed
+data = vol.reacquire("plans/plan.md")         # recover: re-mint identity + mandatory fresh read
+```
+
+The explicit `read` / `write` / `reacquire` / `write_cas` API is the **supported** primitive (`write_cas(path, make_content)` is the optimistic counterpart for same-key contention — the loser gets a typed conflict, never a silent drop). For code you'd rather not rewrite, an **opt-in, demo-grade** `open()` shim routes managed-path opens through the volume so existing `open()` / `pathlib` calls get coherence unchanged:
+
+```python
+from ccs.adapters.coherent_volume import coherent_workspace
+
+with coherent_workspace(workspace_root, managed=("plans/**",)):
+    text = open("plans/plan.md").read()       # registers a SHARED view
+    open("plans/plan.md", "w").write(edit)    # stale view? raises out of close()
+```
+
+**Scope, honestly.** v1 prevents the **sequential** stale-read→write lost update for a single-host fleet sharing one workspace (A reads v1, B reads v1, A commits v2, B's stale write is denied → B re-reads). It does **not** serialize concurrent racing writers, nor catch an agent that re-reads fresh bytes and then writes a buffer computed from older ones. The `open()` shim is convenience, not the contract: it covers `open()`/`pathlib` text+binary read/write, but not raw `os.open`, subprocess redirection, `mmap`, or append/update modes — those delegate to the original `open()` unchanged. Run it yourself: `python -m examples.coherent_volume.main` (offline, deterministic, no keys), or read the [positioning + FAQ](https://agent-coherence.dev/rag/).
+
 ## Status
 
 **`v0.9.3` released — bounded, durable version retention + read-at-version, plus coordinator lifecycle hardening.** The coordinator can now retain a bounded history of committed versions and serve any retained `(artifact, version)` via `read_at_version(...)` — opt-in `RetentionPolicy(max_versions=K, max_age_seconds=T)`, **off by default**; durable across restart for in-process embedders behind an automatic, atomic SQLite `v1 → v2` upgrade. Read-at-version is off-protocol (no MESI grant, no fence capture) and model-checked in `formal/tla/Retention.tla`. Also: watchdog late-completion/degraded-read hardening (A6/A7), spawn/idle lifecycle fixes (L1/L3/L5), the read-generation fence's absent-operand semantics reconciled with the spec, and a reproducible temporal-cost sweep with a token/prompt-cache-dollar translation. See [CHANGELOG.md](CHANGELOG.md).
-
-**`v0.9.2` released — closes a silent lost-update in `CoherentVolume.write_cas` under high same-key write contention.** A peer commit landing between `write_cas`'s `reacquire()` and its version read could pair stale bytes with a fresh version and win the CAS, silently dropping the peer's update on disk (the protocol-level `NoLostUpdate` invariant still held — the bug was below it, in the demo write path). Each retry now derives its `(bytes, version)` comparand from one hash-checked read, so the split is structurally unrepresentable. Also: an additive `hash_differs` signal on the `/hooks/pre-read` fresh-SHARED path (with a `fresh_shared_hash_mismatch_total` counter), and a coordinator fix that preserves the fresh-path `version` field when a preemption notice rides along. See [CHANGELOG.md](CHANGELOG.md).
-
-**`v0.9.1` released — the optimistic commit-CAS write path and the read-generation fence.** Concurrent same-key writes now resolve to one winner with typed, retryable conflicts (`commit_cas` / `write_cas`; `NoLostUpdate` model-checked), and a writer whose grant was reclaimed can no longer land a stale commit even with the version unchanged (`stale_read_generation`; `NoStaleApply` model-checked). SQLite stores upgrade in place — no migration step. Also: `CoherentVolume` stale-cache and grant-release fixes. See [CHANGELOG.md](CHANGELOG.md).
-
-**`v0.9.0` — crash recovery on by default, plus `CoherentVolume` and a temporal cost benchmark.** The crash-recovery default flips from `enabled=False` to **`enabled=True`**, so a bare `CCSStore()` / `CoherenceAdapterCore()` now reclaims stale grants automatically — pass `CrashRecoveryConfig(enabled=False)` to opt out. Byte-identity preservation under the default config now requires explicit `CrashRecoveryConfig(enabled=False)` to reproduce v0.8.x output.
 
 See [CHANGELOG.md](CHANGELOG.md) for the full version history and [releases](https://github.com/hipvlady/agent-coherence/releases) for tagged artifacts. Alpha — APIs may change before `v1.0`.
 

--- a/docs/agent-coherence-approach.md
+++ b/docs/agent-coherence-approach.md
@@ -26,6 +26,15 @@ import and the protocol handles the rest. Agents that hold current data skip re-
 stale data are notified. The protocol enforces single-writer exclusivity and
 monotonic versioning as invariants, not conventions.
 
+The same primitives extend past orchestration state to **retrieval and
+memory** ([Section 6](why-coherence-matters.md#6-the-same-gap-lands-on-rag-and-agent-memory)).
+Because the lost update lives in the agent's cached view of a record — not in
+the store — `CCSStore` works as the consistency layer under a memory store,
+and [`CoherentVolume`](guide.md) brings the same guarantee to plain-file
+corpora and memory shared across processes. It stores no vectors and does no
+ranking: it sits underneath whatever you already use to retrieve and remember,
+keeping the readers honest and refusing stale writes.
+
 ## What this addresses
 
 | Gap (from [Why Coherence Matters](why-coherence-matters.md)) | How agent-coherence responds |
@@ -35,15 +44,19 @@ monotonic versioning as invariants, not conventions.
 | Reducer pattern is append-only (Section 2) | Conflict is avoided by grant, not resolved by merge — only one agent holds write permission at a time |
 | Users requesting optimistic locking (Section 4) | Version-tracked artifacts with monotonic versioning; stale writes are rejected |
 | Full-context rebroadcasting (Section 5) | Invalidation signals notify agents of changes; only stale caches re-fetch |
+| RAG corpora & agent memory are shared mutable state (Section 6) | `CCSStore` and `CoherentVolume` keep the cached *reader* current under any store; the staleness lives in the agent's view, not the store |
 
 ## What this does not address
 
-The [open questions](why-coherence-matters.md#6-open-questions) in the
+The [open questions](why-coherence-matters.md#7-open-questions) in the
 evidence document apply here too:
 
 - The coordination-cost crossover point for small agent counts is not yet
   well-characterized.
-- Interaction with long-term memory systems (e.g., `langmem`) is unexplored.
+- Whether *long-term* memory needs a stronger isolation level than the
+  read-your-writes coherence we provide — snapshot isolation across a
+  multi-step recall, say — is unresolved. Cached-reader coherence for memory
+  and RAG is addressed (above); the right *level* for long-lived memory is not.
 - The right isolation level for different workload shapes remains an open
   research question.
 

--- a/docs/why-coherence-matters.md
+++ b/docs/why-coherence-matters.md
@@ -119,13 +119,41 @@ underlying conflict — they prevent or sidestep it. In all cases, the default
 context-passing mechanism is full rebroadcasting: correct (no stale reads)
 but expensive, and scaling poorly as agent count or shared state size grows.
 
-## 6. Open questions
+## 6. The same gap lands on RAG and agent memory
+
+The evidence above is drawn from orchestration state, but the identical
+failure lands on a surface most teams add later: **retrieval corpora and
+agent memory**. A RAG index and a memory store are shared mutable state —
+agents read records, recompute, and write them back — so the
+stale-read→write lost update applies unchanged. Two agents read a memory
+record at v1; one writes v2; the other, still holding the v1 it read, writes
+an edit derived from v1 and silently clobbers v2. Section 4's
+optimistic-locking request is this same need surfacing from the memory side:
+a `get → modify → put` over `langmem` is exactly the read-recompute-write
+that loses updates when the read is stale.
+
+The non-obvious part: **a consistent store does not save you.** The staleness
+is not in the store — it is in the *agent's cached view of a record*. Agents
+cache retrieved state locally to avoid re-paying for the full history on every
+step, and that local copy goes stale the moment a peer writes, no matter how
+strongly consistent the backing store is. Coherence here is about keeping the
+*readers* honest, not replacing the store: it is the consistency layer
+underneath whatever vector store, memory library (Mem0, Letta, LlamaIndex), or
+plain file you already use to retrieve and remember.
+
+The boundary is worth stating plainly. Writes that go through the coordinator
+are caught. Auto-watching an *unmanaged external source* that changes with no
+coordinator write — a hand-edited corpus file, an out-of-band re-index — is a
+separate problem (a source-watcher), not solved by keeping cached readers
+coherent.
+
+## 7. Open questions
 
 Several questions remain unanswered by any framework or library:
 
 - **What isolation level do multi-agent workloads actually need?** Read-your-writes may suffice for most; some may need snapshot isolation or serializable access. The answer likely varies by workload shape.
 - **Is coherence worth its coordination cost for small agent counts?** At 2–3 agents with small shared state, full rebroadcasting may be cheaper than maintaining coherence metadata. The crossover point is not well-characterized.
-- **How should coherence interact with agent memory systems?** Long-term memory (e.g., `langmem`) and ephemeral shared state have different consistency requirements. Whether they should share a coherence model or remain separate is an open design question.
+- **What isolation level does agent memory specifically need?** Section 6 argues the same read-your-writes coherence that applies to orchestration state applies to memory and RAG — the staleness is in the cached view, not the store. What remains open is whether *long-term* memory (e.g., `langmem`) needs a stronger level than ephemeral shared state — snapshot isolation across a multi-step recall, say — or whether read-your-writes suffices there too.
 
 ---
 


### PR DESCRIPTION
## Summary
- **README — CoherentVolume positioning.** Promotes `CoherentVolume` from a thin adapter mention to the **data-plane appliance**: a dedicated *Coherent workspace* section (out-of-process coordinator client; supported `read`/`write`/`reacquire`/`write_cas` API; opt-in demo-grade `open()` shim; honest scope), a split-out Architecture bullet, and a docs-link row.
- **README — Status trim.** Keeps only the last released update (`v0.9.3`); the v0.9.0–v0.9.2 detail already lives in `CHANGELOG.md`.
- **Concept docs — RAG/memory made explicit.** `why-coherence-matters.md` gains a new section 6 (*the same gap lands on RAG and agent memory* — a consistent store doesn't save you; the staleness is in the agent's cached view), with Open questions renumbered to 7. `agent-coherence-approach.md` extends the approach to retrieval/memory, adds a table row, refreshes the stale 'memory unexplored' note, and fixes the open-questions anchor.

## Test Plan
- [x] Docs-only; no code paths touched.
- [x] Internal links/anchors verified to resolve (README section anchor, cross-doc `#6-the-same-gap…` and `#7-open-questions`, `guide.md`, `examples/coherent_volume/main.py`).
- [x] README `python` code fences balanced; snippet API matches actual signatures (`read→bytes`, `write(bytes)`, `reacquire→bytes`, `write_cas(path, make_content)`, `coherent_workspace`).
- [x] No release / version bump / tag — pure documentation.