### PR TITLE
feat: pre-write content-CAS guard against foreign-edit clobbers (write surface)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Alpha — APIs may change before `v1.0`.
 
 ## [Unreleased]
 
+### Added
+
+- `CoherentVolume(on_stale_write=...)` — a pre-write content-CAS that denies a
+  write which would clobber a foreign / out-of-band edit (the file on disk changed
+  since this instance last read/wrote a managed path), surfaced as `StaleView`;
+  recover via `reacquire()`. Plumbed through `install()` / `coherent_workspace()`.
+  The MCP `swg_write` tool surfaces it as a typed `stale_view` deny.
+
+### Changed
+
+- **`CoherentVolume.write()` now guards by default** (`on_stale_write="raise"`): a
+  write to a managed path whose on-disk bytes changed out-of-band since the last
+  read/write raises `StaleView` instead of silently overwriting. Set
+  `on_stale_write="allow"` to restore the prior clobber. (`write()` already raised
+  `StaleView` on the INVALID-stale pre-edit; this extends it to the foreign-edit
+  case.)
+
 ## [0.9.3] - 2026-06-14
 
 ### Added

--- a/src/ccs/adapters/claude_code/policy.py
+++ b/src/ccs/adapters/claude_code/policy.py
@@ -179,12 +179,12 @@ class TrackedArtifactPolicy:
         # the string-build loop for ``**`` patterns.
         cache = self._compiled_patterns
         tracked = (
-            _matches_any(normalized, self.tracked_patterns, cache)
-            or _matches_any(normalized, self.user_added_patterns, cache)
+            matches_any(normalized, self.tracked_patterns, cache)
+            or matches_any(normalized, self.user_added_patterns, cache)
         )
         if not tracked:
             return False
-        if _matches_any(normalized, self.ignored_patterns, cache):
+        if matches_any(normalized, self.ignored_patterns, cache):
             return False
         return True
 
@@ -209,7 +209,7 @@ class TrackedArtifactPolicy:
         normalized = _normalize_relative(parent_relative_path)
         if normalized is None:
             return False
-        return _matches_any(normalized, self.strict_mode_paths, self._compiled_patterns)
+        return matches_any(normalized, self.strict_mode_paths, self._compiled_patterns)
 
     def count_strict_mode_matches(self, candidate_paths: Iterable[str]) -> int:
         """Count how many of ``candidate_paths`` are in strict mode.
@@ -291,7 +291,7 @@ def _normalize_relative(p: str) -> str | None:
     return cleaned
 
 
-def _matches_any(
+def matches_any(
     path: str,
     patterns: Iterable[str],
     compiled: dict[str, re.Pattern[str]] | None = None,

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -103,6 +103,14 @@ __all__ = ["CoherentVolume", "coherent_workspace", "install", "uninstall"]
 #   read resets the streak.
 MAX_CAS_REACQUIRES = 8
 
+# SB-23 content-CAS deny message. Byte-stable (no path/hash interpolation) so a
+# model's retry loop sees identical text each attempt (KTD-P), and distinct from
+# the coordinator's INVALID-deny prose so the two are not conflated.
+_SB23_STALE_WRITE_REASON = (
+    "stale write blocked: the file on disk changed since this view was read "
+    "(out-of-band edit). reacquire() and rebuild the write from the fresh bytes."
+)
+
 
 class CoherentVolume:
     """Coherent shared workspace for a single-host agent fleet (v1).
@@ -149,6 +157,21 @@ class CoherentVolume:
       Independent of ``on_error`` (which governs only infra failures);
       :meth:`reacquire`'s recovery read always bypasses it.
 
+    ``on_stale_write`` (write surface — SB-23 content-CAS):
+
+    - ``"raise"`` (default): at :meth:`write`, if the file on disk changed since
+      this instance last read/wrote it (a foreign / out-of-band edit), the write
+      is denied with :class:`~ccs.core.exceptions.StaleView` rather than silently
+      clobbering it — :meth:`reacquire` and rebuild from the fresh bytes. The safe
+      default *guards*, because a write is a data-loss surface (the inverse of
+      ``on_stale_read``, where returning bytes is always safe).
+    - ``"allow"``: the foreign edit is not raised; the write proceeds and clobbers
+      (pre-SB-23 behavior). Adapter-local: fires on a strict (managed-globs) volume
+      whenever a per-path baseline exists, independent of ``on_error`` / coordinator
+      attachment. A non-strict volume is exempt — there a coordinated peer commit
+      can change the disk without an INVALID deny, so a mismatch is not necessarily
+      foreign.
+
     **Fleet requirement (hard, v1).** Every instance coordinating a given
     workspace MUST declare the **same** ``managed`` globs. Strict enforcement is
     verified only coarsely (the coordinator's ``/status`` exposes a strict-pattern
@@ -166,6 +189,7 @@ class CoherentVolume:
         managed: tuple[str, ...] = (),
         on_error: Literal["strict", "degrade"] = "strict",
         on_stale_read: Literal["allow", "raise"] = "allow",
+        on_stale_write: Literal["allow", "raise"] = "raise",
         config: LifecycleConfig | None = None,
         bind_host: str = "127.0.0.1",
     ) -> None:
@@ -175,6 +199,10 @@ class CoherentVolume:
             raise ValueError(
                 f"on_stale_read must be 'allow' or 'raise', got {on_stale_read!r}"
             )
+        if on_stale_write not in ("allow", "raise"):
+            raise ValueError(
+                f"on_stale_write must be 'allow' or 'raise', got {on_stale_write!r}"
+            )
 
         self._root = Path(root).resolve()
         # Managed globs are coordinator-policy patterns (parent-repo-relative,
@@ -183,6 +211,7 @@ class CoherentVolume:
         self._managed: tuple[str, ...] = tuple(managed)
         self._on_error = on_error
         self._on_stale_read = on_stale_read
+        self._on_stale_write = on_stale_write
         self._config = config
         self._bind_host = bind_host
 
@@ -205,6 +234,12 @@ class CoherentVolume:
         # Per-path commit hashes for the Unit 2 write no-op-skip; declared here so
         # the fork handler and reacquire() can reset it.
         self._last_committed_hash: dict[str, str] = {}
+        # SB-23 content-CAS baseline: the hash this instance last OBSERVED on disk
+        # per path (seeded on read, advanced on its own writes). SEPARATE from
+        # _last_committed_hash (own-write hashes for the no-op-skip fast path). At
+        # write time a current disk hash that differs from this baseline is a
+        # foreign / out-of-band edit. Cleared on remint/fork alongside the sibling.
+        self._last_observed_hash: dict[str, str] = {}
 
         self._mint_identity()
         # A forked child must not share the parent's identity (single-writer
@@ -231,6 +266,7 @@ class CoherentVolume:
             self._endpoint = None
             self._needs_reattach = True
             self._last_committed_hash.clear()
+            self._last_observed_hash.clear()  # SB-23: child re-seeds its own baselines
 
     def _ensure_attached(self) -> None:
         """Lazily re-attach after a fork dropped the endpoint.
@@ -493,13 +529,16 @@ class CoherentVolume:
         if not abs_path.is_file():
             raise FileNotFoundError(f"no such file in workspace: {rel}")
         data = self._read_file_bytes(abs_path)  # empty file -> b"" -> sha256(b"")
+        content_hash = self._sha256_bytes(data)
+        # SB-23: seed the foreign-edit baseline with what we just observed on disk.
+        self._last_observed_hash[rel] = content_hash
         if self._endpoint is not None:
             resp = self._post(
                 "/hooks/pre-read",
                 {
                     "session_id": self._session_id,
                     "path": rel,
-                    "content_hash": self._sha256_bytes(data),
+                    "content_hash": content_hash,
                 },
             )
             # A stale / strict-deny response is expected and changes nothing here
@@ -561,9 +600,14 @@ class CoherentVolume:
 
         if self._endpoint is None:
             # Unattached / degraded coordinator (strict already raised at
-            # construction). Degrade mode: best-effort write, no enforcement.
+            # construction). Degrade mode: best-effort write, no coordinator
+            # enforcement — but the SB-23 content-CAS is adapter-local, so it still
+            # fires (gated by on_stale_write, independent of on_error).
+            self._check_foreign_edit(rel, abs_path)
             self._atomic_write(abs_path, data)
-            self._last_committed_hash[rel] = self._sha256_bytes(data)
+            written = self._sha256_bytes(data)
+            self._last_committed_hash[rel] = written
+            self._last_observed_hash[rel] = written  # SB-23: own write advances baseline
             return
 
         # pre-edit: acquire EXCLUSIVE, or be denied because we are INVALID.
@@ -578,17 +622,24 @@ class CoherentVolume:
         # file) would otherwise orphan the grant until the crash-recovery sweep.
         try:
             new_hash = self._sha256_bytes(data)
+            # SB-23 content-CAS: re-hash disk under the held grant and deny a write
+            # whose target diverged on disk since this instance last observed it (a
+            # foreign edit). Returns the disk hash so the no-op-skip below reuses it
+            # (one disk read, hoisted out of the former short-circuit).
+            disk_hash = self._check_foreign_edit(rel, abs_path)
             # No-op skip: skip the os.replace (and its fsync) only when the file
             # ALREADY holds these bytes. _last_committed_hash is a cheap fast-path
-            # gate (it skips the disk read on the common "bytes changed" write); the
-            # CURRENT on-disk hash is the authority, because the cached belief alone
-            # can be stale across a peer commit (see _disk_hash for the full why).
+            # gate; the CURRENT on-disk hash is the authority (see _disk_hash).
             already_on_disk = (
                 self._last_committed_hash.get(rel) == new_hash
-                and self._disk_hash(abs_path) == new_hash
+                and disk_hash == new_hash
             )
             if not already_on_disk:
                 self._atomic_write(abs_path, data)
+            # SB-23 (R5): advance the observed baseline as soon as the bytes are on
+            # disk — BEFORE the post-edit POST — so a post-edit preempt cannot leave
+            # a stale baseline that self-false-denies this instance's next write.
+            self._last_observed_hash[rel] = new_hash
         except Exception:
             # Release the grant so it is not orphaned until the sweep, then
             # re-raise the original error. Best-effort release — a release failure
@@ -669,6 +720,7 @@ class CoherentVolume:
         with self._lock:
             self._session_id = str(uuid.uuid4())  # fresh identity -> no INVALID
             self._last_committed_hash.clear()  # the new identity has committed nothing
+            self._last_observed_hash.clear()  # SB-23: baselines belong to the old identity
 
     def write_cas(
         self,
@@ -755,7 +807,9 @@ class CoherentVolume:
             current = self._current_bytes_or_empty(_abs_path)
             data = bytes(make_content(current))
             self._atomic_write(_abs_path, data)
-            self._last_committed_hash[rel] = self._sha256_bytes(data)
+            written = self._sha256_bytes(data)
+            self._last_committed_hash[rel] = written
+            self._last_observed_hash[rel] = written  # SB-23: own write advances baseline
             return
 
         last_current_version = -1
@@ -846,6 +900,7 @@ class CoherentVolume:
             if outcome == "win":
                 self._atomic_write(_abs_path, data)  # confirmed → persist
                 self._last_committed_hash[rel] = new_hash
+                self._last_observed_hash[rel] = new_hash  # SB-23: own write advances baseline
                 return
             if outcome == "conflict":
                 last_current_version = self._cas_current_version(resp, last_current_version)
@@ -957,6 +1012,7 @@ class CoherentVolume:
         if outcome == "win":
             self._atomic_write(abs_path, new_content)  # confirmed → persist
             self._last_committed_hash[rel] = new_hash
+            self._last_observed_hash[rel] = new_hash  # SB-23: own write advances baseline
             return
         if outcome == "conflict":
             # A peer won the version between our read and the CAS → typed conflict.
@@ -1025,6 +1081,37 @@ class CoherentVolume:
             return CoherentVolume._sha256_bytes(CoherentVolume._read_file_bytes(abs_path))
         except OSError:
             return None
+
+    def _check_foreign_edit(self, rel: str, abs_path: Path) -> str | None:
+        """SB-23 content-CAS. Hash the current on-disk file; if the disk diverged
+        from the baseline this instance last observed for ``rel`` (a foreign /
+        out-of-band edit), raise :class:`StaleView` under ``on_stale_write="raise"``
+        so the caller :meth:`reacquire`s instead of clobbering the foreign bytes.
+        ``on_stale_write="allow"`` falls through (proceed and clobber — pre-SB-23
+        behavior).
+
+        Gated on a **strict** (managed) volume. The check is only sound there: on a
+        strict path a peer commit would have DENIED at pre-edit, so reaching this
+        check means no peer commit landed and a disk mismatch is genuinely foreign.
+        On a tracked-but-non-strict path pre-edit re-grants over a peer commit, so a
+        disk mismatch could be that coordinated peer write — not foreign — and must
+        NOT be denied (the no-op-skip handles it). A missing baseline (never-read
+        path) or an absent file (foreign delete) is a no-baseline skip.
+
+        Returns the disk hash (or ``None`` if absent) so the caller reuses it for
+        the write no-op-skip without a second disk read — returned regardless of the
+        gate, since the no-op-skip needs it on non-strict volumes too."""
+        disk_hash = self._disk_hash(abs_path)
+        baseline = self._last_observed_hash.get(rel)
+        if (
+            self._managed  # SB-23 fires only on a strict-coherence volume (see above)
+            and baseline is not None
+            and disk_hash is not None
+            and disk_hash != baseline
+            and self._on_stale_write == "raise"
+        ):
+            raise StaleView(_SB23_STALE_WRITE_REASON)
+        return disk_hash
 
     def _atomic_write(self, abs_path: Path, data: bytes) -> None:
         """Durable, atomic replace via raw ``os.write`` + ``os.replace`` (NOT
@@ -1101,6 +1188,9 @@ class CoherentVolume:
         if not abs_path.is_file():
             raise FileNotFoundError(f"no such file in workspace: {_rel}")
         data = self._read_file_bytes(abs_path)
+        content_hash = self._sha256_bytes(data)
+        # SB-23: the OCC read path also seeds the foreign-edit baseline.
+        self._last_observed_hash[_rel] = content_hash
         version = 0
         stale_denied = False
         if self._endpoint is not None:
@@ -1109,7 +1199,7 @@ class CoherentVolume:
                 {
                     "session_id": self._session_id,
                     "path": _rel,
-                    "content_hash": self._sha256_bytes(data),
+                    "content_hash": content_hash,
                 },
             )
             if isinstance(resp, dict):
@@ -1425,6 +1515,7 @@ def install(
     managed: tuple[str, ...] = (),
     on_error: Literal["strict", "degrade"] = "strict",
     on_stale_read: Literal["allow", "raise"] = "allow",
+    on_stale_write: Literal["allow", "raise"] = "raise",
     config: LifecycleConfig | None = None,
     bind_host: str = "127.0.0.1",
 ) -> CoherentVolume:
@@ -1439,7 +1530,7 @@ def install(
         return _shim_state.volume
     volume = CoherentVolume(
         root, managed=managed, on_error=on_error, on_stale_read=on_stale_read,
-        config=config, bind_host=bind_host,
+        on_stale_write=on_stale_write, config=config, bind_host=bind_host,
     )
     original_open = builtins.open  # is io.open (same object) at install time
     wrapper = _make_open_wrapper(volume, original_open)
@@ -1466,6 +1557,7 @@ def coherent_workspace(
     managed: tuple[str, ...] = (),
     on_error: Literal["strict", "degrade"] = "strict",
     on_stale_read: Literal["allow", "raise"] = "allow",
+    on_stale_write: Literal["allow", "raise"] = "raise",
     config: LifecycleConfig | None = None,
     bind_host: str = "127.0.0.1",
 ) -> Iterator[CoherentVolume]:
@@ -1480,7 +1572,7 @@ def coherent_workspace(
     already_installed = _shim_state is not None
     volume = install(
         root, managed=managed, on_error=on_error, on_stale_read=on_stale_read,
-        config=config, bind_host=bind_host,
+        on_stale_write=on_stale_write, config=config, bind_host=bind_host,
     )
     try:
         yield volume

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -166,11 +166,11 @@ class CoherentVolume:
       default *guards*, because a write is a data-loss surface (the inverse of
       ``on_stale_read``, where returning bytes is always safe).
     - ``"allow"``: the foreign edit is not raised; the write proceeds and clobbers
-      (pre-SB-23 behavior). Adapter-local: fires on a strict (managed-globs) volume
+      (pre-SB-23 behavior). Adapter-local: fires for a **managed (strict) path**
       whenever a per-path baseline exists, independent of ``on_error`` / coordinator
-      attachment. A non-strict volume is exempt — there a coordinated peer commit
-      can change the disk without an INVALID deny, so a mismatch is not necessarily
-      foreign.
+      attachment. An unmanaged or tracked-but-non-strict path is exempt — there a
+      coordinated peer change can hit the disk without an INVALID deny, so a
+      mismatch is not necessarily foreign.
 
     **Fleet requirement (hard, v1).** Every instance coordinating a given
     workspace MUST declare the **same** ``managed`` globs. Strict enforcement is
@@ -1090,13 +1090,14 @@ class CoherentVolume:
         ``on_stale_write="allow"`` falls through (proceed and clobber — pre-SB-23
         behavior).
 
-        Gated on a **strict** (managed) volume. The check is only sound there: on a
-        strict path a peer commit would have DENIED at pre-edit, so reaching this
-        check means no peer commit landed and a disk mismatch is genuinely foreign.
-        On a tracked-but-non-strict path pre-edit re-grants over a peer commit, so a
-        disk mismatch could be that coordinated peer write — not foreign — and must
-        NOT be denied (the no-op-skip handles it). A missing baseline (never-read
-        path) or an absent file (foreign delete) is a no-baseline skip.
+        Gated on a **managed (strict) path** — ``rel`` matched against this volume's
+        managed globs. The check is only sound there: on a strict path a peer commit
+        would have DENIED at pre-edit, so reaching this check means no peer commit
+        landed and a disk mismatch is genuinely foreign. On a path this volume does
+        NOT manage (untracked, or tracked-but-non-strict) pre-edit re-grants over a
+        peer write, so a disk mismatch could be that coordinated change — not
+        foreign — and must NOT be denied (the no-op-skip handles it). A missing
+        baseline (never-read path) or an absent file (foreign delete) also skips.
 
         Returns the disk hash (or ``None`` if absent) so the caller reuses it for
         the write no-op-skip without a second disk read — returned regardless of the
@@ -1104,7 +1105,12 @@ class CoherentVolume:
         disk_hash = self._disk_hash(abs_path)
         baseline = self._last_observed_hash.get(rel)
         if (
-            self._managed  # SB-23 fires only on a strict-coherence volume (see above)
+            # Only for a path THIS volume manages (strict). Matching `rel` against
+            # the managed globs with the coordinator's own matcher keeps SB-23's
+            # scope identical to is_strict_mode — a volume that manages other globs
+            # but writes an unmanaged path does NOT fire (the unmanaged path is not
+            # strict, so a coordinated change there would not have denied either).
+            _matches_any(rel, self._managed)
             and baseline is not None
             and disk_hash is not None
             and disk_hash != baseline

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -53,7 +53,7 @@ from ccs.adapters.claude_code.lifecycle import (
     read_port_from_file,
     tcp_probe,
 )
-from ccs.adapters.claude_code.policy import _matches_any
+from ccs.adapters.claude_code.policy import matches_any
 from ccs.cli._coherence_client import (
     CoordinatorEndpoint,
     CoordinatorUnavailable,
@@ -106,7 +106,7 @@ MAX_CAS_REACQUIRES = 8
 # SB-23 content-CAS deny message. Byte-stable (no path/hash interpolation) so a
 # model's retry loop sees identical text each attempt (KTD-P), and distinct from
 # the coordinator's INVALID-deny prose so the two are not conflated.
-_SB23_STALE_WRITE_REASON = (
+_STALE_WRITE_DENY_REASON = (
     "stale write blocked: the file on disk changed since this view was read "
     "(out-of-band edit). reacquire() and rebuild the write from the fresh bytes."
 )
@@ -578,6 +578,19 @@ class CoherentVolume:
         infrastructure failure; recover via :meth:`reacquire` and write from the
         fresh bytes.
 
+        Also prevents the **foreign-edit clobber** (content-CAS, write surface):
+        on a managed (strict) path, if the file on disk changed out-of-band since
+        this instance last read/wrote it, the write is denied with
+        :class:`~ccs.core.exceptions.StaleView` rather than silently overwriting
+        it. Governed by ``on_stale_write`` (default ``"raise"`` — a write is a
+        data-loss surface, so the safe default GUARDS, the inverse of
+        ``on_stale_read``; ``"allow"`` opts out and restores the prior clobber).
+        Fires adapter-locally, independent of ``on_error``. Recover via
+        :meth:`reacquire`. (Catch as ``ccs.core.exceptions.StaleView``.) A caller
+        that loops ``reacquire`` + ``write`` against a fast out-of-band editor must
+        bound its OWN retries — there is no built-in cap here (unlike
+        :meth:`write_cas`'s ``MAX_CAS_REACQUIRES``).
+
         Does NOT prevent concurrent racing writers (this is
         single-writer-by-invalidation, not a mutex) nor a caller that ignores
         :meth:`reacquire`'s fresh bytes. ``on_error`` governs only
@@ -603,11 +616,9 @@ class CoherentVolume:
             # construction). Degrade mode: best-effort write, no coordinator
             # enforcement — but the SB-23 content-CAS is adapter-local, so it still
             # fires (gated by on_stale_write, independent of on_error).
-            self._check_foreign_edit(rel, abs_path)
+            self._check_foreign_edit(rel, self._disk_hash(abs_path))
             self._atomic_write(abs_path, data)
-            written = self._sha256_bytes(data)
-            self._last_committed_hash[rel] = written
-            self._last_observed_hash[rel] = written  # SB-23: own write advances baseline
+            self._record_own_write(rel, self._sha256_bytes(data))
             return
 
         # pre-edit: acquire EXCLUSIVE, or be denied because we are INVALID.
@@ -622,11 +633,12 @@ class CoherentVolume:
         # file) would otherwise orphan the grant until the crash-recovery sweep.
         try:
             new_hash = self._sha256_bytes(data)
-            # SB-23 content-CAS: re-hash disk under the held grant and deny a write
+            # SB-23 content-CAS: re-hash disk ONCE under the held grant, deny a write
             # whose target diverged on disk since this instance last observed it (a
-            # foreign edit). Returns the disk hash so the no-op-skip below reuses it
-            # (one disk read, hoisted out of the former short-circuit).
-            disk_hash = self._check_foreign_edit(rel, abs_path)
+            # foreign edit), then reuse the same disk hash for the no-op-skip below
+            # (hoisted out of the former short-circuit — one disk read, not two).
+            disk_hash = self._disk_hash(abs_path)
+            self._check_foreign_edit(rel, disk_hash)
             # No-op skip: skip the os.replace (and its fsync) only when the file
             # ALREADY holds these bytes. _last_committed_hash is a cheap fast-path
             # gate; the CURRENT on-disk hash is the authority (see _disk_hash).
@@ -636,9 +648,12 @@ class CoherentVolume:
             )
             if not already_on_disk:
                 self._atomic_write(abs_path, data)
-            # SB-23 (R5): advance the observed baseline as soon as the bytes are on
-            # disk — BEFORE the post-edit POST — so a post-edit preempt cannot leave
-            # a stale baseline that self-false-denies this instance's next write.
+            # SB-23: advance the observed baseline as soon as the bytes are on disk
+            # — BEFORE the post-edit POST — so a post-edit preempt cannot leave a
+            # stale baseline that self-false-denies this instance's next write. This
+            # is DELIBERATELY split from the _last_committed_hash advance below (after
+            # the post-edit POST); the other own-write sites advance both caches
+            # together, so do not "fix" this into a pair — the ordering is load-bearing.
             self._last_observed_hash[rel] = new_hash
         except Exception:
             # Release the grant so it is not orphaned until the sweep, then
@@ -720,7 +735,14 @@ class CoherentVolume:
         with self._lock:
             self._session_id = str(uuid.uuid4())  # fresh identity -> no INVALID
             self._last_committed_hash.clear()  # the new identity has committed nothing
-            self._last_observed_hash.clear()  # SB-23: baselines belong to the old identity
+            # SB-23: do NOT clear _last_observed_hash here. The observed-disk
+            # baselines are DISK-scoped (what disk looked like when this instance
+            # last read/wrote a path), not identity-scoped — a re-mint changes the
+            # coordinator identity but not the disk. Clearing them would blind the
+            # foreign-edit guard on every OTHER path after a write_cas conflict
+            # remint (the CAS path is re-seeded by the loop's next _read_with_version
+            # anyway). _after_fork still clears them — a forked child is a new
+            # process that must re-establish its own view.
 
     def write_cas(
         self,
@@ -807,9 +829,7 @@ class CoherentVolume:
             current = self._current_bytes_or_empty(_abs_path)
             data = bytes(make_content(current))
             self._atomic_write(_abs_path, data)
-            written = self._sha256_bytes(data)
-            self._last_committed_hash[rel] = written
-            self._last_observed_hash[rel] = written  # SB-23: own write advances baseline
+            self._record_own_write(rel, self._sha256_bytes(data))
             return
 
         last_current_version = -1
@@ -898,9 +918,15 @@ class CoherentVolume:
 
             outcome = self._classify_cas_response(resp)
             if outcome == "win":
+                # SB-23 scope (v1): write_cas is VERSION-CAS, not content-CAS, and
+                # does NOT raise StaleView. It is not unguarded, though: on a strict
+                # path the read-side hash deny makes the comparand read
+                # (_read_with_version) fail closed on a foreign edit, so write_cas
+                # WEDGES (ViewWedged) rather than clobbering. SB-23's content-CAS
+                # guards only plain write(). _record_own_write still advances the
+                # observed baseline so a LATER plain write() on this path is consistent.
                 self._atomic_write(_abs_path, data)  # confirmed → persist
-                self._last_committed_hash[rel] = new_hash
-                self._last_observed_hash[rel] = new_hash  # SB-23: own write advances baseline
+                self._record_own_write(rel, new_hash)
                 return
             if outcome == "conflict":
                 last_current_version = self._cas_current_version(resp, last_current_version)
@@ -1011,8 +1037,7 @@ class CoherentVolume:
         outcome = self._classify_cas_response(resp)
         if outcome == "win":
             self._atomic_write(abs_path, new_content)  # confirmed → persist
-            self._last_committed_hash[rel] = new_hash
-            self._last_observed_hash[rel] = new_hash  # SB-23: own write advances baseline
+            self._record_own_write(rel, new_hash)
             return
         if outcome == "conflict":
             # A peer won the version between our read and the CAS → typed conflict.
@@ -1082,42 +1107,40 @@ class CoherentVolume:
         except OSError:
             return None
 
-    def _check_foreign_edit(self, rel: str, abs_path: Path) -> str | None:
-        """SB-23 content-CAS. Hash the current on-disk file; if the disk diverged
-        from the baseline this instance last observed for ``rel`` (a foreign /
-        out-of-band edit), raise :class:`StaleView` under ``on_stale_write="raise"``
+    def _check_foreign_edit(self, rel: str, disk_hash: str | None) -> None:
+        """SB-23 content-CAS predicate. Given the CURRENT on-disk hash for ``rel``,
+        raise :class:`StaleView` under ``on_stale_write="raise"`` if the disk diverged
+        from the baseline this instance last observed (a foreign / out-of-band edit),
         so the caller :meth:`reacquire`s instead of clobbering the foreign bytes.
-        ``on_stale_write="allow"`` falls through (proceed and clobber — pre-SB-23
-        behavior).
+        ``on_stale_write="allow"`` is a no-op (proceed and clobber — pre-SB-23
+        behavior). A missing baseline (never-read path) or an absent file
+        (``disk_hash is None`` — a foreign delete) also no-ops.
 
         Gated on a **managed (strict) path** — ``rel`` matched against this volume's
         managed globs. The check is only sound there: on a strict path a peer commit
         would have DENIED at pre-edit, so reaching this check means no peer commit
         landed and a disk mismatch is genuinely foreign. On a path this volume does
         NOT manage (untracked, or tracked-but-non-strict) pre-edit re-grants over a
-        peer write, so a disk mismatch could be that coordinated change — not
-        foreign — and must NOT be denied (the no-op-skip handles it). A missing
-        baseline (never-read path) or an absent file (foreign delete) also skips.
-
-        Returns the disk hash (or ``None`` if absent) so the caller reuses it for
-        the write no-op-skip without a second disk read — returned regardless of the
-        gate, since the no-op-skip needs it on non-strict volumes too."""
-        disk_hash = self._disk_hash(abs_path)
+        peer write, so a disk mismatch could be that coordinated change — not foreign
+        — and must NOT be denied (the no-op-skip handles it). The caller fetches
+        ``disk_hash`` once via :meth:`_disk_hash` and reuses it for the no-op-skip."""
         baseline = self._last_observed_hash.get(rel)
-        if (
-            # Only for a path THIS volume manages (strict). Matching `rel` against
-            # the managed globs with the coordinator's own matcher keeps SB-23's
-            # scope identical to is_strict_mode — a volume that manages other globs
-            # but writes an unmanaged path does NOT fire (the unmanaged path is not
-            # strict, so a coordinated change there would not have denied either).
-            _matches_any(rel, self._managed)
-            and baseline is not None
-            and disk_hash is not None
-            and disk_hash != baseline
-            and self._on_stale_write == "raise"
-        ):
-            raise StaleView(_SB23_STALE_WRITE_REASON)
-        return disk_hash
+        diverged = (
+            baseline is not None and disk_hash is not None and disk_hash != baseline
+        )
+        # matches_any (the glob scan) is evaluated last — the cheap checks short-circuit.
+        if diverged and self._on_stale_write == "raise" and matches_any(rel, self._managed):
+            raise StaleView(_STALE_WRITE_DENY_REASON)
+
+    def _record_own_write(self, rel: str, content_hash: str) -> None:
+        """This instance just put ``content_hash`` bytes on disk for ``rel`` — advance
+        BOTH per-path caches together: ``_last_committed_hash`` (the no-op-skip
+        fast-path gate) and ``_last_observed_hash`` (the SB-23 foreign-edit baseline).
+        Use at the own-write sites where the two advance in lockstep. The main
+        :meth:`write` path advances them SEPARATELY (observed before the post-edit
+        POST, committed after — see :meth:`_write_impl`), so it does NOT use this."""
+        self._last_committed_hash[rel] = content_hash
+        self._last_observed_hash[rel] = content_hash
 
     def _atomic_write(self, abs_path: Path, data: bytes) -> None:
         """Durable, atomic replace via raw ``os.write`` + ``os.replace`` (NOT
@@ -1489,7 +1512,7 @@ def _managed_rel(volume: CoherentVolume, file: object) -> str | None:
         return None
     # Use the coordinator's own glob matcher so the shim's notion of "managed" is
     # exactly the coordinator's tracked set (handles ``**`` segment globs).
-    return rel if _matches_any(rel, volume._managed) else None
+    return rel if matches_any(rel, volume._managed) else None
 
 
 def _make_open_wrapper(volume: CoherentVolume, original_open: Callable) -> Callable:

--- a/src/ccs/mcp/server.py
+++ b/src/ccs/mcp/server.py
@@ -49,9 +49,10 @@ when two or more agents share a mutable file. It enforces VERSION LINEAGE via a
 local coherence coordinator; it does NOT merge content for you.
 
 Two guarantees, both single-host and fail-closed:
-  1. Sequential stale-overwrite — if a peer committed a newer version, swg_write
-     is DENIED (reason=stale_view). Recover with swg_reacquire, then write FROM
-     the fresh bytes it returns.
+  1. Sequential stale-overwrite — swg_write is DENIED (reason=stale_view) if the
+     file changed since you read it: either a peer committed a newer version OR it
+     was edited out-of-band (an editor, another tool, a shell script). Recover with
+     swg_reacquire, then write FROM the fresh bytes it returns.
   2. Concurrent same-key lost-update — swg_write_cas(path, expected_version,
      new_content) rejects a stale compare-and-set as a TYPED CONFLICT (not an
      auto-merge): you read, merge, and retry; the server never merges for you.
@@ -87,10 +88,10 @@ _READ_DESC = (
 )
 _WRITE_DESC = (
     "Write a workspace text file (acquire -> write -> commit). DENIED with "
-    "reason=stale_view if a peer committed a newer version: recover with "
-    "swg_reacquire, then write FROM its bytes. A mid-write preempt returns "
-    "reason=commit_preempted (disk may hold un-versioned bytes; "
-    "reacquire_and_reconcile)." + _SCOPE_CLAUSE
+    "reason=stale_view if the file changed since you read it — a peer commit OR an "
+    "out-of-band edit (another tool/editor): recover with swg_reacquire, then write "
+    "FROM its bytes. A mid-write preempt returns reason=commit_preempted (disk may "
+    "hold un-versioned bytes; reacquire_and_reconcile)." + _SCOPE_CLAUSE
 )
 _REACQUIRE_DESC = (
     "Recover from a stale_view deny: re-mint identity and return the CURRENT "

--- a/src/ccs/mcp/session.py
+++ b/src/ccs/mcp/session.py
@@ -55,11 +55,16 @@ def build_volume(config: SessionConfig) -> CoherentVolume:
     Construction self-spawns/attaches the coordinator and RAISES (fail-closed) if
     it cannot attach or enable strict — the server then refuses to start.
     ``idle_shutdown_sec=0`` keeps the coordinator alive for the server's lifetime.
+    ``on_stale_write='raise'`` (SB-23) is the write-surface complement to strict
+    mode: a ``swg_write`` that would clobber a foreign / out-of-band edit is denied
+    rather than silently overwriting it. It is the constructor default; set
+    explicitly here to match the strict-only honesty floor.
     """
     volume = CoherentVolume(
         config.root,
         managed=config.managed,
         on_error="strict",
+        on_stale_write="raise",
         config=LifecycleConfig(idle_shutdown_sec=0),
     )
     # Strict construction guarantees attachment (else it raised); assert loudly so

--- a/src/ccs/mcp/status.py
+++ b/src/ccs/mcp/status.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ccs.adapters.claude_code.policy import _matches_any
+from ccs.adapters.claude_code.policy import matches_any
 
 if TYPE_CHECKING:
     from ccs.adapters.coherent_volume import CoherentVolume
@@ -72,7 +72,7 @@ def _per_path(config: SessionConfig, status_doc: dict | None) -> dict:
         path = artifact.get("path")
         if not isinstance(path, str):
             continue
-        enforced = _matches_any(path, config.managed)
+        enforced = matches_any(path, config.managed)
         per_path[path] = {
             "version": artifact.get("version"),
             "status": "enforced" if enforced else "not_registered",

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -1634,3 +1634,22 @@ def test_install_forwards_on_stale_write(
     finally:
         uninstall()
         stop_coordinator(tmp_path)
+
+
+def test_write_unmanaged_path_in_managed_volume_proceeds(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """SB-23 fires only for a path THIS volume manages. A volume managing other/**
+    that reads+writes data/... (unmanaged here) does NOT deny a divergent disk —
+    that path is not strict, so a coordinated change there is not necessarily a
+    foreign edit (the bool(managed) gate would wrongly fire; the per-path match
+    must not)."""
+    target = _seed_file(tmp_path, rel="data/x.txt", content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("other/**",), config=fast_cfg)
+    try:
+        vol.read("data/x.txt")                   # seeds a baseline, but data/** is unmanaged
+        target.write_bytes(b"v2")                # divergent disk on an unmanaged path
+        vol.write("data/x.txt", b"v3")           # SB-23 does NOT fire -> proceeds
+        assert target.read_bytes() == b"v3"
+    finally:
+        stop_coordinator(tmp_path)

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -1478,3 +1478,159 @@ def test_on_stale_read_raise_independent_of_on_error_degrade(
             vol.read("data/x.txt")
     finally:
         stop_coordinator(tmp_path)
+
+
+# ----------------------------------------------------------------------
+# SB-23 pre-write content-CAS (on_stale_write): deny a write that would
+# clobber a foreign / out-of-band edit since the last read/write.
+# ----------------------------------------------------------------------
+
+
+def test_on_stale_write_invalid_value_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        CoherentVolume(tmp_path, managed=("data/**",), on_stale_write="bogus")
+
+
+def test_write_denies_foreign_edit_by_default(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """Default on_stale_write='raise': a write whose target was edited out-of-band
+    since the last read is denied (StaleView) and does NOT clobber the foreign bytes."""
+    target = _seed_file(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        assert vol.read("data/x.txt") == b"v1"   # seeds baseline = hash(v1)
+        target.write_bytes(b"v2")                # FOREIGN edit (not via the volume)
+        with pytest.raises(StaleView):
+            vol.write("data/x.txt", b"v3")
+        assert target.read_bytes() == b"v2"      # foreign edit NOT clobbered
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_guard_seeded_by_read_only(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """The read seeds the baseline even with no prior write — a first-read-then-write
+    still guards (confirms read-seeding, not write, drives the guard)."""
+    target = _seed_file(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.read("data/x.txt")                   # first access, never written
+        target.write_bytes(b"foreign")
+        with pytest.raises(StaleView):
+            vol.write("data/x.txt", b"mine")
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_succeeds_when_disk_unchanged_and_advances_baseline(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """No foreign edit: the write proceeds; the own write advances the baseline so a
+    second consecutive write does not false-deny."""
+    _seed_file(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.read("data/x.txt")
+        vol.write("data/x.txt", b"v2")           # disk matches baseline -> proceeds
+        assert (tmp_path / "data/x.txt").read_bytes() == b"v2"
+        vol.write("data/x.txt", b"v3")           # own write advanced baseline -> no false deny
+        assert (tmp_path / "data/x.txt").read_bytes() == b"v3"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_reacquire_after_sb23_deny_then_write_succeeds(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """After a foreign-edit deny, reacquire() re-seeds the baseline so the rebuilt
+    write succeeds (no false deny after recovery)."""
+    target = _seed_file(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.read("data/x.txt")
+        target.write_bytes(b"v2")
+        with pytest.raises(StaleView):
+            vol.write("data/x.txt", b"clobber")
+        assert vol.reacquire("data/x.txt") == b"v2"   # re-seeds baseline = hash(v2)
+        vol.write("data/x.txt", b"v3-from-v2")        # rebuilt from fresh -> succeeds
+        assert target.read_bytes() == b"v3-from-v2"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_on_stale_write_allow_proceeds_and_clobbers(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """on_stale_write='allow' restores pre-SB-23 behavior: the foreign edit is not
+    raised; the write proceeds and clobbers."""
+    target = _seed_file(tmp_path, content=b"v1")
+    vol = CoherentVolume(
+        tmp_path, managed=("data/**",), on_stale_write="allow", config=fast_cfg
+    )
+    try:
+        vol.read("data/x.txt")
+        target.write_bytes(b"v2")
+        vol.write("data/x.txt", b"v3")           # no raise; clobbers v2
+        assert target.read_bytes() == b"v3"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_after_foreign_delete_proceeds(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """Foreign delete: the re-hash returns None (absent file) -> no-baseline skip; the
+    write proceeds as a normal create (R6)."""
+    target = _seed_file(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.read("data/x.txt")
+        target.unlink()                          # FOREIGN delete
+        vol.write("data/x.txt", b"recreated")    # None disk hash -> no deny
+        assert target.read_bytes() == b"recreated"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_post_edit_preempt_still_advances_observed_baseline(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch
+) -> None:
+    """R5: if the atomic write lands but the post-edit POST then preempts, the
+    observed baseline must STILL be advanced (the bytes are on disk) so the instance
+    does not self-false-deny on a later write."""
+    from ccs.core.exceptions import CommitPreempted
+
+    _seed_file(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.read("data/x.txt")
+        orig_check = vol._check_grant
+
+        def fake_check_grant(resp, rel, *, phase):
+            if phase == "post-edit":
+                raise CommitPreempted("simulated preempt")
+            return orig_check(resp, rel, phase=phase)
+
+        monkeypatch.setattr(vol, "_check_grant", fake_check_grant)
+        with pytest.raises(CoherenceError):
+            vol.write("data/x.txt", b"v2")
+        # Bytes landed AND the observed baseline advanced to hash(v2).
+        assert (tmp_path / "data/x.txt").read_bytes() == b"v2"
+        assert vol._last_observed_hash["data/x.txt"] == vol._sha256_bytes(b"v2")
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_install_forwards_on_stale_write(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """install()/coherent_workspace() forward on_stale_write to the volume."""
+    _seed_file(tmp_path, content=b"v1")
+    vol = install(tmp_path, managed=("data/**",), on_stale_write="allow", config=fast_cfg)
+    try:
+        assert vol._on_stale_write == "allow"
+    finally:
+        uninstall()
+        stop_coordinator(tmp_path)

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -1653,3 +1653,131 @@ def test_write_unmanaged_path_in_managed_volume_proceeds(
         assert target.read_bytes() == b"v3"
     finally:
         stop_coordinator(tmp_path)
+
+
+def test_remint_preserves_other_paths_baseline(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """A re-mint (here via reacquire of a DIFFERENT path) must NOT clear the
+    foreign-edit baseline of OTHER managed paths — observed-disk hashes are
+    disk-scoped, not identity-scoped. Otherwise every write_cas conflict (which
+    re-mints) would blind SB-23 on all other previously-read paths."""
+    a = _seed_file(tmp_path, rel="data/a.txt", content=b"a1")
+    _seed_file(tmp_path, rel="data/b.txt", content=b"b1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.read("data/a.txt")               # seed A's baseline
+        vol.read("data/b.txt")               # seed B's baseline
+        vol.reacquire("data/b.txt")          # re-mints; A's baseline must SURVIVE
+        a.write_bytes(b"foreign-a2")         # foreign edit on A
+        with pytest.raises(StaleView):
+            vol.write("data/a.txt", b"a3")   # A's baseline survived -> deny
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_denies_foreign_edit_independent_of_on_error_degrade(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """SB-23 is adapter-local: the foreign-edit deny fires regardless of on_error
+    (the guard does not need the coordinator). Write-side mirror of
+    test_on_stale_read_raise_independent_of_on_error_degrade."""
+    target = _seed_file(tmp_path, content=b"v1")
+    vol = CoherentVolume(
+        tmp_path, managed=("data/**",), on_error="degrade", config=fast_cfg
+    )
+    try:
+        vol.read("data/x.txt")
+        target.write_bytes(b"v2")
+        with pytest.raises(StaleView):
+            vol.write("data/x.txt", b"v3")
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_after_write_cas_win_no_false_deny(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """A write_cas win advances the observed baseline, so a following plain write on
+    the same path (no foreign edit) does NOT false-deny."""
+    _seed_file(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.write_cas("data/x.txt", lambda cur: cur + b"-cas")  # win -> advances baseline
+        vol.write("data/x.txt", b"plain-after-cas")             # no foreign edit -> succeeds
+        assert (tmp_path / "data/x.txt").read_bytes() == b"plain-after-cas"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_cas_seeds_baseline_then_plain_write_denies_foreign_edit(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """The OCC read path seeds the baseline: after a write_cas win, a foreign edit
+    then a plain write is denied (confirms the OCC-read seeding feeds the guard)."""
+    target = _seed_file(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.write_cas("data/x.txt", lambda cur: b"v2")   # win; baseline=hash(v2), disk=v2
+        target.write_bytes(b"foreign-v3")                # foreign edit
+        with pytest.raises(StaleView):
+            vol.write("data/x.txt", b"v4")
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_managed_path_without_prior_read_proceeds(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """No baseline (a managed path never read through this volume) -> SB-23 skips;
+    the write proceeds (the guard needs a prior observation to compare against)."""
+    _seed_file(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.write("data/x.txt", b"v2")   # never read -> no baseline -> proceeds
+        assert (tmp_path / "data/x.txt").read_bytes() == b"v2"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_stale_write_deny_reason_is_byte_stable(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """The foreign-edit deny raises with the exact static _STALE_WRITE_DENY_REASON
+    constant — no path/hash/timestamp interpolation, so a model's retry loop sees
+    identical text every time (KTD-P). Regression pin against future interpolation."""
+    from ccs.adapters.coherent_volume import _STALE_WRITE_DENY_REASON
+
+    target = _seed_file(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.read("data/x.txt")
+        target.write_bytes(b"v2")
+        with pytest.raises(StaleView) as exc:
+            vol.write("data/x.txt", b"v3")
+        assert str(exc.value) == _STALE_WRITE_DENY_REASON  # static, no interpolation
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_write_cas_on_foreign_edit_wedges_not_stale_view(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """SB-23 scope boundary: write_cas is version-CAS, not content-CAS — it does NOT
+    raise StaleView. But on a strict path it is NOT unguarded: the read-side hash
+    deny makes write_cas's comparand read (_read_with_version) fail closed, so a
+    pre-existing foreign edit WEDGES the CAS (ViewWedged after the reacquire budget)
+    rather than silently clobbering it. Pins both: SB-23's content-CAS guards only
+    the plain write() path, and write_cas still fails closed (no silent loss)."""
+    from ccs.core.exceptions import ViewWedged
+
+    target = _seed_file(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.read("data/x.txt")
+        target.write_bytes(b"foreign-v2")    # foreign edit (coordinator version unchanged)
+        with pytest.raises(ViewWedged):      # fail-closed — NOT StaleView, NOT a clobber
+            vol.write_cas("data/x.txt", lambda cur: cur + b"-cas")
+        assert target.read_bytes() == b"foreign-v2"  # foreign edit intact (not clobbered)
+    finally:
+        stop_coordinator(tmp_path)

--- a/tests/mcp/test_lifecycle.py
+++ b/tests/mcp/test_lifecycle.py
@@ -91,6 +91,8 @@ def test_build_volume_is_strict_only(tmp_path: Path) -> None:
         # The server never constructs a degrade-mode volume (the fail-open hole).
         assert volume._on_error == "strict"
         assert volume.strict_mode_active() is True
+        # The write-surface guard is armed too (foreign-edit clobber -> stale_view).
+        assert volume._on_stale_write == "raise"
     finally:
         stop_coordinator(tmp_path)
 

--- a/tests/mcp/test_write_cas.py
+++ b/tests/mcp/test_write_cas.py
@@ -241,3 +241,26 @@ def test_write_cas_counter_resets_after_a_win(tmp_path: Path, fast_cfg: Lifecycl
         assert conflicts[_PATH] == 1
     finally:
         stop_coordinator(tmp_path)
+
+
+# --- SB-23: foreign-edit-at-write via swg_write -------------------------------
+
+
+def test_swg_write_denies_foreign_edit(tmp_path: Path, fast_cfg: LifecycleConfig) -> None:
+    """SB-23 via swg_write: a plain write that would clobber a foreign / out-of-band
+    edit (no peer commit — the disk changed OUTSIDE the coordinator) is the
+    recoverable ``stale_view`` deny, not a silent overwrite."""
+    target = _seed(tmp_path, b"v1")
+    config = _config(tmp_path)
+    vol = _vol(tmp_path, fast_cfg)
+    try:
+        _do_read(vol, config, _PATH)               # seeds the SB-23 baseline
+        target.write_bytes(b"foreign-v2")          # out-of-band edit (not via the volume)
+        denied = _do_write(vol, config, _PATH, "clobber")
+        assert denied.isError is True
+        sc = denied.structuredContent
+        assert sc["reason"] == "stale_view"
+        assert sc["recover"] == "reacquire"
+        assert target.read_bytes() == b"foreign-v2"  # foreign edit NOT clobbered
+    finally:
+        stop_coordinator(tmp_path)


### PR DESCRIPTION
## Summary

The write-surface complement to the read-time-hash fix (#126). That fix catches a foreign / out-of-band edit when the agent **re-reads**; this catches it when the agent **writes from cached bytes without re-reading** — preventing the silent lost update (clobbering the foreign edit). Honest defense-in-depth for the stale-cache-write window.

Implemented as adapter-local **content-CAS**, the mirror of OCC's version-CAS:

| Mechanism | Write succeeds iff… | Catches |
|---|---|---|
| `commit_cas` (OCC) | coordinator **version** unchanged | peer **commits** |
| **this** | on-disk **content** unchanged since you read it | foreign **edits** that bypass the coordinator |

Single-host, coordinator-free, cooperative.

## How it works

- New per-path `_last_observed_hash` baseline: **seeded on read** (`read()` and the OCC `_read_with_version`), **advanced on every own write** (plain, degrade, `write_cas` wins), **cleared on remint/fork**.
- At `write()`, after the pre-edit grant and before the atomic write, re-hash disk (reusing the no-op-skip's read); if it diverged from the baseline → deny `StaleView` (byte-stable reason) → caller `reacquire()`s and rebuilds from the fresh bytes.
- **Gated on a strict (managed-globs) volume.** Only sound there: on a strict path a peer commit denies at pre-edit, so a mismatch reaching the check is genuinely foreign. A non-strict volume is exempt — a coordinated peer commit can change the disk without an INVALID deny (pinned by a pre-existing no-op-skip regression test).
- `on_stale_write="raise"` (default — guards; a write is a data-loss surface) | `"allow"` (opt-out → pre-existing clobber behavior). Plumbed through `install()` / `coherent_workspace()`. MCP `swg_write` inherits it (typed `stale_view` deny, `recover: reacquire`).

## Scope

In: the plain `CoherentVolume.write()` path + MCP `swg_write`. Out (documented non-goals): the plugin Edit/Write surface (would need a pre-edit protocol change), `write_cas` content-CAS at entry (it advances the baseline but isn't entry-checked), the foreign-delete vs hash-mismatch message distinction, cross-host, and the post-grant→atomic-write TOCTOU (best-effort).

## Test Plan

- [x] CoherentVolume: foreign-edit deny + no-clobber, read-seeded baseline, no-false-deny on consecutive own writes, `reacquire` recovery, `allow` opt-out, foreign-delete skip, post-edit-preempt baseline advance, **non-strict exemption** (pre-existing regression), `install` plumbing, invalid-value rejected
- [x] MCP `swg_write` on a foreign-edited file → typed `stale_view` deny, no clobber
- [x] Regression: `test_coherent_volume` 66 · `tests/mcp` 81 · other CoherentVolume consumers + `protocol_corpus` 32 · ruff clean — no regressions
