### PR TITLE
docs(cross-host): remove internal jargon from the demo docs

### DIFF
--- a/examples/cross_host/ADAPTER-CONTRACT.md
+++ b/examples/cross_host/ADAPTER-CONTRACT.md
@@ -1,21 +1,17 @@
-# Substrate-adapter contract (DX-3)
+# Substrate-adapter contract
 
 The cross-host demo claims: *"same protocol, two topologies."* This document
-makes that claim **testable** — defines the version-CAS contract any substrate
-adapter must satisfy, lists the shipped implementations, and points at the
-parity test that proves both adapters exhibit the same deny semantics against
-the same scenario.
+makes that claim **testable** — it defines the version-CAS contract any substrate
+adapter must satisfy, lists the shipped implementations, and points at the parity
+test that proves both adapters exhibit the same deny semantics against the same
+scenario.
 
 ## Why this exists
 
 Without a written contract, "the protocol is the same, only the substrate
-differs" is an assertion. With this contract + the parity test, it's a *passing
-test* — the version-CAS surface that prevents the silent lost update is shown
-to generalize beyond any single substrate, on the same shipped primitives.
-
-Anchored to the north-star [Slices + the path](../../docs/bizops/north-star-research-agenda.md) §
-DX-3 ("Pluggable artifact substrate — the *same* protocol drives ≥2 adapters")
-and the cross-host pilot one-pager § "Honest scope" NR-2.
+differs" is an assertion. With this contract plus the parity test, it is a
+*passing test* — the version-CAS surface that prevents the silent lost update is
+shown to generalize beyond any single substrate, on the same shipped primitives.
 
 ## The contract
 
@@ -63,11 +59,11 @@ is exercised by the LangGraph integration tests.
 ### Why this matters for cross-host
 
 Adapter-substrate independence is **half the cross-host story** (the other half
-is the networked coordinator itself, NR-1). A file-on-volume vendor and a
-KV-store vendor coordinate concurrent writes through the *same* version-CAS
-protocol; the substrate adapter abstracts the bytes, the coordinator owns the
-version. A pilot can pick whichever substrate matches its workload without
-buying into a different coordination model.
+is the networked coordinator itself — a single centralized coordinator). A
+file-on-volume project and a KV-store project coordinate concurrent writes
+through the *same* version-CAS protocol; the substrate adapter abstracts the
+bytes, the coordinator owns the version. A team can pick whichever substrate
+matches its workload without buying into a different coordination model.
 
 ## Parity test
 
@@ -95,23 +91,23 @@ The test asserts both adapters:
 - successfully recover after A re-reads + retries against the fresh version.
 
 If a future adapter is added, this test grows by one parametrized case — the
-contract stays the same, the parity claim stays testable, and the demo's
-DX-3 ("same protocol, two topologies") stops being asserted and starts being
-proved.
+contract stays the same, the parity claim stays testable, and the "same
+protocol, two topologies" claim stops being asserted and starts being proved.
 
 ## What this contract is NOT
 
 - **Not a transport spec** — the contract defines the version-CAS *surface*,
   not how `read`/`write` reach the coordinator (HTTP, in-process, FUSE, MCP all
-  qualify; the cross-host demo's NR-2 names which one is in-scope today).
+  qualify). The demo names which transport is in scope today — see its
+  "Honest scope" section.
 - **Not a strict-mode spec** — the version-CAS deny is independent of strict
   mode's read-fence; both shipped adapters version-CAS write-deny without
-  needing strict-mode enforcement (the cross-host demo runs `tracked != strict`
-  per the README, NR-2).
+  needing strict-mode enforcement. The cross-host demo runs with the shared key
+  *tracked* but *not strict* (see the README).
 - **Not a durability spec** — `synchronous=FULL` durability is a separate
   axis from version-CAS atomicity. A future adapter that backs onto a durable
   log adds durability without changing the CAS surface this contract defines.
-- **Not a snapshot/transaction spec** — multi-key consistent reads (SB-17)
-  and atomic multi-key publish (SB-18) are *additional* surfaces on top of
-  this contract, gated behind separate demand signals. The slice-1 +
-  slice-2 demo lives strictly inside this contract.
+- **Not a snapshot/transaction spec** — multi-key consistent reads and atomic
+  multi-key publish are *additional* surfaces on top of this contract, each
+  gated behind its own demand. The two demo scenarios live strictly inside this
+  contract.

--- a/examples/cross_host/README.md
+++ b/examples/cross_host/README.md
@@ -1,21 +1,41 @@
-# Cross-host coherence demo — slice 1 (stale-write deny) + slice 2 (effect-ordering)
+# Cross-host coherence demo — stale-write deny + effect ordering
 
-Two clients coordinate **one** centralized coordinator over the network. **Slice 1
-(artifact-coordination):** a stale write is denied by version-CAS *across the
-boundary*, and the loser recovers via re-read + retry — no silent lost update.
-**Slice 2 (effect-ordering, EO-1..EO-3):** an effect gated on `config@vN` FIRES
-when the config is unchanged and is HELD when the config advanced under the
-agent — never fired on stale input.
+Two clients coordinate **one** centralized coordinator over the network.
 
-**Honest scope (Gate A, demo-grade) — owned by NR-number so each limit is named, not implied:**
+- **Scenario 1 — stale-write deny.** A stale write is denied by version-CAS
+  *across the host boundary*, and the loser recovers via re-read + retry — no
+  silent lost update.
+- **Scenario 2 — effect ordering.** An effect gated on `config@vN` fires when the
+  config is unchanged and is held when the config advanced under the agent —
+  never fired on stale input.
 
-- **NR-1 — Single centralized coordinator.** A SPOF, single-region. NOT distributed / replicated / HA. The HA version is the production rung, co-developed with a pilot — not papered over.
-- **NR-2 — Coordinator-version-only, NOT unmediated shared-FS coherence.** The shared artifact is **tracked** on the coordinator (so it is versioned) but **not strict** — the deny is the OCC version-CAS; no strict read-enforcement is needed. The artifact is coordinated *through* the protocol, NOT by intercepting raw filesystem writes — catching a writer that **bypasses** the coordinator (FUSE / kernel watcher) is out (cooperative trust, not kernel enforcement).
-- **NR-3 — NOT cross-host fencing, partition tolerance, or durability/HA.** `coordinator_epoch` is seeded-but-unused at the network layer; durability beyond sqlite's `synchronous=NORMAL` is a separate `synchronous=FULL` decision; partition behavior is undefined.
-- **NR-4 — Plaintext bearer over a *trusted, encrypted* link** (WireGuard, not bare VPC). Production hardening = mTLS + cert rotation, co-developed. Single-uid cooperative trust; no multi-tenant isolation.
-- **NR-5 — Reduces, doesn't eliminate.** The gate only sees writes that go *through* the coordinator. An un-coordinated open, a write to a path the coordinator doesn't `track`, a value cached in another process, an FS-level edit by a tool not party to the protocol — all invisible. Best-effort point-in-time, not a lock; across hosts, network latency widens the window between version-check and effect.
+**Honest scope (demo-grade).** Each limitation is named explicitly:
 
-All cross-host behavior is gated by `CCS_REMOTE_COORDINATOR`; the default loopback path is unchanged.
+- **Single centralized coordinator.** A single point of failure, single-region —
+  not distributed, replicated, or highly available. The production (HA) version
+  is a separate effort.
+- **Coordinator-version-only, not unmediated shared-filesystem coherence.** The
+  shared artifact is **tracked** on the coordinator (so it is versioned) but
+  **not strict** — the deny is the optimistic version-CAS; no strict
+  read-enforcement is needed. The artifact is coordinated *through* the protocol,
+  not by intercepting raw filesystem writes — catching a writer that **bypasses**
+  the coordinator (e.g. a FUSE layer or kernel watcher) is out of scope
+  (cooperative trust, not kernel enforcement).
+- **Not cross-host fencing, partition tolerance, or durability/HA.** Durability
+  beyond SQLite's `synchronous=NORMAL` is a separate decision; partition behavior
+  is undefined.
+- **Plaintext bearer token over a *trusted, encrypted* link** (e.g. WireGuard,
+  not a bare VPC). Production hardening would add mTLS + certificate rotation.
+  Single-user cooperative trust; no multi-tenant isolation.
+- **Reduces, doesn't eliminate.** The gate only sees writes that go *through* the
+  coordinator. An un-coordinated open, a write to a path the coordinator doesn't
+  track, a value cached in another process, or a filesystem-level edit by a tool
+  not party to the protocol — all invisible. It is best-effort point-in-time, not
+  a lock; across hosts, network latency widens the window between version-check
+  and effect.
+
+All cross-host behavior is gated by `CCS_REMOTE_COORDINATOR`; the default
+loopback path is unchanged.
 
 ## 1. Local smoke (any platform — proves the mechanism, not a host boundary)
 
@@ -24,9 +44,9 @@ python examples/cross_host/main.py
 ```
 
 Spawns a loopback coordinator and runs both clients in one process. Exit `0` iff
-slice-1's stale write was denied **and** recovery succeeded **and** slice-2's
-effect was held on a stale config. This proves the version-CAS deny + recovery +
-effect-gate; it does **not** cross a real host boundary.
+Scenario 1's stale write was denied **and** recovery succeeded **and** Scenario
+2's effect was held on a stale config. This proves the version-CAS deny +
+recovery + effect gate; it does **not** cross a real host boundary.
 
 ### Negative control — the honest contract (`--baseline`)
 
@@ -34,12 +54,11 @@ effect-gate; it does **not** cross a real host boundary.
 python examples/cross_host/main.py --baseline
 ```
 
-Runs the **negative control first** — slice-1 silent lost update + slice-2 stale
-effect fire — *then* the with-CCS pass. Exit `0` iff **broken-must-lose AND
-fixed-must-prevent**. This is the screen-share contract: the deny is *measured*
-against its absence, not asserted. The baseline reproduces the classic
-un-coordinated, convention-only lost-update — a concrete failure CCS prevents in
-the with-CCS pass.
+Runs the **negative control first** — the silent lost update and the stale effect
+fire — *then* the with-coordination pass. Exit `0` iff **broken-must-lose AND
+fixed-must-prevent**. The deny is *measured against its absence*, not asserted.
+The baseline reproduces the classic un-coordinated, convention-only lost update —
+a concrete failure this library prevents in the with-coordination pass.
 
 ## 2. Cross-host (the real demo — Linux netns or two VMs)
 
@@ -52,7 +71,7 @@ shared key:
 ```
 # Start a coordinator bound to a private-range interface (RFC-1918).
 CCS_REMOTE_COORDINATOR=1 agent-coherence-coordinator --bind-host 10.0.0.1
-# Track the shared key so it is versioned (tracked != strict):
+# Track the shared key so it is versioned (tracked, not strict):
 agent-coherence-track shared.txt
 # Note the printed port and the secret file: <root>/.coherence/hook.secret
 ```
@@ -67,8 +86,8 @@ export CCS_REMOTE_SECRET_FILE=/path/to/mounted/hook.secret   # provisioned out-o
 python examples/cross_host/main.py
 ```
 
-The client connects (never spawning a local coordinator), runs A/B, and exits
-`0` on a denied-then-recovered stale write.
+The client connects (never spawning a local coordinator), runs both clients (A
+and B), and exits `0` on a denied-then-recovered stale write.
 
 ### Docker (recommended — genuine cross-container, one command, verified)
 
@@ -86,8 +105,7 @@ The coordinator binds to `172.28.0.2` (RFC-1918, validated) and serves; the clie
 connects from a *separate container* with `Host: 172.28.0.2` — exercising the
 validated-bind allowlist branch for real, never spawning a local coordinator. The
 bearer secret + port travel via a shared `.coherence` volume. Exit `0` on a
-denied-then-recovered run. (Verified output: slice-1 deny + recover, slice-2
-fire/hold.)
+denied-then-recovered run (Scenario 1 deny + recover, Scenario 2 fire/hold).
 
 ### Linux netns variant
 
@@ -96,10 +114,11 @@ The same two roles also run in two `ip netns` joined by a `veth` pair (requires
 proves the same boundary with less host-specific setup; the raw-netns wrapper is
 left as a Linux-host exercise.
 
-## Security boundary (R7)
+## Security boundary
 
-Before recording/sharing a cross-host run: the relaxed Host-allowlist still 403s
-any non-bind host; `bind_host` is validated to RFC-1918/4193 (wildcard, loopback
-aliases, link-local, CGNAT, public all rejected); the secret is provisioned via
-a confidential channel (not an inline env var — it would leak in `ps`/`docker
-inspect`); the link is encrypted. See the `coherence-security-reviewer` pass.
+Before recording or sharing a cross-host run, the demo upholds these properties:
+the relaxed Host-allowlist still rejects (403) any non-bind host; `bind_host` is
+validated to RFC-1918/4193 (wildcard, loopback aliases, link-local, CGNAT, and
+public addresses are all rejected); the bearer secret is provisioned via a
+confidential channel (never an inline env var — it would leak in `ps` /
+`docker inspect`); and the link is encrypted.

--- a/examples/cross_host/docker/Dockerfile
+++ b/examples/cross_host/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Cross-host coherence demo image (Gate A). Lightweight: stdlib + pyyaml only.
+# Cross-host coherence demo image (demo-grade). Lightweight: stdlib + pyyaml only.
 FROM python:3.11-slim
 
 RUN pip install --no-cache-dir "pyyaml>=6.0"

--- a/examples/cross_host/docker/docker-compose.yml
+++ b/examples/cross_host/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-# Genuine cross-host slice-1/slice-2 demo: two containers (separate network
+# Genuine cross-host demo (both scenarios): two containers (separate network
 # namespaces) on a private-range bridge, one centralized coordinator.
 #   coordinator (172.28.0.2) — binds beyond loopback, serves; the shared .coherence
 #                              volume carries the bearer secret + port to the client.

--- a/examples/cross_host/docker/run.sh
+++ b/examples/cross_host/docker/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Genuine cross-container slice-1/slice-2 demo: two containers (separate network
+# Genuine cross-container demo (both scenarios): two containers (separate network
 # namespaces) on a private-range bridge, one centralized coordinator. Exits with
 # the client's code (0 = stale write denied then recovered).
 set -uo pipefail

--- a/examples/cross_host/main.py
+++ b/examples/cross_host/main.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 # Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
-"""Cross-host coherence demo — slice 1 (artifact-coordination) + slice 2
-(effect-ordering), with an optional negative-control (--baseline) mode.
+"""Cross-host coherence demo — Scenario 1 (stale-write deny) + Scenario 2
+(effect ordering), with an optional negative-control (--baseline) mode.
 
 Two clients coordinate ONE coordinator over the network: a stale write is denied
 by version-CAS *across the host boundary*, and the loser recovers via re-read +
 retry — no silent lost update.
 
-Topology (honest scope): a SINGLE centralized coordinator (SPOF, single-region);
-NOT distributed/HA. Coordinator-version-only: the shared artifact is TRACKED on
-the coordinator (so it is versioned) but NOT strict — the deny is the OCC
-version-CAS; no strict read-enforcement is needed.
+Topology (honest scope): a SINGLE centralized coordinator (a single point of
+failure, single-region); not distributed/HA. Coordinator-version-only: the shared
+artifact is TRACKED on the coordinator (so it is versioned) but NOT strict — the
+deny is the optimistic version-CAS; no strict read-enforcement is needed.
 
 Run modes:
   - Local (default): with no CCS_REMOTE_HOST set, this spawns a loopback
@@ -25,17 +25,16 @@ Run modes:
 
 CLI:
   - python examples/cross_host/main.py
-        Runs the with-CCS demo only (slice 1 deny + recover, slice 2 fire/hold).
-        Exit 0 iff the with-CCS contract holds.
+        Runs the with-coordination demo only (Scenario 1 deny + recover,
+        Scenario 2 fire/hold). Exit 0 iff the with-coordination contract holds.
   - python examples/cross_host/main.py --baseline
-        Runs the negative control FIRST (silent lost update for slice 1, stale
-        effect fire for slice 2 — the failure modes we claim CCS prevents),
-        then the with-CCS demo. Exit 0 iff broken-must-lose AND fixed-must-prevent.
-        This is the honest screen-share contract: the deny is measured against
-        its absence, not asserted.
+        Runs the negative control FIRST (silent lost update for Scenario 1, stale
+        effect fire for Scenario 2 — the failure modes this library prevents),
+        then the with-coordination demo. Exit 0 iff broken-must-lose AND
+        fixed-must-prevent: the deny is measured against its absence, not asserted.
 
-Exit code: 0 iff the honest contract holds (deny + recover with CCS — and, with
---baseline, ALSO silent loss + stale fire without CCS); 1 otherwise.
+Exit code: 0 iff the honest contract holds (deny + recover with coordination —
+and, with --baseline, ALSO silent loss + stale fire without it); 1 otherwise.
 """
 
 from __future__ import annotations
@@ -73,8 +72,8 @@ def _log(msg: str) -> None:
 def _make_vols(tmp: str, make_endpoint, seed_a: bytes | None = None, seed_b: bytes | None = None):
     """Two CoherentVolumes on separate roots, both attached to the coordinator.
 
-    Same setup for every scene; the baseline-vs-with-CCS contrast is in HOW the
-    clients then use the volume API, not in the volume construction itself.
+    Same setup for every scene; the baseline-vs-with-coordination contrast is in
+    HOW the clients then use the volume API, not in the volume construction itself.
     """
     root_a = Path(tmp) / "a"
     root_b = Path(tmp) / "b"
@@ -90,8 +89,8 @@ def _make_vols(tmp: str, make_endpoint, seed_a: bytes | None = None, seed_b: byt
 
 
 def _run_demo(make_endpoint) -> bool:
-    """Slice 1 (with CCS): A reads@vN; B commits@vN+1; A's stale write is denied;
-    A recovers. Returns True iff denied-then-recovered.
+    """Scenario 1 (with coordination): A reads@vN; B commits@vN+1; A's stale write
+    is denied; A recovers. Returns True iff denied-then-recovered.
     """
     with tempfile.TemporaryDirectory() as tmp:
         vol_a, vol_b = _make_vols(tmp, make_endpoint, seed_a=b"v0", seed_b=b"v0")
@@ -120,15 +119,15 @@ def _run_demo(make_endpoint) -> bool:
 
 
 def _run_demo_baseline(make_endpoint) -> bool:
-    """Slice 1 (NEGATIVE CONTROL — no version-CAS discipline):
+    """Scenario 1 (negative control — no version-CAS discipline):
     A reads@vN but DOES NOT track its decision-time version; B commits@vN+1;
     A re-reads the current version right before writing and commits against it
     (the classic convention-only / un-coordinated lost-update bug pattern). B's
     bytes are silently lost.
 
-    Returns True iff the lost update occurred as expected — i.e., the failure we
-    claim CCS prevents is real and reproducible. This makes the deny in
-    ``_run_demo`` meaningful (measured against its absence, not asserted).
+    Returns True iff the lost update occurred as expected — i.e., the failure this
+    library prevents is real and reproducible. This makes the deny in ``_run_demo``
+    meaningful (measured against its absence, not asserted).
     """
     with tempfile.TemporaryDirectory() as tmp:
         vol_a, vol_b = _make_vols(tmp, make_endpoint, seed_a=b"v0", seed_b=b"v0")
@@ -157,14 +156,13 @@ def _run_demo_baseline(make_endpoint) -> bool:
 
 
 def _run_effect_gate(make_endpoint) -> bool:
-    """Slice 2 (with CCS): an effect gated on config@vN FIRES when config is
-    unchanged and is HELD when config advanced under it. Returns True iff both
-    hold.
+    """Scenario 2 (with coordination): an effect gated on config@vN FIRES when
+    config is unchanged and is HELD when config advanced under it. Returns True
+    iff both hold.
 
-    Maps to north-star Epic — Effect-Ordering primitives (all shipped):
-      EO-1 ``read_at_version``      — read the gating artifact's version
-      EO-2 version-gated effect     — gate the effect on the decision-time version
-      EO-3 Deny → HOLD              — stale gate holds the effect; no fire on stale input
+    The effect ordering has three steps: read the gating artifact's version;
+    gate the effect on that decision-time version; and on a stale gate, hold the
+    effect (never fire on stale input).
     """
     with tempfile.TemporaryDirectory() as tmp:
         root_a = Path(tmp) / "a"
@@ -176,7 +174,7 @@ def _run_effect_gate(make_endpoint) -> bool:
         vol_a = CoherentVolume(root_a, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint())
         vol_b = CoherentVolume(root_b, on_error="strict", on_stale_write="allow", remote_endpoint=make_endpoint())
         _c, v_decision = vol_a.read_with_version(CONFIG_KEY)
-        _log(f"  EO-1 ‹read_at_version›: A read {CONFIG_KEY} @ v{v_decision}")
+        _log(f"  A read {CONFIG_KEY} @ v{v_decision} (the version the effect depends on)")
 
         def fires() -> bool:
             """The effect fires only if config is still at the decision version."""
@@ -186,7 +184,7 @@ def _run_effect_gate(make_endpoint) -> bool:
         if not fires():
             _log("  ✗ effect-gate held even though config was unchanged")
             return False
-        _log(f"  EO-2 ‹version-gated effect›: config unchanged @ v{v_decision} → effect would FIRE")
+        _log(f"  ✓ config unchanged @ v{v_decision} → effect would FIRE")
 
         _cb, v_b = vol_b.read_with_version(CONFIG_KEY)
         vol_b.write_cas_at(CONFIG_KEY, v_b, b'{"v": 1}')
@@ -194,19 +192,19 @@ def _run_effect_gate(make_endpoint) -> bool:
         if fires():
             _log("  ✗ effect-gate FIRED on a stale config — coherence FAILED")
             return False
-        _log("  ✓ EO-3 ‹HOLD›: config advanced under A → effect HELD (not fired on stale input)")
+        _log("  ✓ config advanced under A → effect HELD (not fired on stale input)")
         return True
 
 
 def _run_effect_gate_baseline(make_endpoint) -> bool:
-    """Slice 2 (NEGATIVE CONTROL — no effect-gate):
+    """Scenario 2 (negative control — no effect gate):
     A "fires" the effect against the latest config without gating on its
     decision-time version. The effect fires on stale config — a silent stale
     execution (the CI failure pattern where a build runs against a config that
     was edited while the runner was deciding).
 
     Returns True iff the stale fire occurred as expected — codifying the failure
-    that EO-1..EO-3 prevent.
+    that the effect gate prevents.
     """
     with tempfile.TemporaryDirectory() as tmp:
         root_a = Path(tmp) / "a"
@@ -245,47 +243,47 @@ def _track(endpoint) -> None:
 
 
 def _run_slices(make_endpoint, *, baseline: bool) -> bool:
-    """Run the slices end-to-end.
+    """Run both scenarios end-to-end.
 
-    Default (baseline=False): with-CCS only — slice 1 deny+recover, slice 2 EO
-    fire/HOLD. Exit 0 iff both with-CCS contracts hold.
+    Default (baseline=False): with-coordination only — Scenario 1 deny+recover,
+    Scenario 2 effect fire/HOLD. Exit 0 iff both with-coordination contracts hold.
 
-    --baseline (baseline=True): negative control FIRST — slice 1 silent loss,
-    slice 2 stale fire (the failures we claim CCS prevents); then the with-CCS
-    pass. Exit 0 iff broken-must-lose AND fixed-must-prevent — the screen-share
-    contract that makes the deny meaningful, not asserted.
+    --baseline (baseline=True): negative control FIRST — Scenario 1 silent loss,
+    Scenario 2 stale fire (the failures this library prevents); then the
+    with-coordination pass. Exit 0 iff broken-must-lose AND fixed-must-prevent —
+    so the deny is measured against its absence, not asserted.
     """
     if baseline:
         _log("=== Negative control — agents WITHOUT version-CAS discipline ===")
-        _log("Slice 1 baseline — un-coordinated write (the silent lost update we prevent):")
+        _log("Scenario 1 baseline — un-coordinated write (the silent lost update we prevent):")
         b1 = _run_demo_baseline(make_endpoint)
-        _log("Slice 2 baseline — un-gated effect (the stale fire EO-1..EO-3 prevents):")
+        _log("Scenario 2 baseline — un-gated effect (the stale fire the effect gate prevents):")
         b2 = _run_effect_gate_baseline(make_endpoint)
         if not (b1 and b2):
             _log("  ✗ baseline did not reproduce the failure — the negative control is broken")
             return False
         _log("")
 
-    _log("=== With CCS — version-CAS spine + effect-ordering ===")
-    _log("Slice 1 — artifact-coordination (stale write denied across the endpoint):")
-    slice1 = _run_demo(make_endpoint)
-    _log("Slice 2 — effect-ordering (EO-1..EO-3: gate effect on config@vN):")
-    slice2 = _run_effect_gate(make_endpoint)
-    return slice1 and slice2
+    _log("=== With coordination — version-CAS spine + effect ordering ===")
+    _log("Scenario 1 — artifact coordination (stale write denied across the endpoint):")
+    scenario1 = _run_demo(make_endpoint)
+    _log("Scenario 2 — effect ordering (gate the effect on config@vN):")
+    scenario2 = _run_effect_gate(make_endpoint)
+    return scenario1 and scenario2
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="examples/cross_host/main.py",
-        description=("Cross-host coherence demo — slice 1 + slice 2, with optional negative-control mode."),
+        description=("Cross-host coherence demo — two scenarios, with optional negative-control mode."),
     )
     parser.add_argument(
         "--baseline",
         action="store_true",
         help=(
             "Run the negative control FIRST (silent lost update + stale fire), "
-            "then the with-CCS demo. Exit 0 iff broken-must-lose AND "
-            "fixed-must-prevent — the honest screen-share contract."
+            "then the with-coordination demo. Exit 0 iff broken-must-lose AND "
+            "fixed-must-prevent — so the deny is measured against its absence."
         ),
     )
     return parser.parse_args(argv)

--- a/tests/test_adapter_contract_parity.py
+++ b/tests/test_adapter_contract_parity.py
@@ -1,4 +1,4 @@
-"""Cross-substrate adapter parity test (DX-3): same protocol, two adapters.
+"""Cross-substrate adapter parity test: same protocol, two adapters.
 
 Documents the version-CAS contract in
 ``examples/cross_host/ADAPTER-CONTRACT.md`` and proves it as a passing test
@@ -8,10 +8,9 @@ satisfying the same Protocol is exercised in-process. Both must reject A's
 stale write with a typed ``CoherenceError`` and let A recover via re-read +
 retry.
 
-This is the demo's "DX-3 (Pluggable substrate adapters — same protocol, two
-topologies)" claim made testable. A future adapter (HTTP MCP, SQL, blob store)
-gets added here as one more parametrize case; the protocol surface and the
-recover-by-reread invariant stay the same.
+This makes the demo's "same protocol, two topologies" claim testable. A future
+adapter (HTTP MCP, SQL, blob store) gets added here as one more parametrize
+case; the protocol surface and the recover-by-reread invariant stay the same.
 """
 
 from __future__ import annotations
@@ -150,7 +149,7 @@ def memory_kv_adapter_pair():
 
 
 def _scenario_deny_then_recover(a: CoherenceAdapter, b: CoherenceAdapter) -> None:
-    """The slice-1 scenario, written once against the contract surface.
+    """The stale-write-deny scenario, written once against the contract surface.
 
     Both adapters must:
       1. Surface a decision-time version on read.

--- a/tests/test_cross_host_deny.py
+++ b/tests/test_cross_host_deny.py
@@ -266,7 +266,7 @@ def test_slice2_effect_gate_across_hosts(
 # ---------------------------------------------------------------------------
 # Negative controls — codify the baselines the demo's --baseline flag runs.
 #
-# These tests assert that the FAILURES we claim CCS prevents are real and
+# These tests assert that the FAILURES this library prevents are real and
 # reproducible. If a future library change quietly made the baseline 'work',
 # the demo's contrast would erode and we would notice here first.
 # ---------------------------------------------------------------------------

--- a/tests/test_cross_host_deny.py
+++ b/tests/test_cross_host_deny.py
@@ -1,4 +1,4 @@
-"""Unit 5 (R3): slice-1 cross-host deny + recover.
+"""Scenario 1 cross-host deny + recover.
 
 This loopback integration test proves the full chain end-to-end on a real socket
 (runnable on any platform): two remote-endpoint clients (never-spawn) coordinate
@@ -218,9 +218,9 @@ def test_remote_volume_reattaches_to_remote_coordinator_after_fork(
 def test_slice2_effect_gate_across_hosts(
     tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Slice-2 (R4): an effect gated on config@vN FIRES when config is unchanged
-    and is HELD when config advanced under it — across the endpoint, on the
-    shipped read_with_version primitive."""
+    """Scenario 2 effect ordering: an effect gated on config@vN FIRES when config
+    is unchanged and is HELD when config advanced under it — across the endpoint,
+    on the shipped read_with_version primitive."""
     monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
     coord_root = tmp_path / "coord"
     coord_root.mkdir()
@@ -281,7 +281,7 @@ def test_slice1_baseline_silent_lost_update_without_decision_time_version(
     Pattern: A reads@v_a but writes against the LATEST version (the classic
     convention-only / un-coordinated lost-update bug pattern). B's bytes are
     dropped from the canonical record. This is the failure
-    ``test_slice1_cross_endpoint_deny_and_recover`` proves CCS prevents.
+    ``test_slice1_cross_endpoint_deny_and_recover`` proves this library prevents.
     """
     monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
     coord_root = tmp_path / "coord"
@@ -333,8 +333,8 @@ def test_slice2_baseline_stale_fire_without_effect_gate(
 
     Pattern: A decides @ v_decision, B advances config, A's effect fires
     ungated. This is the CI failure (build/deploy against a config that was
-    edited mid-decision) that EO-1/EO-2/EO-3 prevent in
-    ``test_slice2_effect_gate_across_hosts``.
+    edited mid-decision) that the version-CAS effect gate in
+    ``test_slice2_effect_gate_across_hosts`` prevents.
     """
     monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
     coord_root = tmp_path / "coord"
@@ -384,8 +384,8 @@ def test_main_baseline_flag_runs_negative_control_then_with_ccs(
     tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:
     """End-to-end CLI smoke: ``python examples/cross_host/main.py --baseline``
-    runs the negative control then the with-CCS pass, exits 0, and the output
-    contains both phases. This pins the screen-share contract: broken-must-lose
+    runs the negative control then the with-coordination pass, exits 0, and the
+    output contains both phases. This pins the honest contract: broken-must-lose
     AND fixed-must-prevent in one invocation.
     """
     # main() spawns a coordinator + clients in this process; the env nudge
@@ -410,5 +410,5 @@ def test_main_baseline_flag_runs_negative_control_then_with_ccs(
     out = capsys.readouterr().out
     assert rc == 0, f"--baseline should exit 0 on a green run, got {rc}; output:\n{out}"
     assert "Negative control" in out, "baseline phase must be labeled in output"
-    assert "With CCS" in out, "with-CCS phase must be labeled in output"
+    assert "With coordination" in out, "with-coordination phase must be labeled in output"
     assert "RESULT: PASS" in out


### PR DESCRIPTION
Makes the cross-host demo docs end-user-ready: removes internal work-item / requirement IDs (DX-/NR-/EO-/R-/SB-numbers), the "Gate A" staging label, "slice 1/2" section names, a "screen-share" reference, and a broken link to a non-public doc. README + ADAPTER-CONTRACT rewritten in plain language; demo output + docstrings use "Scenario 1/2" and "with coordination"; docker comments + the two cross-host test docstrings cleaned. No behavior change. Folds into the in-flight v0.10.1 (the tag will be moved to include this before publish).