### PR TITLE
feat(mcp): stale-write-guard-fs coherence MCP server (v1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install package and test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev,diagnose]"
+          python -m pip install -e ".[dev,diagnose,mcp]"
 
       # Node toolchain for the refactor-demo's TypeScript fixture. Without
       # this, _has_tsc() in tests/test_refactor_demo.py is False and all real

--- a/examples/mcp_stale_write_guard/README.md
+++ b/examples/mcp_stale_write_guard/README.md
@@ -1,0 +1,31 @@
+# stale-write-guard-fs — red→green front door
+
+A constructed, deterministic, offline demo of the `stale-write-guard-fs` MCP
+server. The **same** read→write sequence loses an update without the guard and is
+prevented with it. The green path is driven through the server's own tool
+contract, so it proves the server — not just the coordinator beneath it.
+
+```bash
+python -m examples.mcp_stale_write_guard.main
+```
+
+Exits `0` only if **all four** hold:
+
+| Case | What it shows |
+|------|---------------|
+| **RED** — no coherence | the agent's stale buffer clobbers a peer's commit → the update is lost |
+| **GREEN** sequential | the stale write is **denied** (`stale_view`); the agent reacquires and does not clobber → the peer's value survives *exactly* |
+| **GREEN** concurrent | two writers compare-and-set the same version; the loser re-reads, re-merges, re-CASes → both lines land (the *exact* golden merge) |
+| **CONTROL** | the green flow with the deny **disabled** → the loss returns, proving green depends on the deny, not on a refetch that masks it |
+
+Two single-host regimes, both fail-closed:
+
+- **sequential** stale-overwrite — denied, recover with reacquire.
+- **concurrent** same-key — typed conflict, *not* auto-merge: you read, merge, retry.
+
+## Scope (the honesty floor)
+
+Single-host only. **Out of guarantee and not detected in v1:** writers on
+different hosts or across a synced/network mount, divergent-history
+reconciliation, semantic correctness, server-enforced auto-merge. The server
+enforces *version lineage*, not that your content was derived from what you read.

--- a/examples/mcp_stale_write_guard/__init__.py
+++ b/examples/mcp_stale_write_guard/__init__.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Red→green front door for the stale-write-guard-fs MCP server.
+
+A constructed, deterministic, offline demo: the SAME read→write sequence loses an
+update without the guard (RED) and is denied/merged with it (GREEN). The GREEN
+path drives the server's own tool contract (``ccs.mcp.server._do_*``) so the
+demo proves the server, not just the coordinator. A NEGATIVE CONTROL re-runs the
+green flow with the deny disabled and confirms the loss returns — so a passing
+green cannot be a refetch/merge masking the loss.
+
+Two single-host regimes:
+  - sequential — a stale overwrite is DENIED; the peer's value survives untouched.
+  - concurrent — two writers compare-and-set the same key; the loser re-reads,
+    re-merges, and retries → both contributions land (the golden merge).
+
+Generic agents over a shared notes file; no incident, no names, no network.
+"""
+
+from __future__ import annotations
+
+# The shared artifact + the two regimes' content. Generic and de-named.
+REL = "data/notes.md"
+
+BASE = "# shared notes\n"
+PEER_LINE = "- line from the peer\n"
+AGENT_LINE = "- line from the agent\n"
+LINE_A = "- line from agent a\n"
+LINE_B = "- line from agent b\n"
+
+# Sequential GREEN: the peer's commit survives, the agent's stale buffer does not.
+PEER_VALUE = BASE + PEER_LINE
+# Concurrent GREEN: agent A lands first, agent B re-merges on top — both lines.
+GOLDEN = BASE + LINE_A + LINE_B

--- a/examples/mcp_stale_write_guard/broken.py
+++ b/examples/mcp_stale_write_guard/broken.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Broken case: no coherence → a stale buffer silently clobbers a peer's commit.
+
+The agent reads the file (deriving its buffer from that version), a peer commits a
+new line, then the agent writes its STALE buffer back — last-writer-wins, and the
+peer's line is gone. Plain file writes, no coordinator: the lost update the guard
+exists to prevent.
+
+    python -m examples.mcp_stale_write_guard.broken
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from examples.mcp_stale_write_guard import AGENT_LINE, BASE, PEER_LINE, PEER_VALUE, REL
+
+
+def run_broken() -> dict[str, object]:
+    """Sequenced read→clobber with no coordination; returns a structured trace."""
+    workspace = Path(tempfile.mkdtemp(prefix="swg_broken_"))
+    target = workspace / REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(BASE)
+    try:
+        agent_buffer = target.read_text() + AGENT_LINE  # agent derived from BASE
+        target.write_text(PEER_VALUE)  # peer commits its line
+        target.write_text(agent_buffer)  # agent's STALE write clobbers the peer
+        final = target.read_text()
+        return {"final": final, "lost_update": PEER_LINE not in final}
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def main() -> int:
+    trace = run_broken()
+    print("BROKEN (no coherence) — the agent's stale write clobbers the peer")
+    print(f"  LOST UPDATE: {trace['lost_update']}  (the peer's line is gone)")
+    return 0 if trace["lost_update"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/mcp_stale_write_guard/fixed.py
+++ b/examples/mcp_stale_write_guard/fixed.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Fixed cases: the same sequence, routed through the stale-write-guard-fs server.
+
+GREEN drives the server's OWN tool contract (``ccs.mcp.server._do_*``: validate →
+serialize → CoherentVolume → typed CallToolResult), so the demo proves the
+server, not just the coordinator underneath it.
+
+  - ``run_sequential(guarded=True)`` — the agent's stale write is DENIED
+    (reason=stale_view); the agent reacquires and does NOT clobber → the peer's
+    value survives EXACTLY. ``guarded=False`` is the NEGATIVE CONTROL: the same
+    flow with the path left unguarded (the deny disabled) → the loss returns,
+    proving the green depends on the deny.
+  - ``run_concurrent()`` — two writers compare-and-set the same version; the
+    loser gets a typed version_mismatch, re-reads, re-merges, and re-CASes → both
+    lines land (the golden merge).
+
+Sequenced, deterministic, offline: each run spawns a local coordinator subprocess
+and tears it down in ``finally``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+# A spawned coordinator subprocess must import ``ccs`` too; propagate the src
+# path so the demo also runs from a bare checkout (harmless when installed).
+_pp = os.environ.get("PYTHONPATH", "")
+if str(SRC_ROOT) not in _pp.split(os.pathsep):
+    os.environ["PYTHONPATH"] = f"{SRC_ROOT}{os.pathsep}{_pp}" if _pp else str(SRC_ROOT)
+
+from ccs.adapters.claude_code.lifecycle import LifecycleConfig, stop_coordinator
+from ccs.adapters.coherent_volume import CoherentVolume
+from ccs.mcp.server import _do_reacquire, _do_read, _do_write, _do_write_cas
+from ccs.mcp.session import SessionConfig
+from examples.mcp_stale_write_guard import (
+    AGENT_LINE,
+    BASE,
+    GOLDEN,
+    LINE_A,
+    LINE_B,
+    PEER_VALUE,
+    REL,
+)
+
+# Snappy local spawn for a one-command demo; no idle shutdown mid-run.
+_DEMO_CFG = LifecycleConfig(
+    idle_shutdown_sec=0,
+    sweep_interval_sec=0.1,
+    port_file_retry_attempts=40,
+    port_file_retry_interval_sec=0.05,
+    connect_retry_attempts=20,
+    connect_retry_interval_sec=0.05,
+)
+
+
+def _content(result) -> str:
+    return result.structuredContent["content"]
+
+
+def run_sequential(*, guarded: bool) -> dict[str, object]:
+    """Stale-overwrite, denied + recovered through the server's tools.
+
+    ``guarded`` toggles whether the artifact's glob is strict-enforced: True
+    guards ``data/**`` (the deny fires); False guards an unrelated glob so the
+    same flow runs with the deny DISABLED (the negative control)."""
+    workspace = Path(tempfile.mkdtemp(prefix="swg_seq_"))
+    target = workspace / REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(BASE)
+    managed = ("data/**",) if guarded else ("other/**",)
+    config = SessionConfig(root=workspace.resolve(), managed=managed)
+    agent = CoherentVolume(workspace, managed=managed, on_error="strict", config=_DEMO_CFG)
+    try:
+        peer = CoherentVolume(workspace, managed=managed, on_error="strict", config=_DEMO_CFG)
+
+        agent_buffer = _content(_do_read(agent, config, REL)) + AGENT_LINE  # derived from BASE
+        _do_read(peer, config, REL)
+        _do_write(peer, config, REL, PEER_VALUE)  # peer commits its line
+
+        wrote = _do_write(agent, config, REL, agent_buffer)  # agent's STALE write
+        denied = bool(wrote.isError)
+        if denied:
+            # Recover: reacquire shows the peer's value; the agent does NOT clobber.
+            _do_reacquire(agent, config, REL)
+
+        final = target.read_text()
+        return {
+            "guarded": guarded,
+            "stale_write_denied": denied,
+            "deny_reason": wrote.structuredContent.get("reason") if denied else None,
+            "final": final,
+            "preserved_peer_value": final == PEER_VALUE,
+        }
+    finally:
+        stop_coordinator(workspace)
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def run_concurrent() -> dict[str, object]:
+    """Two writers CAS the same version; the loser re-reads, re-merges, re-CASes →
+    both lines land (the golden merge), never a silent loss."""
+    workspace = Path(tempfile.mkdtemp(prefix="swg_conc_"))
+    target = workspace / REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(BASE)
+    config = SessionConfig(root=workspace.resolve(), managed=("data/**",))
+    vol_a = CoherentVolume(workspace, managed=("data/**",), on_error="strict", config=_DEMO_CFG)
+    try:
+        vol_b = CoherentVolume(workspace, managed=("data/**",), on_error="strict", config=_DEMO_CFG)
+
+        read_a = _do_read(vol_a, config, REL)
+        read_b = _do_read(vol_b, config, REL)
+        va = read_a.structuredContent["version"]
+        vb = read_b.structuredContent["version"]
+        conflicts_a: dict[str, int] = {}
+        conflicts_b: dict[str, int] = {}
+
+        res_a = _do_write_cas(vol_a, config, conflicts_a, REL, va, _content(read_a) + LINE_A)
+        res_b = _do_write_cas(vol_b, config, conflicts_b, REL, vb, _content(read_b) + LINE_B)
+        b_first_conflicted = bool(res_b.isError)
+
+        # B re-reads A's commit, re-merges its line, re-CASes.
+        read_b2 = _do_read(vol_b, config, REL)
+        vb2 = read_b2.structuredContent["version"]
+        res_b2 = _do_write_cas(vol_b, config, conflicts_b, REL, vb2, _content(read_b2) + LINE_B)
+
+        final = target.read_text()
+        return {
+            "a_committed": not bool(res_a.isError),
+            "b_first_conflicted": b_first_conflicted,
+            "b_merged_and_committed": not bool(res_b2.isError),
+            "final": final,
+            "merged_golden": final == GOLDEN,
+        }
+    finally:
+        stop_coordinator(workspace)
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def main() -> int:
+    seq = run_sequential(guarded=True)
+    conc = run_concurrent()
+    print("FIXED (stale-write-guard-fs) — driven through the server's tools")
+    print(f"  sequential: stale write denied={seq['stale_write_denied']}")
+    print(f"  sequential: peer value preserved={seq['preserved_peer_value']}")
+    print(f"  concurrent: golden merge={conc['merged_golden']}")
+    ok = bool(seq["preserved_peer_value"]) and bool(conc["merged_golden"])
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/mcp_stale_write_guard/main.py
+++ b/examples/mcp_stale_write_guard/main.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Red→green gate for stale-write-guard-fs: RED loses, GREEN holds, control proves it.
+
+Runs four cases and exits 0 only if ALL hold:
+  - RED       — no coherence → the update is lost.
+  - GREEN seq — the stale overwrite is denied; the peer value survives EXACTLY.
+  - GREEN cas — two writers merge to the EXACT golden value.
+  - CONTROL   — the green flow with the deny disabled → the loss returns,
+                proving green depends on the deny, not on a refetch/merge.
+
+Constructed, deterministic, offline (a local coordinator subprocess; no network).
+
+    python -m examples.mcp_stale_write_guard.main
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from examples.mcp_stale_write_guard import GOLDEN, PEER_VALUE, broken, fixed
+
+
+def main() -> int:
+    print("stale-write-guard-fs — red→green front door (single-host, sequential + concurrent).")
+    print("Same read→write sequence each time; only the coordination differs.\n")
+
+    red = broken.run_broken()
+    green_seq = fixed.run_sequential(guarded=True)
+    green_cas = fixed.run_concurrent()
+    control = fixed.run_sequential(guarded=False)  # deny disabled
+
+    # Exact-equal finals (not inequalities): a green that merely "differs from the
+    # broken value" could still be wrong. Pin the exact expected content.
+    checks = {
+        "RED  no coherence loses the update": bool(red["lost_update"]),
+        "GREEN sequential preserves the peer value (exact)": (
+            green_seq["final"] == PEER_VALUE and bool(green_seq["stale_write_denied"])
+        ),
+        "GREEN concurrent merges to the golden value (exact)": (
+            green_cas["final"] == GOLDEN and bool(green_cas["merged_golden"])
+        ),
+        "CONTROL with the deny off, the loss returns": not bool(control["preserved_peer_value"]),
+    }
+
+    for label, passed in checks.items():
+        print(f"  [{'ok' if passed else 'FAIL'}] {label}")
+
+    ok = all(checks.values())
+    print("\nGREEN" if ok else "\nRED — a check failed; do not trust this build")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,10 @@ diagnose = ["agent-coherence[langgraph]", "jinja2>=3.1", "langchain-core>=0.2"]
 openai = ["openai>=2.0", "httpx>=0.27"]
 openai-agents = ["agent-coherence[openai]", "openai-agents>=0.17,<0.18"]
 mistral = ["mistralai>=2.0"]
-all = ["agent-coherence[langgraph,crewai,otel,langsmith,benchmark,diagnose,openai-agents,mistral]"]
+# MCP-C v1: the stale-write-guard-fs stdio MCP server (ccs.mcp). The official
+# `mcp` SDK is the only new runtime dep; v2-alpha renames FastMCP, so pin <2.
+mcp = ["mcp>=1.27,<2"]
+all = ["agent-coherence[langgraph,crewai,otel,langsmith,benchmark,diagnose,openai-agents,mistral,mcp]"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,10 @@ agent-coherence-hook-client = "ccs.cli.coherence_hook_client:main"
 # stale-read / lost-write) and emits human or JSON findings. Exit-code
 # mapping per docs/proposals/replay_trace_format.md §7.3.
 agent-coherence-replay = "ccs.cli.coherence_replay:main"
+# MCP-C v1: the stale-write-guard-fs stdio MCP server (requires the `mcp` extra).
+# Single-host coherence guard over CoherentVolume; configured via SWG_ROOT /
+# SWG_MANAGED. See src/ccs/mcp/.
+stale-write-guard-fs = "ccs.mcp.server:main"
 # Note: ccs-check-release is intentionally NOT exposed as a public console
 # script. It's a maintainer-only pre-tag-push verifier that queries this
 # repo's GitHub admin settings (hardcoded defaults to hipvlady/agent-coherence).

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -249,7 +249,7 @@ class CoherentVolume:
         identities (``reacquire``/``_after_fork`` re-mint ``_session_id`` while
         the lock-free op path reads it). This guard makes that misuse LOUD rather
         than silently corrupting: a second thread entering while another holds the
-        guard raises ``CoherenceError``.
+        guard raises ``InternalConcurrencyError`` (a ``CoherenceError`` subclass).
 
         Re-entrant for the SAME thread so internal nesting works (``write_cas``
         calls :meth:`reacquire`, which calls :meth:`read`): the owning thread
@@ -426,7 +426,8 @@ class CoherentVolume:
             return None
         try:
             status = _coordinator_get(self._endpoint, "/status")
-        except Exception:  # best-effort; any failure → unknown
+        except Exception as exc:  # best-effort; any failure → unknown
+            logger.debug("coordinator_status probe failed: %s", exc)
             return None
         return status if isinstance(status, dict) else None
 
@@ -492,8 +493,9 @@ class CoherentVolume:
         Prevents the **sequential** stale-read→write lost update: if a peer
         committed a newer version since this instance last read, this instance
         is ``INVALID`` and the coordinator denies the write (``pre-edit``). The
-        deny is surfaced as ``CoherenceError`` carrying the coordinator's
-        byte-stable reason VERBATIM. **A deny always raises, in both
+        deny is surfaced as ``StaleView`` (pre-edit) or ``CommitPreempted``
+        (post-edit preempt) — both ``CoherenceError`` subclasses — carrying the
+        coordinator's byte-stable reason VERBATIM. **A deny always raises, in both
         ``on_error`` modes** — the deny is enforcement working, not an
         infrastructure failure; recover via :meth:`reacquire` and write from the
         fresh bytes.
@@ -656,8 +658,8 @@ class CoherentVolume:
         stale-denied comparand read (the transient window where a peer's commit
         landed but its disk write hasn't) does NOT consume the commit budget;
         instead CONSECUTIVE denied reads are separately bounded (also at
-        ``MAX_CAS_REACQUIRES + 1``) and raise ``CoherenceError`` if the view
-        never clears. Both terminals are the honest fail-closed outcome,
+        ``MAX_CAS_REACQUIRES + 1``) and raise ``ViewWedged`` (a ``CoherenceError``
+        subclass) if the view never clears. Both terminals are the honest fail-closed outcome,
         **never** a silent lost update: the invariant this method guarantees is
         *final == start + every applied delta, OR a typed raise* — a successful
         return always means the update landed.

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -66,11 +66,17 @@ from ccs.cli._coherence_client import (
     post as _coordinator_post,
 )
 from ccs.core.exceptions import (
+    COMMIT_UNCONFIRMED_REASON,
     OCC_CALLER_TRANSIENT_REASON,
     STALE_READ_GENERATION_REASON,
     CasRetriesExhausted,
     CoherenceDegradedWarning,
     CoherenceError,
+    CommitPreempted,
+    CommitUnconfirmed,
+    InternalConcurrencyError,
+    StaleView,
+    ViewWedged,
 )
 
 logger = logging.getLogger(__name__)
@@ -254,7 +260,10 @@ class CoherentVolume:
         ident = threading.get_ident()
         with self._guard_meta_lock:
             if self._guard_owner_ident is not None and self._guard_owner_ident != ident:
-                raise CoherenceError(
+                # A server-misuse bug (the MCP server serializes tool access), not
+                # an agent-recoverable deny — typed so the mapper never relays it
+                # as a retryable stale view.
+                raise InternalConcurrencyError(
                     "CoherentVolume is single-threaded; concurrent use detected. "
                     "One operation at a time per instance — use one instance per "
                     "thread (an in-flight read/write/write_cas can re-mint identity "
@@ -719,7 +728,7 @@ class CoherentVolume:
                 last_current_version = max(last_current_version, expected_version)
                 denied_streak += 1
                 if denied_streak > MAX_CAS_REACQUIRES:
-                    raise CoherenceError(
+                    raise ViewWedged(
                         f"OCC comparand read of {rel} stayed strict-denied across "
                         f"{denied_streak} consecutive reads under re-minted "
                         "identities; cannot establish a clean (bytes, version) "
@@ -760,7 +769,7 @@ class CoherentVolume:
                 # is handled below ("raise"). on_error governs only whether the
                 # infra failure already warned (degrade) or raised (strict) inside
                 # _post; either way an unconfirmed CAS must read as failure.
-                raise CoherenceError(
+                raise CommitUnconfirmed(
                     f"OCC commit of {rel} could not be confirmed (coordinator "
                     "transport failed mid-commit); the write did not land. "
                     "reacquire() and retry from the fresh bytes."
@@ -791,7 +800,19 @@ class CoherentVolume:
                 continue
             # outcome == "raise": a deny, corruption, or the fail-closed
             # commit_unconfirmed degrade body — ALWAYS raises in both modes.
-            # Nothing was written to disk (the CAS did not win).
+            # Nothing was written to disk (the CAS did not win). Type the terminal
+            # so the MCP deny mapper classifies by exception type, not a substring
+            # of the (verbatim) coordinator prose:
+            #  - commit_unconfirmed degrade body → CommitUnconfirmed (re-read, retry
+            #    only if absent — the false-negative-ack window);
+            #  - a permission-style deny → StaleView (recoverable by reacquire);
+            #  - anything else (corruption: commit_cas_corruption / expected>current)
+            #    → plain CoherenceError → the mapper fails it closed as internal_error.
+            if resp.get("reason") == COMMIT_UNCONFIRMED_REASON:
+                raise CommitUnconfirmed(self._deny_reason(resp))
+            hook_output = resp.get("hookSpecificOutput")
+            if isinstance(hook_output, dict) and hook_output.get("permissionDecisionReason"):
+                raise StaleView(self._deny_reason(resp))
             raise CoherenceError(self._deny_reason(resp))
 
     # --- coordinator I/O helpers --------------------------------------------
@@ -1030,7 +1051,15 @@ class CoherentVolume:
         if not isinstance(resp, dict):
             return
         if resp.get("ok") is False:
-            raise CoherenceError(self._deny_reason(resp))
+            # Type the deny by phase so the MCP mapper classifies by exception
+            # type, not a substring of the (verbatim) coordinator prose. A
+            # pre-edit INVALID deny is a recoverable stale view; a post-edit
+            # ok:false is a mid-write preempt/reclaim — the atomic write (:523)
+            # already hit disk un-versioned, so it is a distinct terminal that
+            # needs reconcile, not a bare retry.
+            if phase == "post-edit":
+                raise CommitPreempted(self._deny_reason(resp))
+            raise StaleView(self._deny_reason(resp))
         if resp.get("degraded"):
             self._fail_closed_or_degrade(
                 f"coordinator watchdog timeout on {phase} for {rel}"

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -412,6 +412,23 @@ class CoherentVolume:
             return summary[key]
         return status.get(key)
 
+    def coordinator_status(self) -> dict | None:
+        """The coordinator ``/status`` document, or ``None`` if unattached or the
+        status surface is unreachable.
+
+        Best-effort (any failure → ``None``). The MCP ``swg_status`` tool uses it
+        to split ``off`` (reachable, no strict patterns) from ``unknown``
+        (unreachable) — a distinction :meth:`strict_mode_active` collapses to
+        ``False`` — and to read the tracked-artifact versions for ``per_path``.
+        """
+        if self._endpoint is None:
+            return None
+        try:
+            status = _coordinator_get(self._endpoint, "/status")
+        except Exception:  # best-effort; any failure → unknown
+            return None
+        return status if isinstance(status, dict) else None
+
     # --- read / write / reacquire contract (Unit 2) -------------------------
 
     def read(self, path: str | os.PathLike[str]) -> bytes:
@@ -909,6 +926,19 @@ class CoherentVolume:
                 f"coordinator request to {endpoint_path} failed: {exc}"
             )
             return None  # reached only in degrade mode
+
+    def read_with_version(self, path: str | os.PathLike[str]) -> tuple[bytes, int]:
+        """Read current bytes + the coordinator's authoritative version.
+
+        The version is the OCC comparand an Option-A writer (the MCP
+        ``swg_write_cas`` tool) passes back as ``expected_version``. Like
+        :meth:`read`, a sticky-INVALID instance still returns fresh bytes and the
+        version reflects the peer's commit; the instance stays INVALID until
+        :meth:`reacquire` re-mints. ``FileNotFoundError`` for a missing file.
+        """
+        with self._single_op_guard():
+            data, version, _stale_denied = self._read_with_version(path)
+            return data, version
 
     def _read_with_version(self, rel: str) -> tuple[bytes, int, bool]:
         """OCC helper: register a SHARED view and return

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -70,6 +70,7 @@ from ccs.core.exceptions import (
     OCC_CALLER_TRANSIENT_REASON,
     STALE_READ_GENERATION_REASON,
     CasRetriesExhausted,
+    CasVersionConflict,
     CoherenceDegradedWarning,
     CoherenceError,
     CommitPreempted,
@@ -831,6 +832,92 @@ class CoherentVolume:
             if isinstance(hook_output, dict) and hook_output.get("permissionDecisionReason"):
                 raise StaleView(self._deny_reason(resp))
             raise CoherenceError(self._deny_reason(resp))
+
+    def write_cas_at(
+        self,
+        path: str | os.PathLike[str],
+        expected_version: int,
+        new_content: bytes | bytearray,
+    ) -> None:
+        """Single-shot, version-checked CAS (Option A — the MCP ``swg_write_cas``).
+
+        Commit ``new_content`` IFF the coordinator's current version ==
+        ``expected_version``. Unlike :meth:`write_cas` (which auto-retries by
+        re-deriving from the latest bytes), this does NOT retry and does NOT
+        re-derive: a stale ``expected_version`` raises
+        :class:`~ccs.core.exceptions.CasVersionConflict` carrying the current
+        version — the AGENT re-reads, re-merges, and retries
+        (typed-conflict, not auto-merge). This is the correct primitive for an
+        agent that already merged against a specific version it read: it never
+        commits content derived from version V over a peer's later V+1 (the
+        split-comparand lost update; ``coherent-volume-write-cas-split-comparand``).
+
+        The CAS commits against the AGENT's ``expected_version``, NOT a re-read
+        one, so a peer winning the version between the comparand read and the
+        commit is rejected as a conflict — never a silent overwrite. ``new_content``
+        touches disk ONLY on a confirmed win.
+        """
+        if not isinstance(new_content, (bytes, bytearray)):
+            raise TypeError(f"new_content must be bytes, got {type(new_content).__name__}")
+        with self._single_op_guard():
+            self._write_cas_at_impl(path, int(expected_version), bytes(new_content))
+
+    def _write_cas_at_impl(
+        self, path: str | os.PathLike[str], expected_version: int, new_content: bytes
+    ) -> None:
+        self._ensure_attached()
+        abs_path, rel = self._to_relative(path)
+        if self._endpoint is None:
+            # Strict-only construction prevents this for the server; fail closed
+            # rather than best-effort writing an unversioned blob.
+            raise CoherenceError(
+                f"cannot CAS {rel}: coordinator endpoint unavailable (fail-closed)"
+            )
+        # Re-mint first / read second: a hash-checked None-state read establishes
+        # a VALIDATED (bytes, version) comparand under a fresh identity (do NOT
+        # re-create the split-comparand hole — KTD-LU).
+        self._remint()
+        _current_bytes, current_version, stale_denied = self._read_with_version(rel)
+        if stale_denied:
+            # The comparand view is INVALID / the disk lags a just-landed commit;
+            # the agent must reacquire / re-read before it can CAS.
+            raise ViewWedged(
+                f"OCC comparand read of {rel} is strict-denied; cannot establish a "
+                "clean (bytes, version) view to CAS from. reacquire() / re-read first."
+            )
+        if current_version != expected_version:
+            # Stale expected_version → typed conflict; NO write, NO server retry.
+            raise CasVersionConflict(rel, expected_version, current_version)
+        new_hash = self._sha256_bytes(new_content)
+        resp = self._post(
+            "/hooks/post-edit-cas",
+            {
+                "session_id": self._session_id,
+                "path": rel,
+                "success": True,
+                "content_hash": new_hash,
+                "expected_version": expected_version,
+            },
+        )
+        if resp is None:
+            raise CommitUnconfirmed(
+                f"OCC commit of {rel} could not be confirmed (coordinator transport "
+                "failed mid-commit); the write did not land. re-read and retry."
+            )
+        outcome = self._classify_cas_response(resp)
+        if outcome == "win":
+            self._atomic_write(abs_path, new_content)  # confirmed → persist
+            self._last_committed_hash[rel] = new_hash
+            return
+        if outcome == "conflict":
+            # A peer won the version between our read and the CAS → typed conflict.
+            raise CasVersionConflict(
+                rel, expected_version, self._cas_current_version(resp, current_version)
+            )
+        # outcome == "raise": corruption or the commit_unconfirmed degrade body.
+        if resp.get("reason") == COMMIT_UNCONFIRMED_REASON:
+            raise CommitUnconfirmed(self._deny_reason(resp))
+        raise CoherenceError(self._deny_reason(resp))
 
     # --- coordinator I/O helpers --------------------------------------------
 

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -137,6 +137,27 @@ STORE_OPEN_SIGNALS: frozenset[str] = frozenset(
 # Renaming the value is a wire break; add, do not mutate.
 CROSS_RUNTIME_SCHEMA_REASON = "cross_runtime_schema"
 
+# ---------------------------------------------------------------------------
+# MCP-C deny vocabulary (stale-write-guard-fs, 2026-06-18 plan, Unit 1)
+# ---------------------------------------------------------------------------
+#
+# Each fail-closed coherence terminal carries a typed ``.reason`` CONSTANT on its
+# class (below). The MCP deny mapper (``ccs.mcp.deny``) classifies by exception
+# TYPE and reads ``.reason`` — NEVER a substring of the message, which stays the
+# byte-stable coordinator ``permissionDecisionReason`` prose (the model's retry
+# loop depends on that stability, auto-memory
+# ``project_cc_strict_mode_retry_hazard``; the typed-signal-not-substring house
+# rule). Renaming a value is a wire break; add, do not mutate.
+STALE_VIEW_REASON = "stale_view"
+COMMIT_PREEMPTED_REASON = "commit_preempted"
+VIEW_WEDGED_REASON = "view_wedged"
+COMMIT_UNCONFIRMED_REASON = "commit_unconfirmed"
+CAS_EXHAUSTED_REASON = "cas_exhausted"
+INTERNAL_CONCURRENCY_REASON = "internal_concurrency_error"
+# Type B — synthesized by the mapper (no adapter raise-site) when the volume is
+# unattached / coordinator transport failed; the write is NOT version-committed.
+COORDINATOR_UNAVAILABLE_REASON = "coordinator_unavailable"
+
 
 class CoherenceError(Exception):
     """Base error for coherence domain failures."""
@@ -217,7 +238,13 @@ class CasRetriesExhausted(CoherenceError):
 
     A subclass of :class:`CoherenceError` so the deny-always-raises consumers
     (CoherentVolume / CCSStore strict mode) already treat it as a hard failure.
+
+    Carries :data:`CAS_EXHAUSTED_REASON` (MCP-C Unit 1) so the deny mapper
+    classifies it by type; the wire reason ``cas_exhausted`` is deliberately
+    distinct from the ``cas_retries_exhausted`` prose token in the message.
     """
+
+    reason = CAS_EXHAUSTED_REASON
 
     def __init__(self, artifact_id: object, attempts: int, last_current_version: int) -> None:
         super().__init__(
@@ -228,6 +255,56 @@ class CasRetriesExhausted(CoherenceError):
         self.artifact_id = artifact_id
         self.attempts = attempts
         self.last_current_version = last_current_version
+
+
+class StaleView(CoherenceError):
+    """Pre-edit deny (MCP-C Unit 1): this instance's view is INVALID — a peer
+    committed a newer version, so the coordinator denied the write BEFORE any
+    disk mutation. Recoverable: ``reacquire()`` for fresh bytes, then write FROM
+    them. Carries :data:`STALE_VIEW_REASON`; the message stays the verbatim
+    coordinator ``permissionDecisionReason`` (matched by type, not substring)."""
+
+    reason = STALE_VIEW_REASON
+
+
+class CommitPreempted(CoherenceError):
+    """Post-edit deny (MCP-C Unit 1): the EXCLUSIVE grant was preempted /
+    sweep-reclaimed AFTER the atomic disk write but BEFORE the commit landed, so
+    the bytes may already be on disk *un-versioned* (disk ahead of the
+    coordinator version). NOT only a concurrent edge — a lone sequential writer's
+    grant can age out mid-write (crash-recovery sweep, default-on). Recover by
+    re-reading fresh bytes and reconciling the pending buffer (agent-driven; v1
+    has no server reconcile primitive). Carries :data:`COMMIT_PREEMPTED_REASON`."""
+
+    reason = COMMIT_PREEMPTED_REASON
+
+
+class ViewWedged(CoherenceError):
+    """OCC comparand wedged (MCP-C Unit 1): a ``write_cas`` comparand read stayed
+    strict-denied across the bounded reacquire streak — the view never cleared to
+    a usable state. Not retry-eligible in-loop: wait or escalate. Carries
+    :data:`VIEW_WEDGED_REASON`."""
+
+    reason = VIEW_WEDGED_REASON
+
+
+class CommitUnconfirmed(CoherenceError):
+    """OCC commit unconfirmed (MCP-C Unit 1): the coordinator transport failed
+    mid-commit, a false-negative ack — NOT a confirmed loss. The write may or may
+    not have landed; reconcile by re-reading, then retry only if absent. Carries
+    :data:`COMMIT_UNCONFIRMED_REASON`."""
+
+    reason = COMMIT_UNCONFIRMED_REASON
+
+
+class InternalConcurrencyError(CoherenceError):
+    """The single-op guard fired (MCP-C Unit 1): one CoherentVolume instance was
+    used concurrently from another thread — a SERVER misuse bug (the MCP server
+    serializes tool access), never an agent-recoverable deny. Mapped to
+    :data:`INTERNAL_CONCURRENCY_REASON`, distinct from ``stale_view`` so it is
+    never relayed to the model as a retryable view."""
+
+    reason = INTERNAL_CONCURRENCY_REASON
 
 
 class ScenarioValidationError(CoherenceError):

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -154,6 +154,10 @@ VIEW_WEDGED_REASON = "view_wedged"
 COMMIT_UNCONFIRMED_REASON = "commit_unconfirmed"
 CAS_EXHAUSTED_REASON = "cas_exhausted"
 INTERNAL_CONCURRENCY_REASON = "internal_concurrency_error"
+# Option-A single-shot CAS (MCP-C Unit 5): the caller's expected_version no
+# longer matches the coordinator's current version. Typed-conflict, NOT
+# auto-merge — the agent re-reads at current_version, re-merges, and retries.
+VERSION_MISMATCH_REASON = "version_mismatch"
 # Type B — synthesized by the mapper (no adapter raise-site) when the volume is
 # unattached / coordinator transport failed; the write is NOT version-committed.
 COORDINATOR_UNAVAILABLE_REASON = "coordinator_unavailable"
@@ -305,6 +309,26 @@ class InternalConcurrencyError(CoherenceError):
     never relayed to the model as a retryable view."""
 
     reason = INTERNAL_CONCURRENCY_REASON
+
+
+class CasVersionConflict(CoherenceError):
+    """Option-A CAS rejected (MCP-C Unit 5): the caller's ``expected_version`` no
+    longer matches the coordinator's current version — a peer committed in
+    between, OR the caller's comparand was stale. Typed-conflict, NOT auto-merge:
+    NO write landed; the agent re-reads at ``current_version``, re-merges, and
+    retries. Carries both versions so the client can re-CAS without another read.
+    """
+
+    reason = VERSION_MISMATCH_REASON
+
+    def __init__(self, artifact_id: object, expected_version: int, current_version: int) -> None:
+        super().__init__(
+            f"version_mismatch artifact={artifact_id} expected={expected_version} "
+            f"current={current_version} (no write landed; re-read at current and re-merge)"
+        )
+        self.artifact_id = artifact_id
+        self.expected_version = expected_version
+        self.current_version = current_version
 
 
 class ScenarioValidationError(CoherenceError):

--- a/src/ccs/hardening/architecture.py
+++ b/src/ccs/hardening/architecture.py
@@ -25,6 +25,7 @@ _LAYER_BY_NAMESPACE = {
     "validation": "interface",
     "diagnose": "interface",
     "replay": "interface",
+    "mcp": "interface",
 }
 
 _ALLOWED_LAYER_IMPORTS = {

--- a/src/ccs/mcp/__init__.py
+++ b/src/ccs/mcp/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""MCP-C — the ``stale-write-guard-fs`` coherence MCP server (interface layer).
+
+A thin stdio MCP binding over the already-shipped ``CoherentVolume`` appliance.
+Imports are lazy via ``__getattr__`` so ``import ccs.mcp`` stays cheap and does
+NOT pull in the optional ``mcp`` SDK until a symbol that needs it is accessed
+(the SDK lives behind the ``mcp`` extra; the deny mapper imports ``mcp.types``).
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+__all__ = ["coordinator_unavailable_result", "deny_result"]
+
+if TYPE_CHECKING:  # static analysers / IDEs resolve the real symbols
+    from ccs.mcp.deny import coordinator_unavailable_result, deny_result
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve the public API from submodules (PEP 562)."""
+    if name in __all__:
+        return getattr(importlib.import_module("ccs.mcp.deny"), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/ccs/mcp/deny.py
+++ b/src/ccs/mcp/deny.py
@@ -33,8 +33,11 @@ from dataclasses import dataclass
 from mcp.types import CallToolResult, TextContent
 
 from ccs.core.exceptions import (
+    CAS_EXHAUSTED_REASON,
     COORDINATOR_UNAVAILABLE_REASON,
+    VERSION_MISMATCH_REASON,
     CasRetriesExhausted,
+    CasVersionConflict,
     CommitPreempted,
     CommitUnconfirmed,
     InternalConcurrencyError,
@@ -71,25 +74,37 @@ _TERMINALS: dict[type, _Terminal] = {
 _UNRECOGNIZED = _Terminal("internal_error", "none", False)
 
 
-def _result(terminal: _Terminal, detail: str) -> CallToolResult:
+def _result(terminal: _Terminal, detail: str, extra: dict | None = None) -> CallToolResult:
     """Build the non-ignorable tool result. ``detail`` is the verbatim deny prose,
     carried in BOTH ``structuredContent`` (structured clients) and the text
-    content (clients that surface only the text channel still see the deny)."""
+    content (clients that surface only the text channel still see the deny).
+    ``extra`` merges terminal-specific fields (e.g. the CAS versions)."""
+    structured = {
+        "reason": terminal.reason,
+        "recover": terminal.recover,
+        "retryable": terminal.retryable,
+        "detail": detail,
+    }
+    if extra:
+        structured.update(extra)
     return CallToolResult(
         isError=True,
         content=[TextContent(type="text", text=detail)],
-        structuredContent={
-            "reason": terminal.reason,
-            "recover": terminal.recover,
-            "retryable": terminal.retryable,
-            "detail": detail,
-        },
+        structuredContent=structured,
     )
 
 
 def deny_result(exc: BaseException) -> CallToolResult:
     """Map a coherence terminal (Type A) to a non-ignorable ``isError`` result,
     preserving the coordinator deny text verbatim in ``detail``."""
+    if isinstance(exc, CasVersionConflict):
+        # Surface both versions so the agent can re-read at current_version and
+        # re-CAS without another round-trip. Typed-conflict, NOT auto-merge.
+        return _result(
+            _Terminal(VERSION_MISMATCH_REASON, "read_then_merge", False),
+            str(exc),
+            {"expected_version": exc.expected_version, "current_version": exc.current_version},
+        )
     terminal = _TERMINALS.get(type(exc), _UNRECOGNIZED)
     return _result(terminal, str(exc))
 
@@ -102,3 +117,12 @@ def coordinator_unavailable_result(detail: str) -> CallToolResult:
         _Terminal(COORDINATOR_UNAVAILABLE_REASON, "retry_later", False),
         detail,
     )
+
+
+def cas_exhausted_result(detail: str) -> CallToolResult:
+    """Synthesized: the per-session conflict counter bounded a COOPERATING agent
+    (too many consecutive version_mismatch conflicts on one path). ``retryable``
+    is false so a cooperating agent stops. The no-livelock bound is scoped to
+    cooperating agents — a fresh session or one that ignores ``retryable:false``
+    resets it (coordinator-side fencing → v1.1)."""
+    return _result(_Terminal(CAS_EXHAUSTED_REASON, "stop", False), detail)

--- a/src/ccs/mcp/deny.py
+++ b/src/ccs/mcp/deny.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""MCP-C deny-contract mapper (stale-write-guard-fs, Unit 1).
+
+Translates every fail-closed coherence terminal into a *non-ignorable* MCP tool
+result — ``CallToolResult(isError=True, structuredContent={...})`` — so a client
+relays the deny to the model as a business-logic error it self-corrects on,
+NEVER as a success. Degrade/deny are HTTP-200 bodies inside the coordinator, so a
+mapping bug here silently reintroduces the lost update: this is the load-bearing
+first deliverable, built and tested before any tool binding.
+
+Two input types (plan §"Deny reason-flow"):
+
+- **Type A** — typed adapter exceptions, matched by EXACT ``type(exc)`` and read
+  via the ``.reason`` constant carried on the exception class. The exception
+  *message* stays the verbatim coordinator ``permissionDecisionReason`` (it is
+  surfaced as ``detail``; the model's retry loop depends on that byte-stability,
+  auto-memory ``project_cc_strict_mode_retry_hazard``). An unrecognized
+  ``CoherenceError`` (a CAS corruption raise, a path escape) fails closed as
+  ``internal_error`` — the mapper never lets an exception become a success.
+- **Type B** — synthesized here (NO adapter raise-site) when the volume is
+  unattached / the coordinator transport failed → ``coordinator_unavailable``.
+
+The ``reason`` token is NEVER substring-matched off the message (the
+typed-signal-not-substring house rule).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.types import CallToolResult, TextContent
+
+from ccs.core.exceptions import (
+    COORDINATOR_UNAVAILABLE_REASON,
+    CasRetriesExhausted,
+    CommitPreempted,
+    CommitUnconfirmed,
+    InternalConcurrencyError,
+    StaleView,
+    ViewWedged,
+)
+
+
+@dataclass(frozen=True)
+class _Terminal:
+    """The wire shape for one deny terminal: a typed ``reason``, a ``recover``
+    verb the agent can act on, and whether a bare retry is safe."""
+
+    reason: str
+    recover: str
+    retryable: bool
+
+
+# Type A — matched by EXACT exception type (so a future subclass cannot silently
+# inherit a mapping). ``reason`` mirrors the constant carried on the exception
+# class itself; recover/retryable are this layer's contract.
+_TERMINALS: dict[type, _Terminal] = {
+    StaleView: _Terminal(StaleView.reason, "reacquire", True),
+    CommitPreempted: _Terminal(CommitPreempted.reason, "reacquire_and_reconcile", False),
+    ViewWedged: _Terminal(ViewWedged.reason, "wait_or_escalate", False),
+    CommitUnconfirmed: _Terminal(CommitUnconfirmed.reason, "read_then_retry", False),
+    CasRetriesExhausted: _Terminal(CasRetriesExhausted.reason, "stop", False),
+    InternalConcurrencyError: _Terminal(InternalConcurrencyError.reason, "none", False),
+}
+
+# Fallback for any unrecognized exception (an unexpected ``CoherenceError`` such
+# as a CAS corruption raise or a path escape): fail closed as a generic internal
+# error — never a success, never a recoverable ``stale_view``.
+_UNRECOGNIZED = _Terminal("internal_error", "none", False)
+
+
+def _result(terminal: _Terminal, detail: str) -> CallToolResult:
+    """Build the non-ignorable tool result. ``detail`` is the verbatim deny prose,
+    carried in BOTH ``structuredContent`` (structured clients) and the text
+    content (clients that surface only the text channel still see the deny)."""
+    return CallToolResult(
+        isError=True,
+        content=[TextContent(type="text", text=detail)],
+        structuredContent={
+            "reason": terminal.reason,
+            "recover": terminal.recover,
+            "retryable": terminal.retryable,
+            "detail": detail,
+        },
+    )
+
+
+def deny_result(exc: BaseException) -> CallToolResult:
+    """Map a coherence terminal (Type A) to a non-ignorable ``isError`` result,
+    preserving the coordinator deny text verbatim in ``detail``."""
+    terminal = _TERMINALS.get(type(exc), _UNRECOGNIZED)
+    return _result(terminal, str(exc))
+
+
+def coordinator_unavailable_result(detail: str) -> CallToolResult:
+    """Type B (synthesized): no adapter raised, but the volume is unattached or
+    the coordinator transport failed. Fail closed — the write is NOT
+    version-committed."""
+    return _result(
+        _Terminal(COORDINATOR_UNAVAILABLE_REASON, "retry_later", False),
+        detail,
+    )

--- a/src/ccs/mcp/server.py
+++ b/src/ccs/mcp/server.py
@@ -105,8 +105,9 @@ _STATUS_DESC = (
 )
 
 _WRITE_CAS_DESC = (
-    "Concurrent same-key write via compare-and-set. You read (swg_read returns a "
-    "version), MERGE, then call swg_write_cas(path, expected_version, "
+    "Concurrent same-key write via compare-and-set. You read (swg_read returns the "
+    "version comparand; swg_reacquire does NOT — it is for swg_write recovery), "
+    "MERGE, then call swg_write_cas(path, expected_version, "
     "new_content). Stale-write-rejected: if a peer committed since your read, the "
     "CAS is a TYPED CONFLICT (reason=version_mismatch, current_version returned) "
     "— NOT an auto-merge; re-read at current_version, re-merge, and retry. The "
@@ -206,6 +207,8 @@ def _do_read(volume: CoherentVolume, config: SessionConfig, path: str) -> CallTo
         return _client_error_result("file_not_found", "check_path", str(exc))
     except CoherenceError as exc:
         return deny_result(exc)
+    except OSError as exc:  # disk/permission failure → fail closed, never escape to FastMCP
+        return _client_error_result("io_error", "none", str(exc))
     text = _decode_text(data)
     if text is None:
         return _client_error_result("binary_unsupported", "use_text", f"{key} is not UTF-8 text (v1 guards text only)")
@@ -225,6 +228,8 @@ def _do_write(volume: CoherentVolume, config: SessionConfig, path: str, content:
         volume.write(key, content.encode("utf-8"))
     except CoherenceError as exc:
         return deny_result(exc)
+    except OSError as exc:  # disk/permission failure → fail closed, never escape to FastMCP
+        return _client_error_result("io_error", "none", str(exc))
     return _ok_result({"ok": True, "path": key}, f"wrote {key}")
 
 
@@ -241,6 +246,8 @@ def _do_reacquire(volume: CoherentVolume, config: SessionConfig, path: str) -> C
         return _client_error_result("file_not_found", "check_path", str(exc))
     except CoherenceError as exc:
         return deny_result(exc)
+    except OSError as exc:  # disk/permission failure → fail closed, never escape to FastMCP
+        return _client_error_result("io_error", "none", str(exc))
     text = _decode_text(data)
     if text is None:
         return _client_error_result("binary_unsupported", "use_text", f"{key} is not UTF-8 text (v1 guards text only)")
@@ -280,8 +287,12 @@ def _do_write_cas(
             )
         conflicts[key] = count
         return deny_result(exc)
+    except FileNotFoundError as exc:
+        return _client_error_result("file_not_found", "check_path", str(exc))
     except CoherenceError as exc:
         return deny_result(exc)
+    except OSError as exc:  # disk/permission failure → fail closed, never escape to FastMCP
+        return _client_error_result("io_error", "none", str(exc))
     conflicts.pop(key, None)  # a win resets the cooperating-agent conflict streak
     return _ok_result({"ok": True, "path": key}, f"committed {key}")
 

--- a/src/ccs/mcp/server.py
+++ b/src/ccs/mcp/server.py
@@ -11,9 +11,9 @@ offload), so FastMCP's coroutine dispatch cannot interleave two volume ops — t
 volume's A5 thread-guard only sees *different threads*, not coroutine interleave,
 so we serialize in code rather than rely on it.
 
-Unit 2 ships the lifecycle skeleton (lifespan + serialization + fail-closed
-construction). Tools are registered in Units 4 (read/write/reacquire/status) and
-5 (write_cas).
+Tool logic lives in sync ``_do_*`` helpers (real ``volume`` + ``config`` in,
+``CallToolResult`` out); the async tool wrappers are thin (lock + delegate), so
+the contract is testable against a real coordinator without a FastMCP client.
 """
 
 from __future__ import annotations
@@ -25,19 +25,24 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from ccs.adapters.claude_code.lifecycle import stop_coordinator
 from ccs.adapters.coherent_volume import CoherentVolume
+from ccs.core.exceptions import CoherenceError
+from ccs.mcp.deny import coordinator_unavailable_result, deny_result
 from ccs.mcp.session import SessionConfig, build_volume
+from ccs.mcp.status import build_status
+from ccs.mcp.uri import UriValidationError, validate_uri
 
 logger = logging.getLogger(__name__)
 
 SERVER_NAME = "stale-write-guard-fs"
 
 # The honesty ceiling (origin §5 / R5): the server-level instructions, the
-# per-tool descriptions (Units 4/5), and the deny ``structuredContent`` together
-# bound what may be claimed. Annotations are untrusted hints; this prose is not.
+# per-tool descriptions, and the deny ``structuredContent`` together bound what
+# may be claimed. Annotations are untrusted hints; this prose is not.
 INSTRUCTIONS = """\
 stale-write-guard-fs guards a SINGLE-HOST workspace against silent lost updates
 when two or more agents share a mutable file. It enforces VERSION LINEAGE via a
@@ -61,7 +66,45 @@ TRUST BOUNDARY: the server enforces that your write descends from a version you
 read; it CANNOT verify you derived your content from the bytes you read. Same-uid
 local processes can reach the coordinator directly, bypassing this server — the
 model is single-uid, single-host.
+
+v1 guards UTF-8 TEXT artifacts (config, notes, memory, code); a non-text file is
+reported, not silently mangled (binary support → v1.1).
 """
+
+# Appended to every tool description so the honesty floor travels with each tool
+# (a client that surfaces only descriptions still sees the scope).
+_SCOPE_CLAUSE = (
+    " SINGLE-HOST only. Out of guarantee and NOT detected in v1: writers on "
+    "different hosts or across a synced/network mount, divergent-history "
+    "reconciliation, semantic correctness, server-enforced auto-merge."
+)
+
+_READ_DESC = (
+    "Read a workspace text file under coherence tracking. Returns {content, "
+    "version}; the version is the comparand you pass to swg_write_cas. A "
+    "sticky-INVALID view returns fresh bytes but stays INVALID — use "
+    "swg_reacquire to recover before writing." + _SCOPE_CLAUSE
+)
+_WRITE_DESC = (
+    "Write a workspace text file (acquire -> write -> commit). DENIED with "
+    "reason=stale_view if a peer committed a newer version: recover with "
+    "swg_reacquire, then write FROM its bytes. A mid-write preempt returns "
+    "reason=commit_preempted (disk may hold un-versioned bytes; "
+    "reacquire_and_reconcile)." + _SCOPE_CLAUSE
+)
+_REACQUIRE_DESC = (
+    "Recover from a stale_view deny: re-mint identity and return the CURRENT "
+    "bytes. You MUST write FROM these exact bytes — the server enforces version "
+    "lineage, NOT that your content was derived from what you read." + _SCOPE_CLAUSE
+)
+_STATUS_DESC = (
+    "Report coherence state: coordinator on|off|unknown (unknown is NOT off), "
+    "per-path enforced|not_registered, is_attached/is_degraded/session_id, and "
+    "heterogeneous_scope_detectable=false (a multi-host or differently-scoped "
+    "setup is NOT distinguishable in v1)." + _SCOPE_CLAUSE
+)
+
+_REACQUIRE_NOTE = "write FROM these exact bytes — the server enforces version lineage, not content derivation"
 
 
 @dataclass
@@ -96,13 +139,157 @@ async def lifespan(server: FastMCP) -> AsyncIterator[ServerContext]:
         logger.info("stale-write-guard-fs coordinator stopped: root=%s", config.root)
 
 
-def register_tools(server: FastMCP) -> None:
-    """Register the ``swg_*`` tools.
+# --- result builders ---------------------------------------------------------
 
-    Populated in Unit 4 (``swg_read`` / ``swg_write`` / ``swg_reacquire`` /
-    ``swg_status``) and Unit 5 (``swg_write_cas``). Unit 2 is the bare skeleton.
+
+def _ok_result(structured: dict, text: str) -> CallToolResult:
+    return CallToolResult(
+        isError=False,
+        content=[TextContent(type="text", text=text)],
+        structuredContent=structured,
+    )
+
+
+def _client_error_result(reason: str, recover: str, detail: str) -> CallToolResult:
+    """A non-deny client/input error (invalid path, missing file, binary). Still
+    a non-ignorable isError, but NOT a coherence deny (never ``stale_view``)."""
+    return CallToolResult(
+        isError=True,
+        content=[TextContent(type="text", text=detail)],
+        structuredContent={
+            "reason": reason,
+            "recover": recover,
+            "retryable": False,
+            "detail": detail,
+        },
+    )
+
+
+def _decode_text(data: bytes) -> str | None:
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+# --- tool logic (sync, testable: real volume + config in, CallToolResult out) -
+
+
+def _do_read(volume: CoherentVolume, config: SessionConfig, path: str) -> CallToolResult:
+    try:
+        key = validate_uri(path, root=config.root)
+    except UriValidationError as exc:
+        return _client_error_result("invalid_path", "fix_path", str(exc))
+    if not volume.is_attached:
+        return coordinator_unavailable_result(f"coordinator unattached; cannot read {path}")
+    try:
+        data, version = volume.read_with_version(key)
+    except FileNotFoundError as exc:
+        return _client_error_result("file_not_found", "check_path", str(exc))
+    except CoherenceError as exc:
+        return deny_result(exc)
+    text = _decode_text(data)
+    if text is None:
+        return _client_error_result("binary_unsupported", "use_text", f"{key} is not UTF-8 text (v1 guards text only)")
+    return _ok_result({"content": text, "version": version, "encoding": "utf-8"}, text)
+
+
+def _do_write(volume: CoherentVolume, config: SessionConfig, path: str, content: str) -> CallToolResult:
+    try:
+        key = validate_uri(path, root=config.root)
+    except UriValidationError as exc:
+        return _client_error_result("invalid_path", "fix_path", str(exc))
+    # is_attached re-check BEFORE the write — a mid-session endpoint loss must
+    # fail closed here, never reach the adapter's best-effort unversioned write.
+    if not volume.is_attached:
+        return coordinator_unavailable_result(f"coordinator unattached; refusing write of {key}")
+    try:
+        volume.write(key, content.encode("utf-8"))
+    except CoherenceError as exc:
+        return deny_result(exc)
+    return _ok_result({"ok": True, "path": key}, f"wrote {key}")
+
+
+def _do_reacquire(volume: CoherentVolume, config: SessionConfig, path: str) -> CallToolResult:
+    try:
+        key = validate_uri(path, root=config.root)
+    except UriValidationError as exc:
+        return _client_error_result("invalid_path", "fix_path", str(exc))
+    if not volume.is_attached:
+        return coordinator_unavailable_result(f"coordinator unattached; cannot reacquire {key}")
+    try:
+        data = volume.reacquire(key)
+    except FileNotFoundError as exc:
+        return _client_error_result("file_not_found", "check_path", str(exc))
+    except CoherenceError as exc:
+        return deny_result(exc)
+    text = _decode_text(data)
+    if text is None:
+        return _client_error_result("binary_unsupported", "use_text", f"{key} is not UTF-8 text (v1 guards text only)")
+    return _ok_result({"content": text, "encoding": "utf-8", "note": _REACQUIRE_NOTE}, text)
+
+
+def _do_status(volume: CoherentVolume, config: SessionConfig) -> CallToolResult:
+    status = build_status(volume, config)
+    return _ok_result(status, f"coordinator={status['coordinator']}")
+
+
+# --- registration ------------------------------------------------------------
+
+
+def _server_context(ctx: Context) -> ServerContext:
+    return ctx.request_context.lifespan_context
+
+
+def register_tools(server: FastMCP) -> None:
+    """Register the sequential ``swg_*`` tools under the serialization lock.
+
+    ``swg_write_cas`` (the concurrent regime) is added in Unit 5.
     """
-    return None
+
+    @server.tool(
+        name="swg_read",
+        description=_READ_DESC,
+        annotations=ToolAnnotations(readOnlyHint=False),  # pre-read mutates coordinator MESI state
+        structured_output=False,
+    )
+    async def swg_read(path: str, ctx: Context) -> CallToolResult:
+        sctx = _server_context(ctx)
+        async with sctx.lock:
+            return _do_read(sctx.volume, sctx.config, path)
+
+    @server.tool(
+        name="swg_write",
+        description=_WRITE_DESC,
+        annotations=ToolAnnotations(readOnlyHint=False),
+        structured_output=False,
+    )
+    async def swg_write(path: str, content: str, ctx: Context) -> CallToolResult:
+        sctx = _server_context(ctx)
+        async with sctx.lock:
+            return _do_write(sctx.volume, sctx.config, path, content)
+
+    @server.tool(
+        name="swg_reacquire",
+        description=_REACQUIRE_DESC,
+        annotations=ToolAnnotations(readOnlyHint=False),
+        structured_output=False,
+    )
+    async def swg_reacquire(path: str, ctx: Context) -> CallToolResult:
+        sctx = _server_context(ctx)
+        async with sctx.lock:
+            return _do_reacquire(sctx.volume, sctx.config, path)
+
+    @server.tool(
+        name="swg_status",
+        description=_STATUS_DESC,
+        annotations=ToolAnnotations(readOnlyHint=True),
+        structured_output=False,
+    )
+    async def swg_status(ctx: Context) -> CallToolResult:
+        sctx = _server_context(ctx)
+        async with sctx.lock:
+            return _do_status(sctx.volume, sctx.config)
 
 
 def build_server() -> FastMCP:

--- a/src/ccs/mcp/server.py
+++ b/src/ccs/mcp/server.py
@@ -23,15 +23,15 @@ import logging
 import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from ccs.adapters.claude_code.lifecycle import stop_coordinator
 from ccs.adapters.coherent_volume import CoherentVolume
-from ccs.core.exceptions import CoherenceError
-from ccs.mcp.deny import coordinator_unavailable_result, deny_result
+from ccs.core.exceptions import CasVersionConflict, CoherenceError
+from ccs.mcp.deny import cas_exhausted_result, coordinator_unavailable_result, deny_result
 from ccs.mcp.session import SessionConfig, build_volume
 from ccs.mcp.status import build_status
 from ccs.mcp.uri import UriValidationError, validate_uri
@@ -104,7 +104,22 @@ _STATUS_DESC = (
     "setup is NOT distinguishable in v1)." + _SCOPE_CLAUSE
 )
 
+_WRITE_CAS_DESC = (
+    "Concurrent same-key write via compare-and-set. You read (swg_read returns a "
+    "version), MERGE, then call swg_write_cas(path, expected_version, "
+    "new_content). Stale-write-rejected: if a peer committed since your read, the "
+    "CAS is a TYPED CONFLICT (reason=version_mismatch, current_version returned) "
+    "— NOT an auto-merge; re-read at current_version, re-merge, and retry. The "
+    "per-session conflict counter bounds only a COOPERATING agent (one session, "
+    "stops on retryable=false); it is NOT livelock-proof against a fresh session "
+    "or one that ignores retryable=false." + _SCOPE_CLAUSE
+)
+
 _REACQUIRE_NOTE = "write FROM these exact bytes — the server enforces version lineage, not content derivation"
+
+# The per-session bound on consecutive CAS conflicts for one path (the
+# cooperating-agent livelock guard). Mirrors the adapter's MAX_CAS_REACQUIRES=8.
+MAX_CAS_CONFLICTS = 8
 
 
 @dataclass
@@ -118,6 +133,9 @@ class ServerContext:
     volume: CoherentVolume
     config: SessionConfig
     lock: asyncio.Lock
+    # path → consecutive CAS-conflict count, the cooperating-agent livelock bound
+    # for swg_write_cas (reset on a win; survives only within one stdio session).
+    cas_conflicts: dict[str, int] = field(default_factory=dict)
 
 
 @asynccontextmanager
@@ -234,6 +252,40 @@ def _do_status(volume: CoherentVolume, config: SessionConfig) -> CallToolResult:
     return _ok_result(status, f"coordinator={status['coordinator']}")
 
 
+def _do_write_cas(
+    volume: CoherentVolume,
+    config: SessionConfig,
+    conflicts: dict[str, int],
+    path: str,
+    expected_version: int,
+    new_content: str,
+) -> CallToolResult:
+    try:
+        key = validate_uri(path, root=config.root)
+    except UriValidationError as exc:
+        return _client_error_result("invalid_path", "fix_path", str(exc))
+    if not volume.is_attached:
+        return coordinator_unavailable_result(f"coordinator unattached; refusing CAS of {key}")
+    try:
+        volume.write_cas_at(key, expected_version, new_content.encode("utf-8"))
+    except CasVersionConflict as exc:
+        # Bound a COOPERATING agent's retry loop: too many consecutive conflicts
+        # on one path in this session → tell it to stop (retryable=false).
+        count = conflicts.get(key, 0) + 1
+        if count > MAX_CAS_CONFLICTS:
+            conflicts.pop(key, None)
+            return cas_exhausted_result(
+                f"{key}: {count} consecutive CAS conflicts in this session — stop "
+                "(the cooperating-agent livelock bound; coordinator-side fencing is v1.1)"
+            )
+        conflicts[key] = count
+        return deny_result(exc)
+    except CoherenceError as exc:
+        return deny_result(exc)
+    conflicts.pop(key, None)  # a win resets the cooperating-agent conflict streak
+    return _ok_result({"ok": True, "path": key}, f"committed {key}")
+
+
 # --- registration ------------------------------------------------------------
 
 
@@ -290,6 +342,17 @@ def register_tools(server: FastMCP) -> None:
         sctx = _server_context(ctx)
         async with sctx.lock:
             return _do_status(sctx.volume, sctx.config)
+
+    @server.tool(
+        name="swg_write_cas",
+        description=_WRITE_CAS_DESC,
+        annotations=ToolAnnotations(readOnlyHint=False),
+        structured_output=False,
+    )
+    async def swg_write_cas(path: str, expected_version: int, new_content: str, ctx: Context) -> CallToolResult:
+        sctx = _server_context(ctx)
+        async with sctx.lock:
+            return _do_write_cas(sctx.volume, sctx.config, sctx.cas_conflicts, path, expected_version, new_content)
 
 
 def build_server() -> FastMCP:

--- a/src/ccs/mcp/server.py
+++ b/src/ccs/mcp/server.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""The ``stale-write-guard-fs`` MCP server: a stdio FastMCP binding over CoherentVolume.
+
+**stdio invariant:** NEVER write to stdout — the MCP JSON-RPC stream owns fd 1.
+All logging goes to stderr; the coordinator subprocess's stdout is redirected by
+``connect_or_spawn``. **Serialization:** access to the single shared volume is
+guarded by an ``asyncio.Lock`` and runs on the event-loop thread (no thread
+offload), so FastMCP's coroutine dispatch cannot interleave two volume ops — the
+volume's A5 thread-guard only sees *different threads*, not coroutine interleave,
+so we serialize in code rather than rely on it.
+
+Unit 2 ships the lifecycle skeleton (lifespan + serialization + fail-closed
+construction). Tools are registered in Units 4 (read/write/reacquire/status) and
+5 (write_cas).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+from ccs.adapters.claude_code.lifecycle import stop_coordinator
+from ccs.adapters.coherent_volume import CoherentVolume
+from ccs.mcp.session import SessionConfig, build_volume
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "stale-write-guard-fs"
+
+# The honesty ceiling (origin §5 / R5): the server-level instructions, the
+# per-tool descriptions (Units 4/5), and the deny ``structuredContent`` together
+# bound what may be claimed. Annotations are untrusted hints; this prose is not.
+INSTRUCTIONS = """\
+stale-write-guard-fs guards a SINGLE-HOST workspace against silent lost updates
+when two or more agents share a mutable file. It enforces VERSION LINEAGE via a
+local coherence coordinator; it does NOT merge content for you.
+
+Two guarantees, both single-host and fail-closed:
+  1. Sequential stale-overwrite — if a peer committed a newer version, swg_write
+     is DENIED (reason=stale_view). Recover with swg_reacquire, then write FROM
+     the fresh bytes it returns.
+  2. Concurrent same-key lost-update — swg_write_cas(path, expected_version,
+     new_content) rejects a stale compare-and-set as a TYPED CONFLICT (not an
+     auto-merge): you read, merge, and retry; the server never merges for you.
+
+OUT OF GUARANTEE (do not rely on this server for): writers on DIFFERENT hosts or
+across a synced/network mount; divergent-history reconciliation; semantic/content
+correctness; any server-enforced auto-merge. These are NOT detected in v1 — a
+heterogeneous multi-host setup looks identical to a guarded one (swg_status
+reports heterogeneous_scope_detectable=false).
+
+TRUST BOUNDARY: the server enforces that your write descends from a version you
+read; it CANNOT verify you derived your content from the bytes you read. Same-uid
+local processes can reach the coordinator directly, bypassing this server — the
+model is single-uid, single-host.
+"""
+
+
+@dataclass
+class ServerContext:
+    """Lifespan-owned session state shared by every tool.
+
+    ``lock`` serializes access to ``volume`` — every tool acquires it for the
+    duration of its volume interaction (see module docstring).
+    """
+
+    volume: CoherentVolume
+    config: SessionConfig
+    lock: asyncio.Lock
+
+
+@asynccontextmanager
+async def lifespan(server: FastMCP) -> AsyncIterator[ServerContext]:
+    """Own the coordinator for the server's lifetime.
+
+    Enter → construct the strict-only volume (self-spawns/attaches; raises
+    fail-closed if it can't). Exit → ``stop_coordinator``. Does NOT call
+    ``connect_or_spawn`` — construction already did, so calling it again would
+    double-spawn.
+    """
+    config = SessionConfig.from_env()
+    volume = build_volume(config)  # blocking, fail-closed
+    logger.info("stale-write-guard-fs attached: root=%s managed=%s", config.root, config.managed)
+    try:
+        yield ServerContext(volume=volume, config=config, lock=asyncio.Lock())
+    finally:
+        stop_coordinator(config.root)
+        logger.info("stale-write-guard-fs coordinator stopped: root=%s", config.root)
+
+
+def register_tools(server: FastMCP) -> None:
+    """Register the ``swg_*`` tools.
+
+    Populated in Unit 4 (``swg_read`` / ``swg_write`` / ``swg_reacquire`` /
+    ``swg_status``) and Unit 5 (``swg_write_cas``). Unit 2 is the bare skeleton.
+    """
+    return None
+
+
+def build_server() -> FastMCP:
+    """Build the FastMCP server (lifespan wired, tools registered)."""
+    server = FastMCP(name=SERVER_NAME, instructions=INSTRUCTIONS, lifespan=lifespan)
+    register_tools(server)
+    return server
+
+
+def _configure_stderr_logging() -> None:
+    """Route all logging to stderr — stdout is the JSON-RPC channel (stdio invariant)."""
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    root = logging.getLogger()
+    root.handlers[:] = [handler]
+    root.setLevel(logging.INFO)
+
+
+def main() -> None:
+    """Console-script entrypoint: run the server over stdio."""
+    _configure_stderr_logging()
+    build_server().run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ccs/mcp/session.py
+++ b/src/ccs/mcp/session.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Per-session configuration + coordinator binding for the stale-write-guard-fs server.
+
+The MCP client spawns this server as a stdio subprocess per session; the server
+owns exactly ONE :class:`~ccs.adapters.coherent_volume.CoherentVolume` for that
+session's workspace. Constructing the volume self-spawns/attaches the loopback
+coordinator (strict-only, fail-closed); the server lifespan calls
+``stop_coordinator`` on exit. The server NEVER constructs a degrade-mode volume —
+a degrade write skips the version check and silently re-opens the lost update, so
+strict-only is the honesty floor.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from ccs.adapters.claude_code.lifecycle import LifecycleConfig
+from ccs.adapters.coherent_volume import CoherentVolume
+
+# Env keys the MCP client sets when spawning the server subprocess.
+ROOT_ENV = "SWG_ROOT"
+MANAGED_ENV = "SWG_MANAGED"
+# Guard the whole workspace unless the client narrows it. A non-empty managed set
+# is REQUIRED for the INVALID-deny to fire (is_strict_mode ⊂ is_tracked).
+_DEFAULT_MANAGED: tuple[str, ...] = ("**",)
+
+
+@dataclass(frozen=True)
+class SessionConfig:
+    """Resolved workspace root + the managed (strict-enforced) glob set."""
+
+    root: Path
+    managed: tuple[str, ...]
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> SessionConfig:
+        """Resolve config from the spawn environment. ``SWG_ROOT`` defaults to the
+        process cwd; ``SWG_MANAGED`` is a comma-separated glob list (default ``**``)."""
+        environ = os.environ if env is None else env
+        root = Path(environ.get(ROOT_ENV) or os.getcwd()).resolve()
+        raw = environ.get(MANAGED_ENV, "")
+        managed = tuple(g.strip() for g in raw.split(",") if g.strip()) or _DEFAULT_MANAGED
+        return cls(root=root, managed=managed)
+
+
+def build_volume(config: SessionConfig) -> CoherentVolume:
+    """Construct the session's strict-only volume.
+
+    ``on_error='strict'`` is non-negotiable: a degrade-mode volume writes with no
+    version check (the fail-open hole), so the server never constructs one.
+    Construction self-spawns/attaches the coordinator and RAISES (fail-closed) if
+    it cannot attach or enable strict — the server then refuses to start.
+    ``idle_shutdown_sec=0`` keeps the coordinator alive for the server's lifetime.
+    """
+    volume = CoherentVolume(
+        config.root,
+        managed=config.managed,
+        on_error="strict",
+        config=LifecycleConfig(idle_shutdown_sec=0),
+    )
+    # Strict construction guarantees attachment (else it raised); assert loudly so
+    # a future regression that admits an unattached volume is caught at startup,
+    # not at the first silent lost-write.
+    if not volume.is_attached:
+        raise RuntimeError("coherence coordinator did not attach; strict construction must fail closed")
+    return volume

--- a/src/ccs/mcp/status.py
+++ b/src/ccs/mcp/status.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""The ``swg_status`` payload: an honest, 3-state view of coherence enforcement.
+
+The load-bearing honesty bug this avoids (SC5): conflating ``off`` (coordinator
+reachable, no strict patterns) with ``unknown`` (coordinator unreachable). A
+caller that reads ``off`` may assume it is safe to write unguarded; ``unknown``
+must NOT collapse to that. The shipped ``strict_mode_active()`` returns ``False``
+for both, so this composes the raw ``/status`` instead.
+
+``per_path`` enforcement is the CLIENT's belief — a tracked artifact that matches
+THIS server's managed globs — not a cross-checked coordinator fact. A sibling
+volume with different managed globs is indistinguishable
+(``heterogeneous_scope_detectable=false``); v1 makes that gap loud, not
+detectable.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ccs.adapters.claude_code.policy import _matches_any
+
+if TYPE_CHECKING:
+    from ccs.adapters.coherent_volume import CoherentVolume
+    from ccs.mcp.session import SessionConfig
+
+
+def build_status(volume: CoherentVolume, config: SessionConfig) -> dict:
+    """Compose the ``swg_status`` payload from the coordinator ``/status`` + the
+    volume's local view + this server's managed scope."""
+    status_doc = volume.coordinator_status()  # None if unattached / unreachable
+    return {
+        "coordinator": _coordinator_state(volume, status_doc),
+        "is_attached": volume.is_attached,
+        "is_degraded": volume.is_degraded,
+        "session_id": volume.session_id,
+        "managed": list(config.managed),
+        "per_path": _per_path(config, status_doc),
+        "single_host_only": True,
+        # v1 cannot tell a guarded workspace from a heterogeneous multi-host or
+        # differently-scoped one. The gap is loud here, not programmatically
+        # detectable (per-glob detection → v1.1).
+        "heterogeneous_scope_detectable": False,
+    }
+
+
+def _coordinator_state(volume: CoherentVolume, status_doc: dict | None) -> str:
+    """``on`` (reachable + strict patterns) / ``off`` (reachable + none) /
+    ``unknown`` (unattached or unreachable) — ``unknown`` is NEVER reported as
+    ``off``."""
+    if not volume.is_attached or status_doc is None:
+        return "unknown"
+    summary = status_doc.get("policy_summary")
+    count = summary.get("strict_mode_pattern_count") if isinstance(summary, dict) else None
+    if not isinstance(count, int) or isinstance(count, bool):
+        return "unknown"
+    return "on" if count > 0 else "off"
+
+
+def _per_path(config: SessionConfig, status_doc: dict | None) -> dict:
+    """Per tracked artifact: its version and whether it is ``enforced`` (matches
+    this server's managed globs) or merely ``not_registered`` for strict
+    enforcement by this server."""
+    per_path: dict[str, dict] = {}
+    if not isinstance(status_doc, dict):
+        return per_path
+    for artifact in status_doc.get("tracked_artifacts", []):
+        if not isinstance(artifact, dict):
+            continue
+        path = artifact.get("path")
+        if not isinstance(path, str):
+            continue
+        enforced = _matches_any(path, config.managed)
+        per_path[path] = {
+            "version": artifact.get("version"),
+            "status": "enforced" if enforced else "not_registered",
+        }
+    return per_path

--- a/src/ccs/mcp/uri.py
+++ b/src/ccs/mcp/uri.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""URI→coordinator-key validation for the stale-write-guard-fs server.
+
+Client tools pass an opaque path string; this module turns it into a SAFE
+workspace-relative coordinator key BEFORE it reaches ``CoherentVolume``. It:
+
+- reuses the coordinator's authoritative :func:`validate_path` (control chars,
+  backslash, length, ``..``, leading ``/``) so the server and coordinator agree;
+- reuses :func:`policy._normalize_relative` (``removeprefix`` — NEVER ``lstrip``;
+  an ``lstrip`` slip silently untracks dotfiles like ``.env``);
+- canonicalises repeated slashes via posix normalisation;
+- rejects every ``.coherence/**`` path — the coordinator's SQLite state, PID/port
+  file, hook secret, and policy YAMLs are an info-disclosure surface, not a user
+  artifact (matched case-insensitively; the dir is always literally
+  ``.coherence`` and a case-variant maps to it on a case-insensitive filesystem);
+- rejects path/symlink escapes via realpath containment.
+
+**TOCTOU residual (stated, v1):** a regular file swapped for an out-of-root
+symlink AFTER validation but BEFORE the adapter's open is an accepted same-uid
+residual — the adapter open is not ``O_NOFOLLOW`` in v1, and the trust model is
+single-uid single-host. v1.1 wires ``O_NOFOLLOW`` into the adapter open.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from ccs.adapters.claude_code.coordinator_server import validate_path
+from ccs.adapters.claude_code.policy import _normalize_relative
+
+_COHERENCE_DIR = ".coherence"
+
+
+class UriValidationError(ValueError):
+    """A client URI failed validation (traversal, absolute, control chars,
+    ``.coherence`` state, or a path/symlink escape).
+
+    A client-INPUT error, NOT a coherence deny — the tool layer maps it to a
+    non-deny tool error, never to ``stale_view``.
+    """
+
+
+def validate_uri(uri: object, *, root: Path) -> str:
+    """Validate a client URI into a workspace-relative coordinator key.
+
+    Returns the normalised relative key on success; raises
+    :class:`UriValidationError` on any unsafe input.
+    """
+    # 1. The coordinator's authoritative string checks (control chars, backslash,
+    #    length, leading '/', '..'). Reused so server and coordinator never drift.
+    reason = validate_path(uri)
+    if reason is not None:
+        raise UriValidationError(reason)
+    assert isinstance(uri, str)  # validate_path guarantees a non-empty str here
+
+    # 2. Normalise: strip a leading './' (removeprefix), reject absolute / '..'.
+    normalized = _normalize_relative(uri)
+    if normalized is None:
+        raise UriValidationError("path is absolute, empty, or contains '..'")
+
+    # 3. Canonicalise repeated/trailing slashes so the coordinator key is stable
+    #    and matches what the adapter's `_to_relative` would track.
+    key = Path(normalized).as_posix()
+
+    # 4. Reject the coordinator's own state directory (info-disclosure surface).
+    if _targets_coherence_state(key):
+        raise UriValidationError("path targets coordinator state (.coherence/**) and is not a user artifact")
+
+    # 5. Reject path/symlink escapes: realpath resolves intermediate + final-
+    #    component symlinks; a target resolving outside root escapes the guard.
+    _reject_path_escape(root, key)
+    return key
+
+
+def _targets_coherence_state(key: str) -> bool:
+    parts = Path(key).parts
+    return bool(parts) and parts[0].lower() == _COHERENCE_DIR
+
+
+def _reject_path_escape(root: Path, key: str) -> None:
+    root_real = os.path.realpath(root)
+    target_real = os.path.realpath(Path(root) / key)
+    if not _is_within(target_real, root_real):
+        raise UriValidationError("path escapes the workspace root (traversal or symlink)")
+
+
+def _is_within(candidate: str, root: str) -> bool:
+    try:
+        Path(candidate).relative_to(root)
+        return True
+    except ValueError:
+        return False

--- a/src/ccs/mcp/uri.py
+++ b/src/ccs/mcp/uri.py
@@ -85,6 +85,17 @@ def _reject_path_escape(root: Path, key: str) -> None:
     target_real = os.path.realpath(Path(root) / key)
     if not _is_within(target_real, root_real):
         raise UriValidationError("path escapes the workspace root (traversal or symlink)")
+    # The string-level .coherence check (_targets_coherence_state) inspects the
+    # KEY; a symlink whose target RESOLVES into .coherence (e.g. `data` ->
+    # `.coherence`) has parts[0] == "data" (passes that check) and stays within
+    # root (passes containment). Re-check the RESOLVED path so coordinator state
+    # (state.db, hook.secret, server.pid, *.yaml) can never be read through a
+    # symlink, even by a sandboxed agent that cannot reach .coherence directly.
+    coherence_real = os.path.realpath(os.path.join(root_real, _COHERENCE_DIR))
+    if _is_within(target_real, coherence_real):
+        raise UriValidationError(
+            "path resolves into coordinator state (.coherence/**) via a symlink"
+        )
 
 
 def _is_within(candidate: str, root: str) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,23 @@ if importlib.util.find_spec("openai") is None or importlib.util.find_spec("mistr
     collect_ignore_glob.append("test_*_live.py")
 
 
+def _mcp_server_available() -> bool:
+    # find_spec on a submodule raises ModuleNotFoundError when an ancestor is
+    # absent (mcp missing, OR a partial transitive mcp without mcp.server).
+    try:
+        return importlib.util.find_spec("mcp.server.fastmcp") is not None
+    except ModuleNotFoundError:
+        return False
+
+
+# The front-door demo test imports `examples.mcp_stale_write_guard`, which imports
+# `ccs.mcp.server` -> the `mcp` SDK (the `[mcp]` extra). Skip it on a bare install
+# (the tests/mcp/ package carries its own conftest guard for the rest). CI's Tests
+# job installs `.[...,mcp]` so it runs there.
+if not _mcp_server_available():
+    collect_ignore_glob.append("test_mcp_front_door_demo.py")
+
+
 def pytest_configure(config):
     """Neutralize the v0.9.0 transitional RuntimeWarning at COLLECTION time.
 

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Defensive collection-skip for the stale-write-guard-fs MCP tests.
+
+``ccs.mcp.server`` / ``ccs.mcp.deny`` import the official ``mcp`` SDK, declared
+in the ``[mcp]`` optional extra. On a bare ``pip install -e ".[dev]"`` those
+modules ImportError at COLLECTION, so pytest would error before any test runs.
+
+CI's Tests job installs ``.[dev,diagnose,mcp]`` so these tests run there; this
+guard is the second layer of defense for bare local installs and for CI jobs
+that do not install mcp (e.g. the ``protocol_corpus`` job, which still collects
+the whole tree before deselecting). Mirrors the ``[diagnose]`` / live-API guards
+in the parent ``tests/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+collect_ignore_glob: list[str] = []
+
+
+def _mcp_server_available() -> bool:
+    # find_spec on a submodule raises ModuleNotFoundError when an ancestor is
+    # absent (mcp missing, OR a partial transitive mcp without mcp.server).
+    try:
+        return importlib.util.find_spec("mcp.server.fastmcp") is not None
+    except ModuleNotFoundError:
+        return False
+
+
+if not _mcp_server_available():
+    collect_ignore_glob.append("test_*.py")

--- a/tests/mcp/test_deny_mapping.py
+++ b/tests/mcp/test_deny_mapping.py
@@ -1,0 +1,144 @@
+"""Unit 1 — the deny-contract mapper.
+
+Every fail-closed coherence terminal must become a *non-ignorable* tool result
+(``CallToolResult(isError=True, structuredContent={reason,recover,retryable,detail})``)
+with the coordinator's deny prose preserved **verbatim** in ``detail`` (the
+model's retry loop relies on byte-stable deny text — auto-memory
+``project_cc_strict_mode_retry_hazard``). The ``reason`` token is a typed
+constant carried on the exception *type*, never substring-matched off the
+message. Contract table: plan §"Deny vocabulary" (2026-06-18 plan, lines 101–111).
+
+This is the load-bearing first deliverable: a mapping bug silently reintroduces
+the lost update (degrade/deny are HTTP-200 bodies), so it is built and tested
+before any tool binding.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ccs.core.exceptions import (
+    CasRetriesExhausted,
+    CoherenceError,
+    CommitPreempted,
+    CommitUnconfirmed,
+    InternalConcurrencyError,
+    StaleView,
+    ViewWedged,
+)
+from ccs.mcp.deny import coordinator_unavailable_result, deny_result
+
+# (exc, reason, recover, retryable) — the exact plan contract (lines 103–109).
+_TERMINALS = [
+    (StaleView("stale prose"), "stale_view", "reacquire", True),
+    (
+        CommitPreempted("preempt prose"),
+        "commit_preempted",
+        "reacquire_and_reconcile",
+        False,
+    ),
+    (ViewWedged("wedged prose"), "view_wedged", "wait_or_escalate", False),
+    (
+        CommitUnconfirmed("unconfirmed prose"),
+        "commit_unconfirmed",
+        "read_then_retry",
+        False,
+    ),
+    (CasRetriesExhausted("data/x", 8, 3), "cas_exhausted", "stop", False),
+    (
+        InternalConcurrencyError("concurrent use detected"),
+        "internal_concurrency_error",
+        "none",
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize("exc, reason, recover, retryable", _TERMINALS)
+def test_typed_terminal_maps_to_non_ignorable_iserror(exc, reason, recover, retryable):
+    """Happy path: each typed terminal → isError + the exact {reason,recover,retryable}."""
+    result = deny_result(exc)
+
+    assert result.isError is True
+    sc = result.structuredContent
+    assert sc["reason"] == reason
+    assert sc["recover"] == recover
+    assert sc["retryable"] is retryable
+    # The deny prose survives verbatim — regenerating it worsens model retries.
+    assert sc["detail"] == str(exc)
+    # The body is also relayed as text content (clients that surface only the
+    # text channel still see the deny).
+    assert result.content[0].text == str(exc)
+
+
+def test_reason_token_is_separate_from_verbatim_detail():
+    """The .reason constant lives on the type; the message stays the byte-stable
+    coordinator prose. The two must not be conflated."""
+    prose = "coherence coordinator denied the write (stale view); reacquire() and write from the fresh bytes"
+    result = deny_result(StaleView(prose))
+
+    assert result.structuredContent["detail"] == prose  # verbatim message
+    assert result.structuredContent["reason"] == "stale_view"  # typed constant
+    assert StaleView.reason == "stale_view"  # carried on the type, not parsed
+
+
+def test_stale_view_and_commit_preempt_produce_distinct_reasons():
+    """A pre-edit stale deny (recoverable by reacquire) and a post-edit preempt
+    (disk may hold un-versioned bytes) MUST NOT collapse to one reason."""
+    stale = deny_result(StaleView("same prose")).structuredContent
+    preempt = deny_result(CommitPreempted("same prose")).structuredContent
+
+    assert stale["reason"] == "stale_view"
+    assert stale["recover"] == "reacquire"
+    assert stale["retryable"] is True
+    assert preempt["reason"] == "commit_preempted"
+    assert preempt["recover"] == "reacquire_and_reconcile"
+    assert preempt["retryable"] is False
+
+
+def test_a5_concurrency_never_masquerades_as_stale_view():
+    """The A5 single-op guard is a server bug, not a recoverable deny — it must
+    never be relayed as a stale view the agent would retry."""
+    result = deny_result(InternalConcurrencyError("single-threaded; concurrent use"))
+
+    assert result.isError is True
+    assert result.structuredContent["reason"] == "internal_concurrency_error"
+    assert result.structuredContent["reason"] != "stale_view"
+    assert result.structuredContent["retryable"] is False
+
+
+def test_unrecognized_coherence_error_fails_closed_generic():
+    """A plain/unexpected CoherenceError (e.g. a CAS corruption raise, a path
+    escape) fails closed as a generic internal error — never a success, never a
+    recoverable stale_view."""
+    result = deny_result(CoherenceError("unexpected commit corruption"))
+
+    assert result.isError is True
+    assert result.structuredContent["reason"] == "internal_error"
+    assert result.structuredContent["reason"] != "stale_view"
+    assert result.structuredContent["retryable"] is False
+    assert result.structuredContent["detail"] == "unexpected commit corruption"
+
+
+def test_type_b_coordinator_unavailable_is_synthesized_and_fails_closed():
+    """Type B: no adapter raise-site — when the volume is unattached/transport
+    failed, deny.py synthesizes a fail-closed coordinator_unavailable."""
+    result = coordinator_unavailable_result("coordinator unreachable at attach")
+
+    assert result.isError is True
+    sc = result.structuredContent
+    assert sc["reason"] == "coordinator_unavailable"
+    assert sc["recover"] == "retry_later"
+    assert sc["retryable"] is False
+    assert sc["detail"] == "coordinator unreachable at attach"
+
+
+def test_cas_exhausted_reason_constant_lives_on_the_type():
+    """CasRetriesExhausted is pre-existing; Unit 1 adds .reason so the mapper
+    classifies it by type (reconciling its `cas_retries_exhausted` prose token
+    with the `cas_exhausted` wire reason)."""
+    assert CasRetriesExhausted.reason == "cas_exhausted"
+    exc = CasRetriesExhausted("data/x", 8, 3)
+    assert deny_result(exc).structuredContent["reason"] == "cas_exhausted"
+    # the prose token (the message) is distinct from the wire reason
+    assert "cas_retries_exhausted" in str(exc)

--- a/tests/mcp/test_lifecycle.py
+++ b/tests/mcp/test_lifecycle.py
@@ -1,0 +1,186 @@
+"""Unit 2 — coordinator lifecycle, fail-closed binding, stdout purity, serialization.
+
+The server owns the coordinator for its lifetime: constructing the per-session
+volume self-spawns/attaches (strict-only, fail-closed); the lifespan calls
+``stop_coordinator`` on exit and never double-spawns. Two invariants are
+load-bearing: the JSON-RPC stdout channel must stay byte-clean (the coordinator
+subprocess's stdout must not leak to fd 1), and ``import ccs.mcp`` must work
+without the optional ``mcp`` SDK (lazy package).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from ccs.adapters.claude_code.lifecycle import LifecycleConfig, stop_coordinator
+from ccs.mcp.server import build_server, lifespan
+from ccs.mcp.session import SessionConfig, build_volume
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def fast_cfg() -> LifecycleConfig:
+    """Coordinator config tuned for fast tests (no idle shutdown)."""
+    return LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0.1,
+        notice_evict_max_age_sec=1.0,
+        port_file_retry_attempts=20,
+        port_file_retry_interval_sec=0.05,
+        connect_retry_attempts=10,
+        connect_retry_interval_sec=0.05,
+    )
+
+
+def _seed(tmp_path: Path, rel: str = "data/shared.txt", content: bytes = b"v1") -> Path:
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    return target
+
+
+def _subprocess_env(tmp_path: Path, managed: str = "data/**") -> dict[str, str]:
+    return {
+        **os.environ,
+        "PYTHONPATH": str(REPO_ROOT / "src"),
+        "SWG_ROOT": str(tmp_path),
+        "SWG_MANAGED": managed,
+    }
+
+
+# --- happy path: attach + strict + clean stop --------------------------------
+
+
+def test_lifespan_attaches_strict_and_stops(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SWG_ROOT", str(tmp_path))
+    monkeypatch.setenv("SWG_MANAGED", "data/**")
+    _seed(tmp_path)
+    server = build_server()
+
+    async def go() -> None:
+        async with lifespan(server) as ctx:
+            assert ctx.volume.is_attached
+            assert ctx.volume.strict_mode_active() is True
+            assert not ctx.volume.is_degraded
+            assert ctx.config.root == tmp_path.resolve()
+            assert ctx.config.managed == ("data/**",)
+
+    asyncio.run(go())
+    # The lifespan's finally already stopped the coordinator; a second stop in
+    # THIS process reports False (nothing left for us to stop).
+    assert stop_coordinator(tmp_path) is False
+
+
+# --- strict-only construction (no degrade-mode volume) -----------------------
+
+
+def test_build_volume_is_strict_only(tmp_path: Path) -> None:
+    config = SessionConfig(root=tmp_path, managed=("data/**",))
+    _seed(tmp_path)
+    volume = build_volume(config)
+    try:
+        assert volume.is_attached
+        # The server never constructs a degrade-mode volume (the fail-open hole).
+        assert volume._on_error == "strict"
+        assert volume.strict_mode_active() is True
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- serialization: concurrent coroutines do not trip the A5 thread-guard -----
+
+
+def test_concurrent_volume_access_serializes_without_a5(tmp_path: Path, monkeypatch) -> None:
+    """Three overlapping coroutines each touch the one shared volume under the
+    lock. The volume's A5 guard raises on a *different thread*; serialized
+    main-thread access under the lock must never trip it."""
+    monkeypatch.setenv("SWG_ROOT", str(tmp_path))
+    monkeypatch.setenv("SWG_MANAGED", "data/**")
+    _seed(tmp_path, content=b"v1")
+    server = build_server()
+
+    async def go() -> list[bytes]:
+        async with lifespan(server) as ctx:
+
+            async def op() -> bytes:
+                async with ctx.lock:
+                    return ctx.volume.read("data/shared.txt")
+
+            return await asyncio.gather(op(), op(), op())
+
+    results = asyncio.run(go())
+    assert results == [b"v1", b"v1", b"v1"]
+    assert stop_coordinator(tmp_path) is False
+
+
+# --- stdout purity (fd-level, via a real subprocess) -------------------------
+
+
+def test_lifespan_keeps_stdout_byte_clean(tmp_path: Path) -> None:
+    """Enter the lifespan (spawns a real coordinator) and exit, in a subprocess
+    whose REAL fd 1 we capture. Nothing — not the server, not the spawned
+    coordinator subprocess — may write to stdout (the JSON-RPC channel)."""
+    _seed(tmp_path)
+    script = textwrap.dedent(
+        """
+        import asyncio
+        from ccs.mcp.server import build_server, lifespan
+
+        async def go():
+            async with lifespan(build_server()) as ctx:
+                assert ctx.volume.is_attached
+
+        asyncio.run(go())
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=_subprocess_env(tmp_path),
+        timeout=60,
+    )
+    assert result.returncode == 0, f"subprocess failed:\n{result.stderr}"
+    assert result.stdout == "", f"stdout polluted (JSON-RPC channel): {result.stdout!r}"
+
+
+# --- lazy package: import ccs.mcp without the mcp SDK ------------------------
+
+
+def test_import_ccs_mcp_does_not_require_mcp_sdk() -> None:
+    """``import ccs.mcp`` must succeed even when the optional ``mcp`` SDK is
+    unimportable — the package is lazy (only ``deny``/``server`` pull it in)."""
+    script = textwrap.dedent(
+        """
+        import sys
+        import importlib.abc
+
+        class _BlockMcp(importlib.abc.MetaPathFinder):
+            def find_spec(self, name, path, target=None):
+                if name == "mcp" or name.startswith("mcp."):
+                    raise ImportError("mcp SDK blocked for the lazy-import test")
+                return None
+
+        sys.meta_path.insert(0, _BlockMcp())
+        import ccs.mcp  # must NOT import mcp
+        assert "mcp" not in sys.modules, "ccs.mcp eagerly imported the mcp SDK"
+        print("ok")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "src")},
+        timeout=30,
+    )
+    assert result.returncode == 0, f"lazy import failed:\n{result.stderr}"
+    assert "ok" in result.stdout

--- a/tests/mcp/test_status_three_state.py
+++ b/tests/mcp/test_status_three_state.py
@@ -1,0 +1,103 @@
+"""Unit 4 — swg_status is honest about the THREE states.
+
+The load-bearing bug (SC5): never report ``unknown`` (coordinator unreachable)
+as ``off`` (reachable, no strict patterns). A caller that reads ``off`` may write
+unguarded; ``unknown`` must not collapse to that. The 3-state logic is tested as
+a pure function over synthetic ``/status`` docs, plus one live ``on`` check.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ccs.adapters.claude_code.lifecycle import LifecycleConfig, stop_coordinator
+from ccs.mcp.session import SessionConfig
+from ccs.mcp.status import _coordinator_state, _per_path, build_status
+
+
+class _StubVolume:
+    def __init__(self, attached: bool, degraded: bool = False, session: str = "sess-1") -> None:
+        self.is_attached = attached
+        self.is_degraded = degraded
+        self.session_id = session
+
+
+def _doc(count: int | None) -> dict:
+    summary = {} if count is None else {"strict_mode_pattern_count": count}
+    return {"policy_summary": summary}
+
+
+def test_state_on_when_reachable_with_strict_patterns() -> None:
+    assert _coordinator_state(_StubVolume(True), _doc(2)) == "on"
+
+
+def test_state_off_when_reachable_with_no_strict_patterns() -> None:
+    assert _coordinator_state(_StubVolume(True), _doc(0)) == "off"
+
+
+def test_state_unknown_when_unreachable_never_off() -> None:
+    """SC5: a None status doc (unreachable) is unknown, NOT off."""
+    assert _coordinator_state(_StubVolume(True), None) == "unknown"
+
+
+def test_state_unknown_when_unattached() -> None:
+    assert _coordinator_state(_StubVolume(False), _doc(2)) == "unknown"
+
+
+def test_state_unknown_when_count_missing() -> None:
+    assert _coordinator_state(_StubVolume(True), _doc(None)) == "unknown"
+
+
+def test_per_path_enforced_vs_not_registered() -> None:
+    doc = {
+        "tracked_artifacts": [
+            {"path": "data/a.txt", "version": 3},
+            {"path": "other/b.txt", "version": 1},
+        ]
+    }
+    config = SessionConfig(root=Path("/x"), managed=("data/**",))
+    per_path = _per_path(config, doc)
+    assert per_path["data/a.txt"] == {"version": 3, "status": "enforced"}
+    assert per_path["other/b.txt"] == {"version": 1, "status": "not_registered"}
+
+
+def test_per_path_empty_when_no_status() -> None:
+    assert _per_path(SessionConfig(root=Path("/x"), managed=("data/**",)), None) == {}
+
+
+# --- live integration --------------------------------------------------------
+
+
+@pytest.fixture
+def fast_cfg() -> LifecycleConfig:
+    return LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0.1,
+        notice_evict_max_age_sec=1.0,
+        port_file_retry_attempts=20,
+        port_file_retry_interval_sec=0.05,
+        connect_retry_attempts=10,
+        connect_retry_interval_sec=0.05,
+    )
+
+
+def test_build_status_live_reports_on(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "shared.txt").write_bytes(b"v1")
+    config = SessionConfig(root=tmp_path.resolve(), managed=("data/**",))
+    # build_volume ignores the config's LifecycleConfig; construct directly for speed.
+    from ccs.adapters.coherent_volume import CoherentVolume
+
+    volume = CoherentVolume(tmp_path, managed=("data/**",), on_error="strict", config=fast_cfg)
+    try:
+        status = build_status(volume, config)
+        assert status["coordinator"] == "on"
+        assert status["is_attached"] is True
+        assert status["is_degraded"] is False
+        assert status["single_host_only"] is True
+        assert status["heterogeneous_scope_detectable"] is False
+        assert status["managed"] == ["data/**"]
+    finally:
+        stop_coordinator(tmp_path)

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -1,0 +1,199 @@
+"""Unit 4 — swg_read / swg_write / swg_reacquire against a real coordinator.
+
+Tests drive the sync ``_do_*`` helpers (the tool logic) with real
+``CoherentVolume`` instances + a real loopback coordinator, so the contract is
+exercised end-to-end without a FastMCP client. The headline is the sequential
+deny→reacquire→write loop; the rest is fail-closed + edge coverage + the honesty
+surface (SC4).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ccs.adapters.claude_code.lifecycle import LifecycleConfig, stop_coordinator
+from ccs.adapters.coherent_volume import CoherentVolume
+from ccs.mcp.server import (
+    _READ_DESC,
+    _STATUS_DESC,
+    _WRITE_DESC,
+    INSTRUCTIONS,
+    _do_reacquire,
+    _do_read,
+    _do_write,
+)
+from ccs.mcp.session import SessionConfig
+
+
+@pytest.fixture
+def fast_cfg() -> LifecycleConfig:
+    return LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0.1,
+        notice_evict_max_age_sec=1.0,
+        port_file_retry_attempts=20,
+        port_file_retry_interval_sec=0.05,
+        connect_retry_attempts=10,
+        connect_retry_interval_sec=0.05,
+    )
+
+
+def _seed(tmp_path: Path, rel: str = "data/shared.txt", content: bytes = b"v1") -> Path:
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    return target
+
+
+def _vol(tmp_path: Path, cfg: LifecycleConfig) -> CoherentVolume:
+    return CoherentVolume(tmp_path, managed=("data/**",), on_error="strict", config=cfg)
+
+
+def _config(tmp_path: Path) -> SessionConfig:
+    return SessionConfig(root=tmp_path.resolve(), managed=("data/**",))
+
+
+# --- happy + the headline sequential loop ------------------------------------
+
+
+def test_read_then_write_happy(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    target = _seed(tmp_path, content=b"v1")
+    config = _config(tmp_path)
+    vol = _vol(tmp_path, fast_cfg)
+    try:
+        read = _do_read(vol, config, "data/shared.txt")
+        assert read.isError is False
+        assert read.structuredContent["content"] == "v1"
+        assert isinstance(read.structuredContent["version"], int)
+
+        wrote = _do_write(vol, config, "data/shared.txt", "v2")
+        assert wrote.isError is False
+        assert target.read_bytes() == b"v2"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_sequential_deny_reacquire_write_loop(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    """read v → peer commits v+1 → swg_write(stale_view) → swg_reacquire(v+1) →
+    swg_write(from those bytes) ok. The lost update is denied, not silent."""
+    target = _seed(tmp_path, content=b"v1")
+    config = _config(tmp_path)
+    vol_a = _vol(tmp_path, fast_cfg)
+    vol_b = _vol(tmp_path, fast_cfg)
+    try:
+        assert _do_read(vol_a, config, "data/shared.txt").structuredContent["content"] == "v1"
+
+        # Peer B commits v2 → A goes INVALID.
+        _do_read(vol_b, config, "data/shared.txt")
+        assert _do_write(vol_b, config, "data/shared.txt", "v2-from-b").isError is False
+
+        # A's stale write is DENIED with the recoverable stale_view terminal.
+        denied = _do_write(vol_a, config, "data/shared.txt", "v2-from-a")
+        assert denied.isError is True
+        assert denied.structuredContent["reason"] == "stale_view"
+        assert denied.structuredContent["recover"] == "reacquire"
+        assert denied.structuredContent["retryable"] is True
+        assert target.read_bytes() == b"v2-from-b"  # A's stale write did NOT land
+
+        # A reacquires → fresh bytes, then writes FROM them → ok.
+        reacq = _do_reacquire(vol_a, config, "data/shared.txt")
+        assert reacq.isError is False
+        assert reacq.structuredContent["content"] == "v2-from-b"
+        assert "version lineage" in reacq.structuredContent["note"]
+
+        wrote = _do_write(vol_a, config, "data/shared.txt", "v3-from-a")
+        assert wrote.isError is False
+        assert target.read_bytes() == b"v3-from-a"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- fail-closed -------------------------------------------------------------
+
+
+def test_write_unattached_fails_closed_no_disk_write(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    """A mid-session endpoint loss must fail closed BEFORE the adapter's
+    best-effort unversioned write — coordinator_unavailable, disk untouched."""
+    target = _seed(tmp_path, content=b"v1")
+    config = _config(tmp_path)
+    vol = _vol(tmp_path, fast_cfg)
+    try:
+        vol._endpoint = None  # simulate a post-construction endpoint loss
+        result = _do_write(vol, config, "data/shared.txt", "should-not-land")
+        assert result.isError is True
+        assert result.structuredContent["reason"] == "coordinator_unavailable"
+        assert target.read_bytes() == b"v1"  # NO disk write
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- edges -------------------------------------------------------------------
+
+
+def test_read_invalid_path_is_non_deny_error(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    config = _config(tmp_path)
+    vol = _vol(tmp_path, fast_cfg)
+    try:
+        result = _do_read(vol, config, "../escape")
+        assert result.isError is True
+        assert result.structuredContent["reason"] == "invalid_path"
+        assert result.structuredContent["reason"] != "stale_view"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_read_missing_file_is_not_stale_view(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    _seed(tmp_path, content=b"v1")  # creates data/ but not nope.txt
+    config = _config(tmp_path)
+    vol = _vol(tmp_path, fast_cfg)
+    try:
+        result = _do_read(vol, config, "data/nope.txt")
+        assert result.isError is True
+        assert result.structuredContent["reason"] == "file_not_found"
+        assert result.structuredContent["reason"] != "stale_view"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_read_empty_file_is_valid_view(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    _seed(tmp_path, rel="data/empty.txt", content=b"")
+    config = _config(tmp_path)
+    vol = _vol(tmp_path, fast_cfg)
+    try:
+        result = _do_read(vol, config, "data/empty.txt")
+        assert result.isError is False
+        assert result.structuredContent["content"] == ""
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_read_binary_file_unsupported(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    _seed(tmp_path, rel="data/bin.dat", content=b"\xff\xfe\x00\x01")
+    config = _config(tmp_path)
+    vol = _vol(tmp_path, fast_cfg)
+    try:
+        result = _do_read(vol, config, "data/bin.dat")
+        assert result.isError is True
+        assert result.structuredContent["reason"] == "binary_unsupported"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- honesty surface (SC4) ---------------------------------------------------
+
+
+def test_tool_descriptions_state_the_scope() -> None:
+    for desc in (_READ_DESC, _WRITE_DESC, _STATUS_DESC):
+        assert "SINGLE-HOST" in desc
+        assert "auto-merge" in desc
+    assert "heterogeneous_scope_detectable=false" in _STATUS_DESC
+
+
+def test_instructions_state_forbidden_and_trust_boundary() -> None:
+    text = INSTRUCTIONS.lower()
+    assert "different hosts" in text
+    assert "auto-merge" in text
+    assert "trust boundary" in text
+    assert "single-uid" in text

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -197,3 +197,47 @@ def test_instructions_state_forbidden_and_trust_boundary() -> None:
     assert "auto-merge" in text
     assert "trust boundary" in text
     assert "single-uid" in text
+
+
+# --- fail-closed: unattached read/reacquire + IO errors ----------------------
+
+
+def test_read_unattached_fails_closed(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    _seed(tmp_path, content=b"v1")
+    config = _config(tmp_path)
+    vol = _vol(tmp_path, fast_cfg)
+    try:
+        vol._endpoint = None
+        result = _do_read(vol, config, "data/shared.txt")
+        assert result.isError is True
+        assert result.structuredContent["reason"] == "coordinator_unavailable"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_reacquire_unattached_fails_closed(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    _seed(tmp_path, content=b"v1")
+    config = _config(tmp_path)
+    vol = _vol(tmp_path, fast_cfg)
+    try:
+        vol._endpoint = None
+        result = _do_reacquire(vol, config, "data/shared.txt")
+        assert result.isError is True
+        assert result.structuredContent["reason"] == "coordinator_unavailable"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_os_error_fails_closed(tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch) -> None:
+    """A non-CoherenceError OSError (disk full / permission) from the underlying
+    write must fail closed as a tool error, never escape to FastMCP."""
+    _seed(tmp_path, content=b"v1")
+    config = _config(tmp_path)
+    vol = _vol(tmp_path, fast_cfg)
+    try:
+        monkeypatch.setattr(vol, "write", lambda *a, **k: (_ for _ in ()).throw(PermissionError("disk")))
+        result = _do_write(vol, config, "data/shared.txt", "x")
+        assert result.isError is True
+        assert result.structuredContent["reason"] == "io_error"
+    finally:
+        stop_coordinator(tmp_path)

--- a/tests/mcp/test_uri_validator.py
+++ b/tests/mcp/test_uri_validator.py
@@ -135,3 +135,17 @@ def test_new_nonexistent_file_allowed(tmp_path: Path) -> None:
     """A write target that does not exist yet validates (realpath resolves the
     existing prefix and stays within root)."""
     assert validate_uri("data/brand_new.txt", root=tmp_path) == "data/brand_new.txt"
+
+
+def test_symlink_to_coherence_dir_rejected(tmp_path: Path) -> None:
+    """A within-root symlink whose target RESOLVES into .coherence must be rejected
+    even though its key (parts[0]) is not '.coherence' and it stays within root —
+    otherwise the coordinator secret/state is readable through the symlink."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    coherence = ws / ".coherence"
+    coherence.mkdir()
+    (coherence / "hook.secret").write_text("secret")
+    (ws / "data").symlink_to(coherence, target_is_directory=True)
+    with pytest.raises(UriValidationError):
+        validate_uri("data/hook.secret", root=ws)

--- a/tests/mcp/test_uri_validator.py
+++ b/tests/mcp/test_uri_validator.py
@@ -1,0 +1,137 @@
+"""Unit 3 — URI→coordinator-key validation (traversal + TOCTOU guard).
+
+The validator front-runs the adapter: it turns a client path into a safe
+workspace-relative key, or rejects it. Coverage: the happy normalisation, the
+dotfile-preservation regression (removeprefix vs lstrip), traversal/absolute/
+control/backslash rejection, the `.coherence/**` info-disclosure surface, and
+real symlink escapes (file + dir), with a within-root symlink allowed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ccs.mcp.uri import UriValidationError, validate_uri
+
+# --- happy + canonicalisation ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "uri, expected",
+    [
+        ("data/notes.md", "data/notes.md"),
+        ("./data/x", "data/x"),  # leading './' stripped
+        ("data//notes.md", "data/notes.md"),  # repeated slash canonicalised
+        ("data/sub/", "data/sub"),  # trailing slash canonicalised
+    ],
+)
+def test_valid_uri_normalises_to_key(tmp_path: Path, uri: str, expected: str) -> None:
+    assert validate_uri(uri, root=tmp_path) == expected
+
+
+@pytest.mark.parametrize("uri", [".env", "subdir/.env", "a/.gitignore"])
+def test_dotfiles_preserved_exactly(tmp_path: Path, uri: str) -> None:
+    """The removeprefix-not-lstrip regression: a dotfile must NOT lose its dot
+    (lstrip('./') would turn '.env' into 'env', silently untracking it)."""
+    assert validate_uri(uri, root=tmp_path) == uri
+
+
+# --- rejection: traversal / absolute / control / backslash -------------------
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "../escape",
+        "a/../../escape",
+        "/abs/path",
+        "\\windows\\path",  # leading backslash
+        "..\\escape",  # backslash traversal
+        "data/\x00bad",  # NUL control char
+        "data/\x1bbad",  # ESC control char
+        "data/\x7fbad",  # DEL control char
+        "",  # empty
+    ],
+)
+def test_unsafe_uri_rejected(tmp_path: Path, uri: str) -> None:
+    with pytest.raises(UriValidationError):
+        validate_uri(uri, root=tmp_path)
+
+
+def test_non_string_uri_rejected(tmp_path: Path) -> None:
+    with pytest.raises(UriValidationError):
+        validate_uri(42, root=tmp_path)  # type: ignore[arg-type]
+
+
+def test_overlong_uri_rejected(tmp_path: Path) -> None:
+    with pytest.raises(UriValidationError):
+        validate_uri("a/" * 700, root=tmp_path)  # exceeds MAX_PATH_LEN (1024)
+
+
+# --- rejection: .coherence/** info-disclosure surface ------------------------
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        ".coherence",
+        ".coherence/state.db",
+        ".coherence/state.db-wal",
+        ".coherence/server.pid",
+        ".coherence/hook.secret",
+        ".coherence/tracked.yaml",
+        ".coherence/ignored.yaml",
+        ".coherence/strict_mode.yaml",
+        ".coherence/audit.log",
+        "./.coherence/state.db",
+        ".COHERENCE/state.db",  # case-variant maps to the same dir on case-insensitive FS
+    ],
+)
+def test_coherence_state_paths_rejected(tmp_path: Path, uri: str) -> None:
+    with pytest.raises(UriValidationError):
+        validate_uri(uri, root=tmp_path)
+
+
+# --- symlink escapes (real filesystem) ---------------------------------------
+
+
+def test_symlink_out_file_rejected(tmp_path: Path) -> None:
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    outside = tmp_path / "secret.txt"
+    outside.write_text("secret")
+    (ws / "link.txt").symlink_to(outside)
+    with pytest.raises(UriValidationError):
+        validate_uri("link.txt", root=ws)
+
+
+def test_symlink_out_dir_rejected(tmp_path: Path) -> None:
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    (outside_dir / "f.txt").write_text("x")
+    (ws / "sub").symlink_to(outside_dir, target_is_directory=True)
+    with pytest.raises(UriValidationError):
+        validate_uri("sub/f.txt", root=ws)
+
+
+def test_symlink_within_root_allowed(tmp_path: Path) -> None:
+    """A symlink whose target stays INSIDE root is contained → allowed. The
+    validator's security job is preventing ESCAPE; the within-root
+    version-tracking ambiguity is out of v1 scope. (Note: a regular file swapped
+    for an out-of-root symlink AFTER validation is the accepted same-uid TOCTOU
+    residual — O_NOFOLLOW adapter open is v1.1.)"""
+    ws = tmp_path / "ws"
+    (ws / "data").mkdir(parents=True)
+    (ws / "data" / "real.txt").write_text("x")
+    (ws / "data" / "alias.txt").symlink_to(ws / "data" / "real.txt")
+    assert validate_uri("data/alias.txt", root=ws) == "data/alias.txt"
+
+
+def test_new_nonexistent_file_allowed(tmp_path: Path) -> None:
+    """A write target that does not exist yet validates (realpath resolves the
+    existing prefix and stays within root)."""
+    assert validate_uri("data/brand_new.txt", root=tmp_path) == "data/brand_new.txt"

--- a/tests/mcp/test_write_cas.py
+++ b/tests/mcp/test_write_cas.py
@@ -199,3 +199,45 @@ def test_write_cas_description_states_cooperating_caveat() -> None:
     assert "livelock-proof" in _WRITE_CAS_DESC
     assert "version_mismatch" in _WRITE_CAS_DESC
     assert "auto-merge" in _WRITE_CAS_DESC
+
+
+# --- fail-closed + counter semantics -----------------------------------------
+
+
+def test_write_cas_missing_file_is_file_not_found(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    """A CAS on a non-existent file is a non-deny client error (file_not_found),
+    not an escaped FileNotFoundError."""
+    (tmp_path / "data").mkdir()
+    config = _config(tmp_path)
+    vol = _vol(tmp_path, fast_cfg)
+    try:
+        result = _do_write_cas(vol, config, {}, "data/nope.txt", 0, "x")
+        assert result.isError is True
+        assert result.structuredContent["reason"] == "file_not_found"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_cas_counter_resets_after_a_win(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    """A win mid-streak resets the per-path conflict counter — a subsequent
+    conflict starts fresh at 1, not at the prior streak."""
+    _seed(tmp_path, b"v1")
+    config = _config(tmp_path)
+    vol = _vol(tmp_path, fast_cfg)
+    try:
+        conflicts: dict[str, int] = {}
+        # expected_version=0 always conflicts against a v>0 file.
+        for _ in range(MAX_CAS_CONFLICTS - 1):
+            assert _do_write_cas(vol, config, conflicts, _PATH, 0, "x").structuredContent["reason"] == "version_mismatch"
+        assert conflicts[_PATH] == MAX_CAS_CONFLICTS - 1
+
+        # A win resets the streak ...
+        version = _do_read(vol, config, _PATH).structuredContent["version"]
+        assert _do_write_cas(vol, config, conflicts, _PATH, version, "won").isError is False
+        assert _PATH not in conflicts
+
+        # ... so the next conflict starts at 1, not near the exhaustion bound.
+        assert _do_write_cas(vol, config, conflicts, _PATH, 0, "x").structuredContent["reason"] == "version_mismatch"
+        assert conflicts[_PATH] == 1
+    finally:
+        stop_coordinator(tmp_path)

--- a/tests/mcp/test_write_cas.py
+++ b/tests/mcp/test_write_cas.py
@@ -1,0 +1,201 @@
+"""Unit 5 — swg_write_cas (Option A): the concurrent single-host regime, honestly.
+
+Option A is a SINGLE-SHOT version-checked CAS: commit IFF current == the agent's
+expected_version, else a TYPED conflict (current_version returned) — never an
+auto-merge, never a silent overwrite (the split-comparand lost update). The
+per-session counter bounds a cooperating agent's retry loop.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ccs.adapters.claude_code.lifecycle import LifecycleConfig, stop_coordinator
+from ccs.adapters.coherent_volume import CoherentVolume
+from ccs.core.exceptions import CasVersionConflict
+from ccs.mcp.server import (
+    _WRITE_CAS_DESC,
+    MAX_CAS_CONFLICTS,
+    _do_read,
+    _do_write,
+    _do_write_cas,
+)
+from ccs.mcp.session import SessionConfig
+
+
+@pytest.fixture
+def fast_cfg() -> LifecycleConfig:
+    return LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0.1,
+        notice_evict_max_age_sec=1.0,
+        port_file_retry_attempts=20,
+        port_file_retry_interval_sec=0.05,
+        connect_retry_attempts=10,
+        connect_retry_interval_sec=0.05,
+    )
+
+
+def _seed(tmp_path: Path, content: bytes = b"v1") -> Path:
+    target = tmp_path / "data" / "shared.txt"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    return target
+
+
+def _vol(tmp_path: Path, cfg: LifecycleConfig) -> CoherentVolume:
+    return CoherentVolume(tmp_path, managed=("data/**",), on_error="strict", config=cfg)
+
+
+def _config(tmp_path: Path) -> SessionConfig:
+    return SessionConfig(root=tmp_path.resolve(), managed=("data/**",))
+
+
+_PATH = "data/shared.txt"
+
+
+# --- happy -------------------------------------------------------------------
+
+
+def test_write_cas_commits_at_current_version(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    target = _seed(tmp_path, b"v1")
+    config = _config(tmp_path)
+    vol = _vol(tmp_path, fast_cfg)
+    try:
+        version = _do_read(vol, config, _PATH).structuredContent["version"]
+        result = _do_write_cas(vol, config, {}, _PATH, version, "v1-merged")
+        assert result.isError is False
+        assert target.read_bytes() == b"v1-merged"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- stale expected_version → typed conflict, no write -----------------------
+
+
+def test_write_cas_stale_version_is_typed_conflict(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    target = _seed(tmp_path, b"v1")
+    config = _config(tmp_path)
+    vol_a = _vol(tmp_path, fast_cfg)
+    vol_b = _vol(tmp_path, fast_cfg)
+    try:
+        version = _do_read(vol_a, config, _PATH).structuredContent["version"]
+        # Peer B commits → current advances past A's read version.
+        _do_read(vol_b, config, _PATH)
+        assert _do_write(vol_b, config, _PATH, "v2-from-b").isError is False
+
+        conflicts: dict[str, int] = {}
+        result = _do_write_cas(vol_a, config, conflicts, _PATH, version, "stale-merge")
+        assert result.isError is True
+        sc = result.structuredContent
+        assert sc["reason"] == "version_mismatch"
+        assert sc["recover"] == "read_then_merge"
+        assert sc["retryable"] is False
+        assert sc["current_version"] > version  # the agent learns where to re-CAS
+        assert target.read_bytes() == b"v2-from-b"  # A's stale CAS did NOT land
+        assert conflicts[_PATH] == 1  # cooperating-agent counter ticked
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_cas_expected_zero_loses_cleanly(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    target = _seed(tmp_path, b"v1")
+    config = _config(tmp_path)
+    vol = _vol(tmp_path, fast_cfg)
+    try:
+        version = _do_read(vol, config, _PATH).structuredContent["version"]
+        assert version > 0
+        result = _do_write_cas(vol, config, {}, _PATH, 0, "overwrite")
+        assert result.isError is True
+        assert result.structuredContent["reason"] == "version_mismatch"
+        assert target.read_bytes() == b"v1"  # no silent overwrite
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- cooperating-agent counter exhaustion ------------------------------------
+
+
+def test_write_cas_counter_exhausts_for_cooperating_agent(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    _seed(tmp_path, b"v1")
+    config = _config(tmp_path)
+    vol_a = _vol(tmp_path, fast_cfg)
+    vol_b = _vol(tmp_path, fast_cfg)
+    try:
+        stale = _do_read(vol_a, config, _PATH).structuredContent["version"]
+        _do_read(vol_b, config, _PATH)
+        _do_write(vol_b, config, _PATH, "advanced")  # current now != stale forever
+
+        conflicts: dict[str, int] = {}
+        # MAX_CAS_CONFLICTS conflicts return version_mismatch ...
+        for _ in range(MAX_CAS_CONFLICTS):
+            r = _do_write_cas(vol_a, config, conflicts, _PATH, stale, "x")
+            assert r.structuredContent["reason"] == "version_mismatch"
+        # ... the next one trips the cooperating-agent bound.
+        exhausted = _do_write_cas(vol_a, config, conflicts, _PATH, stale, "x")
+        assert exhausted.structuredContent["reason"] == "cas_exhausted"
+        assert exhausted.structuredContent["retryable"] is False
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- no silent loss (the core property) --------------------------------------
+
+
+def test_write_cas_two_writers_no_silent_loss(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    """Two writers read the same version and both CAS at it: exactly one wins, the
+    other is a typed version_mismatch, and the file holds the winner's content —
+    never a silent lost update."""
+    target = _seed(tmp_path, b"base")
+    config = _config(tmp_path)
+    vol_a = _vol(tmp_path, fast_cfg)
+    vol_b = _vol(tmp_path, fast_cfg)
+    try:
+        va = _do_read(vol_a, config, _PATH).structuredContent["version"]
+        vb = _do_read(vol_b, config, _PATH).structuredContent["version"]
+        assert va == vb
+
+        res_a = _do_write_cas(vol_a, config, {}, _PATH, va, "a-merged")
+        res_b = _do_write_cas(vol_b, config, {}, _PATH, vb, "b-merged")
+
+        wins = [r for r in (res_a, res_b) if not r.isError]
+        conflicts = [r for r in (res_a, res_b) if r.isError]
+        assert len(wins) == 1
+        assert len(conflicts) == 1
+        assert conflicts[0].structuredContent["reason"] == "version_mismatch"
+
+        winner = b"a-merged" if not res_a.isError else b"b-merged"
+        assert target.read_bytes() == winner
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- adapter primitive -------------------------------------------------------
+
+
+def test_adapter_write_cas_at_raises_typed_conflict(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    _seed(tmp_path, b"v1")
+    vol_a = _vol(tmp_path, fast_cfg)
+    vol_b = _vol(tmp_path, fast_cfg)
+    try:
+        _bytes, va = vol_a.read_with_version(_PATH)
+        vol_b.read_with_version(_PATH)
+        vol_b.write(_PATH, b"v2")  # advance current
+        with pytest.raises(CasVersionConflict) as exc:
+            vol_a.write_cas_at(_PATH, va, b"stale")
+        assert exc.value.expected_version == va
+        assert exc.value.current_version > va
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- honesty surface ---------------------------------------------------------
+
+
+def test_write_cas_description_states_cooperating_caveat() -> None:
+    assert "COOPERATING" in _WRITE_CAS_DESC
+    assert "livelock-proof" in _WRITE_CAS_DESC
+    assert "version_mismatch" in _WRITE_CAS_DESC
+    assert "auto-merge" in _WRITE_CAS_DESC

--- a/tests/test_mcp_front_door_demo.py
+++ b/tests/test_mcp_front_door_demo.py
@@ -1,0 +1,62 @@
+"""Unit 6 — the red→green front-door artifact is a trustworthy gate.
+
+RED loses, both GREEN regimes hold to their EXACT finals, and the negative
+control proves the green depends on the deny (not on a refetch that masks the
+loss). Deterministic and de-named.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from examples.mcp_stale_write_guard import GOLDEN, PEER_VALUE, broken, fixed
+from examples.mcp_stale_write_guard.main import main
+
+
+def test_demo_gate_exits_zero() -> None:
+    assert main() == 0
+
+
+def test_red_broken_loses_the_update() -> None:
+    assert broken.run_broken()["lost_update"] is True
+
+
+def test_green_sequential_preserves_peer_value_exactly() -> None:
+    trace = fixed.run_sequential(guarded=True)
+    assert trace["stale_write_denied"] is True
+    assert trace["deny_reason"] == "stale_view"
+    assert trace["final"] == PEER_VALUE  # exact, not an inequality
+
+
+def test_green_concurrent_merges_to_golden_exactly() -> None:
+    trace = fixed.run_concurrent()
+    assert trace["a_committed"] is True
+    assert trace["b_first_conflicted"] is True
+    assert trace["b_merged_and_committed"] is True
+    assert trace["final"] == GOLDEN  # both lines, exact
+
+
+def test_negative_control_loses_with_deny_off() -> None:
+    """The SAME green flow with the path unguarded (deny disabled) must lose —
+    proving the deny is load-bearing, not a masking refetch."""
+    trace = fixed.run_sequential(guarded=False)
+    assert trace["stale_write_denied"] is False
+    assert trace["preserved_peer_value"] is False
+
+
+def test_concurrent_is_deterministic() -> None:
+    assert fixed.run_concurrent()["final"] == GOLDEN
+    assert fixed.run_concurrent()["final"] == GOLDEN
+
+
+def test_demo_artifact_is_de_named() -> None:
+    """The shipped demo carries no incident/codenames (publication honesty)."""
+    import examples.mcp_stale_write_guard as pkg
+
+    pkg_dir = Path(pkg.__file__).parent
+    forbidden = ("viktor", "jacniacki", "zeta labs", "zeta-labs", "zetalabs")
+    files = list(pkg_dir.glob("*.py")) + list(pkg_dir.glob("*.md"))
+    for path in files:
+        text = path.read_text().lower()
+        for name in forbidden:
+            assert name not in text, f"{path.name} contains forbidden name {name!r}"


### PR DESCRIPTION
## Summary

A new `src/ccs/mcp/` interface package: a thin **5-tool stdio MCP server**
(`stale-write-guard-fs`) over the shipped `CoherentVolume` adapter — a
single-host coherence guard against silent lost updates when two or more agents
share a mutable file. Strict-only, fail-closed.

- **Sequential** stale-overwrite: `swg_write` is denied (`stale_view`); recover
  with `swg_reacquire`, then write from the fresh bytes.
- **Concurrent** same-key: `swg_write_cas(path, expected_version, new_content)`
  is a single-shot, version-checked CAS — a typed conflict (`version_mismatch`
  with `current_version`), not auto-merge.
- `swg_status`: coordinator `on|off|unknown` (unknown is never reported as
  `off`), per-path enforcement, and the loud `heterogeneous_scope_detectable=false`
  limitation.

Behind a new `mcp` extra (`pip install -e ".[mcp]"` → `stale-write-guard-fs`).
The coherence engine and its TLA+ proofs are reused, not rebuilt; this is
typed-exception + binding work, with no new coherence mechanism.

## What's included

- Typed deny terminals in `core/exceptions.py` + a deny→non-ignorable-`isError`
  mapper (`mcp/deny.py`), built test-first.
- Lifecycle/binding (`session.py` / `server.py`): strict-only construction,
  serialization lock, fd-level stdout purity, lazy import (no `mcp` dependency
  until a symbol that needs it is accessed).
- URI→key validator (`uri.py`): traversal / `.coherence` / symlink-escape guard,
  reusing the coordinator's authoritative path checks.
- The five tools + a single-shot `write_cas_at` adapter primitive that avoids the
  split-comparand lost-update (re-mint first / read second; CAS against the
  agent's `expected_version`).
- A constructed red→green front-door demo with a negative control
  (`examples/mcp_stale_write_guard/`): exact-equal finals; green is shown to
  depend on the deny, not on a refetch that masks the loss.

## Honesty floor / scope

Single-host only. Out of guarantee (and not detected in v1): writers on
different hosts or across a synced/network mount, divergent-history
reconciliation, semantic correctness, server-enforced auto-merge. The server
enforces version lineage, not content derivation; the trust model is single-uid,
single-host. These are stated in the tool descriptions, the server instructions,
and the deny payloads.

## Test plan

- [x] New `tests/mcp/` suite + front-door demo test: the deny→reacquire→write
  loop, the no-silent-loss CAS property, the 3-state status split, the
  fail-closed paths, and the URI guard (incl. the symlink-into-`.coherence`
  regression).
- [x] Full suite: **2116 passed**; `python tools/check_architecture.py` clean;
  `ruff check src/ tests/` clean.
- [x] Self-reviewed via `/ce:review` (11 personas) + an adversarial pass; the two
  P1 findings (symlink-into-`.coherence` info-disclosure; IO-error fail-closed)
  are fixed in this branch.

## Follow-ups (not in this PR)

- A README section documenting the server (branched from `main` per repo
  convention for README-touching changes).
- v1.1: per-glob heterogeneous-scope detection, coordinator-side CAS fencing,
  atomic-write rollback on post-edit preempt, `O_NOFOLLOW` adapter open, binary
  artifacts.



## Merge order

Base of the stack: #126 (`feat/read-time-hash-enforcement`) is built on top of this branch and adds the read-time-hash change. Merge this PR (#125) **first**; #126 then contributes only its read-time-hash delta.
