### PR TITLE
feat: cross-host coordination (slice-1 deny + slice-2 effect-gate), default-off

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -15,6 +15,15 @@ If you find any outbound traffic from this package in v0, please [open a
 security advisory](https://github.com/hipvlady/agent-coherence/security/advisories)
 — it would be a bug.
 
+**Cross-host mode (default OFF).** Setting `CCS_REMOTE_COORDINATOR=1` and pointing
+a `CoherentVolume` at a remote coordinator (`CCS_REMOTE_HOST` / `CCS_REMOTE_PORT` /
+`CCS_REMOTE_SECRET_FILE`) makes the client open HTTP connections to that
+**user-configured, private-range coordinator endpoint** — never the internet, and
+no telemetry. This is the only network traffic the library generates, it is opt-in,
+and the coordinator only binds beyond loopback to an RFC-1918/4193 address (see the
+cross-host demo, `examples/cross_host/`). With the flag unset the zero-outbound
+posture above is unchanged.
+
 ## Env-var kill switches
 
 Set any of these to a truthy value (`1`, `true`, `yes`) to disable

--- a/examples/cross_host/ADAPTER-CONTRACT.md
+++ b/examples/cross_host/ADAPTER-CONTRACT.md
@@ -1,0 +1,117 @@
+# Substrate-adapter contract (DX-3)
+
+The cross-host demo claims: *"same protocol, two topologies."* This document
+makes that claim **testable** — defines the version-CAS contract any substrate
+adapter must satisfy, lists the shipped implementations, and points at the
+parity test that proves both adapters exhibit the same deny semantics against
+the same scenario.
+
+## Why this exists
+
+Without a written contract, "the protocol is the same, only the substrate
+differs" is an assertion. With this contract + the parity test, it's a *passing
+test* — the version-CAS surface that prevents the silent lost update is shown
+to generalize beyond any single substrate, on the same shipped primitives.
+
+Anchored to the north-star [Slices + the path](../../docs/bizops/north-star-research-agenda.md) §
+DX-3 ("Pluggable artifact substrate — the *same* protocol drives ≥2 adapters")
+and the cross-host pilot one-pager § "Honest scope" NR-2.
+
+## The contract
+
+A *substrate adapter* is any object that exposes:
+
+```python
+class CoherenceAdapter(Protocol):
+    """The version-CAS contract any substrate adapter satisfies."""
+
+    def read_with_version(self, key: str) -> tuple[bytes, int]:
+        """Return ``(data, version)`` for ``key``. Untracked / missing keys
+        return ``(b'', 0)``. The returned version is the decision-time version
+        a subsequent ``write_cas_at`` will CAS against."""
+
+    def write_cas_at(self, key: str, expected_version: int, data: bytes) -> None:
+        """Commit ``data`` for ``key`` iff the current version equals
+        ``expected_version``. On a stale version, raise a typed
+        ``CoherenceError`` (concretely ``CasVersionConflict`` for the shipped
+        adapters) — never silently overwrite."""
+```
+
+The contract is **not** the storage shape (file, KV, blob). It is the
+version-CAS *deny* — `write_cas_at(stale_version, ...)` raises rather than
+overwrites, and `read_with_version` returns the version the caller must use as
+the decision-time anchor.
+
+### Recovery is part of the contract
+
+A `CasVersionConflict` is **recoverable**, not terminal. The caller re-reads
+(getting a fresh version), reconciles its proposed write against the new state,
+and retries. This is the "broken-must-lose AND fixed-must-prevent" half of the
+demo's exit-code contract.
+
+## Shipped implementations
+
+| Adapter | Substrate | Cross-host transport | Where |
+|---|---|---|---|
+| **`CoherentVolume`** | Files on a (local or shared) volume; per-key version held in the coordinator's registry | HTTP via the networked coordinator (`CCS_REMOTE_COORDINATOR=1`) | `src/ccs/adapters/coherent_volume.py` |
+| **`CCSStore`** | LangGraph `BaseStore` (KV) | In-process today; the same version-CAS surface, no transport change required | `src/ccs/adapters/ccsstore.py` |
+
+Both are first-class shipped adapters in the agent-coherence library. The
+cross-host demo exercises the file substrate over the network; the KV substrate
+is exercised by the LangGraph integration tests.
+
+### Why this matters for cross-host
+
+Adapter-substrate independence is **half the cross-host story** (the other half
+is the networked coordinator itself, NR-1). A file-on-volume vendor and a
+KV-store vendor coordinate concurrent writes through the *same* version-CAS
+protocol; the substrate adapter abstracts the bytes, the coordinator owns the
+version. A pilot can pick whichever substrate matches its workload without
+buying into a different coordination model.
+
+## Parity test
+
+[`tests/test_adapter_contract_parity.py`](../../tests/test_adapter_contract_parity.py)
+runs the **same scenario** through:
+
+1. **`CoherentVolume`** against a real loopback coordinator (the shipped file
+   adapter, the same code path the cross-host demo exercises).
+2. **A minimal in-memory KV adapter** that satisfies the Protocol — *not* a
+   shipped product; a reference implementation that proves the contract
+   generalizes to substrates the shipped library does not provide.
+
+The single scenario both adapters run:
+
+```
+A reads K @ version v_a
+B reads K @ version v_a, writes (v_a, "from-b") — version advances to v_a+1
+A writes (v_a, "from-a")                        — STALE, must deny
+A reads K @ version v_a2 (= v_a+1)              — recovery read
+A writes (v_a2, "from-a-2")                     — fresh CAS, must succeed
+```
+
+The test asserts both adapters:
+- raise `CoherenceError` (the version-CAS deny) on A's stale write,
+- successfully recover after A re-reads + retries against the fresh version.
+
+If a future adapter is added, this test grows by one parametrized case — the
+contract stays the same, the parity claim stays testable, and the demo's
+DX-3 ("same protocol, two topologies") stops being asserted and starts being
+proved.
+
+## What this contract is NOT
+
+- **Not a transport spec** — the contract defines the version-CAS *surface*,
+  not how `read`/`write` reach the coordinator (HTTP, in-process, FUSE, MCP all
+  qualify; the cross-host demo's NR-2 names which one is in-scope today).
+- **Not a strict-mode spec** — the version-CAS deny is independent of strict
+  mode's read-fence; both shipped adapters version-CAS write-deny without
+  needing strict-mode enforcement (the cross-host demo runs `tracked != strict`
+  per the README, NR-2).
+- **Not a durability spec** — `synchronous=FULL` durability is a separate
+  axis from version-CAS atomicity. A future adapter that backs onto a durable
+  log adds durability without changing the CAS surface this contract defines.
+- **Not a snapshot/transaction spec** — multi-key consistent reads (SB-17)
+  and atomic multi-key publish (SB-18) are *additional* surfaces on top of
+  this contract, gated behind separate demand signals. The slice-1 +
+  slice-2 demo lives strictly inside this contract.

--- a/examples/cross_host/README.md
+++ b/examples/cross_host/README.md
@@ -49,13 +49,31 @@ python examples/cross_host/main.py
 The client connects (never spawning a local coordinator), runs A/B, and exits
 `0` on a denied-then-recovered stale write.
 
+### Docker (recommended — genuine cross-container, one command, verified)
+
+Two containers on a private-range bridge — **separate network namespaces, real
+RFC-1918 IPs** — with one centralized coordinator. This is the genuine cross-host
+topology (not loopback) and runs anywhere Docker does:
+
+```
+bash examples/cross_host/docker/run.sh
+# or: docker compose -f examples/cross_host/docker/docker-compose.yml \
+#       up --build --abort-on-container-exit --exit-code-from client
+```
+
+The coordinator binds to `172.28.0.2` (RFC-1918, validated) and serves; the client
+connects from a *separate container* with `Host: 172.28.0.2` — exercising the
+validated-bind allowlist branch for real, never spawning a local coordinator. The
+bearer secret + port travel via a shared `.coherence` volume. Exit `0` on a
+denied-then-recovered run. (Verified output: slice-1 deny + recover, slice-2
+fire/hold.)
+
 ### Linux netns variant
 
-The same two roles run in two network namespaces joined by a `veth` pair (the
-coordinator's namespace holds the RFC-1918 address). Requires `CAP_NET_ADMIN`
-(root). A one-command `run_netns.sh` wrapper is a follow-up to add and **verify
-on a Linux host** — it is intentionally omitted here rather than shipped
-unverified (this demo was authored on macOS, where netns does not exist).
+The same two roles also run in two `ip netns` joined by a `veth` pair (requires
+`CAP_NET_ADMIN`). The Docker path above is the maintained one-command runner that
+proves the same boundary with less host-specific setup; the raw-netns wrapper is
+left as a Linux-host exercise.
 
 ## Security boundary (R7)
 

--- a/examples/cross_host/README.md
+++ b/examples/cross_host/README.md
@@ -1,14 +1,21 @@
-# Cross-host coherence demo (slice 1: stale-write deny across a host boundary)
+# Cross-host coherence demo — slice 1 (stale-write deny) + slice 2 (effect-ordering)
 
-Two clients coordinate **one** centralized coordinator over the network. A stale
-write is denied by version-CAS *across the boundary*, and the loser recovers via
-re-read + retry — no silent lost update.
+Two clients coordinate **one** centralized coordinator over the network. **Slice 1
+(artifact-coordination):** a stale write is denied by version-CAS *across the
+boundary*, and the loser recovers via re-read + retry — no silent lost update.
+**Slice 2 (effect-ordering, EO-1..EO-3):** an effect gated on `config@vN` FIRES
+when the config is unchanged and is HELD when the config advanced under the
+agent — never fired on stale input.
 
-**Honest scope (Gate A, demo-grade):**
-- A **single centralized coordinator** — a SPOF, single-region. NOT distributed / replicated / HA.
-- **Coordinator-version-only**: the shared artifact is **tracked** on the coordinator (so it is versioned) but **not strict** — the deny is the OCC version-CAS; no strict read-enforcement needed.
-- **Plaintext bearer over a trusted, encrypted link** (WireGuard, not bare VPC). Production hardening = mTLS + cert rotation, co-developed.
-- All cross-host behavior is gated by `CCS_REMOTE_COORDINATOR`; the default loopback path is unchanged.
+**Honest scope (Gate A, demo-grade) — owned by NR-number so each limit is named, not implied:**
+
+- **NR-1 — Single centralized coordinator.** A SPOF, single-region. NOT distributed / replicated / HA. The HA version is the production rung, co-developed with a pilot — not papered over.
+- **NR-2 — Coordinator-version-only, NOT unmediated shared-FS coherence.** The shared artifact is **tracked** on the coordinator (so it is versioned) but **not strict** — the deny is the OCC version-CAS; no strict read-enforcement is needed. The artifact is coordinated *through* the protocol, NOT by intercepting raw filesystem writes — catching a writer that **bypasses** the coordinator (FUSE / kernel watcher) is out (cooperative trust, not kernel enforcement).
+- **NR-3 — NOT cross-host fencing, partition tolerance, or durability/HA.** `coordinator_epoch` is seeded-but-unused at the network layer; durability beyond sqlite's `synchronous=NORMAL` is a separate `synchronous=FULL` decision; partition behavior is undefined.
+- **NR-4 — Plaintext bearer over a *trusted, encrypted* link** (WireGuard, not bare VPC). Production hardening = mTLS + cert rotation, co-developed. Single-uid cooperative trust; no multi-tenant isolation.
+- **NR-5 — Reduces, doesn't eliminate.** The gate only sees writes that go *through* the coordinator. An un-coordinated open, a write to a path the coordinator doesn't `track`, a value cached in another process, an FS-level edit by a tool not party to the protocol — all invisible. Best-effort point-in-time, not a lock; across hosts, network latency widens the window between version-check and effect.
+
+All cross-host behavior is gated by `CCS_REMOTE_COORDINATOR`; the default loopback path is unchanged.
 
 ## 1. Local smoke (any platform — proves the mechanism, not a host boundary)
 
@@ -17,8 +24,22 @@ python examples/cross_host/main.py
 ```
 
 Spawns a loopback coordinator and runs both clients in one process. Exit `0` iff
-the stale write was denied **and** recovery succeeded. This proves the
-version-CAS deny + recovery; it does **not** cross a real host boundary.
+slice-1's stale write was denied **and** recovery succeeded **and** slice-2's
+effect was held on a stale config. This proves the version-CAS deny + recovery +
+effect-gate; it does **not** cross a real host boundary.
+
+### Negative control — the honest contract (`--baseline`)
+
+```
+python examples/cross_host/main.py --baseline
+```
+
+Runs the **negative control first** — slice-1 silent lost update + slice-2 stale
+effect fire — *then* the with-CCS pass. Exit `0` iff **broken-must-lose AND
+fixed-must-prevent**. This is the screen-share contract: the deny is *measured*
+against its absence, not asserted. The baseline reproduces the classic
+un-coordinated, convention-only lost-update — a concrete failure CCS prevents in
+the with-CCS pass.
 
 ## 2. Cross-host (the real demo — Linux netns or two VMs)
 

--- a/examples/cross_host/README.md
+++ b/examples/cross_host/README.md
@@ -1,0 +1,66 @@
+# Cross-host coherence demo (slice 1: stale-write deny across a host boundary)
+
+Two clients coordinate **one** centralized coordinator over the network. A stale
+write is denied by version-CAS *across the boundary*, and the loser recovers via
+re-read + retry — no silent lost update.
+
+**Honest scope (Gate A, demo-grade):**
+- A **single centralized coordinator** — a SPOF, single-region. NOT distributed / replicated / HA.
+- **Coordinator-version-only**: the shared artifact is **tracked** on the coordinator (so it is versioned) but **not strict** — the deny is the OCC version-CAS; no strict read-enforcement needed.
+- **Plaintext bearer over a trusted, encrypted link** (WireGuard, not bare VPC). Production hardening = mTLS + cert rotation, co-developed.
+- All cross-host behavior is gated by `CCS_REMOTE_COORDINATOR`; the default loopback path is unchanged.
+
+## 1. Local smoke (any platform — proves the mechanism, not a host boundary)
+
+```
+python examples/cross_host/main.py
+```
+
+Spawns a loopback coordinator and runs both clients in one process. Exit `0` iff
+the stale write was denied **and** recovery succeeded. This proves the
+version-CAS deny + recovery; it does **not** cross a real host boundary.
+
+## 2. Cross-host (the real demo — Linux netns or two VMs)
+
+The genuine non-loopback bind (and `verify_host`'s validated-bind branch) runs
+**only** here. Two ingredients:
+
+**Host 1 — the coordinator**, bound to a private-range address and tracking the
+shared key:
+
+```
+# Start a coordinator bound to a private-range interface (RFC-1918).
+CCS_REMOTE_COORDINATOR=1 agent-coherence-coordinator --bind-host 10.0.0.1
+# Track the shared key so it is versioned (tracked != strict):
+agent-coherence-track shared.txt
+# Note the printed port and the secret file: <root>/.coherence/hook.secret
+```
+
+**Host 2 — the demo client**, pointing at host 1 over the encrypted link:
+
+```
+export CCS_REMOTE_COORDINATOR=1
+export CCS_REMOTE_HOST=10.0.0.1
+export CCS_REMOTE_PORT=<port from host 1>
+export CCS_REMOTE_SECRET_FILE=/path/to/mounted/hook.secret   # provisioned out-of-band; never inline
+python examples/cross_host/main.py
+```
+
+The client connects (never spawning a local coordinator), runs A/B, and exits
+`0` on a denied-then-recovered stale write.
+
+### Linux netns variant
+
+The same two roles run in two network namespaces joined by a `veth` pair (the
+coordinator's namespace holds the RFC-1918 address). Requires `CAP_NET_ADMIN`
+(root). A one-command `run_netns.sh` wrapper is a follow-up to add and **verify
+on a Linux host** — it is intentionally omitted here rather than shipped
+unverified (this demo was authored on macOS, where netns does not exist).
+
+## Security boundary (R7)
+
+Before recording/sharing a cross-host run: the relaxed Host-allowlist still 403s
+any non-bind host; `bind_host` is validated to RFC-1918/4193 (wildcard, loopback
+aliases, link-local, CGNAT, public all rejected); the secret is provisioned via
+a confidential channel (not an inline env var — it would leak in `ps`/`docker
+inspect`); the link is encrypted. See the `coherence-security-reviewer` pass.

--- a/examples/cross_host/docker/Dockerfile
+++ b/examples/cross_host/docker/Dockerfile
@@ -1,0 +1,12 @@
+# Cross-host coherence demo image (Gate A). Lightweight: stdlib + pyyaml only.
+FROM python:3.11-slim
+
+RUN pip install --no-cache-dir "pyyaml>=6.0"
+
+COPY src /app/src
+COPY examples /app/examples
+
+ENV PYTHONPATH=/app/src
+# Cross-host mode is opt-in; the demo containers set it here.
+ENV CCS_REMOTE_COORDINATOR=1
+WORKDIR /app

--- a/examples/cross_host/docker/client_entry.py
+++ b/examples/cross_host/docker/client_entry.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Cross-host demo client entrypoint: wait for the coordinator's port (written to
+# the shared .coherence volume), export CCS_REMOTE_PORT, then run the demo.
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from ccs.adapters.claude_code.lifecycle import read_port_from_file
+
+PID_FILE = Path("/coord/.coherence/server.pid")
+
+
+def main() -> int:
+    port = None
+    for _ in range(120):  # up to ~60s for the coordinator to bind + write the port
+        port = read_port_from_file(PID_FILE)
+        if port:
+            break
+        time.sleep(0.5)
+    if not port:
+        print("client_entry: coordinator port never appeared", file=sys.stderr)
+        return 1
+    os.environ["CCS_REMOTE_PORT"] = str(port)
+    return subprocess.call([sys.executable, "/app/examples/cross_host/main.py"])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/cross_host/docker/docker-compose.yml
+++ b/examples/cross_host/docker/docker-compose.yml
@@ -35,6 +35,9 @@ services:
     volumes:
       - coordstate:/coord/.coherence:ro
     environment:
+      # Also set in the image (Dockerfile ENV); declared here so the cross-host
+      # intent is explicit and the demo never silently falls back to loopback.
+      CCS_REMOTE_COORDINATOR: "1"
       CCS_REMOTE_HOST: 172.28.0.2
       CCS_REMOTE_SECRET_FILE: /coord/.coherence/hook.secret
     command:

--- a/examples/cross_host/docker/docker-compose.yml
+++ b/examples/cross_host/docker/docker-compose.yml
@@ -1,0 +1,51 @@
+# Genuine cross-host slice-1/slice-2 demo: two containers (separate network
+# namespaces) on a private-range bridge, one centralized coordinator.
+#   coordinator (172.28.0.2) — binds beyond loopback, serves; the shared .coherence
+#                              volume carries the bearer secret + port to the client.
+#   client                   — connects to 172.28.0.2 (never spawns), runs the demo.
+# Run:  docker compose up --build --abort-on-container-exit --exit-code-from client
+services:
+  coordinator:
+    build:
+      context: ../../..
+      dockerfile: examples/cross_host/docker/Dockerfile
+    networks:
+      cohnet:
+        ipv4_address: 172.28.0.2
+    volumes:
+      - coordstate:/coord/.coherence
+    command:
+      - python
+      - -m
+      - ccs.cli.coherence_coordinator
+      - --_daemonized
+      - --root
+      - /coord
+      - --bind-host
+      - 172.28.0.2
+
+  client:
+    build:
+      context: ../../..
+      dockerfile: examples/cross_host/docker/Dockerfile
+    depends_on:
+      - coordinator
+    networks:
+      - cohnet
+    volumes:
+      - coordstate:/coord/.coherence:ro
+    environment:
+      CCS_REMOTE_HOST: 172.28.0.2
+      CCS_REMOTE_SECRET_FILE: /coord/.coherence/hook.secret
+    command:
+      - python
+      - /app/examples/cross_host/docker/client_entry.py
+
+networks:
+  cohnet:
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16
+
+volumes:
+  coordstate:

--- a/examples/cross_host/docker/run.sh
+++ b/examples/cross_host/docker/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Genuine cross-container slice-1/slice-2 demo: two containers (separate network
+# namespaces) on a private-range bridge, one centralized coordinator. Exits with
+# the client's code (0 = stale write denied then recovered).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+cd "$HERE"
+docker compose up --build --abort-on-container-exit --exit-code-from client
+code=$?
+docker compose down -v >/dev/null 2>&1 || true
+exit "$code"

--- a/examples/cross_host/docker/run.sh
+++ b/examples/cross_host/docker/run.sh
@@ -5,6 +5,9 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 cd "$HERE"
+# Clean slate: drop any coordstate volume left by an interrupted prior run, so
+# the client never reads a stale server.pid / port from a dead coordinator.
+docker compose down -v >/dev/null 2>&1 || true
 docker compose up --build --abort-on-container-exit --exit-code-from client
 code=$?
 docker compose down -v >/dev/null 2>&1 || true

--- a/examples/cross_host/main.py
+++ b/examples/cross_host/main.py
@@ -166,10 +166,24 @@ def main() -> int:
         def make_ep():
             return resolve_remote_endpoint(remote.host, remote.port, remote.secret)
 
-        _track(make_ep())
-        ok = _run_slices(make_ep)
+        try:
+            _track(make_ep())
+            ok = _run_slices(make_ep)
+        except (OSError, CoherenceError) as exc:
+            # Coordinator unreachable / auth failure -> a clean FAIL verdict,
+            # never a raw traceback that reads as a crash rather than a deny.
+            _log(f"Cross-host coordinator unreachable or rejected the client: {exc}")
+            ok = False
     else:
         # Local smoke: spawn a loopback coordinator, run both clients here.
+        # Guard against the silent-loopback footgun: CCS_REMOTE_HOST set but the
+        # gate flag off means we are NOT testing a host boundary — say so loudly.
+        if os.environ.get("CCS_REMOTE_HOST"):
+            _log(
+                "WARNING: CCS_REMOTE_HOST is set but CCS_REMOTE_COORDINATOR is off "
+                "→ running LOCAL loopback smoke, not cross-host. Set "
+                "CCS_REMOTE_COORDINATOR=1 to reach the remote coordinator."
+            )
         os.environ.setdefault("CCS_REMOTE_COORDINATOR", "1")  # remote-mode clients on loopback
         _log("Local smoke (loopback, one process) — proves the mechanism, not a host boundary")
         with tempfile.TemporaryDirectory() as tmp:

--- a/examples/cross_host/main.py
+++ b/examples/cross_host/main.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+"""Slice-1 cross-host coherence demo (Gate A).
+
+Two clients coordinate ONE coordinator over the network: a stale write is denied
+by version-CAS *across the host boundary*, and the loser recovers via re-read +
+retry — no silent lost update.
+
+Topology (honest scope): a SINGLE centralized coordinator (SPOF, single-region);
+NOT distributed/HA. Coordinator-version-only: the shared artifact is TRACKED on
+the coordinator (so it is versioned) but NOT strict — the deny is the OCC
+version-CAS; no strict read-enforcement is needed.
+
+Run modes:
+  - Local (default): with no CCS_REMOTE_HOST set, this spawns a loopback
+    coordinator and runs both clients in one process — the mechanism smoke test,
+    runnable anywhere. Proves the deny + recovery, NOT a real host boundary.
+  - Cross-host: start a coordinator on host 1 bound to a private-range address,
+    track the shared key, then on host 2 set CCS_REMOTE_COORDINATOR=1,
+    CCS_REMOTE_HOST=<host1>, CCS_REMOTE_PORT=<port>, CCS_REMOTE_SECRET_FILE=<path>
+    and run this script. See README.md. The genuine non-loopback bind/Host check
+    runs only here (Linux netns/veth or two VMs).
+
+Exit code: 0 iff the stale write was denied AND recovery succeeded (the honest
+"broken-must-lose AND fixed-must-prevent" contract); 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from ccs.adapters.claude_code.lifecycle import (
+    LifecycleConfig,
+    ensure_coordinator,
+    stop_coordinator,
+)
+from ccs.adapters.coherent_volume import CoherentVolume
+from ccs.cli._coherence_client import (
+    RemoteCoordinatorConfig,
+    resolve_endpoint,
+    resolve_remote_endpoint,
+)
+from ccs.cli._coherence_client import (
+    post as _cc_post,
+)
+from ccs.core.exceptions import CoherenceError
+
+SHARED_KEY = "shared.txt"
+
+
+def _log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def _seed(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / SHARED_KEY).write_text("v0", encoding="utf-8")
+
+
+def _run_demo(make_endpoint) -> bool:
+    """A reads@vN; B commits@vN+1; A's stale write is denied; A recovers.
+
+    ``make_endpoint`` returns a fresh CoordinatorEndpoint per client (each client
+    is an independent writer). Returns True iff denied-then-recovered.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root_a = Path(tmp) / "a"
+        root_b = Path(tmp) / "b"
+        _seed(root_a)
+        _seed(root_b)
+        vol_a = CoherentVolume(
+            root_a, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint()
+        )
+        vol_b = CoherentVolume(
+            root_b, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint()
+        )
+
+        _data_a, v_a = vol_a.read_with_version(SHARED_KEY)
+        _log(f"  A read {SHARED_KEY} @ version {v_a}")
+
+        _data_b, v_b = vol_b.read_with_version(SHARED_KEY)
+        vol_b.write_cas_at(SHARED_KEY, v_b, b"from-b")
+        _log(f"  B committed a new version (was {v_b})")
+
+        try:
+            vol_a.write_cas_at(SHARED_KEY, v_a, b"from-a")
+            _log("  ✗ A's STALE write SUCCEEDED — coherence FAILED (silent lost update)")
+            return False
+        except CoherenceError as exc:
+            _log(f"  ✓ A's stale write DENIED across the boundary: {type(exc).__name__}")
+
+        _data_a2, v_a2 = vol_a.read_with_version(SHARED_KEY)
+        if v_a2 <= v_a:
+            _log("  ✗ recovery read did not advance the version")
+            return False
+        vol_a.write_cas_at(SHARED_KEY, v_a2, b"from-a-2")
+        _log(f"  ✓ A recovered: re-read @ version {v_a2}, retried, committed")
+        return True
+
+
+def _track(endpoint) -> None:
+    """Make the shared key TRACKED on the coordinator (so it is versioned)."""
+    _cc_post(endpoint, "/policy/track", {"paths": [SHARED_KEY]})
+
+
+def main() -> int:
+    remote = RemoteCoordinatorConfig.from_env()
+    if remote.enabled and remote.host:
+        # Cross-host: connect to a coordinator started separately on host 1.
+        if not (remote.port and remote.secret):
+            _log("CCS_REMOTE_HOST set but CCS_REMOTE_PORT / CCS_REMOTE_SECRET_FILE missing")
+            return 1
+        _log(f"Cross-host demo against coordinator at {remote.host}:{remote.port}")
+
+        def make_ep():
+            return resolve_remote_endpoint(remote.host, remote.port, remote.secret)
+
+        _track(make_ep())
+        ok = _run_demo(make_ep)
+    else:
+        # Local smoke: spawn a loopback coordinator, run both clients here.
+        os.environ.setdefault("CCS_REMOTE_COORDINATOR", "1")  # remote-mode clients on loopback
+        _log("Local smoke (loopback, one process) — proves the mechanism, not a host boundary")
+        with tempfile.TemporaryDirectory() as tmp:
+            coord_root = Path(tmp) / "coord"
+            coord_root.mkdir()
+            ensure_coordinator(coord_root, config=LifecycleConfig(idle_shutdown_sec=0))
+            try:
+                ep = resolve_endpoint(coord_root)
+                _track(ep)
+
+                def make_ep():
+                    return resolve_remote_endpoint("127.0.0.1", ep.port, ep.bearer)
+
+                ok = _run_demo(make_ep)
+            finally:
+                stop_coordinator(coord_root)
+
+    _log("RESULT: PASS" if ok else "RESULT: FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/cross_host/main.py
+++ b/examples/cross_host/main.py
@@ -50,6 +50,7 @@ from ccs.cli._coherence_client import (
 from ccs.core.exceptions import CoherenceError
 
 SHARED_KEY = "shared.txt"
+CONFIG_KEY = "config.json"
 
 
 def _log(msg: str) -> None:
@@ -102,9 +103,55 @@ def _run_demo(make_endpoint) -> bool:
         return True
 
 
+def _run_effect_gate(make_endpoint) -> bool:
+    """Slice 2: an effect gated on config@vN FIRES when config is unchanged and
+    is HELD when config advanced under it. Returns True iff both hold."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root_a = Path(tmp) / "a"
+        root_b = Path(tmp) / "b"
+        root_a.mkdir(parents=True, exist_ok=True)
+        root_b.mkdir(parents=True, exist_ok=True)
+        (root_a / CONFIG_KEY).write_text('{"v": 0}', encoding="utf-8")
+        (root_b / CONFIG_KEY).write_text('{"v": 0}', encoding="utf-8")
+        vol_a = CoherentVolume(
+            root_a, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint()
+        )
+        vol_b = CoherentVolume(
+            root_b, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint()
+        )
+        _c, v_decision = vol_a.read_with_version(CONFIG_KEY)
+
+        def fires() -> bool:
+            """The effect fires only if config is still at the decision version."""
+            _cur, current = vol_a.read_with_version(CONFIG_KEY)
+            return current == v_decision
+
+        if not fires():
+            _log("  ✗ effect-gate held even though config was unchanged")
+            return False
+        _log(f"  ✓ config@{v_decision} unchanged → effect would FIRE")
+
+        _cb, v_b = vol_b.read_with_version(CONFIG_KEY)
+        vol_b.write_cas_at(CONFIG_KEY, v_b, b'{"v": 1}')
+        if fires():
+            _log("  ✗ effect-gate FIRED on a stale config — coherence FAILED")
+            return False
+        _log("  ✓ config advanced under A → effect HELD (not fired on stale input)")
+        return True
+
+
 def _track(endpoint) -> None:
-    """Make the shared key TRACKED on the coordinator (so it is versioned)."""
-    _cc_post(endpoint, "/policy/track", {"paths": [SHARED_KEY]})
+    """Track the demo keys on the coordinator (so they are versioned)."""
+    _cc_post(endpoint, "/policy/track", {"paths": [SHARED_KEY, CONFIG_KEY]})
+
+
+def _run_slices(make_endpoint) -> bool:
+    """Run slice 1 (deny + recover) then slice 2 (effect-gate)."""
+    _log("Slice 1 — artifact-coordination (stale write denied across the endpoint):")
+    slice1 = _run_demo(make_endpoint)
+    _log("Slice 2 — effect-ordering (gate an effect on config@vN):")
+    slice2 = _run_effect_gate(make_endpoint)
+    return slice1 and slice2
 
 
 def main() -> int:
@@ -120,7 +167,7 @@ def main() -> int:
             return resolve_remote_endpoint(remote.host, remote.port, remote.secret)
 
         _track(make_ep())
-        ok = _run_demo(make_ep)
+        ok = _run_slices(make_ep)
     else:
         # Local smoke: spawn a loopback coordinator, run both clients here.
         os.environ.setdefault("CCS_REMOTE_COORDINATOR", "1")  # remote-mode clients on loopback
@@ -136,7 +183,7 @@ def main() -> int:
                 def make_ep():
                     return resolve_remote_endpoint("127.0.0.1", ep.port, ep.bearer)
 
-                ok = _run_demo(make_ep)
+                ok = _run_slices(make_ep)
             finally:
                 stop_coordinator(coord_root)
 

--- a/examples/cross_host/main.py
+++ b/examples/cross_host/main.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
-"""Slice-1 cross-host coherence demo (Gate A).
+"""Cross-host coherence demo — slice 1 (artifact-coordination) + slice 2
+(effect-ordering), with an optional negative-control (--baseline) mode.
 
 Two clients coordinate ONE coordinator over the network: a stale write is denied
 by version-CAS *across the host boundary*, and the loser recovers via re-read +
@@ -22,12 +23,24 @@ Run modes:
     and run this script. See README.md. The genuine non-loopback bind/Host check
     runs only here (Linux netns/veth or two VMs).
 
-Exit code: 0 iff the stale write was denied AND recovery succeeded (the honest
-"broken-must-lose AND fixed-must-prevent" contract); 1 otherwise.
+CLI:
+  - python examples/cross_host/main.py
+        Runs the with-CCS demo only (slice 1 deny + recover, slice 2 fire/hold).
+        Exit 0 iff the with-CCS contract holds.
+  - python examples/cross_host/main.py --baseline
+        Runs the negative control FIRST (silent lost update for slice 1, stale
+        effect fire for slice 2 — the failure modes we claim CCS prevents),
+        then the with-CCS demo. Exit 0 iff broken-must-lose AND fixed-must-prevent.
+        This is the honest screen-share contract: the deny is measured against
+        its absence, not asserted.
+
+Exit code: 0 iff the honest contract holds (deny + recover with CCS — and, with
+--baseline, ALSO silent loss + stale fire without CCS); 1 otherwise.
 """
 
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 import tempfile
@@ -57,31 +70,34 @@ def _log(msg: str) -> None:
     print(msg, flush=True)
 
 
-def _seed(root: Path) -> None:
-    root.mkdir(parents=True, exist_ok=True)
-    (root / SHARED_KEY).write_text("v0", encoding="utf-8")
+def _make_vols(tmp: str, make_endpoint, seed_a: bytes | None = None, seed_b: bytes | None = None):
+    """Two CoherentVolumes on separate roots, both attached to the coordinator.
+
+    Same setup for every scene; the baseline-vs-with-CCS contrast is in HOW the
+    clients then use the volume API, not in the volume construction itself.
+    """
+    root_a = Path(tmp) / "a"
+    root_b = Path(tmp) / "b"
+    root_a.mkdir(parents=True, exist_ok=True)
+    root_b.mkdir(parents=True, exist_ok=True)
+    if seed_a is not None:
+        (root_a / SHARED_KEY).write_bytes(seed_a)
+    if seed_b is not None:
+        (root_b / SHARED_KEY).write_bytes(seed_b)
+    vol_a = CoherentVolume(root_a, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint())
+    vol_b = CoherentVolume(root_b, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint())
+    return vol_a, vol_b
 
 
 def _run_demo(make_endpoint) -> bool:
-    """A reads@vN; B commits@vN+1; A's stale write is denied; A recovers.
-
-    ``make_endpoint`` returns a fresh CoordinatorEndpoint per client (each client
-    is an independent writer). Returns True iff denied-then-recovered.
+    """Slice 1 (with CCS): A reads@vN; B commits@vN+1; A's stale write is denied;
+    A recovers. Returns True iff denied-then-recovered.
     """
     with tempfile.TemporaryDirectory() as tmp:
-        root_a = Path(tmp) / "a"
-        root_b = Path(tmp) / "b"
-        _seed(root_a)
-        _seed(root_b)
-        vol_a = CoherentVolume(
-            root_a, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint()
-        )
-        vol_b = CoherentVolume(
-            root_b, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint()
-        )
+        vol_a, vol_b = _make_vols(tmp, make_endpoint, seed_a=b"v0", seed_b=b"v0")
 
         _data_a, v_a = vol_a.read_with_version(SHARED_KEY)
-        _log(f"  A read {SHARED_KEY} @ version {v_a}")
+        _log(f"  A read {SHARED_KEY} @ version {v_a} (decision-time version, tracked)")
 
         _data_b, v_b = vol_b.read_with_version(SHARED_KEY)
         vol_b.write_cas_at(SHARED_KEY, v_b, b"from-b")
@@ -103,9 +119,53 @@ def _run_demo(make_endpoint) -> bool:
         return True
 
 
+def _run_demo_baseline(make_endpoint) -> bool:
+    """Slice 1 (NEGATIVE CONTROL — no version-CAS discipline):
+    A reads@vN but DOES NOT track its decision-time version; B commits@vN+1;
+    A re-reads the current version right before writing and commits against it
+    (the classic convention-only / un-coordinated lost-update bug pattern). B's
+    bytes are silently lost.
+
+    Returns True iff the lost update occurred as expected — i.e., the failure we
+    claim CCS prevents is real and reproducible. This makes the deny in
+    ``_run_demo`` meaningful (measured against its absence, not asserted).
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        vol_a, vol_b = _make_vols(tmp, make_endpoint, seed_a=b"v0", seed_b=b"v0")
+
+        # A reads, planning to use this as the decision-time version — but the
+        # baseline agent has no version-CAS discipline and "forgets" v_a below.
+        _data_a, v_a = vol_a.read_with_version(SHARED_KEY)
+        _log(f"  A read {SHARED_KEY} @ version {v_a} (no decision-time discipline)")
+
+        _data_b, v_b = vol_b.read_with_version(SHARED_KEY)
+        vol_b.write_cas_at(SHARED_KEY, v_b, b"from-b")
+        _log(f"  B committed 'from-b' @ v{v_b + 1}")
+
+        # The baseline pattern: A re-reads the latest version right before
+        # writing — there is no check that the artifact moved under it.
+        _, v_a_latest = vol_a.read_with_version(SHARED_KEY)
+        vol_a.write_cas_at(SHARED_KEY, v_a_latest, b"from-a")
+        _log(f"  ✗ A's write SUCCEEDED against v{v_a_latest} — no deny (no decision-time check)")
+
+        data_now, v_now = vol_a.read_with_version(SHARED_KEY)
+        if data_now == b"from-b":
+            _log(f"  ✗ unexpected: B's bytes survived at v{v_now} — baseline did not lose")
+            return False
+        _log(f"  ✓ baseline confirmed: canonical now has {data_now!r} @ v{v_now}; B's 'from-b' is LOST")
+        return True
+
+
 def _run_effect_gate(make_endpoint) -> bool:
-    """Slice 2: an effect gated on config@vN FIRES when config is unchanged and
-    is HELD when config advanced under it. Returns True iff both hold."""
+    """Slice 2 (with CCS): an effect gated on config@vN FIRES when config is
+    unchanged and is HELD when config advanced under it. Returns True iff both
+    hold.
+
+    Maps to north-star Epic — Effect-Ordering primitives (all shipped):
+      EO-1 ``read_at_version``      — read the gating artifact's version
+      EO-2 version-gated effect     — gate the effect on the decision-time version
+      EO-3 Deny → HOLD              — stale gate holds the effect; no fire on stale input
+    """
     with tempfile.TemporaryDirectory() as tmp:
         root_a = Path(tmp) / "a"
         root_b = Path(tmp) / "b"
@@ -113,13 +173,10 @@ def _run_effect_gate(make_endpoint) -> bool:
         root_b.mkdir(parents=True, exist_ok=True)
         (root_a / CONFIG_KEY).write_text('{"v": 0}', encoding="utf-8")
         (root_b / CONFIG_KEY).write_text('{"v": 0}', encoding="utf-8")
-        vol_a = CoherentVolume(
-            root_a, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint()
-        )
-        vol_b = CoherentVolume(
-            root_b, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint()
-        )
+        vol_a = CoherentVolume(root_a, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint())
+        vol_b = CoherentVolume(root_b, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint())
         _c, v_decision = vol_a.read_with_version(CONFIG_KEY)
+        _log(f"  EO-1 ‹read_at_version›: A read {CONFIG_KEY} @ v{v_decision}")
 
         def fires() -> bool:
             """The effect fires only if config is still at the decision version."""
@@ -129,14 +186,56 @@ def _run_effect_gate(make_endpoint) -> bool:
         if not fires():
             _log("  ✗ effect-gate held even though config was unchanged")
             return False
-        _log(f"  ✓ config@{v_decision} unchanged → effect would FIRE")
+        _log(f"  EO-2 ‹version-gated effect›: config unchanged @ v{v_decision} → effect would FIRE")
 
         _cb, v_b = vol_b.read_with_version(CONFIG_KEY)
         vol_b.write_cas_at(CONFIG_KEY, v_b, b'{"v": 1}')
+        _log(f"  (B advanced config beyond v{v_decision})")
         if fires():
             _log("  ✗ effect-gate FIRED on a stale config — coherence FAILED")
             return False
-        _log("  ✓ config advanced under A → effect HELD (not fired on stale input)")
+        _log("  ✓ EO-3 ‹HOLD›: config advanced under A → effect HELD (not fired on stale input)")
+        return True
+
+
+def _run_effect_gate_baseline(make_endpoint) -> bool:
+    """Slice 2 (NEGATIVE CONTROL — no effect-gate):
+    A "fires" the effect against the latest config without gating on its
+    decision-time version. The effect fires on stale config — a silent stale
+    execution (the CI failure pattern where a build runs against a config that
+    was edited while the runner was deciding).
+
+    Returns True iff the stale fire occurred as expected — codifying the failure
+    that EO-1..EO-3 prevent.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root_a = Path(tmp) / "a"
+        root_b = Path(tmp) / "b"
+        root_a.mkdir(parents=True, exist_ok=True)
+        root_b.mkdir(parents=True, exist_ok=True)
+        (root_a / CONFIG_KEY).write_text('{"v": 0}', encoding="utf-8")
+        (root_b / CONFIG_KEY).write_text('{"v": 0}', encoding="utf-8")
+        vol_a = CoherentVolume(root_a, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint())
+        vol_b = CoherentVolume(root_b, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint())
+
+        _c, v_decision = vol_a.read_with_version(CONFIG_KEY)
+        _log(f"  A read {CONFIG_KEY} @ v{v_decision} (no gate to enforce)")
+
+        _cb, v_b = vol_b.read_with_version(CONFIG_KEY)
+        vol_b.write_cas_at(CONFIG_KEY, v_b, b'{"v": 1}')
+        _log(f"  B advanced config to v{v_b + 1}")
+
+        # The baseline pattern: A fires the effect ungated. There is no
+        # version-CAS check before the effect runs.
+        _, v_a_when_firing = vol_a.read_with_version(CONFIG_KEY)
+        if v_a_when_firing == v_decision:
+            _log("  ✗ unexpected: config did not advance — baseline did not exercise stale fire")
+            return False
+        # "fired" — in a real CI step this would be the deploy/build invocation.
+        _log(
+            f"  ✗ effect FIRED on stale config (decided @ v{v_decision}, current is "
+            f"v{v_a_when_firing}) — baseline confirmed"
+        )
         return True
 
 
@@ -145,16 +244,57 @@ def _track(endpoint) -> None:
     _cc_post(endpoint, "/policy/track", {"paths": [SHARED_KEY, CONFIG_KEY]})
 
 
-def _run_slices(make_endpoint) -> bool:
-    """Run slice 1 (deny + recover) then slice 2 (effect-gate)."""
+def _run_slices(make_endpoint, *, baseline: bool) -> bool:
+    """Run the slices end-to-end.
+
+    Default (baseline=False): with-CCS only — slice 1 deny+recover, slice 2 EO
+    fire/HOLD. Exit 0 iff both with-CCS contracts hold.
+
+    --baseline (baseline=True): negative control FIRST — slice 1 silent loss,
+    slice 2 stale fire (the failures we claim CCS prevents); then the with-CCS
+    pass. Exit 0 iff broken-must-lose AND fixed-must-prevent — the screen-share
+    contract that makes the deny meaningful, not asserted.
+    """
+    if baseline:
+        _log("=== Negative control — agents WITHOUT version-CAS discipline ===")
+        _log("Slice 1 baseline — un-coordinated write (the silent lost update we prevent):")
+        b1 = _run_demo_baseline(make_endpoint)
+        _log("Slice 2 baseline — un-gated effect (the stale fire EO-1..EO-3 prevents):")
+        b2 = _run_effect_gate_baseline(make_endpoint)
+        if not (b1 and b2):
+            _log("  ✗ baseline did not reproduce the failure — the negative control is broken")
+            return False
+        _log("")
+
+    _log("=== With CCS — version-CAS spine + effect-ordering ===")
     _log("Slice 1 — artifact-coordination (stale write denied across the endpoint):")
     slice1 = _run_demo(make_endpoint)
-    _log("Slice 2 — effect-ordering (gate an effect on config@vN):")
+    _log("Slice 2 — effect-ordering (EO-1..EO-3: gate effect on config@vN):")
     slice2 = _run_effect_gate(make_endpoint)
     return slice1 and slice2
 
 
-def main() -> int:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="examples/cross_host/main.py",
+        description=("Cross-host coherence demo — slice 1 + slice 2, with optional negative-control mode."),
+    )
+    parser.add_argument(
+        "--baseline",
+        action="store_true",
+        help=(
+            "Run the negative control FIRST (silent lost update + stale fire), "
+            "then the with-CCS demo. Exit 0 iff broken-must-lose AND "
+            "fixed-must-prevent — the honest screen-share contract."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    baseline = args.baseline
+
     remote = RemoteCoordinatorConfig.from_env()
     if remote.enabled and remote.host:
         # Cross-host: connect to a coordinator started separately on host 1.
@@ -168,7 +308,7 @@ def main() -> int:
 
         try:
             _track(make_ep())
-            ok = _run_slices(make_ep)
+            ok = _run_slices(make_ep, baseline=baseline)
         except (OSError, CoherenceError) as exc:
             # Coordinator unreachable / auth failure -> a clean FAIL verdict,
             # never a raw traceback that reads as a crash rather than a deny.
@@ -197,7 +337,7 @@ def main() -> int:
                 def make_ep():
                     return resolve_remote_endpoint("127.0.0.1", ep.port, ep.bearer)
 
-                ok = _run_slices(make_ep)
+                ok = _run_slices(make_ep, baseline=baseline)
             finally:
                 stop_coordinator(coord_root)
 

--- a/src/ccs/adapters/claude_code/auth.py
+++ b/src/ccs/adapters/claude_code/auth.py
@@ -247,6 +247,28 @@ def verify_bearer(authorization_header: str | None, expected_secret: str) -> boo
     return hmac.compare_digest(presented, expected_secret)
 
 
+def _host_from_header(host_header: str) -> str:
+    """Extract the host from a Host header, stripping any ``:port`` suffix.
+
+    Handles bracketed IPv6 literals (``[fc00::1]:8080`` → ``fc00::1``) as well as
+    IPv4/hostname forms (``127.0.0.1:54321`` → ``127.0.0.1``). Returns the raw
+    header unchanged when it is malformed — no closing ``]``, or junk between
+    ``]`` and the ``:port`` — so it matches no allowlist entry and verify_host
+    fails closed. Deliberately does NOT trim whitespace/control characters: a real
+    Host header arrives already-clean from http.server, and tolerating padding
+    here would admit values like ``localhost\\r`` that the exact check must reject.
+    """
+    if host_header.startswith("["):
+        end = host_header.find("]")
+        if end == -1:
+            return host_header  # no closing bracket -> malformed -> fail closed
+        rest = host_header[end + 1 :]
+        if rest and not rest.startswith(":"):
+            return host_header  # junk after "]" before the port -> fail closed
+        return host_header[1:end]
+    return host_header.split(":", 1)[0]
+
+
 def verify_host(host_header: str | None, allowlist: frozenset[str] = _HOST_ALLOWLIST) -> bool:
     """Reject Host headers not in ``allowlist`` (default: localhost/127.0.0.1).
 
@@ -254,10 +276,29 @@ def verify_host(host_header: str | None, allowlist: frozenset[str] = _HOST_ALLOW
     attacker.com → 127.0.0.1, browser sends ``Host: attacker.com``, server
     must reject. The cross-host coordinator passes a wider allowlist
     ({loopback, validated bind_host}); every other host still 403s. Allows the
-    allowlisted names with or without a port suffix.
+    allowlisted names with or without a port suffix, including bracketed IPv6.
     """
     if not host_header:
         return False
-    # Strip port suffix if present (e.g., "127.0.0.1:54321")
-    hostname = host_header.split(":", 1)[0]
-    return hostname in allowlist
+    hostname = _host_from_header(host_header)
+    if hostname in allowlist:
+        return True
+    # IP literals: match on the normalized address so equivalent spellings
+    # (e.g. fc00::1 vs fc00:0:0:0:0:0:0:1) resolve to the same allowlist entry.
+    # Non-IP names (localhost, attacker.com) only match via the exact check
+    # above — this never widens admission to a host not already in the allowlist.
+    try:
+        candidate = ipaddress.ip_address(hostname)
+    except ValueError:
+        return False
+    # IPv4-mapped IPv6 (::ffff:127.0.0.1) and scope-id forms are rejected here
+    # by construction: ipaddress compares unequal across IPv4Address/IPv6Address
+    # and across differing scope ids. Do NOT add an .ipv4_mapped unwrap — that
+    # would let a mapped Host alias an allowlisted IPv4 entry.
+    for entry in allowlist:
+        try:
+            if ipaddress.ip_address(entry) == candidate:
+                return True
+        except ValueError:
+            continue
+    return False

--- a/src/ccs/adapters/claude_code/auth.py
+++ b/src/ccs/adapters/claude_code/auth.py
@@ -28,6 +28,7 @@ Threat model:
 from __future__ import annotations
 
 import hmac
+import ipaddress
 import logging
 import os
 import secrets
@@ -58,6 +59,83 @@ chance to make progress before we re-poll."""
 
 _BEARER_PREFIX = "Bearer "
 _HOST_ALLOWLIST: frozenset[str] = frozenset({"localhost", "127.0.0.1"})
+
+#: Truthy env values that opt into cross-host mode (mirrors the client flag).
+_REMOTE_TRUTHY_ENV_VALUES: frozenset[str] = frozenset({"1", "true", "yes", "on"})
+
+#: Explicit private-range networks a cross-host coordinator may bind to. We
+#: range-check explicitly because ``ipaddress.is_private`` returns True for BOTH
+#: ``0.0.0.0`` and loopback aliases (e.g. 127.0.0.2) — admitting either would
+#: defeat the bind guard. Loopback, link-local (169.254/16) and CGNAT (100.64/10)
+#: are deliberately excluded here (loopback is handled separately).
+_PRIVATE_V4_NETS = (
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+)
+_PRIVATE_V6_NET = ipaddress.ip_network("fc00::/7")
+
+
+def _remote_flag_enabled() -> bool:
+    """True when CCS_REMOTE_COORDINATOR opts into cross-host mode (default OFF)."""
+    return (
+        os.environ.get("CCS_REMOTE_COORDINATOR", "").strip().lower()
+        in _REMOTE_TRUTHY_ENV_VALUES
+    )
+
+
+def is_loopback_host(host: str) -> bool:
+    """True for the always-allowed loopback names (localhost / 127.0.0.1)."""
+    return host in _HOST_ALLOWLIST
+
+
+def _is_private_range(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    if ip.version == 4:
+        return any(ip in net for net in _PRIVATE_V4_NETS)
+    return ip in _PRIVATE_V6_NET
+
+
+def validate_bind_host(host: str) -> None:
+    """Validate a coordinator bind address (raise ``ValueError`` if disallowed).
+
+    Loopback (localhost / 127.0.0.1) is always allowed. Any other address
+    requires the cross-host opt-in (``CCS_REMOTE_COORDINATOR``) AND must be an
+    explicit RFC-1918/4193 private-range IP. ``0.0.0.0`` / wildcard, loopback
+    aliases (127.0.0.2), link-local (169.254/16), CGNAT (100.64/10) and public
+    addresses are all rejected — binding to any of them would expose the
+    coordinator beyond the intended private network.
+    """
+    if is_loopback_host(host):
+        return
+    if not _remote_flag_enabled():
+        raise ValueError(
+            f"refusing to bind the coordinator to {host!r} beyond loopback; set "
+            "CCS_REMOTE_COORDINATOR to opt into cross-host mode"
+        )
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError as exc:
+        raise ValueError(f"bind host {host!r} is not a valid IP address") from exc
+    if ip.is_unspecified:
+        raise ValueError(f"refusing to bind the coordinator to the wildcard address {host!r}")
+    if not _is_private_range(ip):
+        raise ValueError(
+            f"bind host {host!r} is not an RFC-1918/4193 private-range address "
+            "(loopback aliases, link-local, CGNAT and public addresses are rejected)"
+        )
+
+
+def build_host_allowlist(bind_host: str) -> frozenset[str]:
+    """The Host-header allowlist for a coordinator bound to ``bind_host``.
+
+    Always includes loopback; for a validated non-loopback bind it also admits
+    that exact host. Validates ``bind_host`` (raises on a disallowed bind), so a
+    coordinator constructed with a bad bind fails loud at construction.
+    """
+    validate_bind_host(bind_host)
+    if is_loopback_host(bind_host):
+        return _HOST_ALLOWLIST
+    return _HOST_ALLOWLIST | {bind_host}
 
 
 class EnsureSecretError(RuntimeError):
@@ -169,16 +247,17 @@ def verify_bearer(authorization_header: str | None, expected_secret: str) -> boo
     return hmac.compare_digest(presented, expected_secret)
 
 
-def verify_host(host_header: str | None) -> bool:
-    """Reject Host headers that don't resolve to localhost/127.0.0.1.
+def verify_host(host_header: str | None, allowlist: frozenset[str] = _HOST_ALLOWLIST) -> bool:
+    """Reject Host headers not in ``allowlist`` (default: localhost/127.0.0.1).
 
     Block DNS rebinding: an attacker page at attacker.com resolves
     attacker.com → 127.0.0.1, browser sends ``Host: attacker.com``, server
-    must reject. We allow ``localhost`` and ``127.0.0.1``, with or without
-    a port suffix.
+    must reject. The cross-host coordinator passes a wider allowlist
+    ({loopback, validated bind_host}); every other host still 403s. Allows the
+    allowlisted names with or without a port suffix.
     """
     if not host_header:
         return False
     # Strip port suffix if present (e.g., "127.0.0.1:54321")
     hostname = host_header.split(":", 1)[0]
-    return hostname in _HOST_ALLOWLIST
+    return hostname in allowlist

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -52,6 +52,7 @@ from uuid import NAMESPACE_URL, UUID, uuid5
 from ccs.adapters.claude_code import audit_log as _audit_log
 from ccs.adapters.claude_code import hook_payloads as _payloads
 from ccs.adapters.claude_code.auth import (
+    build_host_allowlist,
     ensure_secret,
     verify_bearer,
     verify_host,
@@ -321,6 +322,11 @@ class CoordinatorHTTPServer:
     ) -> None:
         self.coordinator_root = Path(coordinator_root).resolve()
         self.bind_host = bind_host
+        # Host-header allowlist: loopback always, plus a validated non-loopback
+        # bind (cross-host demo). Validates bind_host here at construction — a
+        # disallowed bind (wildcard, loopback alias, link-local, CGNAT, public, or
+        # non-loopback without the CCS_REMOTE_COORDINATOR opt-in) raises.
+        self.host_allowlist = build_host_allowlist(bind_host)
         # Monotonic reference points (NOT wall-clock): idle/uptime deltas must
         # survive NTP steps and suspend/resume (finding L5). time.time() stays
         # reserved for operator-facing absolute timestamps elsewhere.
@@ -1148,7 +1154,7 @@ def _make_handler_class(coordinator: CoordinatorHTTPServer) -> type:
                 coordinator.mark_request()
 
                 # Auth + Host check on every endpoint
-                if not verify_host(self.headers.get("Host")):
+                if not verify_host(self.headers.get("Host"), coordinator.host_allowlist):
                     self._json(403, {"error": "host header not allowlisted"})
                     logger.warning(
                         "rejected request with bad Host: %r", self.headers.get("Host")

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -388,7 +388,10 @@ class CoherentVolume:
         try:
             _coordinator_get(endpoint, "/status")
         except CoordinatorUnavailable as exc:
-            # Transport failure = unreachable -> fail closed (strict raises).
+            # Transport failure = unreachable -> fail closed (strict raises, so the
+            # lines below are unreachable today). They are kept defensively: if a
+            # future non-strict remote mode ever lets _fail_closed_or_degrade return
+            # instead of raise, we must stay DETACHED, never attached to a dead endpoint.
             self._fail_closed_or_degrade(f"remote coordinator unreachable: {exc}")
             self._endpoint = None
             return

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -77,6 +77,7 @@ from ccs.core.exceptions import (
     CommitPreempted,
     CommitUnconfirmed,
     InternalConcurrencyError,
+    RemoteAuthFailed,
     StaleView,
     ViewWedged,
 )
@@ -391,10 +392,16 @@ class CoherentVolume:
             self._fail_closed_or_degrade(f"remote coordinator unreachable: {exc}")
             self._endpoint = None
             return
-        except urllib.error.HTTPError:
-            # Reachable but non-2xx (e.g. 401/403): the coordinator is up; the
-            # actual read/write op surfaces the typed deny / auth failure (R2).
-            pass
+        except urllib.error.HTTPError as exc:
+            # R2: a 401 at attach is a wrong/missing secret — fail loud + closed.
+            if exc.code == 401:
+                raise RemoteAuthFailed(
+                    "remote coordinator rejected the bearer token (401) at attach; "
+                    "the remote secret (CCS_REMOTE_SECRET_FILE) does not match the "
+                    "coordinator's hook.secret"
+                ) from exc
+            # Reachable, other non-2xx (e.g. 403): the coordinator is up; the
+            # actual read/write op surfaces the typed deny (R2).
         self._endpoint = endpoint
 
     # --- spawn-with-strict --------------------------------------------------
@@ -1234,7 +1241,21 @@ class CoherentVolume:
         ``None``). Otherwise returns the parsed 200 body."""
         try:
             return _coordinator_post(self._endpoint, endpoint_path, payload)
-        except (CoordinatorUnavailable, urllib.error.HTTPError) as exc:
+        except urllib.error.HTTPError as exc:
+            # R2: a remote 401 is a wrong/missing secret — fail LOUD and CLOSED
+            # with a distinct type, never the generic degrade path (which a
+            # degrade-mode local client could swallow).
+            if self._remote_endpoint is not None and exc.code == 401:
+                raise RemoteAuthFailed(
+                    "remote coordinator rejected the bearer token (401); the remote "
+                    "secret (CCS_REMOTE_SECRET_FILE) does not match the coordinator's "
+                    "hook.secret"
+                ) from exc
+            self._fail_closed_or_degrade(
+                f"coordinator request to {endpoint_path} failed: {exc}"
+            )
+            return None  # reached only in degrade mode
+        except CoordinatorUnavailable as exc:
             self._fail_closed_or_degrade(
                 f"coordinator request to {endpoint_path} failed: {exc}"
             )

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -400,8 +400,13 @@ class CoherentVolume:
                     "the remote secret (CCS_REMOTE_SECRET_FILE) does not match the "
                     "coordinator's hook.secret"
                 ) from exc
-            # Reachable, other non-2xx (e.g. 403): the coordinator is up; the
-            # actual read/write op surfaces the typed deny (R2).
+            # Any other non-2xx at attach (403 Host mismatch, 503 draining, ...)
+            # fails CLOSED here rather than deferring a misconfig to the first op.
+            self._fail_closed_or_degrade(
+                f"remote coordinator returned HTTP {exc.code} at attach"
+            )
+            self._endpoint = None
+            return
         self._endpoint = endpoint
 
     # --- spawn-with-strict --------------------------------------------------

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -57,6 +57,7 @@ from ccs.adapters.claude_code.policy import matches_any
 from ccs.cli._coherence_client import (
     CoordinatorEndpoint,
     CoordinatorUnavailable,
+    RemoteCoordinatorConfig,
     resolve_endpoint,
 )
 from ccs.cli._coherence_client import (
@@ -192,6 +193,7 @@ class CoherentVolume:
         on_stale_write: Literal["allow", "raise"] = "raise",
         config: LifecycleConfig | None = None,
         bind_host: str = "127.0.0.1",
+        remote_endpoint: CoordinatorEndpoint | None = None,
     ) -> None:
         if on_error not in ("strict", "degrade"):
             raise ValueError(f"on_error must be 'strict' or 'degrade', got {on_error!r}")
@@ -203,6 +205,25 @@ class CoherentVolume:
             raise ValueError(
                 f"on_stale_write must be 'allow' or 'raise', got {on_stale_write!r}"
             )
+        if remote_endpoint is not None:
+            # Cross-host demo path (R0b). Defense-in-depth: remote mode is gated by
+            # the default-OFF flag, is strict-only (an unreachable coordinator must
+            # fail closed, never degrade-open), and is coordinator-version-only —
+            # no managed globs, because strict mode is load-once-at-spawn and cannot
+            # be enabled on a coordinator this client did not spawn.
+            if not RemoteCoordinatorConfig.from_env().enabled:
+                raise ValueError(
+                    "remote_endpoint requires the CCS_REMOTE_COORDINATOR env flag"
+                )
+            if on_error != "strict":
+                raise ValueError(
+                    "remote coordinator mode is strict-only (on_error must be 'strict')"
+                )
+            if managed:
+                raise ValueError(
+                    "remote coordinator mode is coordinator-version-only; managed globs "
+                    "are not supported cross-host in v1"
+                )
 
         self._root = Path(root).resolve()
         # Managed globs are coordinator-policy patterns (parent-repo-relative,
@@ -214,6 +235,10 @@ class CoherentVolume:
         self._on_stale_write = on_stale_write
         self._config = config
         self._bind_host = bind_host
+        # Cross-host demo: when set, attach connects to THIS endpoint and never
+        # spawns a local coordinator (R0b / plan C1). Preserved across fork so the
+        # child re-attaches to the same remote coordinator under a fresh identity.
+        self._remote_endpoint = remote_endpoint
 
         self._lock = threading.Lock()
         # A5: single-instance concurrency guard, SEPARATE from self._lock (which
@@ -246,7 +271,7 @@ class CoherentVolume:
         # would conflate them) or its cached endpoint/connection.
         os.register_at_fork(after_in_child=self._after_fork)
 
-        self._attach_with_strict()
+        self._attach()
 
     # --- identity -----------------------------------------------------------
 
@@ -279,7 +304,7 @@ class CoherentVolume:
         """
         if self._endpoint is None and self._needs_reattach:
             self._needs_reattach = False
-            self._attach_with_strict()
+            self._attach()
 
     @property
     def session_id(self) -> str:
@@ -335,6 +360,42 @@ class CoherentVolume:
                 if self._guard_depth <= 0:
                     self._guard_depth = 0
                     self._guard_owner_ident = None
+
+    # --- attach dispatch ----------------------------------------------------
+
+    def _attach(self) -> None:
+        """Dispatch attach: local spawn-with-strict, or remote connect-only.
+
+        Remote mode (the cross-host demo) NEVER spawns a local coordinator."""
+        if self._remote_endpoint is not None:
+            self._attach_remote()
+        else:
+            self._attach_with_strict()
+
+    def _attach_remote(self) -> None:
+        """Connect-only attach to a REMOTE coordinator — never spawn (plan C1).
+
+        The endpoint was supplied explicitly, so we set it directly and read
+        nothing from the local ``.coherence/`` directory. We do NOT call
+        ``connect_or_spawn``: a remote client with no local ``server.pid`` would
+        otherwise spawn a second, LOCAL coordinator and silently split this writer
+        and its peer onto different coordinators — the demo would "work" for the
+        wrong reason. A remote coordinator we cannot reach fails closed (remote
+        mode is strict-only). Response-body semantics (deny / degrade / 401) are
+        enforced on the actual read/write ops (R2)."""
+        endpoint = self._remote_endpoint
+        try:
+            _coordinator_get(endpoint, "/status")
+        except CoordinatorUnavailable as exc:
+            # Transport failure = unreachable -> fail closed (strict raises).
+            self._fail_closed_or_degrade(f"remote coordinator unreachable: {exc}")
+            self._endpoint = None
+            return
+        except urllib.error.HTTPError:
+            # Reachable but non-2xx (e.g. 401/403): the coordinator is up; the
+            # actual read/write op surfaces the typed deny / auth failure (R2).
+            pass
+        self._endpoint = endpoint
 
     # --- spawn-with-strict --------------------------------------------------
 

--- a/src/ccs/cli/_coherence_client.py
+++ b/src/ccs/cli/_coherence_client.py
@@ -252,24 +252,30 @@ class RemoteCoordinatorConfig:
     def _read_secret(env: dict[str, str]) -> str | None:
         """Read the bearer from ``CCS_REMOTE_SECRET_FILE`` (not an inline env var).
 
-        Warns (does not fail — cooperative trust) if the file is group/world
-        accessible; the local ``hook.secret`` is created 0600, so a wider mode on
-        the remote copy means the provisioning channel widened the exposure.
+        Hardened: refuses to follow a symlinked secret file (``O_NOFOLLOW`` — an
+        attacker able to set the env var could otherwise repoint it at any
+        readable file), and warns if the file is group/world-accessible (``0600``
+        expected, like the local ``hook.secret``). Fails closed (returns ``None``)
+        on any error.
         """
         secret_path = (env.get("CCS_REMOTE_SECRET_FILE") or "").strip()
         if not secret_path:
             return None
         try:
-            path = Path(secret_path)
-            mode = path.stat().st_mode
-            if mode & 0o077:
-                logger.warning(
-                    "CCS_REMOTE_SECRET_FILE %s is group/world-accessible (mode %o); "
-                    "tighten it to 0600",
-                    secret_path,
-                    mode & 0o777,
-                )
-            secret = path.read_text(encoding="utf-8").strip()
+            fd = os.open(secret_path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        except OSError:
+            return None  # missing, or a symlink (ELOOP) — fail closed
+        try:
+            with os.fdopen(fd, encoding="utf-8") as handle:
+                mode = os.fstat(handle.fileno()).st_mode
+                if mode & 0o077:
+                    logger.warning(
+                        "CCS_REMOTE_SECRET_FILE %s is group/world-accessible (mode %o); "
+                        "tighten it to 0600",
+                        secret_path,
+                        mode & 0o777,
+                    )
+                secret = handle.read().strip()
         except OSError:
             return None
         return secret or None

--- a/src/ccs/cli/_coherence_client.py
+++ b/src/ccs/cli/_coherence_client.py
@@ -246,6 +246,8 @@ class RemoteCoordinatorConfig:
         host = (env.get("CCS_REMOTE_HOST") or "").strip() or None
         port_raw = (env.get("CCS_REMOTE_PORT") or "").strip()
         port = int(port_raw) if port_raw.isdigit() else None
+        if port is not None and not (1 <= port <= 65535):
+            port = None  # out of TCP range -> treat as unset (fail closed downstream)
         return cls(enabled=True, host=host, port=port, secret=cls._read_secret(env))
 
     @staticmethod

--- a/src/ccs/cli/_coherence_client.py
+++ b/src/ccs/cli/_coherence_client.py
@@ -250,12 +250,26 @@ class RemoteCoordinatorConfig:
 
     @staticmethod
     def _read_secret(env: dict[str, str]) -> str | None:
-        """Read the bearer from ``CCS_REMOTE_SECRET_FILE`` (not an inline env var)."""
+        """Read the bearer from ``CCS_REMOTE_SECRET_FILE`` (not an inline env var).
+
+        Warns (does not fail — cooperative trust) if the file is group/world
+        accessible; the local ``hook.secret`` is created 0600, so a wider mode on
+        the remote copy means the provisioning channel widened the exposure.
+        """
         secret_path = (env.get("CCS_REMOTE_SECRET_FILE") or "").strip()
         if not secret_path:
             return None
         try:
-            secret = Path(secret_path).read_text(encoding="utf-8").strip()
+            path = Path(secret_path)
+            mode = path.stat().st_mode
+            if mode & 0o077:
+                logger.warning(
+                    "CCS_REMOTE_SECRET_FILE %s is group/world-accessible (mode %o); "
+                    "tighten it to 0600",
+                    secret_path,
+                    mode & 0o777,
+                )
+            secret = path.read_text(encoding="utf-8").strip()
         except OSError:
             return None
         return secret or None

--- a/src/ccs/cli/_coherence_client.py
+++ b/src/ccs/cli/_coherence_client.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sys
 import urllib.error
 import urllib.request
@@ -136,14 +137,20 @@ def normalize_workspace_path(p: str, root: Path) -> tuple[str, str | None]:
 
 @dataclass(frozen=True)
 class CoordinatorEndpoint:
-    """Resolved (port, bearer_token) pair for the local coordinator."""
+    """Resolved (host, port, bearer_token) for a coordinator.
+
+    ``host`` defaults to loopback so the local path is byte-unchanged; the
+    cross-host demo (gated by :class:`RemoteCoordinatorConfig`) supplies a
+    routable host via :func:`resolve_remote_endpoint`.
+    """
 
     port: int
     bearer: str
+    host: str = "127.0.0.1"
 
     @property
     def base_url(self) -> str:
-        return f"http://127.0.0.1:{self.port}"
+        return f"http://{self.host}:{self.port}"
 
 
 class CoordinatorUnavailable(Exception):
@@ -188,6 +195,72 @@ def resolve_endpoint(coordinator_root: Path) -> CoordinatorEndpoint:
     return CoordinatorEndpoint(port=port, bearer=bearer)
 
 
+def resolve_remote_endpoint(host: str, port: int, secret: str) -> CoordinatorEndpoint:
+    """Build an endpoint for a REMOTE coordinator (cross-host demo).
+
+    Unlike :func:`resolve_endpoint`, this reads nothing from the local
+    ``.coherence/`` directory — host, port, and the bearer secret are supplied
+    by the caller (typically via :meth:`RemoteCoordinatorConfig.from_env`).
+    Gated by :class:`RemoteCoordinatorConfig`; never used on the loopback-only
+    local path.
+    """
+    if not host:
+        raise CoordinatorUnavailable("remote coordinator host is empty")
+    if not secret:
+        raise CoordinatorUnavailable("remote coordinator bearer secret is empty")
+    return CoordinatorEndpoint(port=port, bearer=secret, host=host)
+
+
+#: Truthy env values that enable cross-host remote mode (mirrors the
+#: telemetry kill-switch parser). Everything else (incl. "" and "0") is OFF.
+_REMOTE_TRUTHY_ENV_VALUES: frozenset[str] = frozenset({"1", "true", "yes", "on"})
+
+
+@dataclass(frozen=True)
+class RemoteCoordinatorConfig:
+    """Default-OFF gate for cross-host remote-coordinator mode.
+
+    Absent the ``CCS_REMOTE_COORDINATOR`` env flag, :meth:`from_env` returns a
+    disabled config and every existing loopback-only behavior is byte-unchanged
+    — the cross-host relaxation never reaches local users.
+
+    Secret channel: the bearer is read from a FILE whose path is given by
+    ``CCS_REMOTE_SECRET_FILE`` — never inline in an env var, which would leak in
+    ``ps`` / ``docker inspect`` (the R7 security pass owns this). The file
+    mirrors the local ``hook.secret`` (mode 0600, mounted into the remote
+    container).
+    """
+
+    enabled: bool
+    host: str | None = None
+    port: int | None = None
+    secret: str | None = None
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> RemoteCoordinatorConfig:
+        """Parse the cross-host flag from the environment (default OFF)."""
+        env = os.environ if env is None else env
+        flag = env.get("CCS_REMOTE_COORDINATOR", "").strip().lower()
+        if flag not in _REMOTE_TRUTHY_ENV_VALUES:
+            return cls(enabled=False)
+        host = (env.get("CCS_REMOTE_HOST") or "").strip() or None
+        port_raw = (env.get("CCS_REMOTE_PORT") or "").strip()
+        port = int(port_raw) if port_raw.isdigit() else None
+        return cls(enabled=True, host=host, port=port, secret=cls._read_secret(env))
+
+    @staticmethod
+    def _read_secret(env: dict[str, str]) -> str | None:
+        """Read the bearer from ``CCS_REMOTE_SECRET_FILE`` (not an inline env var)."""
+        secret_path = (env.get("CCS_REMOTE_SECRET_FILE") or "").strip()
+        if not secret_path:
+            return None
+        try:
+            secret = Path(secret_path).read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+        return secret or None
+
+
 def get(
     endpoint: CoordinatorEndpoint,
     path: str,
@@ -204,7 +277,7 @@ def get(
     that header here."""
     headers: dict[str, str] = {
         "Authorization": f"Bearer {endpoint.bearer}",
-        "Host": "127.0.0.1",
+        "Host": endpoint.host,
     }
     if extra_headers:
         headers.update(extra_headers)
@@ -232,7 +305,7 @@ def post(
     payload = json.dumps(body).encode("utf-8")
     headers: dict[str, str] = {
         "Authorization": f"Bearer {endpoint.bearer}",
-        "Host": "127.0.0.1",
+        "Host": endpoint.host,
         "Content-Type": "application/json",
     }
     if extra_headers:

--- a/src/ccs/cli/coherence_coordinator.py
+++ b/src/ccs/cli/coherence_coordinator.py
@@ -88,6 +88,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Suppress the 'port=N' line on stdout (still exits 0 on success).",
     )
     parser.add_argument(
+        "--bind-host",
+        default="127.0.0.1",
+        help=(
+            "Address to bind the coordinator to (default: 127.0.0.1). A non-loopback "
+            "private-range address (RFC-1918) enables the cross-host demo and requires "
+            "CCS_REMOTE_COORDINATOR=1; wildcard / public / loopback-alias are rejected."
+        ),
+    )
+    parser.add_argument(
         "--prepare-for-migration",
         action="store_true",
         help=(
@@ -122,7 +131,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     # Daemonized worker mode: bind + serve, then block forever so the
     # daemon HTTP/sweep/idle threads stay alive.
     if args._daemonized:
-        return _run_daemonized(root)
+        return _run_daemonized(root, bind_host=args.bind_host)
 
     # Unit 8 (Decision 1): release-all-grants + shutdown for backend
     # switch safety. Routed through the running coordinator so we
@@ -135,7 +144,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     # Test mode: keep the legacy in-process behavior so test_claude_code_cli
     # can spawn + assert in the same Python process. Not for users.
     if args.no_detach:
-        port = ensure_coordinator(root)
+        port = ensure_coordinator(root, bind_host=args.bind_host)
         if port == -1:
             err("agent-coherence-coordinator: coordinator could not be spawned")
             return 2
@@ -153,7 +162,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     # No live coordinator — fork a detached child to run it.
-    return _spawn_detached(root, quiet=args.quiet)
+    return _spawn_detached(root, quiet=args.quiet, bind_host=args.bind_host)
 
 
 def _run_prepare_for_migration(root: Path, *, quiet: bool) -> int:
@@ -241,12 +250,12 @@ def _run_prepare_for_migration(root: Path, *, quiet: bool) -> int:
     return 0
 
 
-def _run_daemonized(root: Path) -> int:
+def _run_daemonized(root: Path, *, bind_host: str = "127.0.0.1") -> int:
     """Internal worker — called via ``--_daemonized``. Run the coordinator
     and block indefinitely. Exits on SIGTERM (sent by stop_coordinator)
     or natural idle-shutdown (lifecycle's idle loop also detaches via
     ``return`` in its loop, leaving the main thread to block here)."""
-    port = ensure_coordinator(root)
+    port = ensure_coordinator(root, bind_host=bind_host)
     if port == -1:
         return 2
 
@@ -265,7 +274,7 @@ def _run_daemonized(root: Path) -> int:
     return 0
 
 
-def _spawn_detached(root: Path, *, quiet: bool) -> int:
+def _spawn_detached(root: Path, *, quiet: bool, bind_host: str = "127.0.0.1") -> int:
     """Spawn a detached child running the daemonized worker, then poll
     the port file until the child writes it (or timeout)."""
     pid_file = root / ".coherence" / "server.pid"
@@ -278,7 +287,7 @@ def _spawn_detached(root: Path, *, quiet: bool) -> int:
         subprocess.Popen(
             [
                 sys.executable, "-m", "ccs.cli.coherence_coordinator",
-                "--_daemonized", "--root", str(root),
+                "--_daemonized", "--root", str(root), "--bind-host", bind_host,
             ],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -292,6 +292,15 @@ class ViewWedged(CoherenceError):
     reason = VIEW_WEDGED_REASON
 
 
+class RemoteAuthFailed(CoherenceError):
+    """Remote-coordinator bearer auth rejected (cross-host demo, R2): the
+    coordinator returned ``401`` for the supplied secret. A misconfiguration —
+    the remote ``CCS_REMOTE_SECRET_FILE`` does not match the coordinator's
+    ``hook.secret`` — NOT an infra hiccup. It fails LOUD and CLOSED, typed
+    distinctly from a watchdog-timeout degrade or a stale-view deny, so a remote
+    client never silently degrades past a wrong secret."""
+
+
 class CommitUnconfirmed(CoherenceError):
     """OCC commit unconfirmed (MCP-C Unit 1): the coordinator transport failed
     mid-commit, a false-negative ack — NOT a confirmed loss. The write may or may

--- a/tests/adapters/test_coherent_volume_remote.py
+++ b/tests/adapters/test_coherent_volume_remote.py
@@ -1,0 +1,111 @@
+"""Unit 2 (R0b): CoherentVolume connect-only remote mode — never spawns.
+
+The plan's C1 fix: a remote client must attach to the supplied endpoint and
+NEVER fall through to ``connect_or_spawn`` (which would spawn a second, local
+coordinator and silently split peers onto different coordinators).
+"""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+import pytest
+
+from ccs.adapters.claude_code.lifecycle import LifecycleConfig, stop_coordinator
+from ccs.adapters.coherent_volume import CoherentVolume
+from ccs.cli._coherence_client import resolve_endpoint, resolve_remote_endpoint
+from ccs.core.exceptions import CoherenceError
+
+
+@pytest.fixture
+def fast_cfg() -> LifecycleConfig:
+    return LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0.1,
+        notice_evict_max_age_sec=1.0,
+        port_file_retry_attempts=20,
+        port_file_retry_interval_sec=0.05,
+        connect_retry_attempts=10,
+        connect_retry_interval_sec=0.05,
+    )
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def test_remote_mode_connects_without_spawning(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C1 happy path: a remote volume attaches to an existing coordinator and
+    does NOT spawn its own (no server.pid under its root)."""
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    root_a = tmp_path / "a"
+    root_a.mkdir()
+    root_b = tmp_path / "b"
+    root_b.mkdir()
+
+    # root A spawns the coordinator (stands in for the "remote" one).
+    vol_a = CoherentVolume(root_a, config=fast_cfg)
+    try:
+        ep_a = resolve_endpoint(root_a)
+        remote = resolve_remote_endpoint("127.0.0.1", ep_a.port, ep_a.bearer)
+        vol_b = CoherentVolume(
+            root_b, config=fast_cfg, on_error="strict", remote_endpoint=remote
+        )
+        assert vol_b.is_attached
+        assert vol_b._endpoint is not None and vol_b._endpoint.port == ep_a.port
+        # The C1 invariant: root B never spawned its own coordinator.
+        assert not (root_b / ".coherence" / "server.pid").exists()
+    finally:
+        stop_coordinator(root_a)
+
+
+def test_remote_unreachable_fails_closed_no_spawn(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C1 unreachable: a dead remote endpoint fails CLOSED (strict raises) and
+    still does NOT fall through to spawning a local coordinator."""
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    remote = resolve_remote_endpoint("127.0.0.1", _free_port(), "deadbeef")
+    with pytest.raises(CoherenceError):
+        CoherentVolume(tmp_path, config=fast_cfg, on_error="strict", remote_endpoint=remote)
+    assert not (tmp_path / ".coherence" / "server.pid").exists()
+
+
+def test_remote_endpoint_requires_flag(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("CCS_REMOTE_COORDINATOR", raising=False)
+    remote = resolve_remote_endpoint("127.0.0.1", 8080, "deadbeef")
+    with pytest.raises(ValueError, match="CCS_REMOTE_COORDINATOR"):
+        CoherentVolume(tmp_path, config=fast_cfg, on_error="strict", remote_endpoint=remote)
+
+
+def test_remote_mode_rejects_degrade(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    remote = resolve_remote_endpoint("127.0.0.1", 8080, "deadbeef")
+    with pytest.raises(ValueError, match="strict-only"):
+        CoherentVolume(tmp_path, config=fast_cfg, on_error="degrade", remote_endpoint=remote)
+
+
+def test_remote_mode_rejects_managed(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    remote = resolve_remote_endpoint("127.0.0.1", 8080, "deadbeef")
+    with pytest.raises(ValueError, match="version-only|managed"):
+        CoherentVolume(
+            tmp_path,
+            config=fast_cfg,
+            on_error="strict",
+            managed=("x/**",),
+            remote_endpoint=remote,
+        )

--- a/tests/adapters/test_coherent_volume_remote_failclosed.py
+++ b/tests/adapters/test_coherent_volume_remote_failclosed.py
@@ -1,0 +1,82 @@
+"""Unit 3 (R2): fail-closed remote semantics — typed 401 + the HTTP-200 trap.
+
+Under strict mode (which remote pins) a degraded-200 body and an ok:false deny
+already fail closed; this verifies that holds on the remote path, AND that a 401
+(wrong/missing secret) raises the dedicated RemoteAuthFailed rather than
+degrading silently.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+import ccs.adapters.coherent_volume as cv
+from ccs.adapters.coherent_volume import CoherentVolume
+from ccs.cli._coherence_client import resolve_remote_endpoint
+from ccs.core.exceptions import CoherenceError, RemoteAuthFailed
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError("http://10.0.0.5:8080/x", code, "err", {}, None)
+
+
+def _remote_volume(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, probe=None
+) -> CoherentVolume:
+    """Construct a remote-mode volume with a stubbed-reachable attach probe."""
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    monkeypatch.setattr(
+        cv, "_coordinator_get", probe or (lambda ep, path, **k: {"ok": True})
+    )
+    remote = resolve_remote_endpoint("10.0.0.5", 8080, "secret")
+    return CoherentVolume(tmp_path, on_error="strict", remote_endpoint=remote)
+
+
+def test_remote_auth_failed_is_coherence_error():
+    assert issubclass(RemoteAuthFailed, CoherenceError)
+
+
+def test_op_401_raises_remote_auth_failed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    vol = _remote_volume(tmp_path, monkeypatch)
+
+    def raise_401(ep, path, payload, **k):
+        raise _http_error(401)
+
+    monkeypatch.setattr(cv, "_coordinator_post", raise_401)
+    with pytest.raises(RemoteAuthFailed):
+        vol._post("/hooks/pre-edit", {"session_id": vol.session_id, "path": "x"})
+
+
+def test_attach_401_raises_remote_auth_failed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    def probe_401(ep, path, **k):
+        raise _http_error(401)
+
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    monkeypatch.setattr(cv, "_coordinator_get", probe_401)
+    remote = resolve_remote_endpoint("10.0.0.5", 8080, "secret")
+    with pytest.raises(RemoteAuthFailed):
+        CoherentVolume(tmp_path, on_error="strict", remote_endpoint=remote)
+
+
+def test_non_401_http_error_still_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    vol = _remote_volume(tmp_path, monkeypatch)
+
+    def raise_403(ep, path, payload, **k):
+        raise _http_error(403)
+
+    monkeypatch.setattr(cv, "_coordinator_post", raise_403)
+    with pytest.raises(CoherenceError):
+        vol._post("/hooks/pre-edit", {"session_id": vol.session_id, "path": "x"})
+
+
+def test_degraded_200_body_fails_closed_on_read(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    vol = _remote_volume(tmp_path, monkeypatch)
+    (tmp_path / "f.txt").write_text("hi", encoding="utf-8")
+    monkeypatch.setattr(
+        cv, "_coordinator_post", lambda ep, path, payload, **k: {"degraded": True}
+    )
+    with pytest.raises(CoherenceError):
+        vol.read_with_version("f.txt")

--- a/tests/adapters/test_coherent_volume_remote_failclosed.py
+++ b/tests/adapters/test_coherent_volume_remote_failclosed.py
@@ -80,3 +80,16 @@ def test_degraded_200_body_fails_closed_on_read(tmp_path: Path, monkeypatch: pyt
     )
     with pytest.raises(CoherenceError):
         vol.read_with_version("f.txt")
+
+
+def test_attach_403_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Hardening: any non-2xx at the attach probe (e.g. 403 Host mismatch) fails
+    CLOSED at construction rather than deferring the misconfig to the first op."""
+    def probe_403(ep, path, **k):
+        raise _http_error(403)
+
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    monkeypatch.setattr(cv, "_coordinator_get", probe_403)
+    remote = resolve_remote_endpoint("10.0.0.5", 8080, "secret")
+    with pytest.raises(CoherenceError):
+        CoherentVolume(tmp_path, on_error="strict", remote_endpoint=remote)

--- a/tests/test_adapter_contract_parity.py
+++ b/tests/test_adapter_contract_parity.py
@@ -1,0 +1,221 @@
+"""Cross-substrate adapter parity test (DX-3): same protocol, two adapters.
+
+Documents the version-CAS contract in
+``examples/cross_host/ADAPTER-CONTRACT.md`` and proves it as a passing test
+rather than an assertion. The shipped file adapter (``CoherentVolume``) is
+exercised live against a loopback coordinator; a minimal in-memory KV adapter
+satisfying the same Protocol is exercised in-process. Both must reject A's
+stale write with a typed ``CoherenceError`` and let A recover via re-read +
+retry.
+
+This is the demo's "DX-3 (Pluggable substrate adapters — same protocol, two
+topologies)" claim made testable. A future adapter (HTTP MCP, SQL, blob store)
+gets added here as one more parametrize case; the protocol surface and the
+recover-by-reread invariant stay the same.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Protocol
+
+import pytest
+
+from ccs.adapters.claude_code.lifecycle import (
+    LifecycleConfig,
+    ensure_coordinator,
+    stop_coordinator,
+)
+from ccs.adapters.coherent_volume import CoherentVolume
+from ccs.cli._coherence_client import (
+    post as _cc_post,
+)
+from ccs.cli._coherence_client import (
+    resolve_endpoint,
+    resolve_remote_endpoint,
+)
+from ccs.core.exceptions import CoherenceError
+
+KEY = "shared.txt"
+
+
+# ---------------------------------------------------------------------------
+# The contract — also written in examples/cross_host/ADAPTER-CONTRACT.md as a
+# Protocol, repeated here so the test file is self-contained for a reader.
+# ---------------------------------------------------------------------------
+
+
+class CoherenceAdapter(Protocol):
+    """The version-CAS contract any substrate adapter satisfies."""
+
+    def read_with_version(self, key: str) -> tuple[bytes, int]: ...
+    def write_cas_at(self, key: str, expected_version: int, data: bytes) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Reference KV adapter — NOT a shipped product, a Protocol-satisfying minimal
+# implementation so the parity claim has a second adapter to test against. The
+# point is the protocol surface, not the storage class.
+# ---------------------------------------------------------------------------
+
+
+class _MemoryKVAdapter:
+    """Single in-memory KV implementing the CoherenceAdapter Protocol.
+
+    Two clients share the SAME instance — coordination is the version held
+    here, equivalent to the coordinator's role for ``CoherentVolume``.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._data: dict[str, bytes] = {}
+        self._versions: dict[str, int] = {}
+
+    def read_with_version(self, key: str) -> tuple[bytes, int]:
+        with self._lock:
+            return self._data.get(key, b""), self._versions.get(key, 0)
+
+    def write_cas_at(self, key: str, expected_version: int, data: bytes) -> None:
+        with self._lock:
+            current = self._versions.get(key, 0)
+            if current != expected_version:
+                raise CoherenceError(f"stale write: expected v{expected_version}, current v{current}")
+            self._data[key] = data
+            self._versions[key] = current + 1
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — each adapter pair represents "two clients sharing the same
+# coordination authority for KEY," whatever the substrate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fast_cfg() -> LifecycleConfig:
+    return LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0.1,
+        notice_evict_max_age_sec=1.0,
+        port_file_retry_attempts=20,
+        port_file_retry_interval_sec=0.05,
+        connect_retry_attempts=10,
+        connect_retry_interval_sec=0.05,
+    )
+
+
+@pytest.fixture
+def file_adapter_pair(tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch):
+    """Pair of ``CoherentVolume`` clients against a real loopback coordinator —
+    the file-on-volume substrate the cross-host demo exercises."""
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    coord_root = tmp_path / "coord"
+    coord_root.mkdir()
+    root_a = tmp_path / "a"
+    root_a.mkdir()
+    root_b = tmp_path / "b"
+    root_b.mkdir()
+
+    ensure_coordinator(coord_root, config=fast_cfg)
+    try:
+        ep = resolve_endpoint(coord_root)
+        # Tracked but not strict — the protocol's version-CAS deny is the
+        # whole mechanism the contract defines.
+        _cc_post(ep, "/policy/track", {"paths": [KEY]})
+
+        def _remote():
+            return resolve_remote_endpoint("127.0.0.1", ep.port, ep.bearer)
+
+        a = CoherentVolume(root_a, on_error="strict", on_stale_write="allow", remote_endpoint=_remote())
+        b = CoherentVolume(root_b, on_error="strict", on_stale_write="allow", remote_endpoint=_remote())
+        (root_a / KEY).write_text("v0", encoding="utf-8")
+        (root_b / KEY).write_text("v0", encoding="utf-8")
+        yield a, b
+    finally:
+        stop_coordinator(coord_root)
+
+
+@pytest.fixture
+def memory_kv_adapter_pair():
+    """Pair of clients into the same in-memory KV — a Protocol-satisfying
+    reference adapter, not a shipped product. Demonstrates the contract
+    generalizes beyond the file substrate."""
+    kv = _MemoryKVAdapter()
+    yield kv, kv  # same instance: coordination is the in-memory version
+
+
+# ---------------------------------------------------------------------------
+# Parity test — the SAME scenario, parametrized over the two adapter pairs.
+# ---------------------------------------------------------------------------
+
+
+def _scenario_deny_then_recover(a: CoherenceAdapter, b: CoherenceAdapter) -> None:
+    """The slice-1 scenario, written once against the contract surface.
+
+    Both adapters must:
+      1. Surface a decision-time version on read.
+      2. Reject A's stale write with a ``CoherenceError`` (typed deny, not
+         silent overwrite).
+      3. Let A recover by re-reading the fresh version + retrying.
+    """
+    # A reads its decision-time version.
+    _data_a, v_a = a.read_with_version(KEY)
+
+    # B reads, then commits — the coordination authority advances past v_a.
+    _data_b, v_b = b.read_with_version(KEY)
+    b.write_cas_at(KEY, v_b, b"from-b")
+
+    # A's stale write must be denied across the protocol.
+    with pytest.raises(CoherenceError):
+        a.write_cas_at(KEY, v_a, b"from-a")
+
+    # A recovers — re-read returns a strictly newer version; retry succeeds.
+    _data_a2, v_a2 = a.read_with_version(KEY)
+    assert v_a2 > v_a, "recovery read must advance the version"
+    a.write_cas_at(KEY, v_a2, b"from-a-2")
+
+    # Final read confirms A's recovered write landed and the version advanced
+    # past B's commit — no silent loss in either direction.
+    _data_final, v_final = a.read_with_version(KEY)
+    assert v_final > v_b, "final version must advance past B's commit"
+
+
+def test_file_adapter_satisfies_contract(file_adapter_pair) -> None:
+    """``CoherentVolume`` (file-on-volume substrate, networked coordinator)
+    satisfies the CoherenceAdapter contract."""
+    a, b = file_adapter_pair
+    _scenario_deny_then_recover(a, b)
+
+
+def test_memory_kv_adapter_satisfies_contract(memory_kv_adapter_pair) -> None:
+    """An in-memory KV adapter (Protocol-satisfying reference, not shipped)
+    satisfies the same contract — proving the surface generalizes beyond the
+    file substrate."""
+    a, b = memory_kv_adapter_pair
+    _scenario_deny_then_recover(a, b)
+
+
+def test_memory_kv_adapter_baseline_loses_silently_without_cas() -> None:
+    """The negative control on the reference adapter: writing against the
+    LATEST version (skipping the decision-time-version check) succeeds and
+    silently loses the peer's commit. Codifies that the deny in the
+    contract-satisfying test above is *measured*, not asserted — the SAME
+    storage exhibits the SAME failure mode the contract prevents."""
+    kv = _MemoryKVAdapter()
+
+    # A reads its decision-time version but does not track it.
+    _, v_a = kv.read_with_version(KEY)
+
+    # B commits.
+    _, v_b = kv.read_with_version(KEY)
+    kv.write_cas_at(KEY, v_b, b"from-b")
+
+    # A writes against the LATEST version — the baseline (no CAS discipline).
+    _, v_a_latest = kv.read_with_version(KEY)
+    assert v_a_latest > v_a, "precondition: B's commit advanced the version"
+    kv.write_cas_at(KEY, v_a_latest, b"from-a")
+
+    # B's bytes are gone — the silent lost update the contract prevents.
+    data_now, _v_now = kv.read_with_version(KEY)
+    assert data_now == b"from-a"
+    assert data_now != b"from-b", "baseline should have lost B's bytes"

--- a/tests/test_claude_code_bind_validation.py
+++ b/tests/test_claude_code_bind_validation.py
@@ -74,6 +74,62 @@ def test_verify_host_default_allowlist_unchanged():
     assert verify_host(None) is False
 
 
+def test_build_allowlist_adds_validated_ipv6_bind_host(monkeypatch):
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    allow = build_host_allowlist("fc00::1")  # RFC-4193 unique-local
+    assert "fc00::1" in allow
+    assert {"localhost", "127.0.0.1"} <= allow
+
+
+def test_verify_host_accepts_bracketed_ipv6():
+    """A Host header for an IPv6 bind is bracketed ([addr]:port). The port-strip
+    must parse the bracket form, not split on the address's own colons."""
+    allow = frozenset({"localhost", "127.0.0.1", "fc00::1"})
+    assert verify_host("[fc00::1]:8080", allow) is True
+    assert verify_host("[fc00::1]", allow) is True  # no explicit port
+
+
+def test_verify_host_rejects_other_bracketed_ipv6():
+    """Relaxing to admit one IPv6 bind must NOT admit a different IPv6 host."""
+    allow = frozenset({"localhost", "127.0.0.1", "fc00::1"})
+    assert verify_host("[fc00::2]:8080", allow) is False
+    assert verify_host("[::1]:8080", allow) is False  # not in allowlist
+
+
+def test_verify_host_matches_equivalent_ipv6_spelling():
+    """Equivalent IPv6 spellings (expanded vs compressed) resolve to the same
+    allowlist entry — matching is on the normalized address, not the raw string."""
+    allow = frozenset({"localhost", "127.0.0.1", "fc00::1"})
+    assert verify_host("[fc00:0:0:0:0:0:0:1]:8080", allow) is True
+
+
+def test_verify_host_rejects_malformed_bracket_and_hostname():
+    """Fail-closed: a malformed bracket or a DNS-rebind hostname is rejected."""
+    allow = frozenset({"localhost", "127.0.0.1", "fc00::1"})
+    assert verify_host("[fc00::1", allow) is False  # missing closing bracket
+    assert verify_host("[fc00::1]junk:8080", allow) is False  # junk after "]"
+    assert verify_host("attacker.example.com", allow) is False  # DNS-rebind guard
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "[::ffff:127.0.0.1]:8080",  # IPv4-mapped IPv6 must NOT alias 127.0.0.1
+        "[fc00::1%eth0]:8080",  # scope id must NOT match the non-scoped entry
+        "2130706433",  # integer form of 127.0.0.1
+        "0177.0.0.1",  # octal IPv4
+        "127.1",  # abbreviated IPv4
+        "localhost\r",  # trailing control char (no longer stripped)
+    ],
+)
+def test_verify_host_rejects_ip_aliasing_and_malformed_forms(host):
+    """Security: the normalized-IP fallback admits ONLY a host whose canonical IP
+    is an allowlist entry — never an aliased/mapped/scoped/alt-radix spelling of
+    one, and never a control-char-padded name."""
+    allow = frozenset({"localhost", "127.0.0.1", "fc00::1"})
+    assert verify_host(host, allow) is False
+
+
 def test_coordinator_rejects_bad_bind_host(tmp_path, monkeypatch):
     """Constructing a coordinator with a disallowed bind raises at construction."""
     monkeypatch.delenv("CCS_REMOTE_COORDINATOR", raising=False)

--- a/tests/test_claude_code_bind_validation.py
+++ b/tests/test_claude_code_bind_validation.py
@@ -81,3 +81,12 @@ def test_coordinator_rejects_bad_bind_host(tmp_path, monkeypatch):
 
     with pytest.raises(ValueError):
         CoordinatorHTTPServer(tmp_path, bind_host="10.0.0.5")  # non-loopback, flag off
+
+
+def test_coordinator_cli_has_bind_host_flag():
+    """The coordinator CLI exposes --bind-host (default loopback) so the README's
+    documented cross-host command actually works."""
+    from ccs.cli.coherence_coordinator import build_parser
+
+    assert build_parser().parse_args([]).bind_host == "127.0.0.1"
+    assert build_parser().parse_args(["--bind-host", "10.0.0.5"]).bind_host == "10.0.0.5"

--- a/tests/test_claude_code_bind_validation.py
+++ b/tests/test_claude_code_bind_validation.py
@@ -1,0 +1,83 @@
+"""Unit 4 (R1): cross-host bind validation + configurable Host-allowlist.
+
+Function-level, platform-agnostic (a real non-loopback bind is Linux-only and
+lives in the netns harness, Unit 5). Covers the explicit-range bind validator,
+the derived allowlist, and that a relaxed allowlist still 403s a third host
+(the forged-Host logic, R7 #1).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ccs.adapters.claude_code.auth import (
+    build_host_allowlist,
+    validate_bind_host,
+    verify_host,
+)
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost"])
+def test_loopback_always_allowed_without_flag(host, monkeypatch):
+    monkeypatch.delenv("CCS_REMOTE_COORDINATOR", raising=False)
+    validate_bind_host(host)  # no raise
+
+
+def test_nonloopback_requires_flag(monkeypatch):
+    monkeypatch.delenv("CCS_REMOTE_COORDINATOR", raising=False)
+    with pytest.raises(ValueError, match="CCS_REMOTE_COORDINATOR"):
+        validate_bind_host("10.0.0.5")
+
+
+@pytest.mark.parametrize("host", ["10.0.0.5", "172.16.3.4", "192.168.1.1"])
+def test_private_range_accepted_with_flag(host, monkeypatch):
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    validate_bind_host(host)  # no raise
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["0.0.0.0", "127.0.0.2", "169.254.1.1", "100.64.0.1", "8.8.8.8", "notanip"],
+)
+def test_disallowed_bind_hosts_rejected_even_with_flag(host, monkeypatch):
+    """is_private would wrongly admit 0.0.0.0 and 127.0.0.2 — explicit ranges reject."""
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    with pytest.raises(ValueError):
+        validate_bind_host(host)
+
+
+def test_build_allowlist_loopback_is_default(monkeypatch):
+    monkeypatch.delenv("CCS_REMOTE_COORDINATOR", raising=False)
+    assert build_host_allowlist("127.0.0.1") == frozenset({"localhost", "127.0.0.1"})
+
+
+def test_build_allowlist_adds_validated_bind_host(monkeypatch):
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    allow = build_host_allowlist("10.0.0.5")
+    assert "10.0.0.5" in allow
+    assert {"localhost", "127.0.0.1"} <= allow
+
+
+def test_relaxed_allowlist_still_rejects_third_host():
+    # R7 #1: relaxing to admit the bind host must NOT admit anything else.
+    allow = frozenset({"localhost", "127.0.0.1", "10.0.0.5"})
+    assert verify_host("10.0.0.5", allow) is True
+    assert verify_host("10.0.0.5:8080", allow) is True  # port stripped
+    assert verify_host("attacker.example.com", allow) is False
+    assert verify_host("10.0.0.6", allow) is False
+
+
+def test_verify_host_default_allowlist_unchanged():
+    assert verify_host("127.0.0.1") is True
+    assert verify_host("localhost") is True
+    assert verify_host("attacker.example.com") is False
+    assert verify_host(None) is False
+
+
+def test_coordinator_rejects_bad_bind_host(tmp_path, monkeypatch):
+    """Constructing a coordinator with a disallowed bind raises at construction."""
+    monkeypatch.delenv("CCS_REMOTE_COORDINATOR", raising=False)
+    from ccs.adapters.claude_code.coordinator_server import CoordinatorHTTPServer
+
+    with pytest.raises(ValueError):
+        CoordinatorHTTPServer(tmp_path, bind_host="10.0.0.5")  # non-loopback, flag off

--- a/tests/test_coherence_client_remote_endpoint.py
+++ b/tests/test_coherence_client_remote_endpoint.py
@@ -1,0 +1,121 @@
+"""Unit 1 (R0a): remote-endpoint transport + the default-off cross-host flag.
+
+Verifies the loopback-only local path is byte-unchanged (``host`` defaults to
+127.0.0.1) and that a remote host plumbs into ``base_url`` + the ``Host`` header,
+plus the default-OFF ``RemoteCoordinatorConfig`` gate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ccs.cli import _coherence_client as cc
+from ccs.cli._coherence_client import (
+    CoordinatorEndpoint,
+    CoordinatorUnavailable,
+    RemoteCoordinatorConfig,
+    resolve_remote_endpoint,
+)
+
+# --- CoordinatorEndpoint: local path unchanged, remote host plumbed ---------
+
+def test_endpoint_default_host_is_loopback():
+    ep = CoordinatorEndpoint(port=51234, bearer="deadbeef")
+    assert ep.host == "127.0.0.1"
+    assert ep.base_url == "http://127.0.0.1:51234"
+
+
+def test_endpoint_positional_construction_still_works():
+    # resolve_endpoint builds CoordinatorEndpoint(port=..., bearer=...); the new
+    # defaulted host field must not break existing keyword/positional callers.
+    ep = CoordinatorEndpoint(8080, "secret")
+    assert ep.host == "127.0.0.1"
+
+
+def test_endpoint_remote_host_in_base_url():
+    ep = CoordinatorEndpoint(port=8080, bearer="deadbeef", host="10.0.0.5")
+    assert ep.base_url == "http://10.0.0.5:8080"
+
+
+@pytest.mark.parametrize("method", ["get", "post"])
+def test_request_host_header_follows_endpoint_host(monkeypatch, method):
+    captured: dict[str, str | None] = {}
+
+    def fake_execute(req):
+        captured["host"] = req.get_header("Host")
+        return {"ok": True}
+
+    monkeypatch.setattr(cc, "_execute", fake_execute)
+    ep = CoordinatorEndpoint(port=8080, bearer="deadbeef", host="10.0.0.5")
+    if method == "get":
+        cc.get(ep, "/status")
+    else:
+        cc.post(ep, "/hooks/pre-read", {"path": "x"})
+    assert captured["host"] == "10.0.0.5"
+
+
+# --- resolve_remote_endpoint -----------------------------------------------
+
+def test_resolve_remote_endpoint_builds_endpoint():
+    ep = resolve_remote_endpoint("10.0.0.5", 8080, "s3cr3t")
+    assert (ep.host, ep.port, ep.bearer) == ("10.0.0.5", 8080, "s3cr3t")
+    assert ep.base_url == "http://10.0.0.5:8080"
+
+
+@pytest.mark.parametrize("host,secret", [("", "s"), ("10.0.0.5", "")])
+def test_resolve_remote_endpoint_rejects_empty(host, secret):
+    with pytest.raises(CoordinatorUnavailable):
+        resolve_remote_endpoint(host, 8080, secret)
+
+
+# --- RemoteCoordinatorConfig: default OFF ----------------------------------
+
+def test_flag_off_by_default():
+    cfg = RemoteCoordinatorConfig.from_env(env={})
+    assert cfg.enabled is False
+    assert (cfg.host, cfg.port, cfg.secret) == (None, None, None)
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+def test_flag_truthy_enables(val):
+    cfg = RemoteCoordinatorConfig.from_env(env={"CCS_REMOTE_COORDINATOR": val})
+    assert cfg.enabled is True
+
+
+@pytest.mark.parametrize("val", ["", "0", "false", "no", "off", "  "])
+def test_flag_falsy_stays_off(val):
+    cfg = RemoteCoordinatorConfig.from_env(env={"CCS_REMOTE_COORDINATOR": val})
+    assert cfg.enabled is False
+
+
+def test_from_env_parses_host_port_and_secret_file(tmp_path):
+    secret_file = tmp_path / "remote.secret"
+    secret_file.write_text("  abc123  \n", encoding="utf-8")
+    cfg = RemoteCoordinatorConfig.from_env(
+        env={
+            "CCS_REMOTE_COORDINATOR": "1",
+            "CCS_REMOTE_HOST": "10.0.0.5",
+            "CCS_REMOTE_PORT": "8080",
+            "CCS_REMOTE_SECRET_FILE": str(secret_file),
+        }
+    )
+    assert cfg.enabled is True
+    assert (cfg.host, cfg.port, cfg.secret) == ("10.0.0.5", 8080, "abc123")
+
+
+def test_from_env_missing_secret_file_yields_none(tmp_path):
+    cfg = RemoteCoordinatorConfig.from_env(
+        env={
+            "CCS_REMOTE_COORDINATOR": "1",
+            "CCS_REMOTE_SECRET_FILE": str(tmp_path / "nope.secret"),
+        }
+    )
+    assert cfg.enabled is True
+    assert cfg.secret is None
+
+
+def test_from_env_non_numeric_port_is_none():
+    cfg = RemoteCoordinatorConfig.from_env(
+        env={"CCS_REMOTE_COORDINATOR": "1", "CCS_REMOTE_PORT": "notaport"}
+    )
+    assert cfg.port is None

--- a/tests/test_coherence_client_remote_endpoint.py
+++ b/tests/test_coherence_client_remote_endpoint.py
@@ -119,3 +119,16 @@ def test_from_env_non_numeric_port_is_none():
         env={"CCS_REMOTE_COORDINATOR": "1", "CCS_REMOTE_PORT": "notaport"}
     )
     assert cfg.port is None
+
+
+def test_secret_file_symlink_is_rejected(tmp_path):
+    # Hardening: a symlinked secret file is refused (O_NOFOLLOW) so an attacker
+    # who can set CCS_REMOTE_SECRET_FILE cannot repoint it at another file.
+    real = tmp_path / "real.secret"
+    real.write_text("s3cr3t", encoding="utf-8")
+    link = tmp_path / "link.secret"
+    link.symlink_to(real)
+    cfg = RemoteCoordinatorConfig.from_env(
+        env={"CCS_REMOTE_COORDINATOR": "1", "CCS_REMOTE_SECRET_FILE": str(link)}
+    )
+    assert cfg.secret is None

--- a/tests/test_cross_host_deny.py
+++ b/tests/test_cross_host_deny.py
@@ -68,12 +68,8 @@ def test_slice1_cross_endpoint_deny_and_recover(
         def remote():
             return resolve_remote_endpoint("127.0.0.1", ep.port, ep.bearer)
 
-        vol_a = CoherentVolume(
-            root_a, on_error="strict", on_stale_write="allow", remote_endpoint=remote()
-        )
-        vol_b = CoherentVolume(
-            root_b, on_error="strict", on_stale_write="allow", remote_endpoint=remote()
-        )
+        vol_a = CoherentVolume(root_a, on_error="strict", on_stale_write="allow", remote_endpoint=remote())
+        vol_b = CoherentVolume(root_b, on_error="strict", on_stale_write="allow", remote_endpoint=remote())
         # Coordinator-version-only: per-root file copies; coordination is the
         # coordinator's version of the shared key.
         (root_a / "shared.txt").write_text("v0", encoding="utf-8")
@@ -128,12 +124,8 @@ def test_untracked_key_is_not_versioned_so_deny_passes_vacuously(
         def remote():
             return resolve_remote_endpoint("127.0.0.1", ep.port, ep.bearer)
 
-        vol_a = CoherentVolume(
-            root_a, on_error="strict", on_stale_write="allow", remote_endpoint=remote()
-        )
-        vol_b = CoherentVolume(
-            root_b, on_error="strict", on_stale_write="allow", remote_endpoint=remote()
-        )
+        vol_a = CoherentVolume(root_a, on_error="strict", on_stale_write="allow", remote_endpoint=remote())
+        vol_b = CoherentVolume(root_b, on_error="strict", on_stale_write="allow", remote_endpoint=remote())
         (root_a / "shared.txt").write_text("v0", encoding="utf-8")
         (root_b / "shared.txt").write_text("v0", encoding="utf-8")
 
@@ -173,9 +165,7 @@ def test_remote_volume_reattaches_to_remote_coordinator_after_fork(
         ep = resolve_endpoint(coord_root)
         _cc_post(ep, "/policy/track", {"paths": ["shared.txt"]})
         remote = resolve_remote_endpoint("127.0.0.1", ep.port, ep.bearer)
-        vol = CoherentVolume(
-            root, on_error="strict", on_stale_write="allow", remote_endpoint=remote
-        )
+        vol = CoherentVolume(root, on_error="strict", on_stale_write="allow", remote_endpoint=remote)
         (root / "shared.txt").write_text("v0", encoding="utf-8")
         _d, v_parent = vol.read_with_version("shared.txt")  # parent attaches
         parent_id = vol.session_id
@@ -247,12 +237,8 @@ def test_slice2_effect_gate_across_hosts(
         def remote():
             return resolve_remote_endpoint("127.0.0.1", ep.port, ep.bearer)
 
-        vol_a = CoherentVolume(
-            root_a, on_error="strict", on_stale_write="allow", remote_endpoint=remote()
-        )
-        vol_b = CoherentVolume(
-            root_b, on_error="strict", on_stale_write="allow", remote_endpoint=remote()
-        )
+        vol_a = CoherentVolume(root_a, on_error="strict", on_stale_write="allow", remote_endpoint=remote())
+        vol_b = CoherentVolume(root_b, on_error="strict", on_stale_write="allow", remote_endpoint=remote())
         (root_a / "config.json").write_text('{"v": 0}', encoding="utf-8")
         (root_b / "config.json").write_text('{"v": 0}', encoding="utf-8")
 
@@ -275,3 +261,154 @@ def test_slice2_effect_gate_across_hosts(
         assert effect_fires(v_decision) is False
     finally:
         stop_coordinator(coord_root)
+
+
+# ---------------------------------------------------------------------------
+# Negative controls — codify the baselines the demo's --baseline flag runs.
+#
+# These tests assert that the FAILURES we claim CCS prevents are real and
+# reproducible. If a future library change quietly made the baseline 'work',
+# the demo's contrast would erode and we would notice here first.
+# ---------------------------------------------------------------------------
+
+
+def test_slice1_baseline_silent_lost_update_without_decision_time_version(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """NEGATIVE CONTROL: an agent that does NOT track its decision-time version
+    silently loses a peer's intervening commit.
+
+    Pattern: A reads@v_a but writes against the LATEST version (the classic
+    convention-only / un-coordinated lost-update bug pattern). B's bytes are
+    dropped from the canonical record. This is the failure
+    ``test_slice1_cross_endpoint_deny_and_recover`` proves CCS prevents.
+    """
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    coord_root = tmp_path / "coord"
+    coord_root.mkdir()
+    root_a = tmp_path / "a"
+    root_a.mkdir()
+    root_b = tmp_path / "b"
+    root_b.mkdir()
+
+    ensure_coordinator(coord_root, config=fast_cfg)
+    try:
+        ep = resolve_endpoint(coord_root)
+        _cc_post(ep, "/policy/track", {"paths": ["shared.txt"]})
+
+        def remote():
+            return resolve_remote_endpoint("127.0.0.1", ep.port, ep.bearer)
+
+        vol_a = CoherentVolume(root_a, on_error="strict", on_stale_write="allow", remote_endpoint=remote())
+        vol_b = CoherentVolume(root_b, on_error="strict", on_stale_write="allow", remote_endpoint=remote())
+        (root_a / "shared.txt").write_text("v0", encoding="utf-8")
+        (root_b / "shared.txt").write_text("v0", encoding="utf-8")
+
+        # A's decision-time read — but the baseline agent "forgets" v_a below.
+        _data_a, v_a = vol_a.read_with_version("shared.txt")
+
+        # B commits intervening bytes; coordinator's canonical version advances.
+        _data_b, v_b = vol_b.read_with_version("shared.txt")
+        vol_b.write_cas_at("shared.txt", v_b, b"from-b")
+
+        # The bug pattern: A re-reads to get the LATEST version and writes
+        # against it — no check that the artifact moved relative to v_a.
+        _, v_a_latest = vol_a.read_with_version("shared.txt")
+        assert v_a_latest > v_a, "precondition: B's commit advanced the version"
+        vol_a.write_cas_at("shared.txt", v_a_latest, b"from-a")  # SUCCEEDS — no deny
+
+        # Canonical state now has A's bytes; B's bytes are silently lost.
+        data_now, _v_now = vol_a.read_with_version("shared.txt")
+        assert data_now == b"from-a", "baseline failed: lost-update did not occur"
+        assert data_now != b"from-b", "B's bytes should be gone from the canonical record"
+    finally:
+        stop_coordinator(coord_root)
+
+
+def test_slice2_baseline_stale_fire_without_effect_gate(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """NEGATIVE CONTROL: an agent that does NOT gate its effect on the
+    decision-time version fires on stale config.
+
+    Pattern: A decides @ v_decision, B advances config, A's effect fires
+    ungated. This is the CI failure (build/deploy against a config that was
+    edited mid-decision) that EO-1/EO-2/EO-3 prevent in
+    ``test_slice2_effect_gate_across_hosts``.
+    """
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    coord_root = tmp_path / "coord"
+    coord_root.mkdir()
+    root_a = tmp_path / "a"
+    root_a.mkdir()
+    root_b = tmp_path / "b"
+    root_b.mkdir()
+
+    ensure_coordinator(coord_root, config=fast_cfg)
+    try:
+        ep = resolve_endpoint(coord_root)
+        _cc_post(ep, "/policy/track", {"paths": ["config.json"]})
+
+        def remote():
+            return resolve_remote_endpoint("127.0.0.1", ep.port, ep.bearer)
+
+        vol_a = CoherentVolume(root_a, on_error="strict", on_stale_write="allow", remote_endpoint=remote())
+        vol_b = CoherentVolume(root_b, on_error="strict", on_stale_write="allow", remote_endpoint=remote())
+        (root_a / "config.json").write_text('{"v": 0}', encoding="utf-8")
+        (root_b / "config.json").write_text('{"v": 0}', encoding="utf-8")
+
+        # A decides on config @ v_decision.
+        _c, v_decision = vol_a.read_with_version("config.json")
+
+        # B advances config under A.
+        _cb, v_b = vol_b.read_with_version("config.json")
+        vol_b.write_cas_at("config.json", v_b, b'{"v": 1}')
+
+        # The baseline: A fires the effect ungated — the current version is
+        # NOT compared against v_decision before the effect runs.
+        _, v_when_firing = vol_a.read_with_version("config.json")
+        assert v_when_firing > v_decision, "precondition: config must have advanced"
+
+        # In a real CI step the effect would be the deploy/build invocation.
+        # We assert the failure by observing that NOTHING in the baseline
+        # mechanism would have prevented the effect from firing — the agent
+        # has no gate to enforce.
+        # (Concretely: it would have called effect(v=v_decision) against a
+        # config that is now at v_when_firing.)
+        assert v_when_firing != v_decision, "baseline failed: stale config not exercised"
+    finally:
+        stop_coordinator(coord_root)
+
+
+def test_main_baseline_flag_runs_negative_control_then_with_ccs(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """End-to-end CLI smoke: ``python examples/cross_host/main.py --baseline``
+    runs the negative control then the with-CCS pass, exits 0, and the output
+    contains both phases. This pins the screen-share contract: broken-must-lose
+    AND fixed-must-prevent in one invocation.
+    """
+    # main() spawns a coordinator + clients in this process; the env nudge
+    # below is the same one main() applies for the local loopback path.
+    monkeypatch.delenv("CCS_REMOTE_HOST", raising=False)
+    monkeypatch.delenv("CCS_REMOTE_PORT", raising=False)
+    monkeypatch.delenv("CCS_REMOTE_SECRET_FILE", raising=False)
+
+    # Import lazily so the test file does not depend on the example being on
+    # the import path at collection time.
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "ccs_cross_host_demo_main",
+        Path(__file__).parent.parent / "examples" / "cross_host" / "main.py",
+    )
+    assert spec is not None and spec.loader is not None
+    demo_main = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(demo_main)
+
+    rc = demo_main.main(["--baseline"])
+    out = capsys.readouterr().out
+    assert rc == 0, f"--baseline should exit 0 on a green run, got {rc}; output:\n{out}"
+    assert "Negative control" in out, "baseline phase must be labeled in output"
+    assert "With CCS" in out, "with-CCS phase must be labeled in output"
+    assert "RESULT: PASS" in out

--- a/tests/test_cross_host_deny.py
+++ b/tests/test_cross_host_deny.py
@@ -11,6 +11,7 @@ tests/test_claude_code_bind_validation.py.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -99,6 +100,127 @@ def test_slice1_cross_endpoint_deny_and_recover(
         assert v_a2 > v_a
         vol_a.write_cas_at("shared.txt", v_a2, b"from-a-2")
         assert (root_a / "shared.txt").read_bytes() == b"from-a-2"
+    finally:
+        stop_coordinator(coord_root)
+
+
+def test_untracked_key_is_not_versioned_so_deny_passes_vacuously(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guard: WITHOUT /policy/track the shared key is never versioned (stays
+    version 0), so the version-CAS cannot detect a stale write — A silently
+    overwrites B's commit, NO CasVersionConflict is raised. This is WHY the demo
+    and the deny test must track the key first; it pins the vacuous-pass failure
+    mode so a dropped track() call can't quietly defeat the deny."""
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    coord_root = tmp_path / "coord"
+    coord_root.mkdir()
+    root_a = tmp_path / "a"
+    root_a.mkdir()
+    root_b = tmp_path / "b"
+    root_b.mkdir()
+
+    ensure_coordinator(coord_root, config=fast_cfg)
+    try:
+        ep = resolve_endpoint(coord_root)
+        # Deliberately DO NOT track "shared.txt" — the contrast with the deny test.
+
+        def remote():
+            return resolve_remote_endpoint("127.0.0.1", ep.port, ep.bearer)
+
+        vol_a = CoherentVolume(
+            root_a, on_error="strict", on_stale_write="allow", remote_endpoint=remote()
+        )
+        vol_b = CoherentVolume(
+            root_b, on_error="strict", on_stale_write="allow", remote_endpoint=remote()
+        )
+        (root_a / "shared.txt").write_text("v0", encoding="utf-8")
+        (root_b / "shared.txt").write_text("v0", encoding="utf-8")
+
+        _data_a, v_a = vol_a.read_with_version("shared.txt")
+        _data_b, v_b = vol_b.read_with_version("shared.txt")
+        assert v_a == 0 and v_b == 0  # untracked -> never versioned
+
+        vol_b.write_cas_at("shared.txt", v_b, b"from-b")
+        # A's "stale" write is NOT denied (the version never moved off 0): A's
+        # bytes silently win — the lost update the deny test prevents via tracking.
+        vol_a.write_cas_at("shared.txt", v_a, b"from-a")
+        assert (root_a / "shared.txt").read_bytes() == b"from-a"
+    finally:
+        stop_coordinator(coord_root)
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork (POSIX)")
+def test_remote_volume_reattaches_to_remote_coordinator_after_fork(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A REMOTE-mode volume forked into a child re-attaches to the SAME remote
+    coordinator (connect-only, never spawn): the child re-mints identity, takes
+    the _attach_remote path, and creates NO local server.pid under its own root.
+
+    The child's first post-fork read returns its re-seeded baseline (version 0),
+    so a bare CAS write would be DENIED — fork safety, not a silent overwrite.
+    Recovery is reacquire() (re-mint + mandatory fresh read); only then does the
+    child's write land through the shared coordinator (the parent sees it)."""
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    coord_root = tmp_path / "coord"
+    coord_root.mkdir()
+    root = tmp_path / "a"
+    root.mkdir()
+
+    ensure_coordinator(coord_root, config=fast_cfg)
+    try:
+        ep = resolve_endpoint(coord_root)
+        _cc_post(ep, "/policy/track", {"paths": ["shared.txt"]})
+        remote = resolve_remote_endpoint("127.0.0.1", ep.port, ep.bearer)
+        vol = CoherentVolume(
+            root, on_error="strict", on_stale_write="allow", remote_endpoint=remote
+        )
+        (root / "shared.txt").write_text("v0", encoding="utf-8")
+        _d, v_parent = vol.read_with_version("shared.txt")  # parent attaches
+        parent_id = vol.session_id
+
+        read_fd, write_fd = os.pipe()
+        pid = os.fork()
+        if pid == 0:  # child: first op must re-attach to the remote coordinator
+            os.close(read_fd)
+            try:
+                # First op post-fork: read_with_version returns the re-seeded
+                # baseline (0) and does NOT itself re-attach (documented safe
+                # fallback — a CAS against version 0 loses cleanly, never silently).
+                _dc, v_first = vol.read_with_version("shared.txt")
+                # Recovery: reacquire() re-mints identity + does a mandatory fresh
+                # read, which re-attaches to the remote coordinator (connect-only).
+                vol.reacquire("shared.txt")
+                local_pid = (root / ".coherence" / "server.pid").exists()
+                facts = f"{vol.session_id}|{vol.is_attached}|{local_pid}|{vol._endpoint.port}|{v_first}"
+                _df, v_fresh = vol.read_with_version("shared.txt")
+                vol.write_cas_at("shared.txt", v_fresh, b"from-child")
+                msg = f"{facts}|ok"
+            except Exception as exc:  # noqa: BLE001 - report any failure to the parent
+                msg = f"ERR:{exc!r}"
+            try:
+                os.write(write_fd, msg.encode("utf-8"))
+            finally:
+                os.close(write_fd)
+                os._exit(0)
+        # parent (child os._exit'd above and never reaches the finally below)
+        os.close(write_fd)
+        raw = os.read(read_fd, 256).decode("utf-8")
+        os.close(read_fd)
+        os.waitpid(pid, 0)
+        assert not raw.startswith("ERR:"), raw
+        child_id, attached, local_pid, child_port, first_v, recovered = raw.split("|")
+        assert child_id != parent_id  # re-minted identity
+        assert attached == "True"  # re-attached
+        assert local_pid == "False"  # connect-only: NEVER spawned a local coordinator
+        assert int(child_port) == ep.port  # to the SAME remote coordinator
+        assert int(first_v) == 0  # re-seeded baseline (fork safety: bare CAS would deny)
+        assert recovered == "ok"  # reacquire() recovery path succeeded
+        # The recovered write landed through the shared coordinator.
+        _d2, v_after = vol.read_with_version("shared.txt")
+        assert v_after > v_parent
+        assert (root / "shared.txt").read_bytes() == b"from-child"
     finally:
         stop_coordinator(coord_root)
 

--- a/tests/test_cross_host_deny.py
+++ b/tests/test_cross_host_deny.py
@@ -96,3 +96,55 @@ def test_slice1_cross_endpoint_deny_and_recover(
         vol_a.write_cas_at("shared.txt", v_a2, b"from-a-2")
     finally:
         stop_coordinator(coord_root)
+
+
+def test_slice2_effect_gate_across_hosts(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Slice-2 (R4): an effect gated on config@vN FIRES when config is unchanged
+    and is HELD when config advanced under it — across the endpoint, on the
+    shipped read_with_version primitive."""
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    coord_root = tmp_path / "coord"
+    coord_root.mkdir()
+    root_a = tmp_path / "a"
+    root_a.mkdir()
+    root_b = tmp_path / "b"
+    root_b.mkdir()
+
+    ensure_coordinator(coord_root, config=fast_cfg)
+    try:
+        ep = resolve_endpoint(coord_root)
+        _cc_post(ep, "/policy/track", {"paths": ["config.json"]})
+
+        def remote():
+            return resolve_remote_endpoint("127.0.0.1", ep.port, ep.bearer)
+
+        vol_a = CoherentVolume(
+            root_a, on_error="strict", on_stale_write="allow", remote_endpoint=remote()
+        )
+        vol_b = CoherentVolume(
+            root_b, on_error="strict", on_stale_write="allow", remote_endpoint=remote()
+        )
+        (root_a / "config.json").write_text('{"v": 0}', encoding="utf-8")
+        (root_b / "config.json").write_text('{"v": 0}', encoding="utf-8")
+
+        # A reads config -> the version its effect decision depends on.
+        _c, v_decision = vol_a.read_with_version("config.json")
+
+        def effect_fires(decision_version: int) -> bool:
+            """Gate the effect on config still being at the decision version."""
+            _cur, current = vol_a.read_with_version("config.json")
+            return current == decision_version
+
+        # Unchanged config -> the gate FIRES.
+        assert effect_fires(v_decision) is True
+
+        # B advances config under A.
+        _cb, v_b = vol_b.read_with_version("config.json")
+        vol_b.write_cas_at("config.json", v_b, b'{"v": 1}')
+
+        # Config moved -> the gate HOLDS the effect (not fired on stale input).
+        assert effect_fires(v_decision) is False
+    finally:
+        stop_coordinator(coord_root)

--- a/tests/test_cross_host_deny.py
+++ b/tests/test_cross_host_deny.py
@@ -1,0 +1,98 @@
+"""Unit 5 (R3): slice-1 cross-host deny + recover.
+
+This loopback integration test proves the full chain end-to-end on a real socket
+(runnable on any platform): two remote-endpoint clients (never-spawn) coordinate
+ONE coordinator; a stale write is denied by version-CAS *across the endpoint* and
+recovers via re-read + retry. The genuinely-non-loopback path (a real RFC-1918
+bind exercising verify_host's new branch) is the netns/veth runner in
+examples/cross_host/ (Linux-only); that Host-check logic is unit-covered in
+tests/test_claude_code_bind_validation.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ccs.adapters.claude_code.lifecycle import (
+    LifecycleConfig,
+    ensure_coordinator,
+    stop_coordinator,
+)
+from ccs.adapters.coherent_volume import CoherentVolume
+from ccs.cli._coherence_client import (
+    post as _cc_post,
+)
+from ccs.cli._coherence_client import (
+    resolve_endpoint,
+    resolve_remote_endpoint,
+)
+from ccs.core.exceptions import CoherenceError
+
+
+@pytest.fixture
+def fast_cfg() -> LifecycleConfig:
+    return LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0.1,
+        notice_evict_max_age_sec=1.0,
+        port_file_retry_attempts=20,
+        port_file_retry_interval_sec=0.05,
+        connect_retry_attempts=10,
+        connect_retry_interval_sec=0.05,
+    )
+
+
+def test_slice1_cross_endpoint_deny_and_recover(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    coord_root = tmp_path / "coord"
+    coord_root.mkdir()
+    root_a = tmp_path / "a"
+    root_a.mkdir()
+    root_b = tmp_path / "b"
+    root_b.mkdir()
+
+    ensure_coordinator(coord_root, config=fast_cfg)
+    try:
+        ep = resolve_endpoint(coord_root)
+        # Coordinator-version-only: the artifact must be TRACKED on the coordinator
+        # to be versioned (an untracked path is never versioned -> no CAS). Tracking
+        # is separate from STRICT mode — it gives versioning; strict would add
+        # read-deny enforcement (not needed for the version-CAS write deny).
+        _cc_post(ep, "/policy/track", {"paths": ["shared.txt"]})
+
+        def remote():
+            return resolve_remote_endpoint("127.0.0.1", ep.port, ep.bearer)
+
+        vol_a = CoherentVolume(
+            root_a, on_error="strict", on_stale_write="allow", remote_endpoint=remote()
+        )
+        vol_b = CoherentVolume(
+            root_b, on_error="strict", on_stale_write="allow", remote_endpoint=remote()
+        )
+        # Coordinator-version-only: per-root file copies; coordination is the
+        # coordinator's version of the shared key.
+        (root_a / "shared.txt").write_text("v0", encoding="utf-8")
+        (root_b / "shared.txt").write_text("v0", encoding="utf-8")
+
+        # A reads the shared key -> version v_a (registers SHARED on the coordinator).
+        _data_a, v_a = vol_a.read_with_version("shared.txt")
+
+        # B reads + commits -> the coordinator version advances past v_a.
+        _data_b, v_b = vol_b.read_with_version("shared.txt")
+        vol_b.write_cas_at("shared.txt", v_b, b"from-b")
+
+        # A's write against its now-stale version is DENIED across the endpoint
+        # (a typed CoherenceError: version-mismatch / invalidated view).
+        with pytest.raises(CoherenceError):
+            vol_a.write_cas_at("shared.txt", v_a, b"from-a")
+
+        # A recovers: re-read -> fresh version -> retry succeeds (no silent loss).
+        _data_a2, v_a2 = vol_a.read_with_version("shared.txt")
+        assert v_a2 > v_a
+        vol_a.write_cas_at("shared.txt", v_a2, b"from-a-2")
+    finally:
+        stop_coordinator(coord_root)

--- a/tests/test_cross_host_deny.py
+++ b/tests/test_cross_host_deny.py
@@ -28,7 +28,7 @@ from ccs.cli._coherence_client import (
     resolve_endpoint,
     resolve_remote_endpoint,
 )
-from ccs.core.exceptions import CoherenceError
+from ccs.core.exceptions import CasVersionConflict
 
 
 @pytest.fixture
@@ -86,14 +86,19 @@ def test_slice1_cross_endpoint_deny_and_recover(
         vol_b.write_cas_at("shared.txt", v_b, b"from-b")
 
         # A's write against its now-stale version is DENIED across the endpoint
-        # (a typed CoherenceError: version-mismatch / invalidated view).
-        with pytest.raises(CoherenceError):
+        # (the typed version-CAS conflict, NOT just any CoherenceError — pin the
+        # exact type and the carried versions so the deny can't pass on an
+        # unrelated failure).
+        with pytest.raises(CasVersionConflict) as deny:
             vol_a.write_cas_at("shared.txt", v_a, b"from-a")
+        assert deny.value.expected_version == v_a
+        assert deny.value.current_version > v_a
 
         # A recovers: re-read -> fresh version -> retry succeeds (no silent loss).
         _data_a2, v_a2 = vol_a.read_with_version("shared.txt")
         assert v_a2 > v_a
         vol_a.write_cas_at("shared.txt", v_a2, b"from-a-2")
+        assert (root_a / "shared.txt").read_bytes() == b"from-a-2"
     finally:
         stop_coordinator(coord_root)
 


### PR DESCRIPTION
## Summary
- Adds **optional cross-host coordination** behind a default-off flag (`CCS_REMOTE_COORDINATOR`): a `CoherentVolume` can connect to a remote coordinator over the network and coordinate a shared artifact via version-CAS **across a host boundary**. The default loopback path is byte-unchanged.
- Two demonstrated slices: **artifact-coordination** (a stale write is denied across the boundary, then recovers) and **effect-ordering** (an effect is gated on a tracked artifact's version).

## What's included
- **Remote-endpoint transport** (`_coherence_client.py`): `CoordinatorEndpoint` gains a `host` field; `RemoteCoordinatorConfig.from_env` gates remote mode. The bearer is read from `CCS_REMOTE_SECRET_FILE` (never an inline env var; opened `O_NOFOLLOW`).
- **Connect-only, never-spawn remote mode** (`CoherentVolume`): a remote client attaches to an explicit endpoint and never spawns a local coordinator; fails closed when unreachable, on `401` (typed `RemoteAuthFailed`), and on any non-2xx at attach.
- **Bind validation + configurable Host-allowlist** (`auth.py`, `coordinator_server.py`): `bind_host` is validated to explicit RFC-1918/4193 ranges (`0.0.0.0` / loopback-alias / link-local / CGNAT / public all rejected); the coordinator derives `{loopback} ∪ {validated bind_host}` and still 403s any other host. `--bind-host` added to `agent-coherence-coordinator`.
- **Demo** (`examples/cross_host/`): a runnable narrated demo (loopback smoke + a one-command Docker cross-container run) and an integration test.

## Tests
- New: remote-endpoint transport, never-spawn, fail-closed (`401` / degraded-200 / non-2xx), bind validation (incl. forged-Host + the full disallowed-bind set), symlinked-secret rejection, and the cross-host deny + effect-gate integration test.
- **Docker cross-container run verified PASS** — coordinator on a validated RFC-1918 bind, client in a separate container/network-namespace connecting with a matching `Host` header.
- Full touched-surface regression green. (One pre-existing flaky test, `test_i6_dispatch_decrements_even_when_handler_raises`, passes 3/3 in isolation — unrelated to this change.)

## Scope / limitations (by design)
- Single centralized coordinator — a single point of failure, single-region; not distributed/HA.
- Plaintext bearer over a trusted/encrypted link; production hardening would add mTLS + cert rotation.
- Single-uid cooperative trust; no multi-tenant isolation.
- Everything is gated by the default-off flag — **no behavior change unless `CCS_REMOTE_COORDINATOR` is set.**