### PR TITLE
chore(license): normalize copyright header to agent-coherence contributors

### DIFF
--- a/examples/coherent_volume/__init__.py
+++ b/examples/coherent_volume/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Sequential stale-overwrite (lost-update) demo for CoherentVolume.

--- a/examples/coherent_volume/broken.py
+++ b/examples/coherent_volume/broken.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Broken case: a stale-overwrite lost update over plain files.

--- a/examples/coherent_volume/fixed.py
+++ b/examples/coherent_volume/fixed.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Fixed case: the same stale-overwrite, denied and recovered via CoherentVolume.

--- a/examples/coherent_volume/main.py
+++ b/examples/coherent_volume/main.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Side-by-side runner for the CoherentVolume stale-overwrite demo.

--- a/examples/concurrent_writers/__init__.py
+++ b/examples/concurrent_writers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Concurrent lost-update demo for the v0.9.1 commit-CAS write path (Epic Piece #6).

--- a/examples/concurrent_writers/broken.py
+++ b/examples/concurrent_writers/broken.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Broken case: two CONCURRENT writers, one update silently lost.

--- a/examples/concurrent_writers/fixed.py
+++ b/examples/concurrent_writers/fixed.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Fixed case: the same concurrent race, made safe by CoherentVolume.write_cas.

--- a/examples/concurrent_writers/main.py
+++ b/examples/concurrent_writers/main.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Side-by-side runner for the concurrent lost-update demo (Epic Piece #6).

--- a/examples/conversations_stale_read/__init__.py
+++ b/examples/conversations_stale_read/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Conversations API stale-read demo + Q6 consistency probe (Phase 0/1).

--- a/examples/conversations_stale_read/broken.py
+++ b/examples/conversations_stale_read/broken.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Broken case: a client-side cache goes stale over a *consistent* shared store.

--- a/examples/conversations_stale_read/fixed.py
+++ b/examples/conversations_stale_read/fixed.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Fixed case: ``CoherenceAdapterCore`` invalidates the stale client cache.

--- a/examples/conversations_stale_read/main.py
+++ b/examples/conversations_stale_read/main.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Side-by-side runner for the client-cache stale-read demo.

--- a/examples/conversations_stale_read/probe.py
+++ b/examples/conversations_stale_read/probe.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Q6 consistency probe (Phase 0 / Unit 1) — gate for the OpenAI/Mistral demo.

--- a/examples/multi_agent_planning.py
+++ b/examples/multi_agent_planning.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Minimal multi-agent coherence demo for post-v0.1 validation."""

--- a/examples/refactor_demo/executor.py
+++ b/examples/refactor_demo/executor.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Executor sub-agent (scripted stand-in).

--- a/examples/refactor_demo/main.py
+++ b/examples/refactor_demo/main.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Planner-executor refactor demo for write-side coherence.

--- a/examples/refactor_demo/planner.py
+++ b/examples/refactor_demo/planner.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Planner sub-agent (scripted stand-in).

--- a/examples/refactor_demo/strategies.py
+++ b/examples/refactor_demo/strategies.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Demo variant: CCSStore with peer invalidation suppressed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Token optimization layer for multi-agent LangGraph systems — cut shared-artifact token costs via MESI cache coherence, one import change"
 readme = "README.md"
 license = { text = "Apache-2.0" }
-authors = [{ name = "Arbiter contributors" }]
+authors = [{ name = "agent-coherence contributors" }]
 keywords = ["multi-agent", "llm", "cache-coherence", "mesi", "token-efficiency", "agents"]
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/src/ccs/__init__.py
+++ b/src/ccs/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """agent-coherence core package."""

--- a/src/ccs/adapters/__init__.py
+++ b/src/ccs/adapters/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Framework-facing integration adapters for CCS runtime.

--- a/src/ccs/adapters/autogen.py
+++ b/src/ccs/adapters/autogen.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """AutoGen-oriented coherence adapter utilities."""

--- a/src/ccs/adapters/base.py
+++ b/src/ccs/adapters/base.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Common adapter runtime that wires coordinator, agents, and event bus."""

--- a/src/ccs/adapters/ccsstore.py
+++ b/src/ccs/adapters/ccsstore.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """CCSStore: LangGraph BaseStore adapter with MESI-style cache coherence."""

--- a/src/ccs/adapters/claude_code/__init__.py
+++ b/src/ccs/adapters/claude_code/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Claude Code adapter — cross-process coherence for parallel Claude Code sessions.

--- a/src/ccs/adapters/claude_code/audit_log.py
+++ b/src/ccs/adapters/claude_code/audit_log.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Minimal deny-site audit log — appends strict-mode denial events as

--- a/src/ccs/adapters/claude_code/auth.py
+++ b/src/ccs/adapters/claude_code/auth.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Shared-secret authentication for the local HTTP coordinator (KTD-12).

--- a/src/ccs/adapters/claude_code/bash_path_detector.py
+++ b/src/ccs/adapters/claude_code/bash_path_detector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """File-path detection in Bash command strings.

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Local HTTP coordinator for the Claude Code coherence plugin (Unit 4).

--- a/src/ccs/adapters/claude_code/hook_payloads.py
+++ b/src/ccs/adapters/claude_code/hook_payloads.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Typed JSON shapes for the coordinator's wire contract (KTD per Unit 4).

--- a/src/ccs/adapters/claude_code/lifecycle.py
+++ b/src/ccs/adapters/claude_code/lifecycle.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Race-safe lazy spawn, idle shutdown, and background sweep for the

--- a/src/ccs/adapters/claude_code/migrate_deny.py
+++ b/src/ccs/adapters/claude_code/migrate_deny.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """``agent-coherence-migrate-deny`` — propose ``permissions.deny`` JSON to

--- a/src/ccs/adapters/claude_code/policy.py
+++ b/src/ccs/adapters/claude_code/policy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tracked-artifact policy — decide whether a given path is coordinated.

--- a/src/ccs/adapters/claude_code/resolver.py
+++ b/src/ccs/adapters/claude_code/resolver.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Resolve the parent repo root from any directory inside it, including

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """CoherentVolume — the data-plane coherent-workspace appliance (v1).

--- a/src/ccs/adapters/crewai.py
+++ b/src/ccs/adapters/crewai.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """CrewAI-oriented coherence adapter utilities."""

--- a/src/ccs/adapters/events.py
+++ b/src/ccs/adapters/events.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Shared event types and telemetry protocol for CCSStore adapters.

--- a/src/ccs/adapters/langgraph.py
+++ b/src/ccs/adapters/langgraph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """LangGraph-oriented coherence adapter utilities."""

--- a/src/ccs/adapters/openai_agents.py
+++ b/src/ccs/adapters/openai_agents.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """OpenAI Agents SDK coherence adapter.

--- a/src/ccs/adapters/telemetry/__init__.py
+++ b/src/ccs/adapters/telemetry/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Telemetry exporter protocol and dispatcher for CCSStore.

--- a/src/ccs/adapters/telemetry/langsmith.py
+++ b/src/ccs/adapters/telemetry/langsmith.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """LangSmith run metadata exporter for CCSStore operations."""

--- a/src/ccs/adapters/telemetry/otel.py
+++ b/src/ccs/adapters/telemetry/otel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """OpenTelemetry metrics exporter for CCSStore operations."""

--- a/src/ccs/agent/__init__.py
+++ b/src/ccs/agent/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Agent-side cache and runtime components."""

--- a/src/ccs/agent/cache.py
+++ b/src/ccs/agent/cache.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Local artifact cache used by agent runtime."""

--- a/src/ccs/agent/runtime.py
+++ b/src/ccs/agent/runtime.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Agent runtime encapsulating read/write/invalidation protocol flows."""

--- a/src/ccs/artifacts/__init__.py
+++ b/src/ccs/artifacts/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Artifact-level helpers for payload diffing and reconstruction."""

--- a/src/ccs/artifacts/diff_engine.py
+++ b/src/ccs/artifacts/diff_engine.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Deterministic text/JSON diff helpers for artifact synchronization."""

--- a/src/ccs/bus/__init__.py
+++ b/src/ccs/bus/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Event channel abstractions for invalidation/update propagation."""

--- a/src/ccs/bus/event_bus.py
+++ b/src/ccs/bus/event_bus.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """In-memory event bus for invalidation and update fan-out."""

--- a/src/ccs/cli/__init__.py
+++ b/src/ccs/cli/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Command-line interfaces for simulation and comparison workflows."""

--- a/src/ccs/cli/_coherence_client.py
+++ b/src/ccs/cli/_coherence_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Shared HTTP client helpers for the four agent-coherence-* console scripts.

--- a/src/ccs/cli/coherence_coordinator.py
+++ b/src/ccs/cli/coherence_coordinator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """``agent-coherence-coordinator`` — lazy-spawn the workspace coordinator.

--- a/src/ccs/cli/coherence_hook_client.py
+++ b/src/ccs/cli/coherence_hook_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """``agent-coherence-hook-client`` — command-type hook handler bridge.

--- a/src/ccs/cli/coherence_migrate_rules.py
+++ b/src/ccs/cli/coherence_migrate_rules.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """``agent-coherence-migrate-rules`` — propose ``permissions.deny`` entries

--- a/src/ccs/cli/coherence_replay.py
+++ b/src/ccs/cli/coherence_replay.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """``agent-coherence-replay`` — invariant replay CLI (Unit 5 of D v1).

--- a/src/ccs/cli/coherence_status.py
+++ b/src/ccs/cli/coherence_status.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """``agent-coherence-status`` — print tracked artifacts × sessions × MESI states.

--- a/src/ccs/cli/coherence_track.py
+++ b/src/ccs/cli/coherence_track.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """``agent-coherence-track`` — add one or more paths to the tracked set.

--- a/src/ccs/cli/coherence_untrack.py
+++ b/src/ccs/cli/coherence_untrack.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """``agent-coherence-untrack`` — append paths to the workspace ignored set.

--- a/src/ccs/cli/compare.py
+++ b/src/ccs/cli/compare.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """CLI entrypoint for multi-strategy comparison runs."""

--- a/src/ccs/cli/diagnose.py
+++ b/src/ccs/cli/diagnose.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """CLI entrypoint for ``ccs-diagnose`` (Unit 7 — pipeline integration).

--- a/src/ccs/cli/simulate.py
+++ b/src/ccs/cli/simulate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """CLI entrypoint for single-strategy simulation execution."""

--- a/src/ccs/coordinator/__init__.py
+++ b/src/ccs/coordinator/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Coordinator services for shared artifact coherence."""

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """In-memory artifact registry for coherence coordination."""

--- a/src/ccs/coordinator/retention.py
+++ b/src/ccs/coordinator/retention.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Bounded version-retention policy and the single GC seam (plan item N v1).

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Coordinator service implementing core artifact coherence operations."""

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """SQLite-WAL persistent artifact registry for cross-process coherence coordination.

--- a/src/ccs/core/__init__.py
+++ b/src/ccs/core/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Domain-level core primitives."""

--- a/src/ccs/core/clock.py
+++ b/src/ccs/core/clock.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Logical clock primitives for deterministic simulation."""

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Domain exception hierarchy for coherence protocol operations."""

--- a/src/ccs/core/granularity.py
+++ b/src/ccs/core/granularity.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Artifact granularity levels and v0.1 support boundaries."""

--- a/src/ccs/core/hashing.py
+++ b/src/ccs/core/hashing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Content hashing for audit and cross-validation."""

--- a/src/ccs/core/identity.py
+++ b/src/ccs/core/identity.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Artifact identity helper — deterministic UUIDv5 over a structured name.

--- a/src/ccs/core/invariants.py
+++ b/src/ccs/core/invariants.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Invariant helpers for coherence runtime checks."""

--- a/src/ccs/core/states.py
+++ b/src/ccs/core/states.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """MESI stable/transient state definitions and transition utilities."""

--- a/src/ccs/core/types.py
+++ b/src/ccs/core/types.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Core domain dataclasses for artifact coherence."""

--- a/src/ccs/diagnose/__init__.py
+++ b/src/ccs/diagnose/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """ccs-diagnose — runtime callback + write-pattern classifier for LangGraph graphs.

--- a/src/ccs/diagnose/_labels.py
+++ b/src/ccs/diagnose/_labels.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Shared display labels for ``Bucket`` and ``Confidence`` enums.

--- a/src/ccs/diagnose/calibration.py
+++ b/src/ccs/diagnose/calibration.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Calibration corpus JSONL append for ``ccs-diagnose`` v0-preview (Unit 9).

--- a/src/ccs/diagnose/callback.py
+++ b/src/ccs/diagnose/callback.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """LangGraph callback adapter — passive node-event observer.

--- a/src/ccs/diagnose/checkpointer.py
+++ b/src/ccs/diagnose/checkpointer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """High-fidelity checkpointer for ``ccs-diagnose``.

--- a/src/ccs/diagnose/classifier/__init__.py
+++ b/src/ccs/diagnose/classifier/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Write-pattern classifiers for ``ccs-diagnose``.

--- a/src/ccs/diagnose/classifier/langgraph_v0_preview.py
+++ b/src/ccs/diagnose/classifier/langgraph_v0_preview.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Write-pattern classifier for LangGraph runs (``langgraph-v0-preview``).

--- a/src/ccs/diagnose/detection.py
+++ b/src/ccs/diagnose/detection.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Divergence detection engine for ``ccs-diagnose`` (Unit 4).

--- a/src/ccs/diagnose/ownership.py
+++ b/src/ccs/diagnose/ownership.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Artifact Ownership Map computation for ``ccs-diagnose`` (Unit 5 helper).

--- a/src/ccs/diagnose/render.py
+++ b/src/ccs/diagnose/render.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Single-file HTML renderer for ``ccs-diagnose`` (Unit 5).

--- a/src/ccs/diagnose/summary.py
+++ b/src/ccs/diagnose/summary.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Terminal summary text-builder for ``ccs-diagnose`` (Unit 6).

--- a/src/ccs/diagnose/telemetry.py
+++ b/src/ccs/diagnose/telemetry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Telemetry payload constructor and consent flow surface (Unit 8).

--- a/src/ccs/hardening/__init__.py
+++ b/src/ccs/hardening/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Architecture hardening checks and helpers."""

--- a/src/ccs/hardening/architecture.py
+++ b/src/ccs/hardening/architecture.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Import-boundary and cycle checks for CCS modules."""

--- a/src/ccs/hardening/release_readiness.py
+++ b/src/ccs/hardening/release_readiness.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Pre-release readiness verifier for ``agent-coherence``.

--- a/src/ccs/output/__init__.py
+++ b/src/ccs/output/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Reporting and dashboard output helpers."""

--- a/src/ccs/output/report.py
+++ b/src/ccs/output/report.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """HTML/JSON report generation for simulation strategy comparisons."""

--- a/src/ccs/replay/__init__.py
+++ b/src/ccs/replay/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Replay capture surface for invariant replay (D v1).

--- a/src/ccs/replay/errors.py
+++ b/src/ccs/replay/errors.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Base exception classes for ``ccs.replay``.

--- a/src/ccs/replay/formatters.py
+++ b/src/ccs/replay/formatters.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Human + JSON formatters for the replay CLI (Unit 5 of D v1).

--- a/src/ccs/replay/loader.py
+++ b/src/ccs/replay/loader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Trace loader — merge engine + corruption detection (Unit 3 of D v1).

--- a/src/ccs/replay/predicates.py
+++ b/src/ccs/replay/predicates.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Replay invariant predicates — Core 4 + SKIPPED dispatch (Unit 4 of D v1).

--- a/src/ccs/replay/recorder.py
+++ b/src/ccs/replay/recorder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Capture-side implementation for invariant replay traces (D v1).

--- a/src/ccs/replay/resolver.py
+++ b/src/ccs/replay/resolver.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Read-at-version resolver — the wired ``read_at_version`` consumer (Unit 6 / R5b).

--- a/src/ccs/simulation/__init__.py
+++ b/src/ccs/simulation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Simulation and benchmarking helpers."""

--- a/src/ccs/simulation/aggregation.py
+++ b/src/ccs/simulation/aggregation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Aggregation utilities for multi-run coherence strategy comparisons."""

--- a/src/ccs/simulation/bounds.py
+++ b/src/ccs/simulation/bounds.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Helpers for enforcing strategy-specific staleness bounds."""

--- a/src/ccs/simulation/consistency.py
+++ b/src/ccs/simulation/consistency.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Runtime consistency monitor for coherence simulations."""

--- a/src/ccs/simulation/engine.py
+++ b/src/ccs/simulation/engine.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Deterministic simulation engine for coherence strategy evaluation."""

--- a/src/ccs/simulation/metrics.py
+++ b/src/ccs/simulation/metrics.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Simulation metrics payloads for coherence strategy evaluation."""

--- a/src/ccs/simulation/scenarios.py
+++ b/src/ccs/simulation/scenarios.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Scenario loading and schema validation for coherence simulations."""

--- a/src/ccs/strategies/__init__.py
+++ b/src/ccs/strategies/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Pluggable synchronization strategies for artifact coherence."""

--- a/src/ccs/strategies/access_count.py
+++ b/src/ccs/strategies/access_count.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Access-count bounded strategy for clock-independent staleness control."""

--- a/src/ccs/strategies/base.py
+++ b/src/ccs/strategies/base.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Base strategy contract for synchronization policy decisions."""

--- a/src/ccs/strategies/blind_cache.py
+++ b/src/ccs/strategies/blind_cache.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Blind cache strategy — BENCHMARK COST-FLOOR ONLY, never for production.

--- a/src/ccs/strategies/broadcast.py
+++ b/src/ccs/strategies/broadcast.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Naive broadcast baseline strategy for canonical benchmark comparisons."""

--- a/src/ccs/strategies/eager.py
+++ b/src/ccs/strategies/eager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Eager broadcast strategy with zero permitted staleness."""

--- a/src/ccs/strategies/lazy.py
+++ b/src/ccs/strategies/lazy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Lazy invalidation strategy with on-demand refetch."""

--- a/src/ccs/strategies/lease.py
+++ b/src/ccs/strategies/lease.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Lease strategy with TTL-based local refresh."""

--- a/src/ccs/strategies/selector.py
+++ b/src/ccs/strategies/selector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Strategy name selection and factory helpers."""

--- a/src/ccs/transport/__init__.py
+++ b/src/ccs/transport/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Transport adapters and simulators."""

--- a/src/ccs/transport/network_sim.py
+++ b/src/ccs/transport/network_sim.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Simulated message transport with configurable latency and loss."""

--- a/src/ccs/validation/__init__.py
+++ b/src/ccs/validation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Log validation helpers for CCS materialized JSONL event streams.

--- a/tests/adapters/test_ccsstore.py
+++ b/tests/adapters/test_ccsstore.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for CCSStore LangGraph BaseStore adapter."""

--- a/tests/adapters/test_ccsstore_content_audit.py
+++ b/tests/adapters/test_ccsstore_content_audit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for content audit log wiring through CCSStore and CoherenceAdapterCore."""

--- a/tests/adapters/test_ccsstore_state_log.py
+++ b/tests/adapters/test_ccsstore_state_log.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for CCSStore state_log parameter — end-to-end wiring from CCSStore to registry."""

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit 1 tests for CoherentVolume: spawn-with-strict, identity, fail-closed.

--- a/tests/adapters/test_openai_agents.py
+++ b/tests/adapters/test_openai_agents.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for the OpenAI Agents SDK coherence adapter (Units 4 + 6).

--- a/tests/adapters/test_openai_agents_live.py
+++ b/tests/adapters/test_openai_agents_live.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Live-API smoke tests for the OpenAI Agents adapter (Unit 8).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Pytest configuration: defensive collection-skip for optional-extra tests.

--- a/tests/diagnose_helpers.py
+++ b/tests/diagnose_helpers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Shared helpers for ``ccs.diagnose`` test suites.

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Integration tests requiring external resources (live ``claude`` CLI,

--- a/tests/integration/test_replay_e2e.py
+++ b/tests/integration/test_replay_e2e.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """End-to-end integration tests for the replay tool (Unit 6 of D v1).

--- a/tests/integration/test_strict_mode.py
+++ b/tests/integration/test_strict_mode.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Integration tests for v0.2 strict-mode handler decision-flip (plan Unit 2).

--- a/tests/integration/test_strict_mode_launch_gate.py
+++ b/tests/integration/test_strict_mode_launch_gate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Multi-model strict-mode launch-gate harness (v0.2 plan Unit 5, KTD-S).

--- a/tests/integration/test_warn_mode_behavior_change.py
+++ b/tests/integration/test_warn_mode_behavior_change.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Re-read rate hard-gate harness (Unit 9 / R7 / origin §12 SC4).

--- a/tests/protocol_corpus/__init__.py
+++ b/tests/protocol_corpus/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Cross-implementation protocol corpus.

--- a/tests/protocol_corpus/harness.py
+++ b/tests/protocol_corpus/harness.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Cross-implementation protocol corpus harness (plan Unit 7).

--- a/tests/protocol_corpus/test_strict_mode_corpus.py
+++ b/tests/protocol_corpus/test_strict_mode_corpus.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Cross-implementation strict-mode wire-shape corpus tests (plan Unit 7b).

--- a/tests/protocol_corpus/test_warn_mode_corpus.py
+++ b/tests/protocol_corpus/test_warn_mode_corpus.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Cross-implementation warn-mode wire-shape corpus tests (plan Unit 7a).

--- a/tests/test_adapter_crash_recovery.py
+++ b/tests/test_adapter_crash_recovery.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """End-to-end integration tests: adapter heartbeat + reclamation + recovery.

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for framework adapter integration helpers."""

--- a/tests/test_agent_cache.py
+++ b/tests/test_agent_cache.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for agent local cache behavior."""

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for agent runtime protocol flows."""

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit tests for multi-run coherence aggregation helpers."""

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for architecture boundary and cycle checks."""

--- a/tests/test_bash_path_detector.py
+++ b/tests/test_bash_path_detector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 
 """Tests for the Bash file-path detector (v0.1.1 KTD-N H4 mitigation).
 

--- a/tests/test_benchmark_fixtures.py
+++ b/tests/test_benchmark_fixtures.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for canonical benchmark scenario fixtures."""

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for strategy-aware bounded staleness checks."""

--- a/tests/test_claude_code_cli.py
+++ b/tests/test_claude_code_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for the four agent-coherence-* console scripts (Unit 6).

--- a/tests/test_claude_code_contract.py
+++ b/tests/test_claude_code_contract.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Hook-payload contract test for the Claude Code adapter (Unit 8).

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for the coordinator HTTP server (plan Unit 4).

--- a/tests/test_claude_code_e2e.py
+++ b/tests/test_claude_code_e2e.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """End-to-end tests for the Claude Code adapter (Unit 8).

--- a/tests/test_claude_code_hook_client.py
+++ b/tests/test_claude_code_hook_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for agent-coherence-hook-client — the command-type hook bridge.

--- a/tests/test_claude_code_lifecycle.py
+++ b/tests/test_claude_code_lifecycle.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for the Claude Code coordinator lifecycle module (Unit 5).

--- a/tests/test_claude_code_migrate_deny.py
+++ b/tests/test_claude_code_migrate_deny.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for ``agent-coherence-migrate-deny`` (v0.2 plan Unit 3, KTD-R).

--- a/tests/test_claude_code_migrate_rules.py
+++ b/tests/test_claude_code_migrate_rules.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for the Unit 9 ``agent-coherence-migrate-rules`` CLI (R19).

--- a/tests/test_claude_code_policy.py
+++ b/tests/test_claude_code_policy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for TrackedArtifactPolicy (plan Unit 3).

--- a/tests/test_claude_code_policy_strict_mode.py
+++ b/tests/test_claude_code_policy_strict_mode.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for TrackedArtifactPolicy strict-mode opt-in (v0.2 plan Unit 1, KTD-O).

--- a/tests/test_claude_code_resolver.py
+++ b/tests/test_claude_code_resolver.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for find_coordinator_root (plan Unit 2).

--- a/tests/test_claude_code_strict_mode_telemetry.py
+++ b/tests/test_claude_code_strict_mode_telemetry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for v0.2 Unit 4 strict-mode telemetry: counters + minimal deny-site

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """CLI tests for simulate and compare commands."""

--- a/tests/test_cli_coherence_replay.py
+++ b/tests/test_cli_coherence_replay.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for ``agent-coherence-replay`` CLI (Unit 5 of D v1).

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit tests for the logical clock primitive."""

--- a/tests/test_coherent_volume_demo.py
+++ b/tests/test_coherent_volume_demo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Offline tests for the CoherentVolume stale-overwrite demo (Unit 4).

--- a/tests/test_concurrent_writers_demo.py
+++ b/tests/test_concurrent_writers_demo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Offline tests for the concurrent lost-update demo (Epic Piece #6).

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for simulation consistency monitor."""

--- a/tests/test_content_audit_log.py
+++ b/tests/test_content_audit_log.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for per-agent content audit log (Units 1, 2, 3, 7)."""

--- a/tests/test_conversations_demo.py
+++ b/tests/test_conversations_demo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Offline tests for the client-cache stale-read demo (Unit 2, pivoted).

--- a/tests/test_conversations_probe.py
+++ b/tests/test_conversations_probe.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Offline tests for the Q6 consistency probe's pure classification layer.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Contract tests for coordinator registry/service operations."""

--- a/tests/test_core_identity.py
+++ b/tests/test_core_identity.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for ccs.core.identity.artifact_uuid.

--- a/tests/test_cost_drift_check.py
+++ b/tests/test_cost_drift_check.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for tools/cost_drift_check.py — the cost-lane drift gate.

--- a/tests/test_crash_recovery.py
+++ b/tests/test_crash_recovery.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for crash-recovery: stable-grant sweep + reclamation-aware commit error."""

--- a/tests/test_demo_script.py
+++ b/tests/test_demo_script.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Smoke test for the multi-agent demo script."""

--- a/tests/test_diagnose_calibration.py
+++ b/tests/test_diagnose_calibration.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit 9 tests — calibration corpus JSONL append.

--- a/tests/test_diagnose_callback.py
+++ b/tests/test_diagnose_callback.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for ``ccs.diagnose.callback``.

--- a/tests/test_diagnose_checkpointer.py
+++ b/tests/test_diagnose_checkpointer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for ``ccs.diagnose.checkpointer``.

--- a/tests/test_diagnose_classifier.py
+++ b/tests/test_diagnose_classifier.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit 3 tests — ``langgraph-v0-preview`` write-pattern classifier."""

--- a/tests/test_diagnose_cli.py
+++ b/tests/test_diagnose_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit 7 tests — ``ccs-diagnose`` CLI integration.

--- a/tests/test_diagnose_detection.py
+++ b/tests/test_diagnose_detection.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit 4 tests — divergence detection engine."""

--- a/tests/test_diagnose_no_import_side_effects.py
+++ b/tests/test_diagnose_no_import_side_effects.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit 8 CI guard — diagnose modules must have zero import-time side effects.

--- a/tests/test_diagnose_ownership.py
+++ b/tests/test_diagnose_ownership.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit 5 tests — ownership-map helper for the HTML renderer."""

--- a/tests/test_diagnose_render.py
+++ b/tests/test_diagnose_render.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit 5 tests — HTML renderer (Jinja2 + autoescape).

--- a/tests/test_diagnose_summary.py
+++ b/tests/test_diagnose_summary.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit 6 tests — terminal summary string-builder.

--- a/tests/test_diagnose_telemetry.py
+++ b/tests/test_diagnose_telemetry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit 8 tests — opt-in consent flow + telemetry payload constructor.

--- a/tests/test_diff_engine.py
+++ b/tests/test_diff_engine.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for optional artifact diff engine utilities."""

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Integration tests for simulation engine and comparison runner."""

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for in-memory event bus abstraction."""

--- a/tests/test_granularity.py
+++ b/tests/test_granularity.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for artifact granularity constants and v0.1 support flags."""

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit tests for invariant checks."""

--- a/tests/test_network_sim.py
+++ b/tests/test_network_sim.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit tests for network simulation transport."""

--- a/tests/test_occ_commit_cas.py
+++ b/tests/test_occ_commit_cas.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Concurrent-writer + bounded-progress proof suite for the OCC commit-CAS

--- a/tests/test_property_invariants.py
+++ b/tests/test_property_invariants.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Deterministic randomized invariant tests for coordinator protocol."""

--- a/tests/test_read_at_version.py
+++ b/tests/test_read_at_version.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """read-at-version service surface — typed outcomes, epoch stability, and

--- a/tests/test_refactor_demo.py
+++ b/tests/test_refactor_demo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for the planner-executor refactor demo.

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for the in-memory ArtifactRegistry OCC commit-CAS (plan Unit 2).

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for ``ccs.hardening.release_readiness``.

--- a/tests/test_replay_errors.py
+++ b/tests/test_replay_errors.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for the ``ccs.replay`` exception hierarchy (Gated #11).

--- a/tests/test_replay_loader.py
+++ b/tests/test_replay_loader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for the replay trace loader (Unit 3 of D v1).

--- a/tests/test_replay_predicates.py
+++ b/tests/test_replay_predicates.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for the replay predicate engine (Unit 4 of D v1).

--- a/tests/test_replay_recorder.py
+++ b/tests/test_replay_recorder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for the replay capture surface (Unit 2 of D v1).

--- a/tests/test_replay_resolver.py
+++ b/tests/test_replay_resolver.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Replay CLI resolve mode — the wired ``read_at_version`` consumer (Unit 6 / R5b).

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for report rendering and dashboard payload generation."""

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Bounded version retention — policy unit tests + in-memory registry behavior.

--- a/tests/test_retention_parity.py
+++ b/tests/test_retention_parity.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Cross-registry retention parity — the genuinely net-new Unit 5 scenarios.

--- a/tests/test_run_cost_sweep.py
+++ b/tests/test_run_cost_sweep.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for tools/run_cost_sweep.py — the change-rate × answer-sensitivity sweep.

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for scenario loading and schema validation."""

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for SqliteArtifactRegistry (plan Unit 1).

--- a/tests/test_state_transitions_log.py
+++ b/tests/test_state_transitions_log.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for the state transitions log emitter — registry, service, and CCSStore layers."""

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit tests for MESI states and transition helpers."""

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Behavior tests for synchronization strategy implementations."""

--- a/tests/test_supply_chain_artifacts.py
+++ b/tests/test_supply_chain_artifacts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit 10 — supply-chain hardening artifact tests.

--- a/tests/test_transient_timeout.py
+++ b/tests/test_transient_timeout.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for transient timeout fail-safe behavior."""

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Unit tests for core artifact dataclasses."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Tests for ccs.validation.validate_log."""

--- a/tools/benchmark_regression_smoke.py
+++ b/tools/benchmark_regression_smoke.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Benchmark regression smoke check for CI hardening."""

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Run CCS architecture boundary and cycle checks."""

--- a/tools/check_release_readiness.py
+++ b/tools/check_release_readiness.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Run CCS release-readiness checks (preflight for ``v*`` tag push).

--- a/tools/cost_drift_check.py
+++ b/tools/cost_drift_check.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """CI drift check: compare benchmarks/results/cost_sweep.json against benchmarks/expected_cost.json.

--- a/tools/cost_to_tokens.py
+++ b/tools/cost_to_tokens.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Translate the cost-sweep's ``refetches_avoided`` into token + dollar savings.

--- a/tools/plot_cost_sweep.py
+++ b/tools/plot_cost_sweep.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Plot the temporal-cost savings-regime curve from a cost-sweep payload.

--- a/tools/run_artifact_scaling.py
+++ b/tools/run_artifact_scaling.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Artifact-size sweep with broadcast/eager/lazy savings baselines."""

--- a/tools/run_canonical_benchmarks.py
+++ b/tools/run_canonical_benchmarks.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Canonical benchmark runner for paper Table 1 reproduction checks."""

--- a/tools/run_cost_sweep.py
+++ b/tools/run_cost_sweep.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Cost sweep: change-rate × answer-sensitivity → provenance-labeled savings map.

--- a/tools/run_step5_benchmarks.py
+++ b/tools/run_step5_benchmarks.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Run Step 5 benchmark set and persist reproducible artifacts."""

--- a/tools/run_step_scaling.py
+++ b/tools/run_step_scaling.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """S-scaling sweep: vary duration_ticks with broadcast/eager/lazy baselines."""

--- a/tools/verify_baseline.py
+++ b/tools/verify_baseline.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Arbiter contributors.
+# Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
 """Verify reproduced benchmark values against committed Step5 SUMMARY baseline."""


### PR DESCRIPTION
## Summary
- Replaces the legacy `Arbiter contributors` attribution with `agent-coherence contributors` in the per-file copyright header across the codebase, plus the `authors` field in `pyproject.toml`.
- **Comment / package-metadata only** — no code or behavior changes (223 files, 1 line each).

## Why
`Arbiter` is a legacy internal project name; the project is `agent-coherence`. Normalizing the public attribution.

## Test Plan
- [x] `git grep -i arbiter` → 0 matches after the sweep.
- [x] Only the header line / pyproject authors string changed (223 insertions / 223 deletions).
- [x] No code paths touched.