### PR TITLE
fix(examples): de-name the lost-update demo docstring

### DIFF
--- a/examples/coherent_volume/broken.py
+++ b/examples/coherent_volume/broken.py
@@ -6,8 +6,8 @@
 Two agents each update a shared total. Both read the same starting value; agent
 A commits its update; then agent B commits an update it computed from the value
 it read *before* A's commit. B's write silently overwrites A's — the classic
-lost update (the OpenViktor cron shape: read, compute, write-back-from-the-old-
-read). No coordinator is involved; that is the point. ``fixed.py`` shows the
+lost update (the cron / heartbeat-write shape: read, compute, write-back-from-
+the-old-read). No coordinator is involved; that is the point. ``fixed.py`` shows the
 same sequence denied and recovered through CoherentVolume.
 
 Deterministic and offline — sequenced, not raced.


### PR DESCRIPTION
## Summary
- Removes a third-party product name from `examples/coherent_volume/broken.py`'s docstring; the failure is now described generically as the **cron / heartbeat-write shape** (read, compute, write-back-from-the-old-read).
- Docstring wording only — no code/behavior change; `broken.py` parses unchanged.

## Why
Public-facing example copy should describe the failure class generically, not by reference to any specific third party.

## Test Plan
- [x] `grep -i viktor examples/coherent_volume/` → no matches.
- [x] `broken.py` parses (`ast.parse`).
- [x] Demo behavior unchanged (docstring-only edit).