### PR TITLE
feat(coordinator): consistent multi-artifact snapshot sessions (read-side transaction layer)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,14 @@ cost-benchmark-check: cost-benchmark  ## Re-run the cost sweep, then drift-check
 TLA2TOOLS := formal/tla/lib/tla2tools.jar
 TLC := java -XX:+UseParallelGC -cp $(TLA2TOOLS) tlc2.TLC -workers auto
 
-tla-check:  ## Run TLC model checker on MESI, CrashRecovery, OCC, Fencing, and Retention specs
+tla-check:  ## Run TLC model checker on MESI, CrashRecovery, OCC, Fencing, Retention, and Snapshot specs
 	@java -version 2>&1 | head -1 | grep -qE '"(1[7-9]|[2-9][0-9])\.' || { echo "ERROR: Java 17+ required for TLC model checker"; exit 1; }
 	$(TLC) -config formal/tla/MESI_Standalone.cfg formal/tla/MESI_Standalone.tla
 	$(TLC) -config formal/tla/CrashRecovery_CI.cfg formal/tla/CrashRecovery.tla
 	$(TLC) -config formal/tla/OCC_CI.cfg formal/tla/OCC.tla
 	$(TLC) -config formal/tla/Fencing_CI.cfg formal/tla/Fencing.tla
 	$(TLC) -config formal/tla/Retention_CI.cfg formal/tla/Retention.tla
+	$(TLC) -config formal/tla/Snapshot_CI.cfg formal/tla/Snapshot.tla
 
 help:  ## List available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -1,6 +1,6 @@
 # TLA+ Formal Verification
 
-TLC model checking for the MESI coherence protocol, its crash-recovery extension, the optimistic commit-CAS (OCC), the read-generation fence, and bounded version retention with read-at-version.
+TLC model checking for the MESI coherence protocol, its crash-recovery extension, the optimistic commit-CAS (OCC), the read-generation fence, bounded version retention with read-at-version, and consistent multi-artifact snapshot sessions.
 
 ## What is modeled
 
@@ -14,6 +14,7 @@ TLC model checking for the MESI coherence protocol, its crash-recovery extension
 - **Optimistic commit-CAS (OCC)** — a version-checked commit (`commit_cas`) that bypasses the pessimistic acquire: an S/I writer reads the version (`ObserveAction`), then commits only if its observed version still matches and no other agent holds M∪E. Closes the concurrent lost-update. Corresponds to `commit_cas` in `src/ccs/coordinator/`.
 - **Read-generation fence (Fencing)** — a per-artifact ownership epoch (`ownerGeneration`) bumped atomically on every sweep reclamation, captured into `readGeneration` when an agent establishes its write-claim (`ObserveGenAction` — deliberately decoupled so the sweep can interleave between capture and commit), and enforced by a generation-guarded commit (`FencingCommitAction`): a writer whose captured generation was superseded by a reclamation is rejected even when the version is unchanged — the reclaim-zombie write the version CAS cannot see. Corresponds to `owner_generation` / `read_generation` in `src/ccs/coordinator/`.
 - **Bounded version retention + read-at-version (Retention)** — a per-artifact K-bounded history of committed versions (`history`, content abstracted as the version number), extended and garbage-collected atomically inside the fence-guarded commit (`RetentionCommitAction` — commit + retain + K-GC are one action, mirroring the same-transaction capture discipline), plus an off-protocol read-at-version request (`VersionedReadAction`) proven to be a protocol no-op. Every inherited invariant is re-checked with retention composed in — safety **preservation**, not behavioral equivalence (no refinement mapping). Corresponds to the retention capture points and `CoordinatorService.read_at_version` (plan: `docs/plans/2026-06-10-001-feat-version-retention-read-at-version-plan.md`).
+- **Consistent multi-artifact snapshot sessions (Snapshot)** — a session captures a per-artifact version-vector at ONE atomic linearization point (`BeginSessionAction`), reads a coherent cut with no cross-artifact read skew (`NoReadSkewWithinCut`), and holds its pinned versions against the K-bounded GC for its lifetime via the exemptions seam (`PinAlwaysRetained` — `SnapRetainAndCollect` keeps the newest-K window ∪ live-session pins, with session liveness the state the GC reads). Single-artifact commits only — cross-artifact write skew is SB-18, out of scope. The read-skew detector lives in the commit and is vacuous under atomic capture; the split mutant gives it teeth (the `staleApply`/`collectedRead` idiom). Corresponds to `begin_session` / the read-side transaction layer (plan: `docs/plans/2026-06-26-002-feat-read-side-transaction-snapshot-plan.md`).
 
 ## What is deliberately out of scope
 
@@ -29,6 +30,8 @@ TLC model checking for the MESI coherence protocol, its crash-recovery extension
 | `register_artifact` | No register action exists anywhere in the chain; Retention's initial state retains version 1, covering the trivial case. Per-capture-point coverage is owned by the Python parity suite |
 | Retention policy changes across runs | `MaxRetained` (K) is a per-run CONSTANT; a re-opened store is equivalent to a fresh bounded store. Policy persistence/toggles are owned by Python tests |
 | Behavioral equivalence (refinement mapping) | `Retention.tla` proves safety **preservation** — the inherited invariants re-checked with retention enabled — not behavioral equivalence to Fencing, which would need a refinement mapping |
+| Cross-artifact WRITE skew (atomic multi-artifact commit) | `Snapshot.tla` models only single-artifact commits and proves READ-skew freedom; atomic multi-artifact write — two sessions each reading a coherent cut and each committing one artifact — is SB-18, deferred. The model asserts nothing about cross-artifact write atomicity |
+| Session read-serve / `session.commit` paths | The session read is a pure lookup of the pinned `snapshot[s]`; `session.commit` rides the inherited version-CAS. Neither adds protocol state, so both are owned by the Python suite (plan Units 3/4); `Snapshot.tla` models the cut and its GC-safety |
 | Full liveness proofs | TLC checks safety invariants; liveness is not checked (bounded models make temporal liveness checks infeasible at this scale). OCC's progress / no-starvation obligation is likewise discharged as a safety property (`NoLostUpdate` + a clean no-op conflict) plus a prose argument, not a temporal check. The Retention action property `[][...]_v` is a safety-shaped action check, not a liveness check |
 
 ## File layout
@@ -50,6 +53,9 @@ formal/tla/
 ├── Retention.tla           # amendment: EXTENDS Fencing, adds bounded retention + read-at-version
 ├── Retention.cfg           # TLC config: 3 agents (local deep runs)
 ├── Retention_CI.cfg        # TLC config: 2 agents, MaxRetained=2 (CI, fits 5-min budget)
+├── Snapshot.tla            # amendment: EXTENDS Retention, adds consistent multi-artifact snapshot sessions
+├── Snapshot.cfg            # TLC config: 2 agents, 2 artifacts (local deep runs)
+├── Snapshot_CI.cfg         # TLC config: 1 agent, 2 artifacts, MaxTicks=2 (CI; cross-artifact cut needs >= 2 artifacts)
 ├── lib/
 │   └── tla2tools.jar       # committed TLC binary (see version below)
 └── README.md               # this file
@@ -58,7 +64,7 @@ formal/tla/
 ## Running TLC
 
 ```bash
-# All five specs (recommended)
+# All six specs (recommended)
 make tla-check
 
 # Individual models
@@ -76,6 +82,9 @@ java -XX:+UseParallelGC -cp formal/tla/lib/tla2tools.jar tlc2.TLC \
 
 java -XX:+UseParallelGC -cp formal/tla/lib/tla2tools.jar tlc2.TLC \
   -config formal/tla/Retention_CI.cfg formal/tla/Retention.tla -workers auto
+
+java -XX:+UseParallelGC -cp formal/tla/lib/tla2tools.jar tlc2.TLC \
+  -config formal/tla/Snapshot_CI.cfg formal/tla/Snapshot.tla -workers auto
 ```
 
 Requires Java 17+. CI uses Temurin via `actions/setup-java`.
@@ -84,18 +93,20 @@ Requires Java 17+. CI uses Temurin via `actions/setup-java`.
 
 | ID | TLA+ Name | Checked In | Description |
 |----|-----------|-----------|-------------|
-| I1 | `SingleWriter` | All five | At most one agent holds M∪E per artifact |
-| I2 | `MonotonicVersion` | All five | Artifact version never decreases (≥ 1) |
-| — | `TypeOK` / `CRTypeOK` / `OCCTypeOK` / `FencingTypeOK` / `RetentionTypeOK` | All five | State variables have correct types and bounds (Retention additionally pins the history domain ⊆ `1..MaxVersion`, row count ≤ `MaxRetained`, and the marker-is-the-version content abstraction) |
-| I3 | `SweepExclusivity` | CrashRecovery, OCC, Fencing, Retention | No (agent, artifact) reclaimed twice in one tick |
-| I4 | `TriggerExclusivity` | CrashRecovery, OCC, Fencing, Retention | Each reclamation has exactly one trigger |
-| I5 | `TickMonotonicity` | CrashRecovery, OCC, Fencing, Retention | `lastHeartbeat` never decreases |
-| I6 | `SlotPreservedThroughSHARED` | CrashRecovery, OCC, Fencing, Retention | Reclamation slot persists across I→S, cleared only on I→M∪E |
+| I1 | `SingleWriter` | All six | At most one agent holds M∪E per artifact |
+| I2 | `MonotonicVersion` | All six | Artifact version never decreases (≥ 1) |
+| — | `TypeOK` / `CRTypeOK` / `OCCTypeOK` / `FencingTypeOK` / `RetentionTypeOK` / `SnapshotTypeOK` | All six | State variables have correct types and bounds (Retention pins the history domain ⊆ `1..MaxVersion`, row count ≤ `MaxRetained`, and the marker-is-the-version abstraction; Snapshot relaxes the row-count bound to `MaxRetained + |Sessions|` for the exemptions seam and types the session vars) |
+| I3 | `SweepExclusivity` | CrashRecovery, OCC, Fencing, Retention, Snapshot | No (agent, artifact) reclaimed twice in one tick |
+| I4 | `TriggerExclusivity` | CrashRecovery, OCC, Fencing, Retention, Snapshot | Each reclamation has exactly one trigger |
+| I5 | `TickMonotonicity` | CrashRecovery, OCC, Fencing, Retention, Snapshot | `lastHeartbeat` never decreases |
+| I6 | `SlotPreservedThroughSHARED` | CrashRecovery, OCC, Fencing, Retention, Snapshot | Reclamation slot persists across I→S, cleared only on I→M∪E |
 | — | `NoLostUpdate` | OCC | No successful `commit_cas` ever landed on a stale observed version — the concurrent lost-update is prevented |
-| — | `ReadGenBounded` | Fencing, Retention | A captured read-generation never exceeds the artifact's current ownership epoch |
-| — | `NoStaleApply` | Fencing, Retention | No commit ever applied a write whose captured read-generation was superseded by a reclamation — the reclaim-zombie write is prevented. Re-checked in Retention to prove retention preserves the fence |
-| — | `NoCollectedRead` | Retention | No versioned read ever observed a hole inside the promised K-window strictly below the current version — the GC never collects what the bounded-retention contract promises (current version included, by construction) |
+| — | `ReadGenBounded` | Fencing, Retention, Snapshot | A captured read-generation never exceeds the artifact's current ownership epoch |
+| — | `NoStaleApply` | Fencing, Retention, Snapshot | No commit ever applied a write whose captured read-generation was superseded by a reclamation — the reclaim-zombie write is prevented. Re-checked in Retention to prove retention preserves the fence |
+| — | `NoCollectedRead` | Retention, Snapshot | No versioned read ever observed a hole inside the promised K-window strictly below the current version — the GC never collects what the bounded-retention contract promises (current version included, by construction) |
 | — | `ReadAtVersionIsProtocolNoOp` | Retention (action property, cfg `PROPERTY`) | `[][VersionedReadAction => UNCHANGED fenceVars]_retentionVars` — any transition satisfying the read action changes no MESI/crash-recovery/fence variable. A state invariant cannot express this: a fence-refreshing read is extensionally identical to a legitimate `ObserveGenAction`, so only an action-level check can catch it |
+| — | `NoReadSkewWithinCut` | Snapshot | No commit ever interleaved a partially-captured session — every session reads a coherent multi-artifact cut. Atomic capture makes a partial cut unreachable (vacuous-TRUE in the correct spec); the split mutant (recipe 9) gives it teeth — the `staleApply`/`collectedRead` sticky-flag idiom |
+| — | `PinAlwaysRetained` | Snapshot | Every version a live session pinned is still in the artifact's retained history — the K-bounded GC never collects a pin out from under its session (the exemptions seam: `SnapRetainAndCollect` keeps window ∪ live-session pins; recipe 10 gives it teeth) |
 
 I7 (FlagOffByteIdentity) is a code-level property and is not modelable in TLA+.
 
@@ -123,6 +134,11 @@ I7 (FlagOffByteIdentity) is a code-level property and is not modelable in TLA+.
 | `VersionedReadAction` | `CoordinatorService.read_at_version()` — off-protocol read; never calls `set_agent_state`/`set_agent_transient`, so no fence capture and no MESI transition (plan Unit 4) |
 | `NoCollectedRead` | bounded-retention parity suite (`tests/test_retention.py`, plan Units 2–5) |
 | `ReadAtVersionIsProtocolNoOp` | fence non-capture + MESI non-interaction regression tests (plan Unit 4) |
+| `BeginSessionAction` | `begin_session(read_set)` — the atomic consistent-cut capture; non-mutating, mints no MESI grant (plan Unit 2) |
+| `EndSessionAction` | session end / heartbeat-stale release — the pin-lifetime release that re-enables collection (plan Unit 5) |
+| `SnapRetainAndCollect` | `collectible_versions(exemptions=…)` — the K-GC keeping the window ∪ live-session pins (the exemptions seam, plan Unit 2) |
+| `NoReadSkewWithinCut` | the consistent-cut regression suite — atomic capture across peer commits (plan Units 2–3) |
+| `PinAlwaysRetained` | the exemptions-seam + session-liveness sweep tests (plan Units 2/5) |
 
 The model abstracts away transient states — the implementation's
 `enforce_transient_timeouts` and transient-skip rule in the sweep are not modeled.
@@ -139,7 +155,7 @@ non-decreasing) holds regardless of the bound.
 
 ## CI time budget
 
-Target: **5 minutes** total across the five specs (measured 4min 32s sequential on a machine that reproduces the reference Fencing time — snug; treat further spec additions as needing their own budget review).
+Target: **5 minutes** total across the six specs (the original five measured 4min 32s sequential on the reference machine; Snapshot adds ~18s reference-equivalent on a tight 1-agent × 2-artifact config — see the Snapshot note below). The budget stays snug; treat further spec additions as needing their own budget review.
 
 | Model | Config | Agents | Artifacts | MaxTicks | Distinct States | Wall Time |
 |-------|--------|--------|-----------|----------|----------------|-----------|
@@ -152,6 +168,8 @@ Target: **5 minutes** total across the five specs (measured 4min 32s sequential 
 | Fencing (local) | `Fencing.cfg` | 3 | 1 | 6 | — | minutes |
 | Retention (CI) | `Retention_CI.cfg` | 2 | 1 | 4 | 2,832,014 | ~115s |
 | Retention (local) | `Retention.cfg` | 3 | 1 | 6 | >95M | hours |
+| Snapshot (CI) | `Snapshot_CI.cfg` | 1 | 2 | 2 | 375,180 | ~18s |
+| Snapshot (local) | `Snapshot.cfg` | 2 | 2 | 4 | — | minutes |
 
 Retention's distinct-state count **equals** Fencing's by design: the retained history is a
 deterministic function of the version window (content abstracted as the version number)
@@ -161,6 +179,8 @@ but zero state-space dimensions. The local 3-agent config is overnight-class, no
 quick check: measured ≥95M distinct states (703M generated, queue still growing) at the
 40-minute mark on 8 cores — and since the distinct space equals Fencing's, that is also
 the true size of `Fencing.cfg`'s local space.
+
+Snapshot **inverts** the usual CI shape — **1 agent × 2 artifacts** (the other CI specs are 2 agents × 1 artifact). Read skew is a cross-artifact phenomenon, so ≥ 2 artifacts is mandatory; the agent-contention re-check of the inherited fence invariants is already discharged by the other specs and by the local `Snapshot.cfg` (2 agents). The CI config also disables the sweep (`HeartbeatTimeout` > `MaxTicks`) — the session machinery is fence-uniform and adds no sweep interaction, so suppressing it keeps the run to ~18s without losing Snapshot-specific coverage. The local `Snapshot.cfg` (2 agents, `MaxTicks=4`, sweeps on) is the deep composition check and the home for the mutant recipes.
 
 CI uses `CrashRecovery_CI.cfg` (2 agents, MaxTicks=6) to fit the budget.
 The full 3-agent config (`CrashRecovery.cfg`) is for local deep runs:
@@ -241,7 +261,28 @@ and confirm TLC finds a counterexample:
    and a read inside the K-window observes the never-retained version.
    (Verified 2026-06-11: violation found in ~2s, 4,485 states generated.)
 
+9. **Snapshot read-skew mutation (split the atomic capture)**: In `Snapshot.tla`,
+   replace `BeginSessionAction`'s one-step capture with a per-artifact capture —
+   `\E s \in Sessions, art \in Artifacts : ~sessionLive[s] /\ snapshot[s][art] = None`
+   `/\ snapshot' = [snapshot EXCEPT ![s][art] = version[art]] /\ sessionLive' =`
+   `[sessionLive EXCEPT ![s] = (\A a \in Artifacts : a = art \/ snapshot[s][a] /= None)]`
+   `/\ UNCHANGED <<retentionVars, readSkew>>`. Run TLC on `Snapshot_CI.cfg`. TLC
+   should fail with a `NoReadSkewWithinCut` violation: a commit interleaves a
+   partially-captured session — the exact read-skew window the atomic capture
+   excludes, which no inherited invariant can see. (Verified 2026-06-28:
+   violation found in ~1s, 238 distinct states.)
+
+10. **Snapshot exemption-drop mutation (GC eats a pin)**: In `Snapshot.tla`,
+   change `SnapRetainAndCollect`'s `keepDom` from
+   `(DOMAIN extended) \cap (window \cup PinnedVersions(art))` to
+   `(DOMAIN extended) \cap window` (the GC ignores live-session pins). Run TLC on
+   `Snapshot_CI.cfg`. TLC should fail with a `PinAlwaysRetained` violation once a
+   commit slides the K-window past a pinned version — the exemptions seam the
+   correct GC honors. (Verified 2026-06-28: violation found in ~1s, 821 distinct
+   states.)
+
 These mutations are run manually during development to validate TLC's
-bug-detection capability. The mutated files are not committed. Recipes 5–8
-run TLC directly on `Retention_CI.cfg` (mutating `Retention.tla` cannot affect
-the other four specs, so the full `make tla-check` adds nothing).
+bug-detection capability. The mutated files are not committed. Recipes 5–10
+run TLC directly on their amendment's CI config (`Retention_CI.cfg` /
+`Snapshot_CI.cfg`); mutating one amendment cannot affect the other specs, so the
+full `make tla-check` adds nothing.

--- a/formal/tla/Snapshot.cfg
+++ b/formal/tla/Snapshot.cfg
@@ -1,0 +1,25 @@
+SPECIFICATION SnapshotSpec
+
+CONSTANTS
+    NumAgents = 2
+    NumArtifacts = 2
+    MaxTicks = 4
+    HeartbeatTimeout = 3
+    MaxHoldTicks = 5
+    MaxRetained = 2
+    None = None
+    Sessions = {s1, s2}
+
+INVARIANTS
+    SnapshotTypeOK
+    SingleWriter
+    MonotonicVersion
+    SweepExclusivity
+    TriggerExclusivity
+    TickMonotonicity
+    SlotPreservedThroughSHARED
+    ReadGenBounded
+    NoStaleApply
+    NoCollectedRead
+    NoReadSkewWithinCut
+    PinAlwaysRetained

--- a/formal/tla/Snapshot.tla
+++ b/formal/tla/Snapshot.tla
@@ -1,0 +1,290 @@
+---------------------------- MODULE Snapshot ----------------------------
+(* Consistent multi-artifact snapshot-session amendment to the bounded-
+   retention fenced MESI protocol. Proves that a session which captures a
+   version-vector across SEVERAL artifacts at ONE linearization point
+   (begin_session) reads a coherent cut -- no cross-artifact READ SKEW -- and
+   that the versions it pins are held against the K-bounded GC for the
+   session's lifetime (the exemptions seam), without disturbing any inherited
+   safety invariant.
+
+   Plan: docs/plans/2026-06-26-002-feat-read-side-transaction-snapshot-plan.md
+   (Unit 1). Detailed spec: docs/brainstorms/2026-06-14-sb17-snapshot-sessions-v1-requirements.md.
+   Origin (read-side, EO-4 = SB-17 = TX-1). Composes with Retention via EXTENDS.
+
+   THE PROBLEM. With only the inherited single-artifact reads, an agent that
+   reasons over several artifacts stitches N independent reads. A peer commit
+   can land between read 1 and read N, so the agent observes artifact A at the
+   version it had at t1 and artifact B at the version it had at t2 > t1, with a
+   commit in between -- a snapshot that corresponds to NO single instant of the
+   global version vector (cross-artifact read skew). The fix is a CONSISTENT
+   CUT: capture every artifact's version at ONE atomic linearization point.
+
+   Adds:
+     - snapshot     : per-session captured version-vector, [Sessions ->
+                      [Artifacts -> (1..MaxVersion) \cup {None}]]. A live
+                      session's entry is a full capture (no None); a dead
+                      session's entry is all-None. The pin map.
+     - sessionLive  : [Sessions -> BOOLEAN]. Session liveness -- a STATE
+                      COMPONENT THE GC READS (R4): a pinned version is exempt
+                      from collection only while its session is live.
+     - readSkew     : a sticky history flag -- TRUE iff any commit ever
+                      interleaved a session that was only PARTIALLY captured
+                      (some artifacts pinned, others not). Under the atomic
+                      capture (correct spec) a session is never partial, so the
+                      flag is unreachable-TRUE; the documented split mutant
+                      makes it reachable. Mirrors the staleApply / collectedRead
+                      idiom: the flag flips only when the modeled implementation
+                      would have read a skewed cut; the correct spec never sets
+                      it.
+     - BeginSessionAction : the ATOMIC cut capture -- a not-live session pins
+                      the CURRENT version of every artifact in ONE step.
+                      Non-mutating: no MESI grant, no version bump, no fence
+                      capture, no history change (UNCHANGED retentionVars).
+     - EndSessionAction   : release the pins (sessionLive -> FALSE); the pinned
+                      versions become collectible again (R4 liveness gate).
+     - SnapshotCommitAction : RetentionCommitAction with the pin-aware GC
+                      (SnapRetainAndCollect) PLUS the read-skew detector.
+                      Replaces the inherited RetentionCommitAction.
+
+   KEY MODELING DECISION (the crux). Retention's crux is that retain + bump +
+   GC are ONE action (same-transaction), and mutant recipe 5 splits them to
+   expose the crash window. Snapshot mirrors it for the READ side: the cut
+   capture is ONE atomic action over ALL artifacts, so the correct spec can
+   NEVER reach a state where a session is partially captured. The read-skew
+   detector therefore lives in an action that is ALWAYS present -- the commit
+   (SnapshotCommitAction sets readSkew TRUE when it interleaves a partially-
+   captured session) -- and is vacuous in the correct spec because partial
+   captures are unreachable. The MUTANT (README) splits BeginSessionAction into
+   per-artifact CaptureArtifactAction steps; partial captures become reachable,
+   a commit can interleave one, and TLC finds the NoReadSkewWithinCut violation.
+   We model atomic capture STRUCTURALLY (one action), not by deleting a
+   precondition -- exactly as the plan-review required.
+
+   THE EXEMPTIONS SEAM (R14, bounded-exemptions GC-safety). A live session's
+   pinned version must survive the K-bounded GC even after the retention window
+   has slid past it -- the implementation's collectible_versions(exemptions=...)
+   excludes pinned versions from collection. SnapRetainAndCollect keeps
+   (newest-K window) UNION (versions pinned by live sessions). A pin is never
+   collected while its session is live (PinAlwaysRetained), and the history can
+   exceed K by at most the number of live sessions -- the BOUNDED-exemptions
+   property the relaxed SnapshotTypeOK pins (Cardinality <= MaxRetained +
+   |Sessions|). The window-union-exempt GC preserves NoCollectedRead by
+   construction (it only KEEPS MORE than the window, never less). Mutant recipe
+   10 (README) makes the GC ignore exemptions and TLC finds a pinned version
+   collected out from under a live session (PinAlwaysRetained violation).
+
+   DELIBERATELY OUT OF MODEL:
+     (a) WRITE SKEW (R5) -- two sessions each reading a coherent cut and each
+         committing one artifact can still violate a cross-artifact application
+         invariant. That is SB-18 (atomic multi-artifact write), out of this
+         plan. This spec proves READ-skew freedom only; the model has only
+         single-artifact commits, so it asserts nothing about cross-artifact
+         write atomicity.
+     (b) the session-read SERVE path and session.commit -- the session reads
+         from the pin (a pure lookup of snapshot[s]) and commits via the
+         inherited version-CAS; neither adds protocol state. Their correctness
+         is the runtime units' (plan Units 3/4) and is owned by the Python
+         suite. This spec models the CUT and its GC-safety, which is what the
+         protocol-level invariants can express.
+     (c) coordinator restart / durability -- inherited exclusion (in TLA the
+         state IS the durable truth). Restart-survival of pins is sqlite-only
+         and is an implementation/test property (plan R6 / Unit 9).
+
+   WHAT IS PROVEN: safety PRESERVATION -- every inherited invariant
+   (SingleWriter, MonotonicVersion, the CR I3-I6 family, NoStaleApply,
+   NoCollectedRead, ReadGenBounded) re-checked with the session machinery
+   composed in, PLUS NoReadSkewWithinCut and PinAlwaysRetained. NOT proven:
+   behavioral equivalence (no refinement mapping). LIVENESS is discharged as
+   safety + prose per the repo's safety-only TLC convention (README). *)
+
+EXTENDS Retention
+
+(* The set of session identities (model values). Small for finite checking;
+   one session already exposes read skew and the pin-GC exemption. *)
+CONSTANT Sessions
+
+VARIABLES snapshot, sessionLive, readSkew
+
+snapVars == <<retentionVars, snapshot, sessionLive, readSkew>>
+
+--------------------------------------------------------------------
+(* Session helpers *)
+--------------------------------------------------------------------
+
+(* The versions pinned by currently-live sessions for an artifact -- the GC
+   exemption set (R14). Read by SnapRetainAndCollect; a pinned version is
+   never collected while its session is live. A dead session contributes
+   nothing (its entry is all-None and sessionLive is FALSE). *)
+PinnedVersions(art) ==
+    { snapshot[s][art] : s \in {ss \in Sessions : sessionLive[ss]} }
+
+(* A session is PARTIALLY captured iff some artifact is pinned and some other
+   artifact is not. Under the atomic BeginSessionAction this is ALWAYS FALSE
+   (capture is all-or-nothing in one step) -- the read-skew detector below is
+   therefore vacuous in the correct spec. The split mutant (README recipe 9)
+   makes it reachable. *)
+PartiallyCaptured(s) ==
+    /\ \E a \in Artifacts : snapshot[s][a] /= None
+    /\ \E a \in Artifacts : snapshot[s][a] = None
+
+(* Retain newVer and apply inline K-GC WITH the exemptions seam: keep the
+   newest-K window (current included) UNION every version pinned by a live
+   session. Versions outside the window that no live session pins are
+   collected. A pinned version is held beyond K (the seam). With MaxRetained
+   >= 1 the current version is always in the window, so it is never collectible
+   (R4). Mirrors collectible_versions(exemptions=PinnedVersions). Mutant recipe
+   10 drops the UNION PinnedVersions, collecting a live pin. *)
+SnapRetainAndCollect(art, newVer) ==
+    LET extended == [v \in (DOMAIN history[art]) \cup {newVer} |->
+                        IF v = newVer THEN newVer ELSE history[art][v]]
+        windowLo == IF newVer > MaxRetained THEN newVer - MaxRetained + 1 ELSE 1
+        window   == windowLo..newVer
+        keepDom  == (DOMAIN extended) \cap (window \cup PinnedVersions(art))
+    IN [history EXCEPT ![art] = [v \in keepDom |-> extended[v]]]
+
+--------------------------------------------------------------------
+(* Initialization *)
+--------------------------------------------------------------------
+
+SnapshotInit ==
+    /\ RetentionInit
+    /\ snapshot = [s \in Sessions |-> [art \in Artifacts |-> None]]
+    /\ sessionLive = [s \in Sessions |-> FALSE]
+    /\ readSkew = FALSE
+
+--------------------------------------------------------------------
+(* BeginSessionAction: the ATOMIC consistent-cut capture. A not-live session
+   pins the CURRENT version of EVERY artifact in ONE step -- one linearization
+   point, so no peer commit can be partially visible within the cut. Wholly
+   non-mutating: UNCHANGED retentionVars (no MESI grant, no version bump, no
+   read_generation capture, no history change). This atomicity is the crux:
+   it makes PartiallyCaptured unreachable, which is why the read-skew detector
+   in the commit is vacuous in the correct spec. *)
+--------------------------------------------------------------------
+
+BeginSessionAction ==
+    \E s \in Sessions :
+        /\ ~sessionLive[s]
+        /\ snapshot' = [snapshot EXCEPT ![s] = [art \in Artifacts |-> version[art]]]
+        /\ sessionLive' = [sessionLive EXCEPT ![s] = TRUE]
+        /\ UNCHANGED <<retentionVars, readSkew>>
+
+--------------------------------------------------------------------
+(* EndSessionAction: release the session's pins (R4 -- liveness gates the GC
+   exemption). Once dead, the pinned versions are collectible again on the next
+   commit. Non-mutating. *)
+--------------------------------------------------------------------
+
+EndSessionAction ==
+    \E s \in Sessions :
+        /\ sessionLive[s]
+        /\ snapshot' = [snapshot EXCEPT ![s] = [art \in Artifacts |-> None]]
+        /\ sessionLive' = [sessionLive EXCEPT ![s] = FALSE]
+        /\ UNCHANGED <<retentionVars, readSkew>>
+
+--------------------------------------------------------------------
+(* SnapshotCommitAction: RetentionCommitAction (identical guard + protocol
+   effect -- equality admits, present-but-superseded is a clean no-op, an
+   absent operand admits via version-CAS) but the admitted branches use the
+   PIN-AWARE GC (SnapRetainAndCollect), and the action carries the READ-SKEW
+   DETECTOR: readSkew flips iff this commit interleaves a partially-captured
+   session. PartiallyCaptured is unreachable under the atomic capture, so the
+   detector is vacuous here; the split mutant makes it bite. Replaces the
+   inherited RetentionCommitAction. *)
+--------------------------------------------------------------------
+
+SnapshotCommitAction ==
+    \E ag \in Agents, art \in Artifacts :
+        /\ version[art] < MaxVersion                (* finite bound *)
+        /\ LET rg == readGeneration[ag][art]
+               og == ownerGeneration[art]
+               newVer == version[art] + 1
+           IN \/ (* ADMIT (absent operand): plain OCC writer, version-CAS
+                    arbitrates. Apply + retain (pin-aware) atomically. *)
+                 /\ rg = None
+                 /\ version' = [version EXCEPT ![art] = newVer]
+                 /\ history' = SnapRetainAndCollect(art, newVer)
+                 /\ UNCHANGED staleApply
+              \/ (* WIN: claim present and current. *)
+                 /\ rg /= None
+                 /\ rg = og
+                 /\ version' = [version EXCEPT ![art] = newVer]
+                 /\ history' = SnapRetainAndCollect(art, newVer)
+                 /\ staleApply' = (staleApply \/ (rg < og))
+              \/ (* CONFLICT: present but superseded -- clean no-op. *)
+                 /\ rg /= None
+                 /\ ~(rg = og)
+                 /\ UNCHANGED <<version, staleApply, history>>
+        (* Read-skew detector: a commit landing while a session is mid-capture
+           is the skew window. Vacuous under atomic capture (no partial
+           sessions); the split mutant (README recipe 9) makes it reachable. *)
+        /\ readSkew' = (readSkew \/ (\E s \in Sessions : PartiallyCaptured(s)))
+        /\ UNCHANGED <<clock, mesiState, lastHeartbeat, grantedAtTick,
+                       lastReclamation, ownerGeneration, readGeneration,
+                       collectedRead, snapshot, sessionLive>>
+
+--------------------------------------------------------------------
+(* Specification *)
+--------------------------------------------------------------------
+
+(* Inherited actions keep the session variables unchanged. The retention
+   wrapping mirrors Retention's own Next; RetentionCommitAction is DELIBERATELY
+   replaced by SnapshotCommitAction (the crux). *)
+SnapshotNext ==
+    \/ (CRFetchAction       /\ UNCHANGED <<ownerGeneration, readGeneration, staleApply, history, collectedRead, snapshot, sessionLive, readSkew>>)
+    \/ (FencingWriteAction  /\ UNCHANGED <<history, collectedRead, snapshot, sessionLive, readSkew>>)
+    \/ (CRInvalidateAction  /\ UNCHANGED <<ownerGeneration, readGeneration, staleApply, history, collectedRead, snapshot, sessionLive, readSkew>>)
+    \/ (CRTickAction        /\ UNCHANGED <<ownerGeneration, readGeneration, staleApply, history, collectedRead, snapshot, sessionLive, readSkew>>)
+    \/ (HeartbeatAction     /\ UNCHANGED <<ownerGeneration, readGeneration, staleApply, history, collectedRead, snapshot, sessionLive, readSkew>>)
+    \/ (FencingSweepAction  /\ UNCHANGED <<history, collectedRead, snapshot, sessionLive, readSkew>>)
+    \/ (ObserveGenAction    /\ UNCHANGED <<history, collectedRead, snapshot, sessionLive, readSkew>>)
+    \/ (VersionedReadAction /\ UNCHANGED <<snapshot, sessionLive, readSkew>>)
+    \/ SnapshotCommitAction
+    \/ BeginSessionAction
+    \/ EndSessionAction
+
+SnapshotSpec == SnapshotInit /\ [][SnapshotNext]_snapVars
+
+--------------------------------------------------------------------
+(* Invariants *)
+--------------------------------------------------------------------
+
+(* Relaxes Retention's history-cardinality bound to admit the exemptions seam:
+   the history can exceed K by at most the number of live sessions (each pins
+   at most one version per artifact). Re-states the retention type with the
+   relaxed bound and adds the session-variable types + the
+   live <=> fully-captured well-formedness the atomic capture maintains. *)
+SnapshotTypeOK ==
+    /\ FencingTypeOK
+    /\ collectedRead \in BOOLEAN
+    /\ \A art \in Artifacts :
+         /\ DOMAIN history[art] \subseteq (1..MaxVersion)
+         /\ Cardinality(DOMAIN history[art]) <= MaxRetained + Cardinality(Sessions)
+         /\ \A v \in DOMAIN history[art] : history[art][v] = v
+    /\ readSkew \in BOOLEAN
+    /\ \A s \in Sessions :
+         /\ sessionLive[s] \in BOOLEAN
+         /\ \A art \in Artifacts : snapshot[s][art] \in ({None} \cup (1..MaxVersion))
+         (* a live session is fully captured; a dead one is all-None *)
+         /\ sessionLive[s] <=> (\A art \in Artifacts : snapshot[s][art] /= None)
+
+(* The headline read-side property: no commit ever interleaved a partially-
+   captured session -- equivalently, every session reads a coherent cut. In the
+   correct spec the atomic BeginSessionAction makes a partial capture
+   unreachable, so this is unreachable-TRUE; README mutant recipe 9 (split the
+   capture) makes it reachable and TLC finds a skewed read. NoStaleApply,
+   NoCollectedRead, SingleWriter, MonotonicVersion and the CR invariants are
+   inherited and re-checked to validate composition. *)
+NoReadSkewWithinCut == readSkew = FALSE
+
+(* The exemptions-seam safety property (R14 / R4): every version a LIVE session
+   has pinned is still in the artifact's retained history -- the K-bounded GC
+   never collects a pin out from under its session. Holds by construction
+   (SnapRetainAndCollect keeps window UNION PinnedVersions); README mutant
+   recipe 10 (drop the union) makes it fail once the window slides past a pin. *)
+PinAlwaysRetained ==
+    \A s \in Sessions :
+        sessionLive[s] =>
+            \A art \in Artifacts : snapshot[s][art] \in DOMAIN history[art]
+
+==========================================================================

--- a/formal/tla/Snapshot_CI.cfg
+++ b/formal/tla/Snapshot_CI.cfg
@@ -1,0 +1,25 @@
+SPECIFICATION SnapshotSpec
+
+CONSTANTS
+    NumAgents = 1
+    NumArtifacts = 2
+    MaxTicks = 2
+    HeartbeatTimeout = 4
+    MaxHoldTicks = 5
+    MaxRetained = 2
+    None = None
+    Sessions = {s1}
+
+INVARIANTS
+    SnapshotTypeOK
+    SingleWriter
+    MonotonicVersion
+    SweepExclusivity
+    TriggerExclusivity
+    TickMonotonicity
+    SlotPreservedThroughSHARED
+    ReadGenBounded
+    NoStaleApply
+    NoCollectedRead
+    NoReadSkewWithinCut
+    PinAlwaysRetained

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -51,6 +51,7 @@ from uuid import NAMESPACE_URL, UUID, uuid5
 
 from ccs.adapters.claude_code import audit_log as _audit_log
 from ccs.adapters.claude_code import hook_payloads as _payloads
+from ccs.adapters.claude_code import session_audit_log as _session_audit
 from ccs.adapters.claude_code.auth import (
     build_host_allowlist,
     ensure_secret,
@@ -63,14 +64,24 @@ from ccs.coordinator.service import CoordinatorService
 from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
 from ccs.core.exceptions import (
     OCC_CALLER_TRANSIENT_REASON,
+    SESSION_INVALIDATED_REASON,
     STALE_READ_GENERATION_REASON,
     CoherenceError,
     OccCallerTransientError,
+    SessionInvalidated,
     StaleReadGeneration,
     WatchdogAbandoned,
 )
 from ccs.core.states import MESIState
-from ccs.core.types import ConflictDetail
+from ccs.core.types import (
+    ConflictDetail,
+    DataPlaneDeferredRead,
+    SessionCommitRejection,
+    SessionReadRejection,
+    SnapshotSession,
+    VersionedContent,
+    VersionedReadRejection,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +167,14 @@ to read into memory. Matches MAX_POLICY_YAML_BYTES — generous for the
 ~1 KB hook payloads we actually expect, tight enough that a hostile or
 buggy client cannot OOM the coordinator with a single oversized body.
 Validated BEFORE rfile.read so we never allocate the offending buffer."""
+
+MAX_SESSION_READ_SET_PATHS = 64
+"""SB-17 Unit 8 (R14 wire mirror): cap on the number of read-set paths
+``POST /session/begin`` accepts in one request, mirroring the service's
+``SessionCapsConfig.max_read_set_cardinality`` default. A boundary reject
+(loud 400) keeps a hostile client from forcing the path→id resolution loop
+to walk an unbounded list before the service's own cap fires. The service
+cap remains authoritative; this is defense-in-depth at the wire."""
 
 
 def _resolve_coordinator_version() -> str:
@@ -2535,6 +2554,372 @@ def _handle_pre_grep(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
     _run_or_degrade(req, coordinator, work)
 
 
+# ----------------------------------------------------------------------
+# Snapshot-session endpoints (SB-17 / TX-1, Unit 8 — R7 / R9 / R10a)
+# ----------------------------------------------------------------------
+#
+# Four ADDITIVE routes — registered in the central ``_ROUTES`` table so they
+# ride the SAME ``verify_bearer`` + ``verify_host`` seam every other endpoint
+# uses (the dispatcher applies auth before any handler runs; there is NO
+# parallel router). All four derive the CALLER/OWNER identity SERVER-SIDE from
+# the authenticated ``session_id`` via :func:`session_to_agent_id` — the same
+# agent-identity mechanism the hook endpoints use — and NEVER from a
+# client-supplied identity field. This is the R9 server-capture boundary lock:
+#
+#   * ``begin_session`` captures the cut SERVER-SIDE; the client cannot supply a
+#     cut / pinned versions.
+#   * ``/session/read`` and ``/session/commit`` carry ONLY the ``session_token``
+#     (+ artifact path / content). Any client-supplied ``cut`` / ``pinned_*`` /
+#     ``owner`` / ``caller`` field is IGNORED — the server reads the pinned cut
+#     from the registry by token and derives the owner from the authenticated
+#     session. A forged / replayed token CANNOT forge or bypass the server-side
+#     capture: a token with no live cut fails closed (``session_invalidated`` /
+#     ``session_not_found``), and a foreign caller raises ``SessionInvalidated``.
+#   * The day a client legitimately carries the cut is CROSS-HOST — out of scope
+#     here; the boundary-lock test FAILS if anyone wires a client-carried cut in.
+
+
+def _session_owner_from_request(
+    coordinator: CoordinatorHTTPServer, session_id: str
+) -> UUID:
+    """Derive the session OWNER/CALLER identity SERVER-SIDE from the
+    authenticated ``session_id`` (R9 / R13). Reuses the SAME
+    :func:`session_to_agent_id` derivation the hook endpoints use via
+    ``register_session`` — the identity comes from AUTH (the validated
+    ``session_id``), NEVER a client-supplied ``owner``/``caller`` field. Also
+    registers the session so status/name lookups stay consistent with the hook
+    surface."""
+    return coordinator.register_session(session_id)
+
+
+def _resolve_read_set(
+    coordinator: CoordinatorHTTPServer, paths: list[str]
+) -> list[UUID]:
+    """Resolve repo-relative read-set paths to artifact UUIDs, seeding a v1
+    row (KTD-9 first-observation, mirroring ``/hooks/pre-read``) for any path
+    not yet known. Non-mutating w.r.t. coherence STATE for already-known
+    artifacts (it only looks them up); a first-observation seed registers the
+    artifact row exactly as pre-read does. The returned id order matches the
+    input path order so the begin handler can render a path-keyed cut."""
+    ids: list[UUID] = []
+    for path in paths:
+        artifact_id = coordinator.registry.lookup_artifact_id_by_name(path)
+        if artifact_id is None:
+            artifact_id = coordinator.registry.resolve_or_register(path, content_hash="")
+        ids.append(artifact_id)
+    return ids
+
+
+def _handle_session_begin(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
+    """POST /session/begin — open a consistent multi-artifact snapshot session.
+
+    Request: ``{session_id, read_set: [<repo-rel path>, ...]}``.
+
+    The CALLER/OWNER is derived SERVER-SIDE from ``session_id`` (R9/R13) — the
+    client does NOT supply an owner. The server resolves each read-set PATH to
+    an artifact id (seeding first-observations like pre-read), captures the cut
+    via ``service.begin_session``, and returns the server-minted
+    ``session_token`` plus the INSPECTABLE path-keyed cut. The bytes are never
+    captured here (version-map only); ``retain_versions`` tells the client which
+    serve branch a later ``/session/read`` resolves.
+
+    Responses:
+      - WIN → ``{ok: true, session_token, cut: {path: version}, coordinator_epoch,
+        retain_versions}``
+      - typed rejection (unknown id / caps) → ``{ok: false, reason, ...}``
+    """
+    body = req._read_json()
+    if body is None:
+        return
+    session_id = body.get("session_id")
+    read_set = body.get("read_set")
+    sid_err = validate_session_id(session_id)
+    if sid_err:
+        req._json(400, {"error": sid_err[1]})
+        return
+    if not isinstance(read_set, list) or not all(isinstance(p, str) for p in read_set):
+        req._json(400, {"error": "read_set must be a list of repo-relative path strings"})
+        return
+    if len(read_set) > MAX_SESSION_READ_SET_PATHS:
+        req._json(400, {"error": f"read_set exceeds {MAX_SESSION_READ_SET_PATHS} paths"})
+        return
+    for path in read_set:
+        path_err = validate_path(path)
+        if path_err:
+            req._json(400, {"error": path_err})
+            return
+
+    # OWNER derived from AUTH, never a client field (R9/R13).
+    owner = _session_owner_from_request(coordinator, session_id)
+    now = monotonic_seconds()
+
+    def work() -> dict:
+        read_set_ids = _resolve_read_set(coordinator, read_set)
+        # Keep a path↔id map so the response renders the cut path-keyed (the
+        # client speaks paths; artifact UUIDs stay server-internal).
+        id_to_path = {aid: path for aid, path in zip(read_set_ids, read_set)}
+        result = coordinator.service.begin_session(
+            read_set=read_set_ids, owner=owner, created_at_tick=now,
+        )
+        if isinstance(result, VersionedReadRejection):
+            # Typed cap / unknown-id rejection — NO session opened, no pins.
+            return {"ok": False, "reason": result.reason}
+        assert isinstance(result, SnapshotSession)
+        # Content-free audit (R10a): begin event with ids + pinned versions.
+        _session_audit.append_session_begin(
+            coordinator.coordinator_root,
+            session_token=result.session_token,
+            cut=result.cut,
+        )
+        cut_by_path = {
+            id_to_path.get(aid, str(aid)): version
+            for aid, version in result.cut.items()
+        }
+        return {
+            "ok": True,
+            "session_token": result.session_token,
+            "cut": cut_by_path,
+            "coordinator_epoch": result.coordinator_epoch,
+            "retain_versions": result.retain_versions,
+        }
+
+    _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE)
+
+
+def _handle_session_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
+    """POST /session/read — serve an artifact's PINNED version from a session.
+
+    Request: ``{session_id, session_token, path}``.
+
+    R9 boundary lock: the request carries ONLY the ``session_token`` + ``path``
+    — NO client-supplied cut / pinned version / owner. The server reads the
+    pinned version from the registry by token and derives the caller from the
+    authenticated ``session_id``. A forged/replayed token or a foreign caller
+    cannot forge or bypass the server-side capture.
+
+    Responses:
+      - coordinator-held pinned bytes (LAZY branch) → ``{ok: true, served:
+        "content", version, content, coordinator_epoch}``
+      - bytes live in the data plane (EAGER branch) → ``{ok: true, served:
+        "data_plane_deferred", version, content_hash, coordinator_epoch}``
+      - typed rejection (no valid pin) → ``{ok: false, reason, coordinator_epoch}``
+      - foreign caller / dead session → ``{ok: false, reason: "session_invalidated"}``
+    """
+    body = req._read_json()
+    if body is None:
+        return
+    session_id = body.get("session_id")
+    session_token = body.get("session_token")
+    path = body.get("path", "")
+    sid_err = validate_session_id(session_id)
+    if sid_err:
+        req._json(400, {"error": sid_err[1]})
+        return
+    if not isinstance(session_token, str) or not session_token:
+        req._json(400, {"error": "missing or invalid session_token"})
+        return
+    path_err = validate_path(path)
+    if path_err:
+        req._json(400, {"error": path_err})
+        return
+
+    caller = _session_owner_from_request(coordinator, session_id)
+
+    def work() -> dict:
+        artifact_id = coordinator.registry.lookup_artifact_id_by_name(path)
+        if artifact_id is None:
+            # Unknown path → cannot be in any cut. Mirror the service's
+            # not-in-cut signal rather than seeding a row a read can't serve.
+            return {"ok": False, "reason": "artifact_not_in_cut"}
+        try:
+            result = coordinator.service.session_read(
+                session_token, artifact_id, caller=caller,
+            )
+        except SessionInvalidated as exc:
+            # Foreign caller / fenced-off session — fail closed. Content-free
+            # invalidate audit (R10a).
+            _session_audit.append_session_invalidate(
+                coordinator.coordinator_root,
+                session_token=session_token, reason=exc.reason,
+            )
+            return {"ok": False, "reason": exc.reason}
+        if isinstance(result, VersionedContent):
+            return {
+                "ok": True,
+                "served": "content",
+                "version": result.version,
+                # KTD-13 honesty: serve the body bytes back so the data plane
+                # can read its pinned version; hashing happens client-side.
+                "content": (
+                    result.content.decode("utf-8", "replace")
+                    if isinstance(result.content, bytes) else result.content
+                ),
+                "coordinator_epoch": result.coordinator_epoch,
+            }
+        if isinstance(result, DataPlaneDeferredRead):
+            return {
+                "ok": True,
+                "served": "data_plane_deferred",
+                "version": result.version,
+                "content_hash": result.content_hash,
+                "coordinator_epoch": result.coordinator_epoch,
+            }
+        assert isinstance(result, SessionReadRejection)
+        if result.reason == SESSION_INVALIDATED_REASON:
+            _session_audit.append_session_invalidate(
+                coordinator.coordinator_root,
+                session_token=session_token, reason=result.reason,
+            )
+        return {
+            "ok": False,
+            "reason": result.reason,
+            "coordinator_epoch": result.coordinator_epoch,
+        }
+
+    _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE)
+
+
+def _handle_session_commit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
+    """POST /session/commit — single-artifact OCC commit against the pinned base.
+
+    Request: ``{session_id, session_token, path, content}``.
+
+    R9 boundary lock: the request carries ONLY ``session_token`` + ``path`` +
+    ``content`` — NO client-supplied cut / pinned version / expected_version /
+    owner. The pinned ``expected_version`` is read SERVER-SIDE from the cut
+    (``service.session_commit`` sources it from ``cut[artifact_id]``); a client
+    cannot drive the CAS with a forged comparand. The caller is derived from the
+    authenticated ``session_id``.
+
+    Responses (preserving the shipped ``commit_cas`` taxonomy):
+      - WIN → ``{ok: true, version: N+1, coordinator_epoch}``
+      - retry-eligible ``ConflictDetail`` (HELD) → ``{ok: false, reason, current_version}``
+      - typed validation rejection → ``{ok: false, reason, coordinator_epoch}``
+      - corruption / foreign caller / dead session → ``{ok: false, reason}`` (raised
+        ``CoherenceError`` / ``SessionInvalidated`` mapped to a fail-closed body)
+    """
+    body = req._read_json()
+    if body is None:
+        return
+    session_id = body.get("session_id")
+    session_token = body.get("session_token")
+    path = body.get("path", "")
+    content = body.get("content")
+    sid_err = validate_session_id(session_id)
+    if sid_err:
+        req._json(400, {"error": sid_err[1]})
+        return
+    if not isinstance(session_token, str) or not session_token:
+        req._json(400, {"error": "missing or invalid session_token"})
+        return
+    path_err = validate_path(path)
+    if path_err:
+        req._json(400, {"error": path_err})
+        return
+    if not isinstance(content, str):
+        req._json(400, {"error": "content must be a string"})
+        return
+
+    caller = _session_owner_from_request(coordinator, session_id)
+    now = monotonic_seconds()
+
+    def work() -> dict:
+        artifact_id = coordinator.registry.lookup_artifact_id_by_name(path)
+        if artifact_id is None:
+            return {"ok": False, "reason": "artifact_not_in_cut"}
+        # Read the pinned base BEFORE the commit so the content-free audit can
+        # record (pinned_version, committed_version) on a WIN. Server-side only.
+        cut = coordinator.registry.get_session_cut(session_token)
+        pinned_version = cut.get(artifact_id) if cut else None
+        try:
+            result = coordinator.service.session_commit(
+                session_token, artifact_id, content, caller=caller, issued_at_tick=now,
+            )
+        except SessionInvalidated as exc:
+            _session_audit.append_session_invalidate(
+                coordinator.coordinator_root,
+                session_token=session_token, reason=exc.reason,
+            )
+            return {"ok": False, "reason": exc.reason}
+        except CoherenceError as exc:
+            # Corruption (expected_version > current) — non-retryable. The
+            # client raises on this {ok: false, reason} body.
+            return {"ok": False, "reason": str(exc)}
+        if isinstance(result, ConflictDetail):
+            # HELD: nothing mutated. Byte-stable typed conflict the client maps
+            # to "open a new session + re-read + retry".
+            return {
+                "ok": False,
+                "reason": result.reason,
+                "current_version": result.current_version,
+            }
+        if isinstance(result, SessionCommitRejection):
+            if result.reason == SESSION_INVALIDATED_REASON:
+                _session_audit.append_session_invalidate(
+                    coordinator.coordinator_root,
+                    session_token=session_token, reason=result.reason,
+                )
+            return {
+                "ok": False,
+                "reason": result.reason,
+                "coordinator_epoch": result.coordinator_epoch,
+            }
+        updated, _signals = result
+        # Content-free commit audit (R10a): ids + versions, no body / no hash.
+        _session_audit.append_session_commit(
+            coordinator.coordinator_root,
+            session_token=session_token,
+            artifact_id=artifact_id,
+            pinned_version=pinned_version if pinned_version is not None else updated.version - 1,
+            committed_version=updated.version,
+        )
+        return {
+            "ok": True,
+            "version": updated.version,
+            "coordinator_epoch": coordinator.registry.coordinator_epoch,
+        }
+
+    # Fail-closed degrade: a timed-out session.commit must NOT read as success
+    # (mirror the OCC commit endpoint — a degraded commit is a definite reject).
+    abort = threading.Event()
+    _run_or_degrade(req, coordinator, work, degraded_response=_OCC_DEGRADED_RESPONSE, abort=abort)
+
+
+def _handle_session_heartbeat(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
+    """POST /session/heartbeat — refresh a session's heartbeat lease (R4).
+
+    Request: ``{session_id, session_token}``.
+
+    The OWNER is derived from the authenticated ``session_id`` — a foreign
+    caller cannot keep another agent's session alive (the service enforces the
+    timing-safe owner-binding and returns False on mismatch; the response does
+    NOT reveal whether the token exists). ``{ok: true, refreshed: bool}``.
+    """
+    body = req._read_json()
+    if body is None:
+        return
+    session_id = body.get("session_id")
+    session_token = body.get("session_token")
+    sid_err = validate_session_id(session_id)
+    if sid_err:
+        req._json(400, {"error": sid_err[1]})
+        return
+    if not isinstance(session_token, str) or not session_token:
+        req._json(400, {"error": "missing or invalid session_token"})
+        return
+
+    owner = _session_owner_from_request(coordinator, session_id)
+    now = monotonic_seconds()
+
+    def work() -> dict:
+        refreshed = coordinator.service.record_session_heartbeat(
+            session_token=session_token, owner=owner, now_tick=now,
+        )
+        return {"ok": True, "refreshed": refreshed}
+
+    _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE)
+
+
 def _handle_status(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
     """GET /status — drives the agent-coherence-status console script.
 
@@ -2868,6 +3253,13 @@ _ROUTES: dict[tuple[str, str], Callable] = {
     ("POST", "/hooks/pre-grep"): _handle_pre_grep,
     ("POST", "/policy/track"): _handle_policy_track,
     ("POST", "/policy/untrack"): _handle_policy_untrack,
+    # SB-17 / TX-1 Unit 8 — snapshot-session endpoints. Registered HERE so they
+    # ride the central verify_bearer + verify_host seam the dispatcher applies
+    # to every route (NO parallel router; R9 / Unit 8 endpoint-auth obligation).
+    ("POST", "/session/begin"): _handle_session_begin,
+    ("POST", "/session/read"): _handle_session_read,
+    ("POST", "/session/commit"): _handle_session_commit,
+    ("POST", "/session/heartbeat"): _handle_session_heartbeat,
     ("GET", "/status"): _handle_status,
     ("POST", "/admin/prepare-for-migration"): _handle_prepare_for_migration,
 }

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -34,6 +34,7 @@ Lifecycle (spawn, port-file, idle-shutdown, sweep) lives in :mod:`lifecycle`
 
 from __future__ import annotations
 
+import base64
 import http.server
 import json
 import logging
@@ -2686,6 +2687,28 @@ def _handle_session_begin(req: _RequestProtocol, coordinator: CoordinatorHTTPSer
     _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE)
 
 
+def _session_read_content_fields(content: bytes | str) -> dict:
+    """Render a pinned body for the /session/read response so the client can
+    verify the hash CLIENT-SIDE (finding F5).
+
+    A lossy ``decode("utf-8", "replace")`` corrupted non-UTF-8 bodies — the
+    replacement chars made the client's hash unable to match the pinned
+    ``content_hash``. So: serve valid-UTF-8 (incl. all text) as a plain
+    ``content`` string (the unchanged, byte-stable wire shape), and EXACT-encode
+    non-UTF-8 bytes as base64 under an explicit ``content_encoding: "base64"``
+    flag (``content_b64``) so the round-trip is lossless. ``str`` content (the
+    in-memory registry's stored text) serves directly."""
+    if isinstance(content, bytes):
+        try:
+            return {"content": content.decode("utf-8")}
+        except UnicodeDecodeError:
+            return {
+                "content_b64": base64.b64encode(content).decode("ascii"),
+                "content_encoding": "base64",
+            }
+    return {"content": content}
+
+
 def _handle_session_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
     """POST /session/read — serve an artifact's PINNED version from a session.
 
@@ -2699,7 +2722,9 @@ def _handle_session_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServ
 
     Responses:
       - coordinator-held pinned bytes (LAZY branch) → ``{ok: true, served:
-        "content", version, content, coordinator_epoch}``
+        "content", version, content, coordinator_epoch}``. Non-UTF-8 bytes are
+        served losslessly as ``{..., content_b64, content_encoding: "base64"}``
+        instead of a (lossy) ``content`` string, so the client hash round-trips.
       - bytes live in the data plane (EAGER branch) → ``{ok: true, served:
         "data_plane_deferred", version, content_hash, coordinator_epoch}``
       - typed rejection (no valid pin) → ``{ok: false, reason, coordinator_epoch}``
@@ -2744,18 +2769,14 @@ def _handle_session_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServ
             )
             return {"ok": False, "reason": exc.reason}
         if isinstance(result, VersionedContent):
-            return {
+            resp = {
                 "ok": True,
                 "served": "content",
                 "version": result.version,
-                # KTD-13 honesty: serve the body bytes back so the data plane
-                # can read its pinned version; hashing happens client-side.
-                "content": (
-                    result.content.decode("utf-8", "replace")
-                    if isinstance(result.content, bytes) else result.content
-                ),
                 "coordinator_epoch": result.coordinator_epoch,
             }
+            resp.update(_session_read_content_fields(result.content))
+            return resp
         if isinstance(result, DataPlaneDeferredRead):
             return {
                 "ok": True,
@@ -2834,6 +2855,7 @@ def _handle_session_commit(req: _RequestProtocol, coordinator: CoordinatorHTTPSe
         try:
             result = coordinator.service.session_commit(
                 session_token, artifact_id, content, caller=caller, issued_at_tick=now,
+                abort=abort,
             )
         except SessionInvalidated as exc:
             _session_audit.append_session_invalidate(
@@ -3280,6 +3302,12 @@ _MIGRATION_REJECTED_ROUTES: set[tuple[str, str]] = {
     # bump a version the imminent shutdown then strands; the client retries
     # after the coordinator restarts.
     ("POST", "/hooks/post-edit-cas"),
+    # A snapshot session.commit is a version-bumping OCC write at the pinned base
+    # — same hazard as post-edit-cas: letting it land mid-migration bumps a
+    # version the imminent shutdown then strands. Reject it draining; the client
+    # opens a fresh session + re-reads + re-commits after the restart. (begin /
+    # read / heartbeat are non-mutating and stay out of this set.)
+    ("POST", "/session/commit"),
 }
 
 

--- a/src/ccs/adapters/claude_code/lifecycle.py
+++ b/src/ccs/adapters/claude_code/lifecycle.py
@@ -787,6 +787,30 @@ def _sweep_loop(entry: _SpawnedEntry, cfg: LifecycleConfig) -> None:
                 max_hold_ticks=cfg.grant_max_hold_sec,
                 on_reclaim=_record_reclamation_notice,
             )
+            # SB-17 / TX-1 Unit 5 / R4: the session-liveness sweep — a SEPARATE
+            # axis from the grant sweep above (a snapshot session holds no MESI
+            # grant, so the grant sweep can never see it). Reaps a session whose
+            # heartbeat lease has gone stale, dropping its pins so its pinned
+            # versions become collectible again; afterward a session_read /
+            # session_commit on that token fails closed with session_invalidated.
+            # Reuses the SAME staleness predicate + the grant heartbeat timeout
+            # knob. Best-effort like the rest of the sweep (the outer try guards
+            # it). A slow-but-live session that keeps heartbeating is NOT reaped.
+            # OPERATIONAL DEPENDENCY (Unit 8): the HTTP record_session_heartbeat
+            # endpoint that lets a REMOTE client refresh the lease lands in
+            # Unit 8. Until then a live session over the remote transport is
+            # implicitly bounded by grant_heartbeat_timeout_sec — it is reaped
+            # fail-closed (session_invalidated, never wrong bytes), not broken;
+            # in-process callers can already drive record_session_heartbeat
+            # directly. This only affects the remote/HTTP path pre-Unit-8.
+            reaped_sessions = coordinator.service.enforce_session_liveness(
+                current_tick=now_tick,
+                heartbeat_timeout_ticks=cfg.grant_heartbeat_timeout_sec,
+            )
+            if reaped_sessions:
+                logger.info(
+                    "sweep reaped %d stale snapshot session(s)", reaped_sessions
+                )
             evicted = coordinator.registry.evict_stale_notices(
                 max_age_sec=cfg.notice_evict_max_age_sec,
             )

--- a/src/ccs/adapters/claude_code/lifecycle.py
+++ b/src/ccs/adapters/claude_code/lifecycle.py
@@ -756,14 +756,15 @@ def _sweep_loop(entry: _SpawnedEntry, cfg: LifecycleConfig) -> None:
     # CoordinatorHTTPServer; importing back at module load would cycle.
     from ccs.adapters.claude_code.coordinator_server import (
         SWEEP_RECLAMATION_PREEMPTER_ID,
+        monotonic_seconds,
     )
 
     coordinator = entry.coordinator
 
     def _record_reclamation_notice(artifact_id, agent_id, trigger) -> None:
         """Per-reclamation callback wired into service.enforce_stable_grant_timeouts.
-        Uses wall-clock time (the notice timestamp is operator-visible
-        via the F4 prose) rather than the monotonic sweep tick."""
+        Uses float wall-clock time (the notice timestamp is operator-visible
+        via the F4 prose) rather than the integer sweep tick."""
         coordinator.registry.record_preemption_notice(
             victim_agent_id=agent_id,
             artifact_id=artifact_id,
@@ -775,7 +776,17 @@ def _sweep_loop(entry: _SpawnedEntry, cfg: LifecycleConfig) -> None:
         time.sleep(cfg.sweep_interval_sec)
         if coordinator.shutting_down:
             break
-        now_tick = int(time.monotonic())
+        # The sweep tick MUST share the basis the heartbeat handlers seed from
+        # (``monotonic_seconds`` == ``int(time.time())``, wall-clock seconds): the
+        # grant heartbeat handlers, the session heartbeat, and ``begin_session``'s
+        # ``created_at_tick`` are ALL seeded from ``monotonic_seconds()``. Using
+        # ``int(time.monotonic())`` here (a boot-relative clock ~1.7e9 below
+        # wall-clock) made ``current_tick - last_hb`` permanently negative, so the
+        # transient, grant, AND session sweeps never fired over the HTTP transport
+        # (heartbeat timeouts + the absolute-age ceiling silently inoperative).
+        # Wall-clock also survives a restart — the basis ``deadline_tick`` and the
+        # session ceiling need; monotonic resets on reboot and would break those.
+        now_tick = monotonic_seconds()
         try:
             coordinator.service.enforce_transient_timeouts(
                 current_tick=now_tick,
@@ -796,13 +807,11 @@ def _sweep_loop(entry: _SpawnedEntry, cfg: LifecycleConfig) -> None:
             # Reuses the SAME staleness predicate + the grant heartbeat timeout
             # knob. Best-effort like the rest of the sweep (the outer try guards
             # it). A slow-but-live session that keeps heartbeating is NOT reaped.
-            # OPERATIONAL DEPENDENCY (Unit 8): the HTTP record_session_heartbeat
-            # endpoint that lets a REMOTE client refresh the lease lands in
-            # Unit 8. Until then a live session over the remote transport is
-            # implicitly bounded by grant_heartbeat_timeout_sec — it is reaped
-            # fail-closed (session_invalidated, never wrong bytes), not broken;
-            # in-process callers can already drive record_session_heartbeat
-            # directly. This only affects the remote/HTTP path pre-Unit-8.
+            # A REMOTE client refreshes its lease via the HTTP
+            # POST /session/heartbeat endpoint; an abandoned session is reaped
+            # fail-closed (session_invalidated, never wrong bytes) once the lease
+            # goes stale or the absolute-age ceiling fires, with durable-only
+            # post-restart sessions bounded by that ceiling.
             reaped_sessions = coordinator.service.enforce_session_liveness(
                 current_tick=now_tick,
                 heartbeat_timeout_ticks=cfg.grant_heartbeat_timeout_sec,

--- a/src/ccs/adapters/claude_code/session_audit_log.py
+++ b/src/ccs/adapters/claude_code/session_audit_log.py
@@ -38,10 +38,15 @@ discipline):
   the append still proceeds because the data is content-free lifecycle
   metadata, not credential material.
 
-Concurrent writes: ``os.O_APPEND`` is atomic for small writes on POSIX
-(the write syscall is serialized between concurrent appenders). One JSONL
-line per write keeps each append atomic — no application-layer locking
-needed.
+Concurrent writes: ``os.O_APPEND`` advances the file offset atomically per
+``write`` syscall, but the POSIX whole-write atomicity guarantee only holds
+below ``PIPE_BUF`` (as little as 512 bytes on macOS), and a max-cardinality
+cut record exceeds that — so concurrent ``/session/begin`` appenders could
+interleave and tear a JSONL line (finding F9). A process-level
+``_AUDIT_WRITE_LOCK`` serializes the open+write+close so each record lands
+whole, regardless of size. The coordinator is single-process per host, so an
+in-process lock covers the real concurrency (multiple HTTP handler threads);
+cross-process sharing of one audit file is not a supported topology.
 """
 
 from __future__ import annotations
@@ -51,12 +56,18 @@ import json
 import logging
 import os
 import stat
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal, Mapping
 from uuid import UUID
 
 logger = logging.getLogger(__name__)
+
+_AUDIT_WRITE_LOCK = threading.Lock()
+"""Serializes session-audit appends so a multi-KB record (a max-cardinality
+cut) cannot tear under concurrent ``/session/begin`` writers (finding F9).
+In-process scope — the coordinator is single-process per host."""
 
 
 _SESSION_AUDIT_LOG_FILENAME = "session-audit.log"
@@ -126,16 +137,20 @@ def _append_record(coordinator_root: Path, record: dict) -> bool:
     _check_mode_or_warn(audit_path)
     payload = (json.dumps(record, ensure_ascii=False) + "\n").encode("utf-8")
     # O_NOFOLLOW: refuse to follow a symlink planted at the audit path (a
-    # same-UID adversary could otherwise redirect the append). O_APPEND is
-    # atomic for small (<PIPE_BUF) payloads on POSIX. Mode 0o600 applies only
-    # on file CREATION; an existing file keeps its mode (verified above).
+    # same-UID adversary could otherwise redirect the append). Mode 0o600
+    # applies only on file CREATION; an existing file keeps its mode (verified
+    # above). The ``_AUDIT_WRITE_LOCK`` makes the whole open+write+close
+    # atomic against concurrent in-process appenders so a record larger than
+    # PIPE_BUF cannot tear a JSONL line (finding F9); ``os.write`` of a bounded
+    # record to a regular file is a single physical write under the lock.
     flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY | os.O_NOFOLLOW
     try:
-        fd = os.open(audit_path, flags, _REQUIRED_MODE)
-        try:
-            os.write(fd, payload)
-        finally:
-            os.close(fd)
+        with _AUDIT_WRITE_LOCK:
+            fd = os.open(audit_path, flags, _REQUIRED_MODE)
+            try:
+                os.write(fd, payload)
+            finally:
+                os.close(fd)
         return True
     except OSError as exc:
         logger.error(

--- a/src/ccs/adapters/claude_code/session_audit_log.py
+++ b/src/ccs/adapters/claude_code/session_audit_log.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Content-free snapshot-session audit log — appends session lifecycle
+events (begin / commit / invalidate) as JSONL to
+``<coordinator_root>/.coherence/session-audit.log`` (SB-17 / TX-1, Unit 8 /
+R10a).
+
+Why a SEPARATE module from :mod:`audit_log`:
+- ``audit_log`` carries the LOCKED KTD-V invariant ("Denial events only …
+  ``decision`` is always ``strict_deny``"), guarded by
+  ``test_audit_log_payload_bounded_no_user_content``. Session lifecycle
+  events are a DIFFERENT event family (begin / commit / invalidate, not a
+  strict-deny), so folding them into ``audit_log`` would break that
+  invariant. They go here, in their own file, with their own bounded
+  schema — ``audit_log`` is untouched (two reviewers, plan Unit 8).
+- Single-responsibility helper the session endpoints import.
+
+Content-free invariants (R10a — mirrors KTD-V's bounded-payload
+discipline):
+- **No content bytes. No content HASHES of bodies. No user prose.** A
+  session-audit record carries only session-lifecycle METADATA: a
+  non-secret session id (a hash of the server-minted token, NOT the token
+  itself — see ``_hash_session_token``), the read-set artifact ids, the
+  pinned versions, the event kind, and an ISO-8601 timestamp. The field
+  set is FIXED per event kind and pinned by
+  ``test_session_audit_payload_bounded_no_user_content`` so no body
+  material can creep in.
+- **No raw session token.** The token is secret material (it authorizes
+  ``session.read`` / ``session.commit``); the audit log records a SHA-256
+  hash of it as the correlation handle, so an audit-log reader can join
+  events for one session WITHOUT the log ever carrying credential
+  material.
+- **0o600 file mode + O_NOFOLLOW.** Created with an explicit mode flag and
+  ``O_NOFOLLOW`` so a pre-planted symlink at the audit path cannot
+  redirect the append elsewhere (matches ``audit_log``'s discipline). Mode
+  drift on an existing file (operator chmod 0644) is logged as a warning;
+  the append still proceeds because the data is content-free lifecycle
+  metadata, not credential material.
+
+Concurrent writes: ``os.O_APPEND`` is atomic for small writes on POSIX
+(the write syscall is serialized between concurrent appenders). One JSONL
+line per write keeps each append atomic — no application-layer locking
+needed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal, Mapping
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+
+_SESSION_AUDIT_LOG_FILENAME = "session-audit.log"
+_REQUIRED_MODE = 0o600
+"""R10a locked: session-audit.log must be mode 0o600 (owner read/write
+only). Pinned via ``test_session_audit_required_mode_constant``."""
+
+SessionEvent = Literal["session_begin", "session_commit", "session_invalidate"]
+"""The three lifecycle event kinds. ADDITIVE-only — a new kind is added,
+never folded into an existing literal (wire-stability discipline)."""
+
+
+def _resolve_session_audit_log_path(coordinator_root: Path) -> Path:
+    """Compute ``<coordinator_root>/.coherence/session-audit.log``. The
+    directory is expected to exist (coordinator startup creates it); this
+    helper does NOT create it — a missing directory surfaces as a
+    coordinator misconfiguration (logged, append skipped), not silent log
+    loss elsewhere."""
+    return coordinator_root / ".coherence" / _SESSION_AUDIT_LOG_FILENAME
+
+
+def _hash_session_token(session_token: str) -> str:
+    """Return a SHA-256 hex digest of the server-minted session token — the
+    NON-SECRET correlation handle recorded in the audit log.
+
+    The raw token authorizes ``session.read`` / ``session.commit``, so it is
+    credential material and MUST NOT land in the log. A stable hash lets an
+    audit reader correlate the begin / commit / invalidate events of one
+    session without the log ever carrying the secret. (This hashes the
+    SESSION TOKEN, never any artifact body — the no-body-hash invariant is
+    about CONTENT hashes, which this is not.)"""
+    return hashlib.sha256(session_token.encode("utf-8")).hexdigest()
+
+
+def _check_mode_or_warn(path: Path) -> bool:
+    """Return True iff the existing file mode matches ``_REQUIRED_MODE``. On
+    drift, emit a ``logger.warning`` and return False — the caller still
+    appends (content-free lifecycle metadata is not credential material;
+    refusing would silently drop audit data after an operator chmod).
+    Mirrors ``audit_log._check_mode_or_warn``."""
+    try:
+        actual_mode = stat.S_IMODE(path.stat().st_mode)
+    except OSError:
+        return True  # File doesn't exist yet — will be created with 0o600.
+    if actual_mode != _REQUIRED_MODE:
+        logger.warning(
+            "session-audit.log at %s has mode %o (expected %o). Continuing "
+            "append — content-free lifecycle metadata is not credential "
+            "material — but run `chmod 0600 .coherence/session-audit.log` to "
+            "restore.",
+            path, actual_mode, _REQUIRED_MODE,
+        )
+        return False
+    return True
+
+
+def _append_record(coordinator_root: Path, record: dict) -> bool:
+    """Append one JSONL ``record`` to ``.coherence/session-audit.log`` with
+    the 0o600 + ``O_NOFOLLOW`` + ``O_APPEND`` discipline.
+
+    Returns True if the append succeeded; False on OSError (disk full,
+    symlink at the path → ``O_NOFOLLOW`` ELOOP, unreadable). Errors are
+    LOGGED, not raised — an audit-log failure must NEVER corrupt the
+    coordinator transaction (it has already committed by the time this is
+    called)."""
+    audit_path = _resolve_session_audit_log_path(coordinator_root)
+    _check_mode_or_warn(audit_path)
+    payload = (json.dumps(record, ensure_ascii=False) + "\n").encode("utf-8")
+    # O_NOFOLLOW: refuse to follow a symlink planted at the audit path (a
+    # same-UID adversary could otherwise redirect the append). O_APPEND is
+    # atomic for small (<PIPE_BUF) payloads on POSIX. Mode 0o600 applies only
+    # on file CREATION; an existing file keeps its mode (verified above).
+    flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY | os.O_NOFOLLOW
+    try:
+        fd = os.open(audit_path, flags, _REQUIRED_MODE)
+        try:
+            os.write(fd, payload)
+        finally:
+            os.close(fd)
+        return True
+    except OSError as exc:
+        logger.error(
+            "session-audit.log append failed at %s: %s. Event NOT recorded "
+            "(coordinator transaction already committed; the session call "
+            "proceeded normally).",
+            audit_path, exc,
+        )
+        return False
+
+
+def _serialize_versions(versions: Mapping[UUID, int]) -> dict[str, int]:
+    """Render a ``{artifact_id: version}`` map as a JSON-serializable
+    ``{str(uuid): int}`` dict. Carries ONLY ids + versions — no bytes, no
+    body hashes, no prose."""
+    return {str(artifact_id): int(version) for artifact_id, version in versions.items()}
+
+
+def append_session_begin(
+    coordinator_root: Path,
+    *,
+    session_token: str,
+    cut: Mapping[UUID, int],
+) -> bool:
+    """Append a ``session_begin`` event: a session opened, pinning ``cut``.
+
+    R10a bounded payload — fields fixed at:
+        ts          — ISO-8601 UTC timestamp
+        event       — "session_begin"
+        session     — SHA-256 hash of the session token (non-secret handle)
+        cut         — {artifact_id: pinned_version} (read-set ids + versions)
+
+    NO content bytes. NO body hashes. NO user prose. NO raw token."""
+    record = {
+        "ts": datetime.now(tz=timezone.utc).isoformat(),
+        "event": "session_begin",
+        "session": _hash_session_token(session_token),
+        "cut": _serialize_versions(cut),
+    }
+    return _append_record(coordinator_root, record)
+
+
+def append_session_commit(
+    coordinator_root: Path,
+    *,
+    session_token: str,
+    artifact_id: UUID,
+    pinned_version: int,
+    committed_version: int,
+) -> bool:
+    """Append a ``session_commit`` event: a single-artifact OCC commit WON
+    against its pinned base.
+
+    R10a bounded payload — fields fixed at:
+        ts                 — ISO-8601 UTC timestamp
+        event              — "session_commit"
+        session            — SHA-256 hash of the session token
+        artifact           — committed artifact id (str UUID)
+        pinned_version     — the cut's pinned version (the OCC comparand)
+        committed_version  — the new version after the WIN
+
+    NO content bytes. NO body hashes. NO user prose. NO raw token."""
+    record = {
+        "ts": datetime.now(tz=timezone.utc).isoformat(),
+        "event": "session_commit",
+        "session": _hash_session_token(session_token),
+        "artifact": str(artifact_id),
+        "pinned_version": int(pinned_version),
+        "committed_version": int(committed_version),
+    }
+    return _append_record(coordinator_root, record)
+
+
+def append_session_invalidate(
+    coordinator_root: Path,
+    *,
+    session_token: str,
+    reason: str,
+) -> bool:
+    """Append a ``session_invalidate`` event: a session was found dead /
+    fenced off — its read or commit failed closed (``SessionInvalidated`` or
+    a ``session_invalidated`` / ``session_not_found`` typed rejection).
+
+    R10a bounded payload — fields fixed at:
+        ts        — ISO-8601 UTC timestamp
+        event     — "session_invalidate"
+        session   — SHA-256 hash of the session token
+        reason    — the wire-stable fail-closed reason CONSTANT (never prose)
+
+    ``reason`` is one of the bounded SESSION_READ / SESSION_COMMIT reason
+    constants (a machine token like ``session_invalidated``), never a human
+    message. NO content bytes. NO body hashes. NO user prose. NO raw
+    token."""
+    record = {
+        "ts": datetime.now(tz=timezone.utc).isoformat(),
+        "event": "session_invalidate",
+        "session": _hash_session_token(session_token),
+        "reason": reason,
+    }
+    return _append_record(coordinator_root, record)
+
+
+__all__ = [
+    "SessionEvent",
+    "append_session_begin",
+    "append_session_commit",
+    "append_session_invalidate",
+]

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -746,6 +746,23 @@ class ArtifactRegistry:
         with self._capture_lock:
             self._session_pins.pop(session_token, None)
 
+    def get_session_cut(self, session_token: str) -> dict[UUID, int] | None:
+        """Return the pinned cut ``{artifact_id: version}`` for ``session_token``,
+        or ``None`` if the token has no live cut (SB-17 / TX-1, Unit 3 / R2).
+
+        The single accessor ``session_read`` needs to (a) tell a known token from
+        an unknown/released one (``None`` ⇒ ``session_not_found``) and (b) read
+        the per-artifact pinned version for the serve. Returns a COPY so a caller
+        cannot mutate the live pin store. Parity with
+        :meth:`SqliteArtifactRegistry.get_session_cut` (the two registries share
+        no base class); divergent only on restart-survival (in-memory pins are
+        process-scoped — a restart drops them and a post-restart token reads as
+        ``None``, the Unit-5 fail-closed concern). Taken under ``_capture_lock``
+        so a concurrent capture/release sees a consistent pin store."""
+        with self._capture_lock:
+            pins = self._session_pins.get(session_token)
+            return dict(pins) if pins is not None else None
+
     def _emit_state_log(
         self,
         *,

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -170,6 +170,14 @@ class ArtifactRegistry:
         # in-memory pins do NOT survive a restart (R6; restart-survival is
         # sqlite-only), which the parity harness asserts rather than masks.
         self._session_pins: dict[str, dict[UUID, int]] = {}
+        # Durable owner-binding MIRROR (SB-17 / TX-1, R13/R6/R14):
+        # ``{session_token: (owner, created_at_tick)}``. Symmetric with
+        # :attr:`SqliteArtifactRegistry`'s ``session_meta`` table for API parity,
+        # but PROCESS-SCOPED like the pins — a fresh in-memory instance (the
+        # "restart") has none, so an in-memory session never survives a restart
+        # (the asserted divergence). Lets the sweep enumerate sessions uniformly
+        # across both registries via :meth:`all_session_meta`.
+        self._session_meta: dict[str, tuple[UUID, int]] = {}
         # Cross-artifact capture lock (Unit 2). This registry is otherwise
         # LOCK-FREE by contract (GIL per-access atomicity — see the module/class
         # docstrings). GIL atomicity is per single dict ACCESS, which is
@@ -666,7 +674,12 @@ class ArtifactRegistry:
         return updated, invalidated
 
     def capture_version_vector(
-        self, read_set: "Iterable[UUID]", session_token: str
+        self,
+        read_set: "Iterable[UUID]",
+        session_token: str,
+        *,
+        owner: "UUID | None" = None,
+        created_at_tick: int | None = None,
     ) -> CaptureResult:
         """Atomically pin a consistent multi-artifact CUT (SB-17 / TX-1, Unit 2 /
         R1). Written fresh from the contract — parity with
@@ -737,14 +750,47 @@ class ArtifactRegistry:
             # Insert the pins atomically with the read (same lock hold) so the
             # exemptions seam sees the full cut the instant it becomes live.
             self._session_pins[session_token] = dict(cut)
+            # Mirror the durable owner-binding (R13/R6/R14) so the sweep can
+            # enumerate sessions uniformly. Recorded even for an empty cut, and
+            # only when the caller supplies an owner (direct test captures pass
+            # none and create no session-meta entry).
+            if owner is not None:
+                self._session_meta[session_token] = (owner, int(created_at_tick or 0))
             return cut
 
     def release_session(self, session_token: str) -> None:
-        """Drop a session's pins so its pinned versions become collectible again
-        (Unit 2 / R4). Idempotent — releasing an unknown/already-released token
-        is a no-op (no raise), mirroring the sqlite ``DELETE`` semantics."""
+        """Drop a session's pins AND its owner-binding mirror so its pinned
+        versions become collectible again (Unit 2 / R4). Idempotent — releasing
+        an unknown/already-released token is a no-op (no raise), mirroring the
+        sqlite ``DELETE`` semantics."""
         with self._capture_lock:
             self._session_pins.pop(session_token, None)
+            self._session_meta.pop(session_token, None)
+
+    def get_session_meta(self, session_token: str) -> "tuple[UUID, int] | None":
+        """Return ``(owner, created_at_tick)`` for ``session_token`` or ``None``
+        (SB-17 / TX-1, R13/R6/R14). Parity with
+        :meth:`SqliteArtifactRegistry.get_session_meta`; process-scoped here, so a
+        fresh in-memory instance always returns ``None`` (in-memory sessions do
+        not survive a restart — the asserted divergence)."""
+        with self._capture_lock:
+            return self._session_meta.get(session_token)
+
+    def all_session_meta(self) -> "dict[str, tuple[UUID, int]]":
+        """Return ``{session_token: (owner, created_at_tick)}`` for every live
+        session (SB-17 / TX-1, R6/R14). Parity with
+        :meth:`SqliteArtifactRegistry.all_session_meta`; the sweep enumerates this
+        UNION'd with its in-memory token set (identical here, since both are
+        process-scoped)."""
+        with self._capture_lock:
+            return dict(self._session_meta)
+
+    def session_count(self) -> int:
+        """Return the number of live sessions (SB-17 / TX-1, R14). Parity with
+        :meth:`SqliteArtifactRegistry.session_count`; process-scoped, so a fresh
+        instance is 0 (no durable survivors)."""
+        with self._capture_lock:
+            return len(self._session_meta)
 
     def get_session_cut(self, session_token: str) -> dict[UUID, int] | None:
         """Return the pinned cut ``{artifact_id: version}`` for ``session_token``,

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -9,16 +9,22 @@ import threading
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Callable, Iterator, Optional, TypeAlias
+from typing import Any, Callable, Iterable, Iterator, Optional, TypeAlias
 from uuid import UUID, uuid4
 
 from ccs.core.exceptions import (
     STALE_READ_GENERATION_REASON,
+    UNKNOWN_ARTIFACT_REASON,
     StaleReadGeneration,
     WatchdogAbandoned,
 )
 from ccs.core.states import MESIState, TransientState
-from ccs.core.types import Artifact, CasCorruption, ConflictDetail
+from ccs.core.types import (
+    Artifact,
+    CasCorruption,
+    ConflictDetail,
+    VersionedReadRejection,
+)
 
 from .retention import RetentionPolicy, collectible_versions
 
@@ -52,6 +58,13 @@ CLAIM_CAPTURE_TRIGGERS: frozenset[str] = frozenset({"fetch"})
 # WIN = (updated_artifact, invalidated_agent_ids); loss = ConflictDetail;
 # impossible state = CasCorruption. None is raised by the registry.
 CasResult: TypeAlias = "tuple[Artifact, list[UUID]] | ConflictDetail | CasCorruption"
+
+# Snapshot consistent-cut capture result (SB-17 / TX-1, Unit 2 / R1) — parity
+# with SqliteArtifactRegistry.capture_version_vector. WIN = the pinned cut
+# ``{artifact_id: version}``; a read_set with an unknown id =
+# VersionedReadRejection(reason=UNKNOWN_ARTIFACT) and NO pins inserted (no
+# partial cut, no existence-probe oracle). Neither is raised by the registry.
+CaptureResult: TypeAlias = "dict[UUID, int] | VersionedReadRejection"
 
 
 @dataclass
@@ -150,6 +163,26 @@ class ArtifactRegistry:
         # keeps the four pinned v0.5/recorder suites green. A policy is an
         # explicit opt-in to BOUNDED retention: GC runs only when this is set.
         self._retention_policy = retention_policy
+        # Snapshot session pin store (SB-17 / TX-1, Unit 2 / R1, R4):
+        # ``{session_token: {artifact_id: pinned_version}}``. The version a live
+        # session pins is exempt from the inline retention GC (the exemptions
+        # seam) until ``release_session`` drops it. Process-scoped only —
+        # in-memory pins do NOT survive a restart (R6; restart-survival is
+        # sqlite-only), which the parity harness asserts rather than masks.
+        self._session_pins: dict[str, dict[UUID, int]] = {}
+        # Cross-artifact capture lock (Unit 2). This registry is otherwise
+        # LOCK-FREE by contract (GIL per-access atomicity — see the module/class
+        # docstrings). GIL atomicity is per single dict ACCESS, which is
+        # INSUFFICIENT across N artifacts: a multi-artifact capture reads N
+        # versions then inserts the pin set, and a peer commit interleaving those
+        # reads would yield a torn (read-skewed) cut. This dedicated RLock makes
+        # ONLY the capture/release multi-artifact critical sections atomic; the
+        # existing per-access paths stay lock-free. It also guards the pin-store
+        # dict against an inline-GC exemption read racing a release (both take
+        # this lock), so there is no deadlock: capture/release never call back
+        # into a path that re-takes a DIFFERENT lock, and the GC exemption read
+        # is a short, self-contained critical section.
+        self._capture_lock = threading.RLock()
 
     def _capture_version(
         self, record: ArtifactRecord, version: int, content: bytes | str
@@ -163,32 +196,65 @@ class ArtifactRegistry:
         marks (the current version always survives; unbounded mode skips GC
         entirely, preserving today's semantics).
 
-        Lock-free posture (registry contract): this is plain GIL-atomic dict
-        mutation. The store-then-drop is a sequence of individual dict ops, each
-        atomic under the GIL; a concurrent reader of ``get_content_at_version``
-        sees a consistent value at any single dict access. No locks, no
-        ``BEGIN IMMEDIATE``.
+        Lock-free posture (registry contract): the version-history dict ops are
+        plain GIL-atomic; a concurrent reader of ``get_content_at_version`` sees
+        a consistent value at any single dict access, no ``BEGIN IMMEDIATE``.
+        Caveat (Unit 2): the exemptions read below re-enters ``_capture_lock``
+        via ``_live_pins_for_artifact``. This method is ALWAYS invoked from
+        within an already-held ``_capture_lock`` (the version-move apply in
+        ``commit_cas`` / ``set_artifact_and_content`` / ``register_artifact``),
+        so the RLock re-entry is harmless and the dict ops stay GIL-atomic.
         """
         captured_at = time.time()  # one wall-clock read: stamp == GC reference.
         record.version_history[version] = content
         record.version_captured_at[version] = captured_at
         if self._retention_policy is None:
             return  # unbounded mode (retain_versions=True, no policy): no GC.
+        # Exemptions seam (Unit 2 — the first GC producer to populate it): a
+        # version pinned by ANY live snapshot session for this artifact is held
+        # back from collection until its session is released (R4). Without this,
+        # a bounded K/T policy could collect a pinned version out from under a
+        # live cut, breaking the consistent-read guarantee.
         for dropped in collectible_versions(
             record.version_captured_at,
             current_version=version,
             policy=self._retention_policy,
             now=captured_at,
+            exemptions=self._live_pins_for_artifact(record.artifact.id),
         ):
             record.version_history.pop(dropped, None)
             record.version_captured_at.pop(dropped, None)
 
+    def _live_pins_for_artifact(self, artifact_id: UUID) -> set[int]:
+        """Return the versions pinned by LIVE snapshot sessions for ``artifact_id``
+        — the GC exemption set the inline retention GC honors (Unit 2 / R4).
+
+        Mirrors ``Snapshot.tla``'s ``PinnedVersions(art)``. Taken under the
+        capture lock so a concurrent ``capture_version_vector`` / ``release_session``
+        sees a consistent pin store; the returned set is a plain snapshot the GC
+        loop consumes after the lock is released. A session pins at most one
+        version per artifact (the cut is a map), so the union is naturally
+        deduplicated by the set."""
+        with self._capture_lock:
+            return {
+                pins[artifact_id]
+                for pins in self._session_pins.values()
+                if artifact_id in pins
+            }
+
     def register_artifact(self, artifact: Artifact, content: str) -> None:
-        """Insert artifact record into registry."""
+        """Insert artifact record into registry.
+
+        The version-establishing mutation is performed under ``_capture_lock``
+        (Unit 2): a concurrent ``capture_version_vector`` reads N artifact
+        versions + inserts the pin set under that same lock, so registering /
+        moving a version cannot interleave a multi-artifact capture and tear its
+        cut (read skew). The lock-free READ accessors are untouched."""
         record = ArtifactRecord(artifact=artifact, content=content)
-        if self._retain_versions:
-            self._capture_version(record, artifact.version, content)
-        self._records[artifact.id] = record
+        with self._capture_lock:
+            if self._retain_versions:
+                self._capture_version(record, artifact.version, content)
+            self._records[artifact.id] = record
 
     def has_artifact(self, artifact_id: UUID) -> bool:
         """Return whether an artifact exists in registry."""
@@ -282,11 +348,15 @@ class ArtifactRegistry:
                     f"artifact={artifact_id} read_gen={read_gen} "
                     f"owner_gen={record.owner_generation}"
                 )
-        if self._retain_versions:
-            self._capture_version(record, artifact.version, content)
-        record.artifact = artifact
-        record.content = content
-        record.last_writer = last_writer
+        # Version-moving mutation under _capture_lock (Unit 2): serializes with
+        # a concurrent multi-artifact capture so the cut cannot observe this
+        # artifact moved while a peer in the same read-set is not (read skew).
+        with self._capture_lock:
+            if self._retain_versions:
+                self._capture_version(record, artifact.version, content)
+            record.artifact = artifact
+            record.content = content
+            record.last_writer = last_writer
 
     def get_content_at_version(self, artifact_id: UUID, version: int) -> str | bytes | None:
         """Return content for a specific version, if retained.
@@ -549,25 +619,33 @@ class ArtifactRegistry:
             size_tokens=size_tokens if size_tokens is not None else record.artifact.size_tokens,
             depends_on=record.artifact.depends_on,
         )
-        # Content coherence: when the caller threaded the winning body, advance
-        # record.content to it so a peer re-fetch reads the NEW content at the new
-        # version (without this, version + content_hash bump but the body stays
-        # stale). content is None on the cross-process / sqlite path (no content
-        # stored) — keep the prior body unchanged there.
-        if content is not None:
-            record.content = content
-        # Retention capture joins this APPLIED block (after every state_log emit
-        # succeeded) so a callback raise above cannot leave phantom history —
-        # parity with the stage-then-apply discipline for the MESI mutations.
-        # content=None SKIPS capture entirely (R-fix): the old code retained the
-        # OLD body under the NEW version when content was None — a latent
-        # history-poisoning bug only observable through retention reads. Now an
-        # unsupplied body simply means "no snapshot for this version"; a later
-        # read of next_version misses (None), rather than returning stale bytes.
-        if self._retain_versions and content is not None:
-            self._capture_version(record, next_version, content)
-        record.artifact = updated
-        record.last_writer = agent_id
+        # The version-move apply runs under _capture_lock (Unit 2): the WIN
+        # advances record.artifact.version, and a concurrent multi-artifact
+        # capture reads N versions under that same lock — so this commit cannot
+        # tear a cut (read skew) by moving one read-set member while the capture
+        # has already read its peers. The lock is an RLock, so the nested
+        # _capture_version re-enters freely. The non-WIN branches above mutate
+        # nothing, so they need no lock; only this apply does.
+        with self._capture_lock:
+            # Content coherence: when the caller threaded the winning body,
+            # advance record.content to it so a peer re-fetch reads the NEW
+            # content at the new version (without this, version + content_hash
+            # bump but the body stays stale). content is None on the cross-process
+            # / sqlite path (no content stored) — keep the prior body unchanged.
+            if content is not None:
+                record.content = content
+            # Retention capture joins this APPLIED block (after every state_log
+            # emit succeeded) so a callback raise above cannot leave phantom
+            # history — parity with the stage-then-apply discipline for the MESI
+            # mutations. content=None SKIPS capture entirely (R-fix): the old code
+            # retained the OLD body under the NEW version when content was None —
+            # a latent history-poisoning bug only observable through retention
+            # reads. Now an unsupplied body simply means "no snapshot for this
+            # version"; a later read of next_version misses (None).
+            if self._retain_versions and content is not None:
+                self._capture_version(record, next_version, content)
+            record.artifact = updated
+            record.last_writer = agent_id
 
         invalidated: list[UUID] = []
         for peer_id, peer_from in peers:
@@ -586,6 +664,87 @@ class ArtifactRegistry:
         record.state_by_agent[agent_id] = MESIState.SHARED
 
         return updated, invalidated
+
+    def capture_version_vector(
+        self, read_set: "Iterable[UUID]", session_token: str
+    ) -> CaptureResult:
+        """Atomically pin a consistent multi-artifact CUT (SB-17 / TX-1, Unit 2 /
+        R1). Written fresh from the contract — parity with
+        :meth:`SqliteArtifactRegistry.capture_version_vector` (the two registries
+        share no base class), divergent ONLY on restart-survival (in-memory pins
+        are process-scoped; the parity harness asserts the divergence).
+
+        Captures ``{artifact_id: current_version}`` for every id in ``read_set``
+        at ONE linearization point and records the pins under ``session_token``
+        so the inline retention GC exempts those versions (R4). Non-mutating: it
+        mints NO MESI grant and captures NO ``read_generation`` (it never calls
+        ``set_agent_state`` / the fence-capture path) — a reader is not an owner.
+
+        Atomicity (the cross-artifact lock, Unit 2): GIL per-access atomicity is
+        per single dict access, which is insufficient across N artifacts. The
+        multi-artifact version read AND the pin insert run under
+        ``_capture_lock`` so a peer ``commit_cas`` cannot interleave the reads
+        and yield a torn (read-skewed) cut. The existing per-access paths stay
+        lock-free.
+
+        Unknown-id validation (security, F7): the captured row-count must equal
+        ``len(read_set)``. Any missing id → a typed
+        :class:`~ccs.core.types.VersionedReadRejection` reusing the
+        ``unknown_artifact`` reason, with NO pins inserted (no partial cut, no
+        existence-probe oracle — the rejection is decided before any pin write).
+        The first missing id (sorted for determinism) names the rejection.
+
+        Args:
+            read_set: The artifact ids to pin into the cut. An empty read_set
+                pins an empty cut (a degenerate-but-valid session).
+            session_token: The server-minted session identity the pins are keyed
+                under (owner-binding is the service layer's concern; the registry
+                only keys the pin store by this token).
+
+        Returns:
+            The pinned cut ``{artifact_id: version}`` on success, else a
+            :class:`VersionedReadRejection` (``unknown_artifact``) — no pins
+            inserted.
+        """
+        ids = list(read_set)
+        with self._capture_lock:
+            # ONE linearization point: read every current version while holding
+            # the capture lock. Every version-moving write — commit_cas WIN,
+            # set_artifact_and_content, register_artifact — ALSO takes
+            # _capture_lock around its apply, so a peer write is serialized
+            # entirely before or after this whole capture, never partially
+            # visible within the cut. The atomicity depends on BOTH sides taking
+            # the lock; do NOT remove it from either side.
+            cut: dict[UUID, int] = {}
+            missing: list[UUID] = []
+            for artifact_id in ids:
+                record = self._records.get(artifact_id)
+                if record is None:
+                    missing.append(artifact_id)
+                    continue
+                cut[artifact_id] = record.artifact.version
+            # F7: validate row-count == len(read_set) BEFORE any pin insert. A
+            # missing id rejects the WHOLE capture (no partial cut). Decided
+            # inside the lock but it inserts nothing on this branch.
+            if missing:
+                return VersionedReadRejection(
+                    reason=UNKNOWN_ARTIFACT_REASON,
+                    artifact_id=sorted(missing, key=lambda a: a.int)[0],
+                    requested_version=0,
+                    current_version=None,
+                    coordinator_epoch=self._coordinator_epoch,
+                )
+            # Insert the pins atomically with the read (same lock hold) so the
+            # exemptions seam sees the full cut the instant it becomes live.
+            self._session_pins[session_token] = dict(cut)
+            return cut
+
+    def release_session(self, session_token: str) -> None:
+        """Drop a session's pins so its pinned versions become collectible again
+        (Unit 2 / R4). Idempotent — releasing an unknown/already-released token
+        is a no-op (no raise), mirroring the sqlite ``DELETE`` semantics."""
+        with self._capture_lock:
+            self._session_pins.pop(session_token, None)
 
     def _emit_state_log(
         self,

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -12,7 +12,7 @@ import time
 import warnings
 from dataclasses import dataclass
 from typing import Callable, Iterable, Optional
-from uuid import UUID
+from uuid import NAMESPACE_URL, UUID, uuid5
 
 from ccs.coordinator.retention import collectible_versions
 from ccs.core.exceptions import (
@@ -40,6 +40,7 @@ from ccs.core.types import (
     FetchRequest,
     FetchResponse,
     InvalidationSignal,
+    SessionCommitRejection,
     SessionReadRejection,
     SnapshotSession,
     VersionedContent,
@@ -697,6 +698,151 @@ class CoordinatorService:
             captured_at=captured_at,
             coordinator_epoch=epoch,
         )
+
+    def session_commit(
+        self,
+        session_token: str,
+        artifact_id: UUID,
+        content: bytes | str,
+        *,
+        size_tokens: int | None = None,
+        issued_at_tick: int = 0,
+    ) -> tuple[Artifact, list[InvalidationSignal]] | ConflictDetail | SessionCommitRejection:
+        """Validate one artifact's commit against its PINNED version via the
+        shipped ``commit_cas`` — the single-artifact OCC commit from a snapshot
+        session (SB-17 / TX-1, Unit 4 / R3).
+
+        The commit is arbitrated against the cut's pinned base: ``expected_version``
+        is ``cut[artifact_id]`` (the version captured at ``begin_session``), so a
+        commit WINS only if no peer moved the artifact since the cut was pinned.
+        This reuses the shipped ``commit_cas`` arbitration VERBATIM — no
+        re-implemented OCC, single-shot (NEVER the auto-rederive ``write_cas``
+        loop, whose split-comparand hazard a pinned base is precisely meant to
+        avoid).
+
+        **The admit-on-absent load-bearing path (R3, the reconciled fence).** The
+        commit rides a SESSION-SCOPED committer identity derived deterministically
+        from the ``session_token`` (``uuid5``), NOT the owner's MESI ``agent_id``.
+        The reason is the read-generation fence: ``commit_cas`` ADMITS a committer
+        with NO captured ``read_generation`` (version-CAS then arbitrates) and
+        REJECTS one whose PRESENT ``read_generation`` was superseded by a sweep
+        reclamation. The owner's MESI agent could be carrying such a superseded
+        ``read_generation`` from unrelated prior MESI activity — committing under
+        it would spuriously fail with ``stale_read_generation`` on a perfectly
+        healthy session. The session-derived identity has never established a fence
+        claim (no ``read_generation`` row), so admit-on-absent holds and the
+        pinned-base version-CAS is the sole arbiter. It is deterministic (stable
+        across a session's calls) and collision-free against real agent ids (a
+        ``uuid5`` over a 32-byte server-minted token namespace).
+
+        Validation (Unit 4 scope): the token must have a live pin for
+        ``artifact_id``. An unknown/released token → ``session_not_found``; a live
+        token whose cut lacks ``artifact_id`` → ``artifact_not_in_cut`` — both a
+        typed :class:`~ccs.core.types.SessionCommitRejection`, NEVER a silent
+        fall-through to a live-HEAD commit. (Per-call OWNER-binding validation — a
+        foreign owner committing into another's cut — and the caps are Unit 7; the
+        heartbeat-liveness ``session_invalidated`` axis is Unit 5. Unit 4 does the
+        token-has-pin check only.)
+
+        Outcome mapping (mirrors the shipped ``commit_cas`` orchestration exactly):
+
+        - WIN → ``(updated_artifact, invalidation_signals)``: the artifact moved
+          to ``pinned + 1`` and ``commit_cas`` ALREADY invalidated the peers
+          atomically — this method emits NO additional invalidation signal.
+        - :class:`ConflictDetail` (``version_mismatch`` / ``other_holder`` /
+          ``stale_read_generation``) → RETURNED UNCHANGED (HELD, retry-eligible;
+          nothing mutated, so no invalidation is emitted). Recover via a NEW
+          session + re-read + re-commit.
+        - corruption (``expected_version > current``) → ``commit_cas`` maps the
+          registry's :class:`CasCorruption` sentinel to a RAISED ``CoherenceError``
+          (non-retryable); ``session_commit`` lets it propagate.
+
+        **"Exactly one validated commit" (R11) is naturally enforced — no explicit
+        single-use machinery.** After a WIN the artifact advanced to ``pinned + 1``
+        but the cut still pins ``pinned``; a SECOND ``session_commit`` at the same
+        pin therefore version-mismatches (``expected_version < current``) and is
+        HELD. The pin is not consumed or rewritten here (that would foreclose the
+        SB-18 multi-commit shape, R11) — staleness does the enforcing.
+
+        Args:
+            session_token: The server-minted session identity from
+                ``begin_session``.
+            artifact_id: The pinned artifact to commit. Must be in the cut.
+            content: The new body. ``content_hash`` is derived from it
+                (``compute_content_hash``); the body is threaded to ``commit_cas``
+                so the in-memory path advances ``record.content`` on a WIN (the
+                cross-process / ``content=None`` path keeps no body — see
+                ``commit_cas``).
+            size_tokens: Optional token count to persist with the commit.
+            issued_at_tick: Logical tick for the commit (threaded to ``commit_cas``).
+
+        Returns:
+            ``(updated_artifact, signals)`` on a WIN, a :class:`ConflictDetail` on a
+            retry-eligible lost race, or a :class:`SessionCommitRejection` on a
+            validation failure — all typed RETURNS. Corruption RAISES
+            ``CoherenceError`` (via ``commit_cas``); a missing artifact under a
+            live pin also raises there (the fail-closed ``SessionInvalidated`` for
+            that race is Unit 5).
+        """
+        epoch = self.registry.coordinator_epoch
+
+        # Unit 7: per-call OWNER-binding validation goes HERE — read
+        # ``_session_owners[session_token]`` and reject a foreign caller
+        # (timing-safe compare) BEFORE the pin lookup. Unit 4 does the
+        # token-has-pin check only.
+        cut = self.registry.get_session_cut(session_token)
+        if cut is None:
+            # Unknown / released / (in-memory) post-restart token. Unit 5 splits
+            # the durable-liveness taxonomy (``session_invalidated``); Unit 4
+            # treats every no-cut token as not-found.
+            return SessionCommitRejection(
+                reason=SESSION_NOT_FOUND_REASON,
+                artifact_id=artifact_id,
+                coordinator_epoch=epoch,
+            )
+        if artifact_id not in cut:
+            # A live session, but this artifact was not pinned. Reject — NEVER
+            # commit live HEAD for an un-pinned artifact (a session commits only
+            # against what it pinned).
+            return SessionCommitRejection(
+                reason=SESSION_ARTIFACT_NOT_IN_CUT_REASON,
+                artifact_id=artifact_id,
+                coordinator_epoch=epoch,
+            )
+
+        expected_version = cut[artifact_id]
+        committer_id = self._session_committer_id(session_token)
+        content_hash = compute_content_hash(content)
+
+        # Reuse the shipped service ``commit_cas`` orchestration VERBATIM: it owns
+        # the CasCorruption-sentinel -> raised CoherenceError mapping, returns a
+        # ConflictDetail unchanged (no mutation, no invalidation), and builds the
+        # InvalidationSignal list on a WIN. Single-shot — there is no retry loop.
+        # ``committer_id`` is fence-claimless (admit-on-absent), so the pinned
+        # ``expected_version`` is the sole arbiter.
+        return self.commit_cas(
+            agent_id=committer_id,
+            artifact_id=artifact_id,
+            expected_version=expected_version,
+            content_hash=content_hash,
+            issued_at_tick=issued_at_tick,
+            size_tokens=size_tokens,
+            content=content,
+        )
+
+    @staticmethod
+    def _session_committer_id(session_token: str) -> UUID:
+        """Derive the SESSION-SCOPED committer identity for ``session_commit``.
+
+        A deterministic ``uuid5`` over the server-minted ``session_token`` (under
+        the URL namespace). Stable across a session's commits and collision-free
+        against real MESI agent ids; crucially it has NEVER established a
+        read-generation fence claim, so ``commit_cas`` ADMITS it on absence and
+        the pinned-base version-CAS arbitrates (the R3 load-bearing path). NOT the
+        owner's MESI ``agent_id``, which could carry a superseded
+        ``read_generation`` that would spuriously trip the fence.
+        """
+        return uuid5(NAMESPACE_URL, session_token)
 
     def write(
         self,

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -378,11 +378,31 @@ class CoordinatorService:
         # Snapshot session owner-binding (SB-17 / TX-1, Unit 2 / R13):
         # ``{session_token: owner_id}``. Populated at ``begin_session`` mint; the
         # per-CALL read/commit validation that READS it (a foreign owner →
-        # SessionInvalidated, timing-safe compare) is Unit 7
-        # (:meth:`_validate_session_owner`). Unit 5 owner-binds the HEARTBEAT path
-        # (``record_session_heartbeat``). Service-scoped (a restart drops the
-        # bindings — the durable pins survive on sqlite, but re-validating a
-        # post-restart token is the Unit 5 liveness concern).
+        # SessionInvalidated, timing-safe compare) is in
+        # :meth:`_validate_session_owner`; :meth:`record_session_heartbeat`
+        # owner-binds the heartbeat path. This in-memory map is the FAST tier;
+        # ``begin_session`` ALSO persists the owner durably (the registry's
+        # ``session_meta``). A restart wipes this map but the durable owner
+        # survives, so :meth:`_validate_session_owner` falls back to it: a survived
+        # sqlite session is still owner-validated (R6 + R13 both hold across a
+        # restart — finding F3), while an in-memory-registry session has no durable
+        # owner and so fails closed post-restart (the asserted divergence).
+        #
+        # Free-threading discipline (no-GIL-reliance, finding F4): the snapshot
+        # session maps below (``_session_owners`` / ``_session_created`` /
+        # ``_session_heartbeats`` / ``_reaped_tombstone``) are read AND mutated
+        # across concurrent HTTP handler threads (begin / read / commit /
+        # heartbeat) plus the sweep. The begin_session cap-check + insert is a
+        # compound check-then-act that a bare GIL does not make atomic (two
+        # concurrent begins could both pass the cap and overshoot it), and the
+        # sweep iterates while handlers mutate. This RLock serializes EVERY
+        # session-map access so correctness never depends on the GIL. Re-entrant
+        # because the sweep holds it across ``_reap_session`` (which re-takes it
+        # via ``_drop_session_state``). Lock ORDER is always service-lock →
+        # registry-lock (the registry never calls back into the service), so the
+        # ``with self._session_lock:`` blocks that wrap ``registry`` calls
+        # (capture / release / get_session_meta) cannot deadlock.
+        self._session_lock = threading.RLock()
         self._session_owners: dict[str, UUID] = {}
         # Snapshot session CREATION tick (SB-17 / TX-1, Unit 7 / R14):
         # ``{session_token: created_at_tick}``. The absolute-age ceiling reads
@@ -724,43 +744,66 @@ class CoordinatorService:
                 current_version=self.session_caps.max_read_set_cardinality,
                 coordinator_epoch=epoch,
             )
-        if len(self._session_owners) >= self.session_caps.max_sessions:
-            # The many-sessions GC-starvation bound (threat-model #2). Count the
-            # LIVE owner-bindings (one per open session); an (N+1)th is rejected
-            # until a session is released or the liveness sweep reaps a stale one.
-            return VersionedReadRejection(
-                reason=SESSION_CAP_EXCEEDED_REASON,
-                artifact_id=_NIL_UUID,
-                requested_version=len(self._session_owners),
-                current_version=self.session_caps.max_sessions,
-                coordinator_epoch=epoch,
-            )
+        # The cap-check + token mint + owner-bind + capture + seed run under
+        # ``_session_lock`` as ONE critical section (finding F4): the
+        # ``max_sessions`` check and the owner insert must be atomic, else two
+        # concurrent begins both pass the bare-GIL check and overshoot the cap
+        # (the GC-starvation bound the cap exists to enforce). Holding the lock
+        # across the capture also serializes begin against the sweep — both
+        # acquire ``_session_lock`` first, then the registry lock, so there is no
+        # deadlock and a begin never races a reap of the same maps.
+        with self._session_lock:
+            # The many-sessions GC-starvation bound (threat-model #2). Count ALL
+            # live sessions via the durable session_meta (one row per open session
+            # — in-memory OR a durable-only restart survivor), NOT just the
+            # in-memory ``_session_owners``: post-restart the in-memory map is
+            # empty while durable survivors still hold pins, so counting only it
+            # would let the pinned-cut count transiently reach ~2x max_sessions and
+            # evade the bound (finding). An (N+1)th is rejected until a session is
+            # released or the sweep reaps a stale one.
+            live_sessions = self.registry.session_count()
+            if live_sessions >= self.session_caps.max_sessions:
+                return VersionedReadRejection(
+                    reason=SESSION_CAP_EXCEEDED_REASON,
+                    artifact_id=_NIL_UUID,
+                    requested_version=live_sessions,
+                    current_version=self.session_caps.max_sessions,
+                    coordinator_epoch=epoch,
+                )
 
-        session_token = secrets.token_urlsafe(_SESSION_TOKEN_BYTES)
-        # Owner-bind at mint (R13). Recorded BEFORE the capture so the Unit-7
-        # per-call validator never sees a pinned-but-unowned token; dropped again
-        # if the capture rejects. The INVERSE window — between this line and the
-        # capture below, the token is owned but PINLESS — is handled by Unit 7's
-        # :meth:`_validate_session_owner`: it reads owner-binding AND the cut, and
-        # treats an owned-but-pinless token as NOT-yet-live (fail closed,
-        # ``SessionInvalidated``), never a valid empty session.
-        self._session_owners[session_token] = owner
-        result = self.registry.capture_version_vector(read_set, session_token)
-        if isinstance(result, VersionedReadRejection):
-            # No cut pinned (unknown id) ⇒ no session. Drop the owner binding so
-            # the rejected token cannot linger as a half-open session.
-            self._session_owners.pop(session_token, None)
-            return result
-        # Seed the heartbeat lease at the creation tick (Unit 5 / R4): a session
-        # that never heartbeats still carries a baseline so it is not reaped on
-        # the very first sweep — the lease starts now, exactly like a grant's
-        # ``granted_at_tick``. Recorded only on a SUCCESSFUL capture (a rejected
-        # capture returned above, leaving no lease and no owner binding).
-        self._session_heartbeats[session_token] = created_at_tick
-        # Record the CREATION tick for the absolute-age ceiling (Unit 7 / R14).
-        # The ceiling reads THIS, not the heartbeat lease, so a live-heartbeat
-        # session past the ceiling is still reaped (threat-model #3).
-        self._session_created[session_token] = created_at_tick
+            session_token = secrets.token_urlsafe(_SESSION_TOKEN_BYTES)
+            # Owner-bind at mint (R13). Recorded BEFORE the capture so the Unit-7
+            # per-call validator never sees a pinned-but-unowned token; dropped
+            # again if the capture rejects. The INVERSE window — between this line
+            # and the capture below, the token is owned but PINLESS — is handled
+            # by :meth:`_validate_session_owner`, which treats an owned-but-pinless
+            # token as NOT-yet-live (fail closed), never a valid empty session.
+            self._session_owners[session_token] = owner
+            # Pass ``owner`` + ``created_at_tick`` so the registry persists the
+            # durable owner-binding (``session_meta``) ATOMICALLY with the pins
+            # (R13/R6/R14): a post-restart read falls back to the durable owner —
+            # the legitimate owner is still served (R6) and a leaked-token foreign
+            # caller is still rejected (R13) — and the durable creation tick lets
+            # the absolute-age ceiling bound a survived session (finding F3).
+            result = self.registry.capture_version_vector(
+                read_set, session_token, owner=owner, created_at_tick=created_at_tick
+            )
+            if isinstance(result, VersionedReadRejection):
+                # No cut pinned (unknown id) ⇒ no session. The capture txn wrote
+                # neither pins nor durable meta (atomic), so only the in-memory
+                # owner binding needs dropping — the rejected token cannot linger
+                # as a half-open session.
+                self._session_owners.pop(session_token, None)
+                return result
+            # Seed the heartbeat lease at the creation tick (Unit 5 / R4): a
+            # session that never heartbeats still carries a baseline so it is not
+            # reaped on the very first sweep — the lease starts now, exactly like a
+            # grant's ``granted_at_tick``. Recorded only on a SUCCESSFUL capture.
+            self._session_heartbeats[session_token] = created_at_tick
+            # Record the CREATION tick for the absolute-age ceiling (Unit 7 / R14).
+            # The ceiling reads THIS, not the heartbeat lease, so a live-heartbeat
+            # session past the ceiling is still reaped (threat-model #3).
+            self._session_created[session_token] = created_at_tick
         retain_versions, _policy = self.registry.retention_meta()
         return SnapshotSession(
             session_token=session_token,
@@ -974,6 +1017,7 @@ class CoordinatorService:
         caller: UUID,
         size_tokens: int | None = None,
         issued_at_tick: int = 0,
+        abort: threading.Event | None = None,
     ) -> tuple[Artifact, list[InvalidationSignal]] | ConflictDetail | SessionCommitRejection:
         """Validate one artifact's commit against its PINNED version via the
         shipped ``commit_cas`` — the single-artifact OCC commit from a snapshot
@@ -1050,6 +1094,11 @@ class CoordinatorService:
                 ``commit_cas``).
             size_tokens: Optional token count to persist with the commit.
             issued_at_tick: Logical tick for the commit (threaded to ``commit_cas``).
+            abort: Optional watchdog abort Event (A6). Threaded into ``commit_cas``'s
+                ``abort_guard`` so a watchdog-timed-out commit fails closed at the
+                registry write lock instead of landing as a phantom write after the
+                caller already got a degraded response. ``None`` for in-process
+                callers with no watchdog.
 
         Returns:
             ``(updated_artifact, signals)`` on a WIN, a :class:`ConflictDetail` on a
@@ -1102,6 +1151,14 @@ class CoordinatorService:
         # InvalidationSignal list on a WIN. Single-shot — there is no retry loop.
         # ``committer_id`` is fence-claimless (admit-on-absent), so the pinned
         # ``expected_version`` is the sole arbiter.
+        #
+        # ``abort`` is threaded into ``commit_cas``'s ``abort_guard`` (A6): if the
+        # handler watchdog timed out and the caller already received a degraded
+        # ``commit_unconfirmed`` response, the guard fails this commit closed THE
+        # INSTANT it wins the registry write lock — so a watchdog-late commit never
+        # lands as a phantom write behind the client's back. Every other mutating
+        # path (write / write_cas) threads ``abort`` the same way; ``session_commit``
+        # had silently dropped it before this fix.
         return self.commit_cas(
             agent_id=committer_id,
             artifact_id=artifact_id,
@@ -1110,6 +1167,7 @@ class CoordinatorService:
             issued_at_tick=issued_at_tick,
             size_tokens=size_tokens,
             content=content,
+            abort=abort,
         )
 
     def _validate_session_owner(
@@ -1136,37 +1194,60 @@ class CoordinatorService:
         Unit-5 heartbeat owner-check), NEVER ``==`` / ``in``, so a foreign caller
         learns nothing from response timing about how much of the owner id matched.
 
-        Three outcomes:
+        Owner resolution has TWO tiers (finding F3, R6/R13): the in-memory binding
+        (fast, service-scoped) and — when that is absent — the DURABLE owner from
+        ``registry.get_session_meta`` (persisted alongside the pins, survives a
+        restart). The durable fallback is what lets a sqlite session survive a
+        coordinator restart (R6) WITHOUT opening an owner-isolation hole: the
+        in-memory binding is gone post-restart, but the durable owner still
+        authorizes the legitimate owner and rejects a leaked-token foreigner (R13).
 
-        - **No owner binding** (``bound_owner is None``) — the token was never
-          opened, was released, was reaped, or an in-memory restart wiped the
-          binding. This is NOT an owner-isolation failure (there is no owner to
-          compare against); the validator RETURNS and lets the caller's existing
-          cut-absent path classify it into the wire-stable liveness taxonomy
-          (``session_invalidated`` / ``session_not_found``). Fail-closed is
-          preserved downstream — a no-binding token always has ``cut is None``.
-        - **Foreign caller** (binding present, caller mismatches) — RAISE
-          ``SessionInvalidated``: a sibling cannot read/commit another's cut. This
-          is the ONE genuinely exceptional case — an isolation breach, raised so it
-          is never confused with a benign not-found.
-        - **Owned-but-pinless** (binding present, caller matches, but ``cut is
-          None``) — a token that is OWNED but has NO live pins (the begin_session
-          mint→capture window, or the degenerate empty-read-set sqlite session that
-          durably pins zero rows → ``get_session_cut`` returns ``None``). The
-          validator RETURNS; the caller's existing ``cut is None`` path then fails
-          CLOSED with the wire-stable ``session_invalidated`` reason
-          (:meth:`_classify_no_cut_reason` for an in-shape token) — NOT-yet-live,
-          never a valid empty session, never a live-HEAD fall-through. Returning
-          (rather than raising) keeps owned-but-pinless on the SAME typed
-          fail-closed taxonomy as every other cut-absent case (and preserves the
-          shipped Unit-3 sqlite-empty-session contract, which returns
-          ``session_invalidated`` rather than raising).
+        Outcomes:
+
+        - **Owner resolved, caller matches** — RETURN (the happy path; the caller
+          proceeds to its pin lookup / serve / commit).
+        - **Foreign caller** (owner resolved, caller mismatches) — RAISE
+          ``SessionInvalidated``: a sibling cannot read/commit another's cut, even
+          with a leaked token. The ONE genuinely exceptional case — an isolation
+          breach, raised so it is never confused with a benign not-found. Holds
+          whether the owner came from the in-memory binding OR the durable
+          fallback (so the post-restart isolation guarantee is identical).
+        - **No owner anywhere, but a cut IS present** — RAISE
+          ``SessionInvalidated``. A pinned-but-ownerless token: there is no owner
+          to authorize the caller, so serving the cut would bypass R13. Should not
+          occur given the atomic pins+meta capture, but kept as a defensive
+          fail-closed (never serve a cut we cannot authorize).
+        - **No owner anywhere, no cut** — RETURN. The token was never opened, was
+          released/reaped, or an in-memory-registry restart wiped BOTH the binding
+          and the (process-scoped) pins. Not an isolation failure (no owner, no
+          cut); the caller's ``cut is None`` path classifies it into the
+          wire-stable liveness taxonomy (``session_invalidated`` /
+          ``session_not_found``). This is also the owned-but-pinless case
+          (begin_session mint→capture window, or the degenerate empty-read-set
+          sqlite session whose ``get_session_cut`` is ``None``): owner resolves but
+          ``cut is None``, so the match path returns and the cut-absent path fails
+          closed — preserving the shipped Unit-3 sqlite-empty-session contract.
         """
-        bound_owner = self._session_owners.get(session_token)
+        with self._session_lock:
+            bound_owner = self._session_owners.get(session_token)
         if bound_owner is None:
-            # No owner binding ⇒ not an isolation failure. The caller's cut-absent
-            # path (``_classify_no_cut_reason``) fails closed with the liveness
-            # taxonomy; nothing to validate here.
+            # Fall back to the DURABLE owner (R6/R13): on sqlite the owner survives
+            # a restart even though the in-memory map was wiped, so a survived
+            # session is still owner-validated. On the in-memory registry this is
+            # always None post-restart (process-scoped), so an in-memory restart
+            # still fails closed via the cut-absent path below.
+            durable = self.registry.get_session_meta(session_token)
+            bound_owner = durable[0] if durable is not None else None
+        if bound_owner is None:
+            # No owner in EITHER tier. If a cut is somehow still present (a
+            # pins-without-meta orphan — should not happen given the atomic
+            # capture, but defensive), FAIL CLOSED: there is no owner to authorize
+            # the caller. Otherwise let the caller's cut-absent path classify it.
+            if cut is not None:
+                raise SessionInvalidated(
+                    "session has pins but no owner-binding: no owner remains to "
+                    "authorize the caller (fail closed, R13)"
+                )
             return
         # Timing-safe owner-binding compare (R13): stable 16-byte UUID encoding,
         # never ``==``. A foreign caller is rejected fail-closed and cannot probe
@@ -1331,14 +1412,12 @@ class CoordinatorService:
             )
         finally:
             if release_on_exit:
-                # Best-effort cleanup: drop the pins so a one-shot gate does not
-                # hold versions back from GC until the liveness sweep. Idempotent
-                # on the registry (unknown token → no-op), and the service-layer
-                # lease/owner maps are dropped too so the token cannot linger.
-                self.registry.release_session(token)
-                self._session_heartbeats.pop(token, None)
-                self._session_owners.pop(token, None)
-                self._session_created.pop(token, None)
+                # Best-effort cleanup: drop the pins + durable owner-binding so a
+                # one-shot gate does not hold versions back from GC until the
+                # liveness sweep. The shared teardown (idempotent on the registry,
+                # lock-aware on the in-memory maps) — the SAME path the sweep reaps
+                # through, so the token cannot linger in either store.
+                self._drop_session_state(token)
 
     def _revalidate_cut(
         self, cut: Mapping[UUID, int]
@@ -1486,12 +1565,19 @@ class CoordinatorService:
         timing about how much of the id matched. A mismatch is rejected and the
         lease is NOT refreshed.
 
-        Heartbeating an unknown / released / restart-wiped token is a typed
-        NO-OP: it returns ``False`` (never a crash, never a resurrection — a dead
-        session cannot be revived by a heartbeat; re-establish it via
-        ``begin_session``). It also does NOT create a lease for a token with no
-        owner binding, so a heartbeat cannot conjure a live lease for a
-        cut-less token.
+        Heartbeating an unknown / released token is a typed NO-OP: it returns
+        ``False`` (never a crash, never a resurrection — a genuinely dead session
+        cannot be revived; re-establish it via ``begin_session``). It does NOT
+        create a lease for a token with no owner anywhere, so a heartbeat cannot
+        conjure a live lease for a cut-less token.
+
+        **Restart rehydration (R6).** A sqlite session that SURVIVED a restart has
+        durable pins + a durable owner but no in-memory lease. Its owner's first
+        post-restart heartbeat falls back to the durable owner, and on a match
+        REHYDRATES the in-memory owner + creation tick + lease — so the sweep
+        manages it normally again. An in-memory-registry session has no durable
+        meta, so its post-restart heartbeat stays a no-op (the asserted
+        process-scoped divergence).
 
         Args:
             session_token: The server-minted token from ``begin_session``.
@@ -1507,21 +1593,37 @@ class CoordinatorService:
         """
         if now_tick < 0:
             raise ValueError("now_tick must be >= 0")
-        bound_owner = self._session_owners.get(session_token)
-        if bound_owner is None:
-            # Unknown / released / restart-wiped token: no owner binding ⇒ no
-            # lease to refresh. Typed no-op (never a crash, never a new lease).
-            return False
-        # Timing-safe owner-binding check (R13): compare over the stable 16-byte
-        # big-endian UUID encoding. A foreign caller cannot keep another's
-        # session alive AND cannot probe id-match progress via response timing.
-        if not hmac.compare_digest(
-            bound_owner.bytes, owner.bytes
-        ):
-            return False
-        prev = self._session_heartbeats.get(session_token)
-        if prev is None or now_tick > prev:
-            self._session_heartbeats[session_token] = now_tick
+        with self._session_lock:
+            bound_owner = self._session_owners.get(session_token)
+            rehydrate_created: int | None = None
+            if bound_owner is None:
+                # Fall back to the DURABLE owner (R6): a sqlite session that
+                # survived a restart has no in-memory binding, but its owner can
+                # still refresh the lease — and doing so REHYDRATES the in-memory
+                # state (below) so the sweep lifecycle-manages it normally again. A
+                # foreign caller still cannot keep it alive: the timing-safe check
+                # runs on the durable owner too. An unknown/released token (or any
+                # in-memory-registry token post-restart) has no durable meta →
+                # typed no-op.
+                durable = self.registry.get_session_meta(session_token)
+                if durable is None:
+                    return False
+                bound_owner, rehydrate_created = durable[0], durable[1]
+            # Timing-safe owner-binding check (R13): compare over the stable
+            # 16-byte big-endian UUID encoding. A foreign caller cannot keep
+            # another's session alive AND cannot probe id-match progress via timing.
+            if not hmac.compare_digest(bound_owner.bytes, owner.bytes):
+                return False
+            if rehydrate_created is not None:
+                # Durable-only session (post-restart): adopt it back into the
+                # in-memory maps so subsequent sweeps see + manage it. The creation
+                # tick is the ORIGINAL durable one, so the absolute-age ceiling is
+                # measured from first creation — a restart never resets it (R14).
+                self._session_owners[session_token] = bound_owner
+                self._session_created[session_token] = rehydrate_created
+            prev = self._session_heartbeats.get(session_token)
+            if prev is None or now_tick > prev:
+                self._session_heartbeats[session_token] = now_tick
         return True
 
     def enforce_session_liveness(
@@ -1535,11 +1637,16 @@ class CoordinatorService:
 
         Distinct from :meth:`enforce_stable_grant_timeouts`: that sweep walks
         only M∪E GRANT-HOLDERS, and a snapshot session holds NO grant, so it is
-        invisible to the grant sweep. This sweep ENUMERATES SESSIONS (the
-        owner-bound token set) and reaps any whose lease is stale, reusing the
-        SAME heartbeat-staleness predicate SHAPE as the grant sweep (``current -
-        last_hb >= timeout``, with ``>=`` matching ADV-02) and the same
-        ``CrashRecoveryConfig`` knob (``heartbeat_timeout_ticks``).
+        invisible to the grant sweep. This sweep ENUMERATES SESSIONS (the UNION of
+        the in-memory owner-bound token set AND the durable ``session_meta`` token
+        set, so a restart-survived sqlite session is still bounded) and reaps any
+        whose lease is stale, reusing the SAME heartbeat-staleness predicate SHAPE
+        as the grant sweep (``current - last_hb >= timeout``, with ``>=`` matching
+        ADV-02) and the same ``CrashRecoveryConfig`` knob
+        (``heartbeat_timeout_ticks``). A durable-only session (post-restart, no
+        in-memory lease) is bounded by the absolute-age ceiling ALONE — applying
+        heartbeat-staleness to a leaseless survivor would reap it on the first
+        post-restart sweep and defeat R6.
 
         **TWO reap conditions, OR'd (a session is reaped if EITHER fires):**
 
@@ -1559,16 +1666,18 @@ class CoordinatorService:
            reuse the grant sweep's ``max_hold_ticks`` (that bounds GRANTS, this
            bounds SESSIONS).
 
-        Reaping a session: :meth:`registry.release_session` drops its pins (so its
-        pinned versions become collectible again), then its owner binding,
-        heartbeat lease, and creation tick are cleared and the token is recorded
-        in the bounded reaped tombstone. After reaping, a ``session_read`` /
+        Reaping a session: :meth:`registry.release_session` drops its pins AND its
+        durable owner-binding (so its pinned versions become collectible again and
+        no orphaned owner remains), then its in-memory owner binding, heartbeat
+        lease, and creation tick are cleared and the token is recorded in the
+        bounded reaped tombstone. After reaping, a ``session_read`` /
         ``session_commit`` on that token fails closed with ``session_invalidated``
         (the cut is gone).
 
         Args:
-            current_tick: The sweep's logical clock (monotonic ticks, as the
-                grant sweep uses). Both reap conditions are measured against it.
+            current_tick: The sweep's logical clock (wall-clock ticks via
+                ``monotonic_seconds``, the SAME basis the heartbeat handlers seed
+                from — finding F1). Both reap conditions are measured against it.
             heartbeat_timeout_ticks: Reap any session whose lease is at least
                 this many ticks stale (or that somehow has no lease — defensive).
                 The absolute-age ceiling (``session_caps.absolute_age_ticks``) is
@@ -1581,50 +1690,77 @@ class CoordinatorService:
             raise ValueError("heartbeat_timeout_ticks must be >= 1")
 
         absolute_age_ticks = self.session_caps.absolute_age_ticks
-        # Snapshot the token set first — reaping mutates ``_session_owners`` /
-        # ``_session_heartbeats`` / ``_session_created`` under the loop, so
-        # iterate a stable copy.
-        tokens = list(self._session_owners.keys())
         reaped = 0
-        for session_token in tokens:
-            last_hb = self._session_heartbeats.get(session_token)
-            # Condition 1 — heartbeat staleness. Same predicate SHAPE as the
-            # grant sweep (``>=`` per ADV-02). A missing lease (should not happen
-            # — begin_session seeds one) is treated as stale, defensively, so a
-            # leaseless session is never immortal.
-            stale = (
-                last_hb is None
-                or (current_tick - last_hb) >= heartbeat_timeout_ticks
-            )
-            # Condition 2 — absolute-age ceiling (Unit 7 / R14). Measured from the
-            # CREATION tick, INDEPENDENT of the heartbeat: a live-heartbeat
-            # session past the ceiling is STILL reaped (a live heartbeat must not
-            # exempt the hard ceiling, threat-model #3). A missing creation tick
-            # (should not happen — begin_session seeds one) is treated as
-            # over-age, defensively.
-            created = self._session_created.get(session_token)
-            over_age = (
-                created is None
-                or (current_tick - created) >= absolute_age_ticks
-            )
-            if not (stale or over_age):
-                continue
-            self._reap_session(session_token)
-            reaped += 1
+        with self._session_lock:
+            # Enumerate the UNION of in-memory sessions and DURABLE sessions
+            # (R6/F3). A sqlite session that survived a restart has durable meta
+            # but NO in-memory state, so an in-memory-only walk would never see it
+            # — yet its pins must still be bounded (the age ceiling) and eventually
+            # reaped (else they starve GC). ``durable`` maps token → (owner,
+            # created_at_tick); the in-memory set is authoritative for the lease.
+            # The token set is a snapshot (reaping mutates the maps under the loop).
+            durable = self.registry.all_session_meta()
+            tokens = set(self._session_owners) | set(durable)
+            for session_token in tokens:
+                if session_token in self._session_owners:
+                    # IN-MEMORY session: heartbeat staleness (Condition 1) applies.
+                    # Same predicate SHAPE as the grant sweep (``>=`` per ADV-02);
+                    # a missing lease is treated as stale, defensively.
+                    last_hb = self._session_heartbeats.get(session_token)
+                    stale = (
+                        last_hb is None
+                        or (current_tick - last_hb) >= heartbeat_timeout_ticks
+                    )
+                    created = self._session_created.get(session_token)
+                else:
+                    # DURABLE-ONLY (post-restart, not yet rehydrated): there is NO
+                    # in-memory lease, so heartbeat-staleness does NOT apply —
+                    # applying it would reap a just-survived session on the first
+                    # post-restart sweep and defeat R6. It is bounded ONLY by the
+                    # absolute-age ceiling, measured from the DURABLE creation tick.
+                    # (The owner can rehydrate it to full in-memory management via a
+                    # heartbeat; until then the ceiling is its sole bound.)
+                    stale = False
+                    created = durable[session_token][1]
+                # Condition 2 — absolute-age ceiling (Unit 7 / R14, threat-model
+                # #3): measured from the CREATION tick, INDEPENDENT of the
+                # heartbeat, so a live-heartbeat session past the ceiling is STILL
+                # reaped. A missing creation tick is treated as over-age,
+                # defensively. With wall-clock ticks (finding F1) the durable
+                # creation tick stays comparable to ``current_tick`` across a
+                # restart, so the ceiling correctly bounds a survived session.
+                over_age = (
+                    created is None
+                    or (current_tick - created) >= absolute_age_ticks
+                )
+                if not (stale or over_age):
+                    continue
+                self._reap_session(session_token)
+                reaped += 1
         return reaped
+
+    def _drop_session_state(self, session_token: str) -> None:
+        """Release a session's durable pins+owner-binding AND clear its in-memory
+        lease/owner/creation state (SB-17 / TX-1, Unit 5 / R4). The ONE place this
+        teardown lives — shared by :meth:`_reap_session` (sweep) and the
+        ``effect_gate`` release-on-exit path (finding: dedup the two identical
+        cleanup blocks). Order is fixed: release the durable store FIRST (the
+        registry is the authoritative pin store, idempotent on an unknown token, so
+        a crash mid-teardown leaves no live-pin-without-owner leak on sqlite), then
+        drop the in-memory maps. Holds ``_session_lock`` (re-entrant — the sweep
+        already holds it) so the in-memory drops never race a concurrent handler."""
+        self.registry.release_session(session_token)
+        with self._session_lock:
+            self._session_heartbeats.pop(session_token, None)
+            self._session_owners.pop(session_token, None)
+            self._session_created.pop(session_token, None)
 
     def _reap_session(self, session_token: str) -> None:
         """Drop a session's pins + lease + owner binding and tombstone the token
-        (Unit 5 / R4). The single reap path so the order is consistent: release
-        the pins FIRST (the registry is the durable/authoritative pin store, so a
-        crash mid-reap leaves no live-pin-without-lease leak on sqlite), then
-        clear the service-layer lease + owner binding, then tombstone."""
-        # Pins first: the registry release is idempotent (unknown token → no-op),
-        # so a double-reap or a restart-wiped pin set is harmless.
-        self.registry.release_session(session_token)
-        self._session_heartbeats.pop(session_token, None)
-        self._session_owners.pop(session_token, None)
-        self._session_created.pop(session_token, None)
+        (Unit 5 / R4). Reaping = drop the session state (durable + in-memory) then
+        record the token in the bounded tombstone so a subsequent read/commit
+        attributes it precisely to ``session_invalidated``."""
+        self._drop_session_state(session_token)
         self._tombstone_token(session_token)
 
     def _tombstone_token(self, session_token: str) -> None:
@@ -1634,11 +1770,15 @@ class CoordinatorService:
         ``session_invalidated`` via :func:`looks_like_session_token`, so the
         fail-closed guarantee never depends on tombstone residency."""
         # Move-to-end keeps the most-recently-reaped tokens; popitem(last=False)
-        # evicts the oldest (FIFO) when over the cap.
-        self._reaped_tombstone[session_token] = None
-        self._reaped_tombstone.move_to_end(session_token)
-        while len(self._reaped_tombstone) > _REAPED_TOMBSTONE_CAP:
-            self._reaped_tombstone.popitem(last=False)
+        # evicts the oldest (FIFO) when over the cap. Under ``_session_lock``
+        # (re-entrant — the sweep already holds it): the insert+move+evict is a
+        # compound op a bare GIL would not make atomic against a concurrent
+        # classify read (finding F4).
+        with self._session_lock:
+            self._reaped_tombstone[session_token] = None
+            self._reaped_tombstone.move_to_end(session_token)
+            while len(self._reaped_tombstone) > _REAPED_TOMBSTONE_CAP:
+                self._reaped_tombstone.popitem(last=False)
 
     def _classify_no_cut_reason(self, session_token: str) -> str:
         """Classify a token that has NO live cut into the wire-stable fail-closed
@@ -1658,7 +1798,9 @@ class CoordinatorService:
           genuinely never-opened token. Kept reachable additively so a clearly
           bogus token is still distinguishable.
         """
-        if session_token in self._reaped_tombstone:
+        with self._session_lock:
+            in_tombstone = session_token in self._reaped_tombstone
+        if in_tombstone:
             return SESSION_INVALIDATED_REASON
         if looks_like_session_token(session_token):
             return SESSION_INVALIDATED_REASON

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -26,8 +26,10 @@ from ccs.core.exceptions import (
     OCC_CALLER_TRANSIENT_REASON,
     RETENTION_OFF_REASON,
     SESSION_ARTIFACT_NOT_IN_CUT_REASON,
+    SESSION_CAP_EXCEEDED_REASON,
     SESSION_INVALIDATED_REASON,
     SESSION_NOT_FOUND_REASON,
+    SESSION_READ_SET_TOO_LARGE_REASON,
     UNKNOWN_ARTIFACT_REASON,
     CoherenceError,
     OccCallerTransientError,
@@ -194,10 +196,64 @@ def validate_crash_recovery_config(
     )
 
 
+@dataclass(frozen=True)
+class SessionCapsConfig:
+    """Resource bounds for snapshot sessions (SB-17 / TX-1, Unit 7 / R14).
+
+    Security-calibrated DEFAULTS — placeholder-but-sane, NOT post-hoc tuning.
+    Each cap bounds a distinct snapshot-session DoS surface from the plan's
+    threat model; the defaults are the spec's stated values (R14). A frozen
+    dataclass mirroring :class:`CrashRecoveryConfig`'s shape so a deployment can
+    tighten the bounds (or a test set tiny ones) without touching the sweep.
+
+    Attributes:
+        max_sessions: Maximum CONCURRENT live sessions. ``begin_session`` rejects
+            opening an (N+1)th session with ``session_cap_exceeded`` (no token
+            minted, no cut pinned). Bounds the many-sessions GC-starvation DoS
+            (an attacker opening unboundedly many sessions to hold versions back
+            from GC; threat-model #2). Default 256.
+        max_read_set_cardinality: Maximum artifacts in a single ``read_set``.
+            ``begin_session`` rejects a larger read-set with ``read_set_too_large``
+            (no token minted, no cut pinned). Bounds the enormous-single-read-set
+            GC-starvation DoS (threat-model #2). Default 64.
+        absolute_age_ticks: HARD age ceiling, in logical ticks, SEPARATE from the
+            heartbeat lease. A session older than this (``current_tick -
+            created_at_tick >= absolute_age_ticks``) is reaped by
+            :meth:`CoordinatorService.enforce_session_liveness` EVEN WHEN ITS
+            HEARTBEAT IS LIVE — a live heartbeat must NOT exempt it. Bounds the
+            heartbeat-spoofing-past-the-ceiling DoS (an attacker keeping a stale
+            cut alive indefinitely via heartbeats; threat-model #3). The plan's
+            ``absolute_age_seconds=3600`` expressed in the coordinator's logical
+            tick unit (the runtime is tick-driven, no wall clock); default 3600.
+    """
+
+    max_sessions: int = 256
+    max_read_set_cardinality: int = 64
+    absolute_age_ticks: int = 3600
+
+    def __post_init__(self) -> None:
+        # Fail fast on a nonsensical cap (caller misuse), mirroring the
+        # house "validate at the boundary" rule. A cap < 1 would reject every
+        # session / read-set or never reap — both are configuration bugs.
+        if self.max_sessions < 1:
+            raise ValueError("max_sessions must be >= 1")
+        if self.max_read_set_cardinality < 1:
+            raise ValueError("max_read_set_cardinality must be >= 1")
+        if self.absolute_age_ticks < 1:
+            raise ValueError("absolute_age_ticks must be >= 1")
+
+
 # Snapshot session token entropy (SB-17 / TX-1, Unit 2 / R13). 32 bytes →
 # ~43 url-safe chars; unguessable, server-minted, never client-supplied. The
 # timing-safe compare + per-call validation that consume it are Unit 7.
 _SESSION_TOKEN_BYTES = 32
+
+# Placeholder artifact id for a ``begin_session`` cap rejection (Unit 7 / R14):
+# a cap rejection (``session_cap_exceeded`` / ``read_set_too_large``) is about the
+# WHOLE call, not any single artifact, and must leak NO member id. The
+# ``VersionedReadRejection`` carrier requires an ``artifact_id`` field, so the
+# nil UUID stands in — the consumer matches on ``reason``, never this field.
+_NIL_UUID = UUID(int=0)
 
 
 # Server-minted session-token SHAPE (SB-17 / TX-1, Unit 5 / R4). A
@@ -263,9 +319,18 @@ class SessionView:
     is byte-source-independent.
     """
 
-    def __init__(self, service: "CoordinatorService", session_token: str) -> None:
+    def __init__(
+        self,
+        service: "CoordinatorService",
+        session_token: str,
+        owner: UUID,
+    ) -> None:
         self._service = service
         self._token = session_token
+        # The session's OWNER — threaded through so the view's pinned reads pass
+        # the per-call owner validation (Unit 7 / R13). The view reads the
+        # session's OWN cut, so the caller IS the owner by construction.
+        self._owner = owner
 
     def read(
         self, artifact_id: UUID
@@ -274,7 +339,9 @@ class SessionView:
         session or an un-pinned artifact (a typed rejection → raised
         :class:`SessionInvalidated` / ``CoherenceError``) so a decision never runs
         on an invalid cut."""
-        result = self._service.session_read(self._token, artifact_id)
+        result = self._service.session_read(
+            self._token, artifact_id, caller=self._owner
+        )
         if isinstance(result, SessionReadRejection):
             if result.reason == SESSION_ARTIFACT_NOT_IN_CUT_REASON:
                 # Caller misuse: reading outside the pinned read-set. Not a dead
@@ -294,16 +361,37 @@ class SessionView:
 class CoordinatorService:
     """Control-plane service for artifact read/write/commit synchronization."""
 
-    def __init__(self, registry: ArtifactRegistry):
+    def __init__(
+        self,
+        registry: ArtifactRegistry,
+        *,
+        session_caps: SessionCapsConfig | None = None,
+    ):
         self.registry = registry
+        # Snapshot session resource bounds (SB-17 / TX-1, Unit 7 / R14). Defaults
+        # to the security-calibrated :class:`SessionCapsConfig` (max_sessions,
+        # max_read_set_cardinality, absolute_age_ticks); a deployment or test may
+        # pass tighter caps. Constructor param so the bounds are configurable
+        # without touching the sweep (mirrors how ``crash_recovery`` knobs are
+        # threaded into ``enforce_stable_grant_timeouts``).
+        self.session_caps = session_caps or SessionCapsConfig()
         # Snapshot session owner-binding (SB-17 / TX-1, Unit 2 / R13):
-        # ``{session_token: owner_id}``. Populated at ``begin_session`` mint;
-        # the per-CALL read/commit validation that READS it (a foreign owner →
-        # SessionInvalidated, timing-safe compare) is Unit 7. Unit 5 owner-binds
-        # ONLY the HEARTBEAT path (``record_session_heartbeat``). Service-scoped
-        # (a restart drops the bindings — the durable pins survive on sqlite, but
-        # re-validating a post-restart token is the Unit 5 liveness concern).
+        # ``{session_token: owner_id}``. Populated at ``begin_session`` mint; the
+        # per-CALL read/commit validation that READS it (a foreign owner →
+        # SessionInvalidated, timing-safe compare) is Unit 7
+        # (:meth:`_validate_session_owner`). Unit 5 owner-binds the HEARTBEAT path
+        # (``record_session_heartbeat``). Service-scoped (a restart drops the
+        # bindings — the durable pins survive on sqlite, but re-validating a
+        # post-restart token is the Unit 5 liveness concern).
         self._session_owners: dict[str, UUID] = {}
+        # Snapshot session CREATION tick (SB-17 / TX-1, Unit 7 / R14):
+        # ``{session_token: created_at_tick}``. The absolute-age ceiling reads
+        # THIS — NOT the heartbeat lease — so a session older than
+        # ``session_caps.absolute_age_ticks`` is reaped EVEN with a fresh
+        # heartbeat (a live heartbeat must not exempt the hard ceiling,
+        # threat-model #3). Seeded at ``begin_session`` alongside the lease;
+        # dropped on reap/release with the owner + lease.
+        self._session_created: dict[str, int] = {}
         # Session heartbeat lease (SB-17 / TX-1, Unit 5 / R4):
         # ``{session_token: last_heartbeat_tick}``. Keyed by the server-minted
         # SESSION TOKEN, NOT the MESI ``agent_id`` — a snapshot session is NOT a
@@ -616,14 +704,46 @@ class CoordinatorService:
             :class:`VersionedReadRejection` (``unknown_artifact``) — no session
             opened, no pins held.
         """
+        # Resource caps (Unit 7 / R14) — enforced BEFORE any token mint or pin
+        # insert, so a rejected ``begin_session`` leaves NO half-open session
+        # (no owner binding, no lease, no pins). Typed RETURNS (the
+        # ``VersionedReadRejection`` carrier ``begin_session`` already produces),
+        # never an exception — the caps are a bounded-blast-radius surface, not a
+        # crash. ``read_set`` is materialized ONCE here (it may be a one-shot
+        # iterable) so the cardinality check and the capture see the same set.
+        read_set = list(read_set)
+        epoch = self.registry.coordinator_epoch
+        if len(read_set) > self.session_caps.max_read_set_cardinality:
+            # The enormous-single-read-set GC-starvation bound (threat-model #2).
+            # No artifact id is leaked (artifact_id=None-equivalent uses a nil
+            # UUID); the rejection is about the CARDINALITY, not any member.
+            return VersionedReadRejection(
+                reason=SESSION_READ_SET_TOO_LARGE_REASON,
+                artifact_id=_NIL_UUID,
+                requested_version=len(read_set),
+                current_version=self.session_caps.max_read_set_cardinality,
+                coordinator_epoch=epoch,
+            )
+        if len(self._session_owners) >= self.session_caps.max_sessions:
+            # The many-sessions GC-starvation bound (threat-model #2). Count the
+            # LIVE owner-bindings (one per open session); an (N+1)th is rejected
+            # until a session is released or the liveness sweep reaps a stale one.
+            return VersionedReadRejection(
+                reason=SESSION_CAP_EXCEEDED_REASON,
+                artifact_id=_NIL_UUID,
+                requested_version=len(self._session_owners),
+                current_version=self.session_caps.max_sessions,
+                coordinator_epoch=epoch,
+            )
+
         session_token = secrets.token_urlsafe(_SESSION_TOKEN_BYTES)
-        # Owner-bind at mint (R13). Recorded BEFORE the capture so a concurrent
-        # later-unit validator never sees a pinned-but-unowned token; dropped
-        # again if the capture rejects. NOTE for Unit 7 (the per-call validator):
-        # the INVERSE window also exists — between this line and the capture
-        # below, the token is owned but PINLESS. Unit 7 must treat an owned-but-
-        # pinless token as not-yet-live (or read owner-binding + pins together),
-        # never as a valid empty session.
+        # Owner-bind at mint (R13). Recorded BEFORE the capture so the Unit-7
+        # per-call validator never sees a pinned-but-unowned token; dropped again
+        # if the capture rejects. The INVERSE window — between this line and the
+        # capture below, the token is owned but PINLESS — is handled by Unit 7's
+        # :meth:`_validate_session_owner`: it reads owner-binding AND the cut, and
+        # treats an owned-but-pinless token as NOT-yet-live (fail closed,
+        # ``SessionInvalidated``), never a valid empty session.
         self._session_owners[session_token] = owner
         result = self.registry.capture_version_vector(read_set, session_token)
         if isinstance(result, VersionedReadRejection):
@@ -637,6 +757,10 @@ class CoordinatorService:
         # ``granted_at_tick``. Recorded only on a SUCCESSFUL capture (a rejected
         # capture returned above, leaving no lease and no owner binding).
         self._session_heartbeats[session_token] = created_at_tick
+        # Record the CREATION tick for the absolute-age ceiling (Unit 7 / R14).
+        # The ceiling reads THIS, not the heartbeat lease, so a live-heartbeat
+        # session past the ceiling is still reaped (threat-model #3).
+        self._session_created[session_token] = created_at_tick
         retain_versions, _policy = self.registry.retention_meta()
         return SnapshotSession(
             session_token=session_token,
@@ -649,6 +773,8 @@ class CoordinatorService:
         self,
         session_token: str,
         artifact_id: UUID,
+        *,
+        caller: UUID,
     ) -> VersionedContent | DataPlaneDeferredRead | SessionReadRejection:
         """Serve an artifact's PINNED version from a live snapshot session — the
         non-mutating read from the consistent cut (SB-17 / TX-1, Unit 3 / R2).
@@ -702,18 +828,25 @@ class CoordinatorService:
           data plane for the bytes" signal. The actual eager byte serve is
           **Unit 6 (CoherentVolume)**; this method never reads the data plane.
 
-        Validation (Unit 3 scope): the token must have a live pin for
+        Validation: the caller must be the session OWNER (Unit 7 / R13,
+        timing-safe — see ``caller`` below) AND the token must have a live pin for
         ``artifact_id``. An unknown/released token → ``session_not_found``; a live
         token whose cut lacks ``artifact_id`` → ``artifact_not_in_cut`` — both
         typed :class:`~ccs.core.types.SessionReadRejection`, NEVER a live-HEAD
-        fall-through. (Per-call OWNER-binding validation — a foreign owner reading
-        another's cut — is Unit 7; the heartbeat-liveness ``session_invalidated``
-        axis is Unit 5. Unit 3 does the token-has-pin check only.)
+        fall-through. A FOREIGN caller or an OWNED-BUT-PINLESS token RAISES
+        :class:`SessionInvalidated` (Unit 7, validated BEFORE the pin lookup); the
+        heartbeat-liveness ``session_invalidated`` axis is Unit 5.
 
         Args:
             session_token: The server-minted session identity from
                 ``begin_session``.
             artifact_id: The artifact to read at its pinned version.
+            caller: The CALLER'S identity (the MESI agent/process label). Must be
+                the session's bound owner — validated timing-safe
+                (:func:`hmac.compare_digest`) against the owner bound at
+                ``begin_session``; a foreign caller fails closed
+                (:class:`SessionInvalidated`). Required (R13): a sibling MUST NOT
+                read another's cut.
 
         Returns:
             :class:`VersionedContent` (coordinator-held pinned bytes),
@@ -723,11 +856,15 @@ class CoordinatorService:
         """
         epoch = self.registry.coordinator_epoch
 
-        # Unit 7: per-call OWNER-binding validation goes HERE — read
-        # ``_session_owners[session_token]`` and reject a foreign caller
-        # (timing-safe compare) with the Unit-5 ``session_invalidated`` reason
-        # BEFORE the pin lookup. Unit 3 does the token-has-pin check only.
+        # Per-call OWNER-binding validation (Unit 7 / R13) — read the cut and the
+        # owner binding CONSISTENTLY (one cut read, passed to the validator), then
+        # fail closed BEFORE acting on the pin: a FOREIGN caller or an
+        # OWNED-BUT-PINLESS token raises :class:`SessionInvalidated` (a sibling
+        # MUST NOT read another's cut; an owned-but-pinless token is not-yet-live).
+        # A token with NO owner binding falls through to the cut-absent liveness
+        # taxonomy below (still fail-closed, never live HEAD).
         cut = self.registry.get_session_cut(session_token)
+        self._validate_session_owner(session_token, caller, cut)
         if cut is None:
             # FAIL CLOSED (Unit 5 / R4): no live cut for this token — it was
             # reaped by the session-liveness sweep, GC-raced, wiped by an
@@ -834,6 +971,7 @@ class CoordinatorService:
         artifact_id: UUID,
         content: bytes | str,
         *,
+        caller: UUID,
         size_tokens: int | None = None,
         issued_at_tick: int = 0,
     ) -> tuple[Artifact, list[InvalidationSignal]] | ConflictDetail | SessionCommitRejection:
@@ -864,14 +1002,16 @@ class CoordinatorService:
         across a session's calls) and collision-free against real agent ids (a
         ``uuid5`` over a 32-byte server-minted token namespace).
 
-        Validation (Unit 4 scope): the token must have a live pin for
+        Validation: the caller must be the session OWNER (Unit 7 / R13,
+        timing-safe — see ``caller`` below) AND the token must have a live pin for
         ``artifact_id``. An unknown/released token → ``session_not_found``; a live
         token whose cut lacks ``artifact_id`` → ``artifact_not_in_cut`` — both a
         typed :class:`~ccs.core.types.SessionCommitRejection`, NEVER a silent
-        fall-through to a live-HEAD commit. (Per-call OWNER-binding validation — a
-        foreign owner committing into another's cut — and the caps are Unit 7; the
-        heartbeat-liveness ``session_invalidated`` axis is Unit 5. Unit 4 does the
-        token-has-pin check only.)
+        fall-through to a live-HEAD commit. A FOREIGN caller or an
+        OWNED-BUT-PINLESS token RAISES :class:`SessionInvalidated` (Unit 7,
+        validated BEFORE the pin lookup); the heartbeat-liveness
+        ``session_invalidated`` axis is Unit 5. (The R14 caps are enforced at
+        ``begin_session``, not here — a committed session already passed them.)
 
         Outcome mapping (mirrors the shipped ``commit_cas`` orchestration exactly):
 
@@ -897,6 +1037,12 @@ class CoordinatorService:
             session_token: The server-minted session identity from
                 ``begin_session``.
             artifact_id: The pinned artifact to commit. Must be in the cut.
+            caller: The CALLER'S identity (the MESI agent/process label). Must be
+                the session's bound owner — validated timing-safe
+                (:func:`hmac.compare_digest`) against the owner bound at
+                ``begin_session``; a foreign caller fails closed
+                (:class:`SessionInvalidated`). Required (R13): a sibling MUST NOT
+                commit into another's cut.
             content: The new body. ``content_hash`` is derived from it
                 (``compute_content_hash``); the body is threaded to ``commit_cas``
                 so the in-memory path advances ``record.content`` on a WIN (the
@@ -915,11 +1061,15 @@ class CoordinatorService:
         """
         epoch = self.registry.coordinator_epoch
 
-        # Unit 7: per-call OWNER-binding validation goes HERE — read
-        # ``_session_owners[session_token]`` and reject a foreign caller
-        # (timing-safe compare) BEFORE the pin lookup. Unit 4 does the
-        # token-has-pin check only.
+        # Per-call OWNER-binding validation (Unit 7 / R13) — read the cut and the
+        # owner binding CONSISTENTLY, then fail closed BEFORE acting on the pin: a
+        # FOREIGN caller or an OWNED-BUT-PINLESS token raises
+        # :class:`SessionInvalidated` (a sibling MUST NOT commit into another's
+        # cut; an owned-but-pinless token is not-yet-live). A token with NO owner
+        # binding falls through to the cut-absent liveness taxonomy below (still
+        # fail-closed, never a live-HEAD commit).
         cut = self.registry.get_session_cut(session_token)
+        self._validate_session_owner(session_token, caller, cut)
         if cut is None:
             # FAIL CLOSED (Unit 5 / R4): no live cut for this token — reaped,
             # GC-raced, restart-wiped, released, or never opened. NEVER a silent
@@ -961,6 +1111,71 @@ class CoordinatorService:
             size_tokens=size_tokens,
             content=content,
         )
+
+    def _validate_session_owner(
+        self,
+        session_token: str,
+        caller: UUID,
+        cut: Mapping[UUID, int] | None,
+    ) -> None:
+        """Per-call OWNER-binding validation for ``session_read`` / ``session_commit``
+        (SB-17 / TX-1, Unit 7 / R13). Fails CLOSED — raises
+        :class:`SessionInvalidated` — for a FOREIGN caller (an owner-isolation
+        violation). Returns for every non-foreign case; the cut-absent fail-closed
+        taxonomy (including the OWNED-BUT-PINLESS case) is left to the caller's
+        existing ``cut is None`` path so a single fail-closed shape governs.
+
+        Called BEFORE the pin lookup is acted on, with the cut already read by the
+        caller (so owner-binding and pins are read consistently within one call —
+        no second registry round-trip that could race the first). A SIBLING agent
+        MUST NOT read or commit another session's cut, even with a leaked token:
+        cross-agent access is OUT (R13).
+
+        The owner comparison is TIMING-SAFE: it uses :func:`hmac.compare_digest`
+        over the stable 16-byte ``UUID.bytes`` encoding (the SAME shape as the
+        Unit-5 heartbeat owner-check), NEVER ``==`` / ``in``, so a foreign caller
+        learns nothing from response timing about how much of the owner id matched.
+
+        Three outcomes:
+
+        - **No owner binding** (``bound_owner is None``) — the token was never
+          opened, was released, was reaped, or an in-memory restart wiped the
+          binding. This is NOT an owner-isolation failure (there is no owner to
+          compare against); the validator RETURNS and lets the caller's existing
+          cut-absent path classify it into the wire-stable liveness taxonomy
+          (``session_invalidated`` / ``session_not_found``). Fail-closed is
+          preserved downstream — a no-binding token always has ``cut is None``.
+        - **Foreign caller** (binding present, caller mismatches) — RAISE
+          ``SessionInvalidated``: a sibling cannot read/commit another's cut. This
+          is the ONE genuinely exceptional case — an isolation breach, raised so it
+          is never confused with a benign not-found.
+        - **Owned-but-pinless** (binding present, caller matches, but ``cut is
+          None``) — a token that is OWNED but has NO live pins (the begin_session
+          mint→capture window, or the degenerate empty-read-set sqlite session that
+          durably pins zero rows → ``get_session_cut`` returns ``None``). The
+          validator RETURNS; the caller's existing ``cut is None`` path then fails
+          CLOSED with the wire-stable ``session_invalidated`` reason
+          (:meth:`_classify_no_cut_reason` for an in-shape token) — NOT-yet-live,
+          never a valid empty session, never a live-HEAD fall-through. Returning
+          (rather than raising) keeps owned-but-pinless on the SAME typed
+          fail-closed taxonomy as every other cut-absent case (and preserves the
+          shipped Unit-3 sqlite-empty-session contract, which returns
+          ``session_invalidated`` rather than raising).
+        """
+        bound_owner = self._session_owners.get(session_token)
+        if bound_owner is None:
+            # No owner binding ⇒ not an isolation failure. The caller's cut-absent
+            # path (``_classify_no_cut_reason``) fails closed with the liveness
+            # taxonomy; nothing to validate here.
+            return
+        # Timing-safe owner-binding compare (R13): stable 16-byte UUID encoding,
+        # never ``==``. A foreign caller is rejected fail-closed and cannot probe
+        # id-match progress via response timing.
+        if not hmac.compare_digest(bound_owner.bytes, caller.bytes):
+            raise SessionInvalidated(
+                "session owner mismatch: the caller is not the session's owner "
+                "(cross-agent session access is out of scope, R13)"
+            )
 
     @staticmethod
     def _session_committer_id(session_token: str) -> UUID:
@@ -1098,12 +1313,13 @@ class CoordinatorService:
         token = session.session_token
         try:
             # DECIDE — the caller reads the PINNED cut and computes its decision.
-            view = SessionView(self, token)
+            view = SessionView(self, token, owner)
             decision = decide(view)
 
             if commit is not None:
                 return self._effect_gate_atomic(
                     session=session,
+                    owner=owner,
                     commit=commit,
                     issued_at_tick=issued_at_tick,
                 )
@@ -1122,6 +1338,7 @@ class CoordinatorService:
                 self.registry.release_session(token)
                 self._session_heartbeats.pop(token, None)
                 self._session_owners.pop(token, None)
+                self._session_created.pop(token, None)
 
     def _revalidate_cut(
         self, cut: Mapping[UUID, int]
@@ -1182,6 +1399,7 @@ class CoordinatorService:
         self,
         *,
         session: SnapshotSession,
+        owner: UUID,
         commit: tuple[UUID, bytes | str],
         issued_at_tick: int,
     ) -> EffectFired | EffectHeld:
@@ -1212,6 +1430,7 @@ class CoordinatorService:
             session.session_token,
             artifact_id,
             content,
+            caller=owner,
             issued_at_tick=issued_at_tick,
         )
         if isinstance(outcome, SessionCommitRejection):
@@ -1320,49 +1539,75 @@ class CoordinatorService:
         owner-bound token set) and reaps any whose lease is stale, reusing the
         SAME heartbeat-staleness predicate SHAPE as the grant sweep (``current -
         last_hb >= timeout``, with ``>=`` matching ADV-02) and the same
-        ``CrashRecoveryConfig`` knob (``heartbeat_timeout_ticks``). It does NOT
-        reuse ``max_hold_ticks`` — the absolute-age ceiling that a live heartbeat
-        must not exempt is Unit 7 (a SEPARATE cap), not the liveness lease.
+        ``CrashRecoveryConfig`` knob (``heartbeat_timeout_ticks``).
+
+        **TWO reap conditions, OR'd (a session is reaped if EITHER fires):**
+
+        1. **Heartbeat staleness** (the Unit-5 lease) — ``current_tick - last_hb
+           >= heartbeat_timeout_ticks``. A slow-but-LIVE session heartbeated
+           within the window survives indefinitely; this is a PREDICATE on the
+           lease, not a hard TTL.
+        2. **Absolute-age ceiling** (Unit 7 / R14, threat-model #3) —
+           ``current_tick - created_at_tick >= session_caps.absolute_age_ticks``.
+           A HARD ceiling SEPARATE from the heartbeat lease: a session older than
+           the ceiling is reaped **EVEN WHEN ITS HEARTBEAT IS LIVE** — a live
+           heartbeat MUST NOT exempt it. This bounds the heartbeat-spoofing DoS
+           (an attacker keeping a stale cut pinned indefinitely via heartbeats).
+           The age is measured from ``created_at_tick`` (seeded at
+           ``begin_session``), NOT the last heartbeat, so heartbeating never
+           resets it. This is the ONLY place the ceiling is enforced; it does NOT
+           reuse the grant sweep's ``max_hold_ticks`` (that bounds GRANTS, this
+           bounds SESSIONS).
 
         Reaping a session: :meth:`registry.release_session` drops its pins (so its
-        pinned versions become collectible again), then its owner binding and
-        heartbeat lease are cleared and the token is recorded in the bounded
-        reaped tombstone. After reaping, a ``session_read`` / ``session_commit``
-        on that token fails closed with ``session_invalidated`` (the cut is gone).
-
-        A slow-but-LIVE session — one heartbeated within ``heartbeat_timeout_ticks``
-        — is NOT reaped. This is a PREDICATE on the lease, not a hard TTL: a
-        long-running session that keeps heartbeating survives indefinitely
-        (the absolute-age ceiling that overrides even a live heartbeat is the
-        SEPARATE Unit-7 cap).
+        pinned versions become collectible again), then its owner binding,
+        heartbeat lease, and creation tick are cleared and the token is recorded
+        in the bounded reaped tombstone. After reaping, a ``session_read`` /
+        ``session_commit`` on that token fails closed with ``session_invalidated``
+        (the cut is gone).
 
         Args:
             current_tick: The sweep's logical clock (monotonic ticks, as the
-                grant sweep uses).
+                grant sweep uses). Both reap conditions are measured against it.
             heartbeat_timeout_ticks: Reap any session whose lease is at least
                 this many ticks stale (or that somehow has no lease — defensive).
+                The absolute-age ceiling (``session_caps.absolute_age_ticks``) is
+                applied INDEPENDENTLY — a fresh heartbeat does not exempt it.
 
         Returns:
-            The number of sessions reaped.
+            The number of sessions reaped (by EITHER condition).
         """
         if heartbeat_timeout_ticks < 1:
             raise ValueError("heartbeat_timeout_ticks must be >= 1")
 
+        absolute_age_ticks = self.session_caps.absolute_age_ticks
         # Snapshot the token set first — reaping mutates ``_session_owners`` /
-        # ``_session_heartbeats`` under the loop, so iterate a stable copy.
+        # ``_session_heartbeats`` / ``_session_created`` under the loop, so
+        # iterate a stable copy.
         tokens = list(self._session_owners.keys())
         reaped = 0
         for session_token in tokens:
             last_hb = self._session_heartbeats.get(session_token)
-            # Same staleness predicate SHAPE as the grant sweep (``>=`` per
-            # ADV-02). A missing lease (should not happen — begin_session seeds
-            # one) is treated as stale, defensively, so a leaseless session is
-            # never immortal.
+            # Condition 1 — heartbeat staleness. Same predicate SHAPE as the
+            # grant sweep (``>=`` per ADV-02). A missing lease (should not happen
+            # — begin_session seeds one) is treated as stale, defensively, so a
+            # leaseless session is never immortal.
             stale = (
                 last_hb is None
                 or (current_tick - last_hb) >= heartbeat_timeout_ticks
             )
-            if not stale:
+            # Condition 2 — absolute-age ceiling (Unit 7 / R14). Measured from the
+            # CREATION tick, INDEPENDENT of the heartbeat: a live-heartbeat
+            # session past the ceiling is STILL reaped (a live heartbeat must not
+            # exempt the hard ceiling, threat-model #3). A missing creation tick
+            # (should not happen — begin_session seeds one) is treated as
+            # over-age, defensively.
+            created = self._session_created.get(session_token)
+            over_age = (
+                created is None
+                or (current_tick - created) >= absolute_age_ticks
+            )
+            if not (stale or over_age):
                 continue
             self._reap_session(session_token)
             reaped += 1
@@ -1379,6 +1624,7 @@ class CoordinatorService:
         self.registry.release_session(session_token)
         self._session_heartbeats.pop(session_token, None)
         self._session_owners.pop(session_token, None)
+        self._session_created.pop(session_token, None)
         self._tombstone_token(session_token)
 
     def _tombstone_token(self, session_token: str) -> None:

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -5,11 +5,14 @@
 
 from __future__ import annotations
 
+import hmac
 import logging
 import secrets
+import string
 import threading
 import time
 import warnings
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Callable, Iterable, Optional
 from uuid import NAMESPACE_URL, UUID, uuid5
@@ -23,6 +26,7 @@ from ccs.core.exceptions import (
     OCC_CALLER_TRANSIENT_REASON,
     RETENTION_OFF_REASON,
     SESSION_ARTIFACT_NOT_IN_CUT_REASON,
+    SESSION_INVALIDATED_REASON,
     SESSION_NOT_FOUND_REASON,
     UNKNOWN_ARTIFACT_REASON,
     CoherenceError,
@@ -193,6 +197,52 @@ def validate_crash_recovery_config(
 _SESSION_TOKEN_BYTES = 32
 
 
+# Server-minted session-token SHAPE (SB-17 / TX-1, Unit 5 / R4). A
+# ``secrets.token_urlsafe(32)`` is ALWAYS exactly 43 characters drawn from the
+# URL-safe base64 alphabet ([A-Za-z0-9_-], no padding). The session-liveness
+# fail-closed taxonomy uses this as the structural discriminator: a token of
+# this shape that has NO live cut was, or still looks like, a real session
+# (reaped / GC-raced / restart-wiped) → ``session_invalidated`` (fail closed,
+# never live HEAD). A token NOT of this shape is genuinely never-opened /
+# malformed → ``session_not_found``. The check is structural only (it cannot
+# prove a token was ever minted — fail-closed is the safe default for an
+# in-shape token), and it is NOT an authentication boundary (the unguessable
+# entropy + the Unit-7 owner-binding are). It exists ONLY to make the dead-vs-
+# never-opened reason split honest and survive an in-memory restart that wipes
+# every service-layer map including the tombstone.
+_SESSION_TOKEN_LEN = 43
+_SESSION_TOKEN_ALPHABET = frozenset(string.ascii_letters + string.digits + "-_")
+
+# Bounded reaped-session tombstone cap (SB-17 / TX-1, Unit 5 / R4). The
+# session-liveness sweep records a reaped token here so a subsequent
+# ``session_read`` / ``session_commit`` attributes it precisely to
+# ``session_invalidated`` ("your session died") rather than relying on the shape
+# predicate alone. Capped + oldest-evicted so a long-lived coordinator cannot
+# accumulate unbounded tombstones (a reaper-amplification DoS). Eviction is
+# benign: an evicted token still classifies ``session_invalidated`` via the
+# shape predicate (every server-minted token is in-shape), so dropping the
+# tombstone entry only loses the precise "definitely reaped" attribution, never
+# the fail-closed guarantee.
+_REAPED_TOMBSTONE_CAP = 4096
+
+
+def looks_like_session_token(token: str) -> bool:
+    """Structural predicate: does ``token`` have the server-minted SHAPE?
+
+    ``True`` iff it is exactly :data:`_SESSION_TOKEN_LEN` characters, all in the
+    URL-safe base64 alphabet — the shape every ``begin_session`` token has. Used
+    ONLY by the Unit-5 fail-closed taxonomy to split a dead/restart-wiped session
+    (in-shape, no cut → ``session_invalidated``) from a genuinely-never-opened or
+    malformed token (out-of-shape → ``session_not_found``). NOT an auth check; a
+    well-formed token that was never minted still classifies invalidated, which
+    is the safe (fail-closed) default — it is never served live HEAD either way.
+    """
+    return (
+        len(token) == _SESSION_TOKEN_LEN
+        and all(ch in _SESSION_TOKEN_ALPHABET for ch in token)
+    )
+
+
 class CoordinatorService:
     """Control-plane service for artifact read/write/commit synchronization."""
 
@@ -200,11 +250,30 @@ class CoordinatorService:
         self.registry = registry
         # Snapshot session owner-binding (SB-17 / TX-1, Unit 2 / R13):
         # ``{session_token: owner_id}``. Populated at ``begin_session`` mint;
-        # the per-call validation that READS it (a foreign owner →
-        # SessionInvalidated, timing-safe compare) is Unit 7. Service-scoped (a
-        # restart drops the bindings — the durable pins survive on sqlite, but
+        # the per-CALL read/commit validation that READS it (a foreign owner →
+        # SessionInvalidated, timing-safe compare) is Unit 7. Unit 5 owner-binds
+        # ONLY the HEARTBEAT path (``record_session_heartbeat``). Service-scoped
+        # (a restart drops the bindings — the durable pins survive on sqlite, but
         # re-validating a post-restart token is the Unit 5 liveness concern).
         self._session_owners: dict[str, UUID] = {}
+        # Session heartbeat lease (SB-17 / TX-1, Unit 5 / R4):
+        # ``{session_token: last_heartbeat_tick}``. Keyed by the server-minted
+        # SESSION TOKEN, NOT the MESI ``agent_id`` — a snapshot session is NOT a
+        # MESI agent and holds no grant, so the grant sweep (which walks M∪E
+        # holders) can never see it. The session-liveness sweep is a NEW axis
+        # over THIS map. Seeded at ``begin_session`` with the creation tick so a
+        # never-yet-heartbeated session still carries a lease baseline (mirrors a
+        # grant's ``granted_at_tick``), rather than being reaped on the first
+        # sweep. Service-scoped: an in-memory restart drops the lease (and the
+        # pins), so a post-restart token has no cut and fails closed.
+        self._session_heartbeats: dict[str, int] = {}
+        # Bounded reaped-session tombstone (Unit 5 / R4): recently-reaped tokens,
+        # capped + oldest-evicted (FIFO). Lets ``session_read`` / ``session_commit``
+        # attribute a reaped token precisely to ``session_invalidated``. Eviction
+        # is benign — an evicted in-shape token still classifies invalidated via
+        # ``looks_like_session_token`` (the shape predicate), so the fail-closed
+        # guarantee never depends on the tombstone, only the precise attribution.
+        self._reaped_tombstone: "OrderedDict[str, None]" = OrderedDict()
 
     def register_artifact(
         self,
@@ -459,6 +528,7 @@ class CoordinatorService:
         *,
         read_set: Iterable[UUID],
         owner: UUID,
+        created_at_tick: int = 0,
     ) -> SnapshotSession | VersionedReadRejection:
         """Open a consistent multi-artifact snapshot session (SB-17 / TX-1,
         Unit 2 / R1, R13). Pins a coherent CUT of ``read_set`` at one
@@ -513,6 +583,12 @@ class CoordinatorService:
             # the rejected token cannot linger as a half-open session.
             self._session_owners.pop(session_token, None)
             return result
+        # Seed the heartbeat lease at the creation tick (Unit 5 / R4): a session
+        # that never heartbeats still carries a baseline so it is not reaped on
+        # the very first sweep — the lease starts now, exactly like a grant's
+        # ``granted_at_tick``. Recorded only on a SUCCESSFUL capture (a rejected
+        # capture returned above, leaving no lease and no owner binding).
+        self._session_heartbeats[session_token] = created_at_tick
         retain_versions, _policy = self.registry.retention_meta()
         return SnapshotSession(
             session_token=session_token,
@@ -605,11 +681,16 @@ class CoordinatorService:
         # BEFORE the pin lookup. Unit 3 does the token-has-pin check only.
         cut = self.registry.get_session_cut(session_token)
         if cut is None:
-            # Unknown / released / (in-memory) post-restart token. Unit 5 splits
-            # the durable-liveness taxonomy (``session_invalidated``); Unit 3
-            # treats every no-cut token as not-found.
+            # FAIL CLOSED (Unit 5 / R4): no live cut for this token — it was
+            # reaped by the session-liveness sweep, GC-raced, wiped by an
+            # in-memory restart, released, or never opened. NEVER a live-HEAD
+            # fall-through. ``_classify_no_cut_reason`` splits the wire-stable
+            # taxonomy: ``session_invalidated`` for a reaped / restart-wiped /
+            # in-shape token ("re-establish your session"), ``session_not_found``
+            # for a genuinely never-opened / malformed token. Both are typed
+            # rejections; the split only sharpens the signal.
             return SessionReadRejection(
-                reason=SESSION_NOT_FOUND_REASON,
+                reason=self._classify_no_cut_reason(session_token),
                 artifact_id=artifact_id,
                 coordinator_epoch=epoch,
             )
@@ -792,11 +873,14 @@ class CoordinatorService:
         # token-has-pin check only.
         cut = self.registry.get_session_cut(session_token)
         if cut is None:
-            # Unknown / released / (in-memory) post-restart token. Unit 5 splits
-            # the durable-liveness taxonomy (``session_invalidated``); Unit 4
-            # treats every no-cut token as not-found.
+            # FAIL CLOSED (Unit 5 / R4): no live cut for this token — reaped,
+            # GC-raced, restart-wiped, released, or never opened. NEVER a silent
+            # fall-through to a live-HEAD commit. Same wire-stable taxonomy as
+            # ``session_read``: ``session_invalidated`` for a reaped / restart-
+            # wiped / in-shape token, ``session_not_found`` for a never-opened /
+            # malformed one.
             return SessionCommitRejection(
-                reason=SESSION_NOT_FOUND_REASON,
+                reason=self._classify_no_cut_reason(session_token),
                 artifact_id=artifact_id,
                 coordinator_epoch=epoch,
             )
@@ -843,6 +927,184 @@ class CoordinatorService:
         ``read_generation`` that would spuriously trip the fence.
         """
         return uuid5(NAMESPACE_URL, session_token)
+
+    # ------------------------------------------------------------------
+    # Session pin lifetime — heartbeat lease + liveness sweep (Unit 5 / R4)
+    # ------------------------------------------------------------------
+
+    def record_session_heartbeat(
+        self, *, session_token: str, owner: UUID, now_tick: int
+    ) -> bool:
+        """Refresh a snapshot session's heartbeat LEASE (SB-17 / TX-1, Unit 5 /
+        R4). Keyed by the server-minted SESSION TOKEN, owner-bound.
+
+        A session is NOT a MESI agent — this does NOT key by ``agent_id`` and does
+        NOT reuse :meth:`record_heartbeat` (the grant-holder heartbeat). It keeps
+        the session's own lease alive so the session-liveness sweep
+        (:meth:`enforce_session_liveness`) does not reap its pins while the owner
+        is still working. Monotonic like the grant heartbeat: ``max(prev,
+        incoming)``, so a stale/replayed lower tick never moves the lease back.
+
+        **Owner-bound (R13, security).** The caller must be the session's OWNER —
+        the identity bound at ``begin_session``. A FOREIGN caller must NOT be able
+        to keep another agent's session alive (that would let an attacker pin
+        versions against GC indefinitely under someone else's session). The owner
+        check is TIMING-SAFE: it compares the bound owner and the supplied
+        ``owner`` via :func:`hmac.compare_digest` over their stable 16-byte
+        big-endian encoding, so a foreign caller learns nothing from response
+        timing about how much of the id matched. A mismatch is rejected and the
+        lease is NOT refreshed.
+
+        Heartbeating an unknown / released / restart-wiped token is a typed
+        NO-OP: it returns ``False`` (never a crash, never a resurrection — a dead
+        session cannot be revived by a heartbeat; re-establish it via
+        ``begin_session``). It also does NOT create a lease for a token with no
+        owner binding, so a heartbeat cannot conjure a live lease for a
+        cut-less token.
+
+        Args:
+            session_token: The server-minted token from ``begin_session``.
+            owner: The caller's identity; must match the bound owner (timing-safe).
+            now_tick: The heartbeat tick (``>= 0``). Applied as ``max(prev,
+                incoming)``.
+
+        Returns:
+            ``True`` if the lease was refreshed (known token, owner matched),
+            else ``False`` (unknown/released/wiped token, or a foreign caller —
+            indistinguishable to the caller by design: a foreign caller is not
+            told whether the token exists).
+        """
+        if now_tick < 0:
+            raise ValueError("now_tick must be >= 0")
+        bound_owner = self._session_owners.get(session_token)
+        if bound_owner is None:
+            # Unknown / released / restart-wiped token: no owner binding ⇒ no
+            # lease to refresh. Typed no-op (never a crash, never a new lease).
+            return False
+        # Timing-safe owner-binding check (R13): compare over the stable 16-byte
+        # big-endian UUID encoding. A foreign caller cannot keep another's
+        # session alive AND cannot probe id-match progress via response timing.
+        if not hmac.compare_digest(
+            bound_owner.bytes, owner.bytes
+        ):
+            return False
+        prev = self._session_heartbeats.get(session_token)
+        if prev is None or now_tick > prev:
+            self._session_heartbeats[session_token] = now_tick
+        return True
+
+    def enforce_session_liveness(
+        self,
+        *,
+        current_tick: int,
+        heartbeat_timeout_ticks: int,
+    ) -> int:
+        """Reap snapshot sessions whose heartbeat lease has gone stale — the NEW
+        session-liveness sweep AXIS (SB-17 / TX-1, Unit 5 / R4).
+
+        Distinct from :meth:`enforce_stable_grant_timeouts`: that sweep walks
+        only M∪E GRANT-HOLDERS, and a snapshot session holds NO grant, so it is
+        invisible to the grant sweep. This sweep ENUMERATES SESSIONS (the
+        owner-bound token set) and reaps any whose lease is stale, reusing the
+        SAME heartbeat-staleness predicate SHAPE as the grant sweep (``current -
+        last_hb >= timeout``, with ``>=`` matching ADV-02) and the same
+        ``CrashRecoveryConfig`` knob (``heartbeat_timeout_ticks``). It does NOT
+        reuse ``max_hold_ticks`` — the absolute-age ceiling that a live heartbeat
+        must not exempt is Unit 7 (a SEPARATE cap), not the liveness lease.
+
+        Reaping a session: :meth:`registry.release_session` drops its pins (so its
+        pinned versions become collectible again), then its owner binding and
+        heartbeat lease are cleared and the token is recorded in the bounded
+        reaped tombstone. After reaping, a ``session_read`` / ``session_commit``
+        on that token fails closed with ``session_invalidated`` (the cut is gone).
+
+        A slow-but-LIVE session — one heartbeated within ``heartbeat_timeout_ticks``
+        — is NOT reaped. This is a PREDICATE on the lease, not a hard TTL: a
+        long-running session that keeps heartbeating survives indefinitely
+        (the absolute-age ceiling that overrides even a live heartbeat is the
+        SEPARATE Unit-7 cap).
+
+        Args:
+            current_tick: The sweep's logical clock (monotonic ticks, as the
+                grant sweep uses).
+            heartbeat_timeout_ticks: Reap any session whose lease is at least
+                this many ticks stale (or that somehow has no lease — defensive).
+
+        Returns:
+            The number of sessions reaped.
+        """
+        if heartbeat_timeout_ticks < 1:
+            raise ValueError("heartbeat_timeout_ticks must be >= 1")
+
+        # Snapshot the token set first — reaping mutates ``_session_owners`` /
+        # ``_session_heartbeats`` under the loop, so iterate a stable copy.
+        tokens = list(self._session_owners.keys())
+        reaped = 0
+        for session_token in tokens:
+            last_hb = self._session_heartbeats.get(session_token)
+            # Same staleness predicate SHAPE as the grant sweep (``>=`` per
+            # ADV-02). A missing lease (should not happen — begin_session seeds
+            # one) is treated as stale, defensively, so a leaseless session is
+            # never immortal.
+            stale = (
+                last_hb is None
+                or (current_tick - last_hb) >= heartbeat_timeout_ticks
+            )
+            if not stale:
+                continue
+            self._reap_session(session_token)
+            reaped += 1
+        return reaped
+
+    def _reap_session(self, session_token: str) -> None:
+        """Drop a session's pins + lease + owner binding and tombstone the token
+        (Unit 5 / R4). The single reap path so the order is consistent: release
+        the pins FIRST (the registry is the durable/authoritative pin store, so a
+        crash mid-reap leaves no live-pin-without-lease leak on sqlite), then
+        clear the service-layer lease + owner binding, then tombstone."""
+        # Pins first: the registry release is idempotent (unknown token → no-op),
+        # so a double-reap or a restart-wiped pin set is harmless.
+        self.registry.release_session(session_token)
+        self._session_heartbeats.pop(session_token, None)
+        self._session_owners.pop(session_token, None)
+        self._tombstone_token(session_token)
+
+    def _tombstone_token(self, session_token: str) -> None:
+        """Record a reaped token in the bounded FIFO tombstone (Unit 5 / R4).
+        Capped at :data:`_REAPED_TOMBSTONE_CAP`; the oldest entry is evicted when
+        full. Eviction is benign — an evicted in-shape token still classifies
+        ``session_invalidated`` via :func:`looks_like_session_token`, so the
+        fail-closed guarantee never depends on tombstone residency."""
+        # Move-to-end keeps the most-recently-reaped tokens; popitem(last=False)
+        # evicts the oldest (FIFO) when over the cap.
+        self._reaped_tombstone[session_token] = None
+        self._reaped_tombstone.move_to_end(session_token)
+        while len(self._reaped_tombstone) > _REAPED_TOMBSTONE_CAP:
+            self._reaped_tombstone.popitem(last=False)
+
+    def _classify_no_cut_reason(self, session_token: str) -> str:
+        """Classify a token that has NO live cut into the wire-stable fail-closed
+        reason (Unit 5 / R4). FAIL CLOSED in every branch — this only sharpens
+        the SIGNAL, never serves live HEAD.
+
+        - In the reaped tombstone → ``session_invalidated`` (definitely reaped
+          this process: "your session died, re-establish it").
+        - Shaped like a server-minted token (``looks_like_session_token``) →
+          ``session_invalidated``. This is the POST-RESTART-UNKNOWN safety case:
+          an in-memory restart wiped ``_session_pins`` (and the tombstone), so a
+          previously-valid token now has no cut — but it WAS a real session, so it
+          must fail closed as invalidated, NEVER served live HEAD as if pinned. A
+          well-formed-but-never-minted token also lands here (fail-closed is the
+          safe default for an in-shape token; it is rejected either way).
+        - Otherwise (out-of-shape / malformed) → ``session_not_found``: a
+          genuinely never-opened token. Kept reachable additively so a clearly
+          bogus token is still distinguishable.
+        """
+        if session_token in self._reaped_tombstone:
+            return SESSION_INVALIDATED_REASON
+        if looks_like_session_token(session_token):
+            return SESSION_INVALIDATED_REASON
+        return SESSION_NOT_FOUND_REASON
 
     def write(
         self,

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -14,7 +14,7 @@ import time
 import warnings
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Callable, Iterable, Optional
+from typing import Callable, Iterable, Mapping, Optional
 from uuid import NAMESPACE_URL, UUID, uuid5
 
 from ccs.coordinator.retention import collectible_versions
@@ -31,6 +31,7 @@ from ccs.core.exceptions import (
     UNKNOWN_ARTIFACT_REASON,
     CoherenceError,
     OccCallerTransientError,
+    SessionInvalidated,
     StaleReadGeneration,
 )
 from ccs.core.hashing import compute_content_hash
@@ -41,6 +42,8 @@ from ccs.core.types import (
     CasCorruption,
     ConflictDetail,
     DataPlaneDeferredRead,
+    EffectFired,
+    EffectHeld,
     FetchRequest,
     FetchResponse,
     InvalidationSignal,
@@ -241,6 +244,51 @@ def looks_like_session_token(token: str) -> bool:
         len(token) == _SESSION_TOKEN_LEN
         and all(ch in _SESSION_TOKEN_ALPHABET for ch in token)
     )
+
+
+class SessionView:
+    """A read-only view of a live snapshot session's PINNED cut, handed to the
+    ``effect_gate`` ``decide`` callback (SB-17 / TX-1, Unit 6 / EO-5).
+
+    The decision step reads the consistent cut — NOT live HEAD — through this thin
+    wrapper over :meth:`CoordinatorService.session_read`, so the caller's decision
+    is computed against exactly the pinned versions the gate will re-validate. It
+    is read-only by construction (it exposes no write/commit), and it FAILS CLOSED:
+    a ``session_read`` that returns a dead-session rejection
+    (``session_invalidated`` / ``session_not_found``) raises
+    :class:`SessionInvalidated` rather than letting the decision proceed on an
+    invalid cut. A ``DataPlaneDeferredRead`` (the eager / ``content=None`` branch,
+    where the coordinator holds no body) is returned as-is — the caller fetches the
+    pinned bytes from the data plane; the gate still re-validates by VERSION, which
+    is byte-source-independent.
+    """
+
+    def __init__(self, service: "CoordinatorService", session_token: str) -> None:
+        self._service = service
+        self._token = session_token
+
+    def read(
+        self, artifact_id: UUID
+    ) -> VersionedContent | DataPlaneDeferredRead:
+        """Read ``artifact_id`` at its pinned version. Fails closed on a dead
+        session or an un-pinned artifact (a typed rejection → raised
+        :class:`SessionInvalidated` / ``CoherenceError``) so a decision never runs
+        on an invalid cut."""
+        result = self._service.session_read(self._token, artifact_id)
+        if isinstance(result, SessionReadRejection):
+            if result.reason == SESSION_ARTIFACT_NOT_IN_CUT_REASON:
+                # Caller misuse: reading outside the pinned read-set. Not a dead
+                # session — a hard error, never a live-HEAD fall-through.
+                raise CoherenceError(
+                    f"effect_gate decide read an un-pinned artifact "
+                    f"{artifact_id}: {result.reason}"
+                )
+            # session_invalidated / session_not_found → fail closed.
+            raise SessionInvalidated(
+                f"effect_gate decide read failed closed: {result.reason} "
+                f"(artifact={artifact_id})"
+            )
+        return result
 
 
 class CoordinatorService:
@@ -927,6 +975,270 @@ class CoordinatorService:
         ``read_generation`` that would spuriously trip the fence.
         """
         return uuid5(NAMESPACE_URL, session_token)
+
+    # ------------------------------------------------------------------
+    # Effect-gate wrapper — "fire E iff read-set R unchanged" (Unit 6 / EO-5)
+    # ------------------------------------------------------------------
+
+    def effect_gate(
+        self,
+        *,
+        read_set: Iterable[UUID],
+        owner: UUID,
+        decide: Callable[["SessionView"], object],
+        effect: Callable[[object], object] | None = None,
+        commit: tuple[UUID, bytes | str] | None = None,
+        created_at_tick: int = 0,
+        issued_at_tick: int = 0,
+        release_on_exit: bool = True,
+    ) -> EffectFired | EffectHeld:
+        """Fire an effect IFF the whole read-set is still unchanged — the
+        ergonomic EO-5 surface (SB-17 / TX-1, Unit 6 = EO-4 = SB-17 user surface).
+
+        One call composes the shipped session primitives end to end:
+
+        1. **PIN** — ``begin_session(read_set)`` captures a consistent cut at one
+           linearization point (Unit 2).
+        2. **DECIDE** — the caller's ``decide`` callback reads the PINNED cut (via
+           a :class:`SessionView` over ``session_read``, Unit 3) and computes a
+           decision (the value it returns is threaded to an escaping effect).
+        3. **RE-VALIDATE** — at the effect boundary, re-read each read-set
+           member's CURRENT version (``registry.get_artifact(id).version``) and
+           compare to the pin. If EVERY member matches → fire; if ANY moved (or
+           vanished) → **HELD** (:class:`EffectHeld`), never fire on stale input.
+        4. **FIRE** — per mode (below).
+
+        Two effect modes (exactly one of ``effect`` / ``commit`` — passing both,
+        or neither, is caller misuse → ``ValueError``):
+
+        - **ATOMIC** (``commit=(artifact_id, content)``) — the effect IS an
+          artifact write, routed through :meth:`session_commit` so the shipped
+          ``commit_cas`` arbitrates AT the pinned base in the SAME step. There is
+          NO re-validate→fire window: "unchanged" and "commit" are one atomic
+          arbitration. The pre-fire re-validate still runs as a fast HELD short
+          circuit (it spares the CAS when a peer already moved the target), but
+          the AUTHORITATIVE guard is ``commit_cas`` — even if a peer commits in
+          the instant between the re-validate and the CAS, the CAS at the pinned
+          ``expected_version`` loses cleanly and returns :class:`ConflictDetail`
+          (surfaced as :class:`EffectHeld` with ``conflict`` set). This is the
+          STRONG guarantee.
+        - **ESCAPING** (``effect=callable``) — the effect is a non-commit side
+          effect (deploy / charge / click). The gate re-validates, then fires the
+          callable. **The guarantee is "the read-set was unchanged AS OF the
+          re-validate point", NOT "as of the fire point".** A peer can commit a
+          read-set member in the residual RE-VALIDATE→FIRE window — after the
+          check passed but before the callable runs — and the gate will STILL
+          fire (it gates pre-fire and never rolls back, EO-7). This window is
+          unclosable for escaping effects and is NOT claimed away. Use ATOMIC
+          mode when the effect is an artifact write and you need the window
+          closed; use ESCAPING for genuine side effects, accepting the bound.
+
+        **Fail-closed (in-process typed path).** This gate is a pure in-process
+        coordinator method — it composes the typed session results directly and
+        is NOT the HTTP/CoherentVolume path, so there is no 200-body deny/degrade
+        to translate. A dead session at ANY step (``session_read`` /
+        ``session_commit`` returning ``session_invalidated``/``session_not_found``,
+        or the cut vanishing at re-validate) RAISES :class:`SessionInvalidated`
+        and NEVER fires. (If this gate were ever rebuilt over the
+        ``coherent_volume`` HTTP surface, BOTH the ``ok:false`` deny body and the
+        ``degraded:true`` 200 body would map to a raise — never proceed
+        best-effort on a degrade, learnings #3 ``coordinator-invalidation-not-
+        mutex``. The in-process typed path enforces the same fail-closed shape by
+        construction.)
+
+        Reason classification uses ``reason == CONSTANT`` against the wire-stable
+        session reason sets, never a substring of a human message (the
+        typed-signal-not-substring house rule).
+
+        Args:
+            read_set: The artifacts to pin into the consistent cut.
+            owner: The creating caller's identity (bound to the minted session).
+            decide: Callback ``(view) -> decision``; reads the pinned cut via
+                ``view.read(artifact_id)`` and returns a decision value. For an
+                escaping effect the decision is passed to ``effect``.
+            effect: ESCAPING mode — a side-effect callable ``(decision) -> result``
+                fired only if re-validate passes. Mutually exclusive with ``commit``.
+            commit: ATOMIC mode — ``(artifact_id, content)`` committed via
+                ``session_commit`` at the pinned base. Mutually exclusive with ``effect``.
+            created_at_tick: Logical tick for ``begin_session`` (heartbeat seed).
+            issued_at_tick: Logical tick for the ATOMIC ``session_commit``.
+            release_on_exit: If ``True`` (default), the session's pins are released
+                after the gate resolves (fire or HELD), so a one-shot gate does not
+                leak a pin until the liveness sweep reaps it. Set ``False`` to keep
+                the session live for further use.
+
+        Returns:
+            :class:`EffectFired` if the read-set was unchanged (as of re-validate,
+            or atomically for ``commit``) and the effect fired, else
+            :class:`EffectHeld` (drift detected pre-fire, or an atomic OCC loss).
+
+        Raises:
+            ValueError: neither or both of ``effect`` / ``commit`` supplied.
+            SessionInvalidated: the session died mid-gate (fail-closed; no fire).
+        """
+        if (effect is None) == (commit is None):
+            raise ValueError(
+                "effect_gate requires exactly one of effect= (escaping mode) or "
+                "commit= (atomic mode); got "
+                + ("both" if effect is not None else "neither")
+            )
+
+        read_set = list(read_set)
+        session = self.begin_session(
+            read_set=read_set, owner=owner, created_at_tick=created_at_tick
+        )
+        if isinstance(session, VersionedReadRejection):
+            # An unknown id in the read-set never opened a session; surface it as
+            # a fail-closed raise (no cut to gate against, never a silent fire).
+            raise SessionInvalidated(
+                f"effect_gate could not pin the read-set: {session.reason} "
+                f"(artifact={session.artifact_id})"
+            )
+
+        token = session.session_token
+        try:
+            # DECIDE — the caller reads the PINNED cut and computes its decision.
+            view = SessionView(self, token)
+            decision = decide(view)
+
+            if commit is not None:
+                return self._effect_gate_atomic(
+                    session=session,
+                    commit=commit,
+                    issued_at_tick=issued_at_tick,
+                )
+            assert effect is not None  # narrowed by the XOR check above
+            return self._effect_gate_escaping(
+                session=session,
+                effect=effect,
+                decision=decision,
+            )
+        finally:
+            if release_on_exit:
+                # Best-effort cleanup: drop the pins so a one-shot gate does not
+                # hold versions back from GC until the liveness sweep. Idempotent
+                # on the registry (unknown token → no-op), and the service-layer
+                # lease/owner maps are dropped too so the token cannot linger.
+                self.registry.release_session(token)
+                self._session_heartbeats.pop(token, None)
+                self._session_owners.pop(token, None)
+
+    def _revalidate_cut(
+        self, cut: Mapping[UUID, int]
+    ) -> dict[UUID, "tuple[int, int | None]"]:
+        """Re-read each pinned member's CURRENT version and return the DRIFT map.
+
+        For every ``(artifact_id, pinned)`` in ``cut``, read the live current
+        version (``registry.get_artifact(id).version``); a vanished artifact reads
+        ``None`` (deleted / GC-raced under the pin). Returns ``{artifact_id:
+        (pinned, current)}`` for ONLY the members whose ``current != pinned`` (or
+        whose artifact vanished) — an empty dict means the whole vector is
+        unchanged. This is the pre-fire re-validate vector compare; it is
+        non-mutating (a read-only ``get_artifact`` per member, no grant, no
+        ``read_generation``)."""
+        moved: dict[UUID, "tuple[int, int | None]"] = {}
+        for artifact_id, pinned in cut.items():
+            artifact = self.registry.get_artifact(artifact_id)
+            current = artifact.version if artifact is not None else None
+            if current != pinned:
+                moved[artifact_id] = (pinned, current)
+        return moved
+
+    def _effect_gate_escaping(
+        self,
+        *,
+        session: SnapshotSession,
+        effect: Callable[[object], object],
+        decision: object,
+    ) -> EffectFired | EffectHeld:
+        """ESCAPING mode — re-validate the vector, then fire the side-effect
+        callable. Documents the residual re-validate→fire window (EO-7): the
+        callable fires on a vector proven unchanged AT the re-validate point, not
+        at the fire point — a peer commit in the window is NOT caught and the
+        effect is NOT rolled back. Use ATOMIC mode to close the window."""
+        moved = self._revalidate_cut(session.cut)
+        if moved:
+            # Drift detected BEFORE firing — HELD, the side effect never runs.
+            return EffectHeld(
+                moved=moved,
+                coordinator_epoch=session.coordinator_epoch,
+            )
+
+        # The vector was unchanged AS OF this point. Everything below this line is
+        # the unclosable RE-VALIDATE→FIRE WINDOW for an escaping effect: a peer can
+        # commit a read-set member here, after the check passed, before the
+        # callable runs. The gate gates PRE-FIRE and never rolls back (EO-7), so
+        # the guarantee is "unchanged as of re-validate", NOT "as of fire". This
+        # is intrinsic to a non-commit side effect (deploy/charge/click cannot be
+        # version-CAS'd); ATOMIC mode closes it by riding ``commit_cas``.
+        result = effect(decision)
+        return EffectFired(
+            revalidated_cut=dict(session.cut),
+            coordinator_epoch=session.coordinator_epoch,
+            result=result,
+        )
+
+    def _effect_gate_atomic(
+        self,
+        *,
+        session: SnapshotSession,
+        commit: tuple[UUID, bytes | str],
+        issued_at_tick: int,
+    ) -> EffectFired | EffectHeld:
+        """ATOMIC mode — route the write through ``session_commit`` so the shipped
+        ``commit_cas`` arbitrates at the pinned base in the SAME step. NO
+        re-validate→fire window: the CAS at ``expected_version=pin`` is the
+        authoritative guard. A pre-CAS re-validate runs as a fast HELD short
+        circuit (sparing the CAS when the target already moved), but even without
+        it the CAS would lose cleanly on a raced peer commit."""
+        artifact_id, content = commit
+        # Fast pre-CAS re-validate: if the COMMIT TARGET already moved, hold
+        # before attempting the CAS. (The CAS itself is still authoritative for
+        # the no-window guarantee; this only short-circuits the common case and
+        # surfaces a uniform drift map with the escaping mode.)
+        moved = self._revalidate_cut(session.cut)
+        if artifact_id in moved:
+            return EffectHeld(
+                moved=moved,
+                coordinator_epoch=session.coordinator_epoch,
+            )
+
+        # Atomic arbitration at the pinned base. ``session_commit`` reuses the
+        # shipped ``commit_cas`` verbatim (admit-on-absent → version-CAS), maps
+        # the CasCorruption sentinel to a raised CoherenceError, and returns the
+        # ConflictDetail unchanged on a lost race. A SessionCommitRejection here
+        # means the cut died mid-gate (token/pin gone) → fail closed.
+        outcome = self.session_commit(
+            session.session_token,
+            artifact_id,
+            content,
+            issued_at_tick=issued_at_tick,
+        )
+        if isinstance(outcome, SessionCommitRejection):
+            # Fail-closed: the session is gone (reaped / restart-wiped / released)
+            # — never a silent non-fire. Raise the typed dead-session error.
+            raise SessionInvalidated(
+                f"effect_gate atomic commit failed closed: {outcome.reason} "
+                f"(artifact={outcome.artifact_id})"
+            )
+        if isinstance(outcome, ConflictDetail):
+            # Lost the OCC race AT the pinned base — HELD, nothing mutated. Carry
+            # the shipped ConflictDetail through verbatim (the same taxonomy a
+            # bare session_commit surfaces). Re-read the post-conflict drift so
+            # ``moved`` reflects what actually changed under the commit target.
+            post = self._revalidate_cut(session.cut)
+            return EffectHeld(
+                moved=post,
+                coordinator_epoch=session.coordinator_epoch,
+                conflict=outcome,
+            )
+        # WIN — (updated_artifact, signals); the commit landed atomically at the
+        # pinned base with NO window.
+        return EffectFired(
+            revalidated_cut=dict(session.cut),
+            coordinator_epoch=session.coordinator_epoch,
+            commit=outcome,
+        )
 
     # ------------------------------------------------------------------
     # Session pin lifetime — heartbeat lease + liveness sweep (Unit 5 / R4)

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -22,6 +22,8 @@ from ccs.core.exceptions import (
     NOT_RETAINED_REASON,
     OCC_CALLER_TRANSIENT_REASON,
     RETENTION_OFF_REASON,
+    SESSION_ARTIFACT_NOT_IN_CUT_REASON,
+    SESSION_NOT_FOUND_REASON,
     UNKNOWN_ARTIFACT_REASON,
     CoherenceError,
     OccCallerTransientError,
@@ -34,9 +36,11 @@ from ccs.core.types import (
     Artifact,
     CasCorruption,
     ConflictDetail,
+    DataPlaneDeferredRead,
     FetchRequest,
     FetchResponse,
     InvalidationSignal,
+    SessionReadRejection,
     SnapshotSession,
     VersionedContent,
     VersionedReadRejection,
@@ -407,11 +411,13 @@ class CoordinatorService:
         # we already excluded version==current above, so this only ages the
         # requested historical row. ``policy is None`` ⇒ unbounded ⇒ no T axis.
         #
-        # Unit 3: a live-session pin must ALSO suppress THIS read-side logical
-        # T-expiry (a read-serve allowance distinct from the GC-hold the Unit 2
-        # ``exemptions`` seam already provides at the GC producers), so a pinned-
-        # but-age-collectible row is still SERVED. Not implemented here — the
-        # session-scoped read path is Unit 3; Unit 2 holds the version-map only.
+        # Unit 3 (DONE): the read-serve allowance — a live-session pin suppresses
+        # this read-side logical T-expiry so a pinned-but-age-collectible row is
+        # still SERVED — lives in ``session_read`` (the session-scoped path), NOT
+        # here. The bare ``read_at_version`` deliberately keeps ages-out semantics
+        # (no live session, no allowance); ``session_read`` passes the pinned
+        # version as its OWN ``exemptions`` to this same seam. (The GC-HOLD
+        # exemption — distinct — was wired by Unit 2 at the GC producers.)
         if policy is not None and version in collectible_versions(
             {version: captured_at},
             current_version=current,
@@ -512,6 +518,184 @@ class CoordinatorService:
             cut=result,
             coordinator_epoch=self.registry.coordinator_epoch,
             retain_versions=retain_versions,
+        )
+
+    def session_read(
+        self,
+        session_token: str,
+        artifact_id: UUID,
+    ) -> VersionedContent | DataPlaneDeferredRead | SessionReadRejection:
+        """Serve an artifact's PINNED version from a live snapshot session — the
+        non-mutating read from the consistent cut (SB-17 / TX-1, Unit 3 / R2).
+
+        A NEW service path, NOT an extension of ``read_at_version`` (which is the
+        bare history read with its own frozen 6-reason contract and its
+        deliberate ``version == current`` REJECTION). The two surfaces have
+        OPPOSITE rules for the current version — bare ``read_at_version`` rejects
+        it; ``session_read`` SERVES it — and a different validation gate (a live
+        pin, not raw retention state). Threading session-awareness through
+        ``read_at_version`` would entangle those contracts and muddy the
+        ``current_version`` rejection a pinned test pins; a separate path keeps
+        each surface honest. ``begin_session`` is the coherence event that earns
+        the pinned-version serve (including ``version == current``), so the
+        allowance is scoped to a valid live session here.
+
+        **Non-mutating (R2, the shipped invariant):** like ``read_at_version``,
+        this calls NONE of ``set_agent_state`` / ``set_agent_transient`` / grant /
+        invalidation code. It only READS the registry (``get_session_cut`` /
+        ``get_artifact`` / ``retention_meta`` / ``get_version_record`` /
+        ``coordinator_epoch``) and builds frozen returns, so it mints NO MESI
+        grant and captures NO ``read_generation`` (read-gen capture lives ONLY in
+        ``set_agent_state``). A reader is not an owner.
+
+        Bytes source — the deployment-dependent rule resolved at the serve layer
+        (KTD), keyed off the session's branch (``retain_versions``, recorded at
+        ``begin_session``):
+
+        - **LAZY (``retain_versions=True``)** — the coordinator HAS bodies in
+          history. Serve the PINNED version's body from ``get_version_record``
+          (the retained-history accessor): the current version's body is captured
+          into history at commit, so it serves BOTH ``pinned == current`` AND
+          ``pinned < current`` uniformly. The TRANSITION is automatic — once a
+          peer commits past the pin, ``current`` advances but the pinned row
+          persists in history, so the SAME ``get_version_record(pinned)`` keeps
+          serving the pinned bytes (re-read ``current`` each call, never cache
+          the branch). **Read-serve allowance (the Unit-3 obligation):** the
+          pinned version is passed as its OWN ``exemptions`` to the T-expiry
+          ``collectible_versions`` seam, so a pinned-but-age-collectible row is
+          STILL SERVED (distinct from the GC-hold the Unit-2 exemptions seam
+          already provides at the GC producers — this lifts the read-side LOGICAL
+          T-expiry that ``read_at_version`` would apply). A genuinely absent body
+          (``content=None`` committed even under retain=True, or a GC race)
+          degrades to the data-plane-deferred result, never a crash or wrong
+          bytes.
+        - **EAGER (``retain_versions=False`` / ``content=None`` ICP)** — the
+          coordinator holds NO body for the pinned version (bodies live in the
+          CoherentVolume data plane). Return a typed
+          :class:`~ccs.core.types.DataPlaneDeferredRead` carrying the pinned
+          version + epoch (+ ``content_hash`` when known) — the honest "ask the
+          data plane for the bytes" signal. The actual eager byte serve is
+          **Unit 6 (CoherentVolume)**; this method never reads the data plane.
+
+        Validation (Unit 3 scope): the token must have a live pin for
+        ``artifact_id``. An unknown/released token → ``session_not_found``; a live
+        token whose cut lacks ``artifact_id`` → ``artifact_not_in_cut`` — both
+        typed :class:`~ccs.core.types.SessionReadRejection`, NEVER a live-HEAD
+        fall-through. (Per-call OWNER-binding validation — a foreign owner reading
+        another's cut — is Unit 7; the heartbeat-liveness ``session_invalidated``
+        axis is Unit 5. Unit 3 does the token-has-pin check only.)
+
+        Args:
+            session_token: The server-minted session identity from
+                ``begin_session``.
+            artifact_id: The artifact to read at its pinned version.
+
+        Returns:
+            :class:`VersionedContent` (coordinator-held pinned bytes),
+            :class:`DataPlaneDeferredRead` (bytes live in the data plane), or a
+            :class:`SessionReadRejection` (no valid pin) — all typed RETURNS,
+            never an exception.
+        """
+        epoch = self.registry.coordinator_epoch
+
+        # Unit 7: per-call OWNER-binding validation goes HERE — read
+        # ``_session_owners[session_token]`` and reject a foreign caller
+        # (timing-safe compare) with the Unit-5 ``session_invalidated`` reason
+        # BEFORE the pin lookup. Unit 3 does the token-has-pin check only.
+        cut = self.registry.get_session_cut(session_token)
+        if cut is None:
+            # Unknown / released / (in-memory) post-restart token. Unit 5 splits
+            # the durable-liveness taxonomy (``session_invalidated``); Unit 3
+            # treats every no-cut token as not-found.
+            return SessionReadRejection(
+                reason=SESSION_NOT_FOUND_REASON,
+                artifact_id=artifact_id,
+                coordinator_epoch=epoch,
+            )
+        if artifact_id not in cut:
+            # A live session, but this artifact was not pinned. Reject — NEVER
+            # serve live HEAD for an un-pinned artifact (out of scope: a session
+            # wanting fresh data starts a new session).
+            return SessionReadRejection(
+                reason=SESSION_ARTIFACT_NOT_IN_CUT_REASON,
+                artifact_id=artifact_id,
+                coordinator_epoch=epoch,
+            )
+        pinned = cut[artifact_id]
+
+        # Read ``current`` ONCE (the per-call linearization snapshot) so the
+        # branch routing and the deferred-hash hint are decided against one view.
+        # The artifact may have been deleted out from under a live pin (the
+        # session_pins table deliberately has NO cascade FK); that fail-closed
+        # path is Unit 5 (``SessionInvalidated``). Until then a missing artifact
+        # under a live pin degrades to data-plane-deferred (never wrong bytes).
+        artifact = self.registry.get_artifact(artifact_id)
+        current = artifact.version if artifact is not None else None
+        # The pinned version's hash is knowable only when it is STILL current
+        # (the artifacts table holds the current hash only); a superseded pin's
+        # hash is not separately retained on the coordinator.
+        pinned_hash = (
+            artifact.content_hash
+            if artifact is not None and current == pinned
+            else None
+        )
+
+        retain_versions, policy = self.registry.retention_meta()
+        if not retain_versions:
+            # EAGER branch: the coordinator never retained a body for the pinned
+            # version — the canonical bytes live in the data plane. Honest typed
+            # deferral (pinned coordinates only, NO bytes); the data-plane serve
+            # is Unit 6.
+            return DataPlaneDeferredRead(
+                artifact_id=artifact_id,
+                version=pinned,
+                content_hash=pinned_hash,
+                coordinator_epoch=epoch,
+            )
+
+        # LAZY branch: serve the pinned version's body from retained history
+        # (the current version's body is captured into history at commit, so
+        # this serves both pinned==current and pinned<current). A genuinely
+        # absent body (content=None under retain=True, or a GC race) is NOT a
+        # crash — degrade to the data-plane-deferred signal.
+        record = self.registry.get_version_record(artifact_id, pinned)
+        if record is None:
+            return DataPlaneDeferredRead(
+                artifact_id=artifact_id,
+                version=pinned,
+                content_hash=pinned_hash,
+                coordinator_epoch=epoch,
+            )
+        content, captured_at = record
+
+        # Read-serve allowance (the Unit-3 obligation): the pinned version is its
+        # OWN exemption to the read-side LOGICAL T-expiry, so a pinned-but-age-
+        # collectible row is STILL served. Because ``pinned`` is always in
+        # ``exemptions``, ``collectible_versions`` can never mark it — the call is
+        # kept (rather than skipped) to make the allowance explicit and to age
+        # NOTHING else here. ``policy is None`` ⇒ unbounded ⇒ no T axis. This is
+        # the read-serve counterpart to the Unit-2 GC-hold ``exemptions`` seam.
+        if policy is not None and current is not None:
+            _served_despite_age = pinned not in collectible_versions(
+                {pinned: captured_at},
+                current_version=current,
+                policy=policy,
+                now=time.time(),
+                exemptions={pinned},
+            )
+            # Invariant by construction: a self-exempt version is never
+            # collectible. Asserting documents intent without a runtime branch.
+            assert _served_despite_age, (
+                "pinned version unexpectedly collectible despite self-exemption "
+                "(the read-serve allowance regressed)"
+            )
+
+        return VersionedContent(
+            artifact_id=artifact_id,
+            version=pinned,
+            content=content,
+            captured_at=captured_at,
+            coordinator_epoch=epoch,
         )
 
     def write(

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -6,11 +6,12 @@
 from __future__ import annotations
 
 import logging
+import secrets
 import threading
 import time
 import warnings
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Callable, Iterable, Optional
 from uuid import UUID
 
 from ccs.coordinator.retention import collectible_versions
@@ -36,6 +37,7 @@ from ccs.core.types import (
     FetchRequest,
     FetchResponse,
     InvalidationSignal,
+    SnapshotSession,
     VersionedContent,
     VersionedReadRejection,
 )
@@ -180,11 +182,24 @@ def validate_crash_recovery_config(
     )
 
 
+# Snapshot session token entropy (SB-17 / TX-1, Unit 2 / R13). 32 bytes →
+# ~43 url-safe chars; unguessable, server-minted, never client-supplied. The
+# timing-safe compare + per-call validation that consume it are Unit 7.
+_SESSION_TOKEN_BYTES = 32
+
+
 class CoordinatorService:
     """Control-plane service for artifact read/write/commit synchronization."""
 
     def __init__(self, registry: ArtifactRegistry):
         self.registry = registry
+        # Snapshot session owner-binding (SB-17 / TX-1, Unit 2 / R13):
+        # ``{session_token: owner_id}``. Populated at ``begin_session`` mint;
+        # the per-call validation that READS it (a foreign owner →
+        # SessionInvalidated, timing-safe compare) is Unit 7. Service-scoped (a
+        # restart drops the bindings — the durable pins survive on sqlite, but
+        # re-validating a post-restart token is the Unit 5 liveness concern).
+        self._session_owners: dict[str, UUID] = {}
 
     def register_artifact(
         self,
@@ -391,6 +406,12 @@ class CoordinatorService:
         # the next capture). ``current`` is exempt in collectible_versions, but
         # we already excluded version==current above, so this only ages the
         # requested historical row. ``policy is None`` ⇒ unbounded ⇒ no T axis.
+        #
+        # Unit 3: a live-session pin must ALSO suppress THIS read-side logical
+        # T-expiry (a read-serve allowance distinct from the GC-hold the Unit 2
+        # ``exemptions`` seam already provides at the GC producers), so a pinned-
+        # but-age-collectible row is still SERVED. Not implemented here — the
+        # session-scoped read path is Unit 3; Unit 2 holds the version-map only.
         if policy is not None and version in collectible_versions(
             {version: captured_at},
             current_version=current,
@@ -424,6 +445,73 @@ class CoordinatorService:
             requested_version=requested_version,
             current_version=current_version,
             coordinator_epoch=epoch,
+        )
+
+    def begin_session(
+        self,
+        *,
+        read_set: Iterable[UUID],
+        owner: UUID,
+    ) -> SnapshotSession | VersionedReadRejection:
+        """Open a consistent multi-artifact snapshot session (SB-17 / TX-1,
+        Unit 2 / R1, R13). Pins a coherent CUT of ``read_set`` at one
+        linearization point and returns an inspectable
+        :class:`~ccs.core.types.SnapshotSession`.
+
+        Orchestration (Unit 2 scope):
+
+        1. Mint a server-minted ``session_token`` (``secrets.token_urlsafe`` —
+           unguessable, never client-supplied; R9/R13) and bind it to ``owner``
+           (the creating caller's MESI agent/process identity) in
+           ``_session_owners``. (Unit 2 mints + owner-binds AT CREATION ONLY;
+           per-call token validation, timing-safe compare, caps, the
+           heartbeat-lease, and the absolute-age ceiling are LATER units 5/7.)
+        2. Call the registry's atomic ``capture_version_vector`` — the cut is
+           captured and pinned in one linearization point, non-mutating (no MESI
+           grant, no ``read_generation``). An unknown id in ``read_set`` returns
+           a typed :class:`VersionedReadRejection` (``unknown_artifact``) with NO
+           pins inserted; the token binding is then dropped (no half-open session
+           for a rejected cut).
+        3. Read ``retain_versions`` from the store (the deployment-branch
+           indicator) and return the :class:`SnapshotSession` with the
+           INSPECTABLE cut (R11).
+
+        Byte handling is explicitly NOT here (Unit 3): this captures the
+        version-MAP only and records ``retain_versions``; the eager-vs-lazy serve
+        is resolved at the serve layer. For ``content=None`` / cross-process the
+        bytes live in the data plane, not the coordinator.
+
+        Args:
+            read_set: The artifact ids to pin into the consistent cut.
+            owner: The creating caller's identity (the MESI agent/process label),
+                bound to the minted token for R13 owner-binding.
+
+        Returns:
+            A :class:`SnapshotSession` on success, else a
+            :class:`VersionedReadRejection` (``unknown_artifact``) — no session
+            opened, no pins held.
+        """
+        session_token = secrets.token_urlsafe(_SESSION_TOKEN_BYTES)
+        # Owner-bind at mint (R13). Recorded BEFORE the capture so a concurrent
+        # later-unit validator never sees a pinned-but-unowned token; dropped
+        # again if the capture rejects. NOTE for Unit 7 (the per-call validator):
+        # the INVERSE window also exists — between this line and the capture
+        # below, the token is owned but PINLESS. Unit 7 must treat an owned-but-
+        # pinless token as not-yet-live (or read owner-binding + pins together),
+        # never as a valid empty session.
+        self._session_owners[session_token] = owner
+        result = self.registry.capture_version_vector(read_set, session_token)
+        if isinstance(result, VersionedReadRejection):
+            # No cut pinned (unknown id) ⇒ no session. Drop the owner binding so
+            # the rejected token cannot linger as a half-open session.
+            self._session_owners.pop(session_token, None)
+            return result
+        retain_versions, _policy = self.registry.retention_meta()
+        return SnapshotSession(
+            session_token=session_token,
+            cut=result,
+            coordinator_epoch=self.registry.coordinator_epoch,
+            retain_versions=retain_versions,
         )
 
     def write(

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -113,7 +113,7 @@ CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
 """Reuses the same schema version as in-memory registry (state_log emissions
 are interchangeable from a downstream consumer's perspective)."""
 
-SCHEMA_USER_VERSION = 3
+SCHEMA_USER_VERSION = 4
 """Schema version stamped via ``PRAGMA user_version`` on init.
 
 **v1 -> v2** (plan item N v1) added the durable ``artifact_versions`` table and
@@ -127,6 +127,18 @@ snapshot session's cut survives a coordinator restart (R6, sqlite-only). The
 migration is idempotent (``CREATE TABLE IF NOT EXISTS`` + an in-txn version
 stamp) and additive — it touches NO existing table, so the v2->v3 step is
 purely a new-surface add.
+
+**v3 -> v4** (SB-17 / TX-1, durable owner-binding) adds the ``session_meta``
+table (the durable session owner + creation tick, so a survived session is
+owner-validated post-restart — R13 holds across a restart) and the
+``idx_session_pins_artifact`` index (the GC-exemption lookup probes
+``session_pins`` by the non-leftmost-PK ``artifact_id`` on every commit). Both
+are additive; the v3->v4 step is required because earlier commits of this branch
+already stamped ``user_version=3`` with ``session_pins`` but WITHOUT
+``session_meta`` — a bare in-place add would leave such a db unable to find
+``session_meta`` (it opens via the write-free rehydrate path). The dedicated
+``_migrate_v3_to_v4`` creates both for any v3 db; a Node-v3 db is rejected by
+``_reject_foreign_ledger_db`` before reaching it.
 
 **CROSS-RUNTIME LEDGER DIVERGENCE (security).** The sibling Node coordinator
 (agent-coherence-plugin) shares the SAME ``state.db`` path but keeps its OWN
@@ -143,10 +155,17 @@ implementable. See ``_migrate_v1_to_v2`` / ``_migrate_v2_to_v3`` and
 
 _V2_USER_VERSION = 2
 """The intermediate v2 stamp the v1->v2 migration writes (before the chained
-v2->v3 step advances to ``SCHEMA_USER_VERSION``). Pinned as a literal because
-the v1->v2 migration must NOT jump straight to the current
-``SCHEMA_USER_VERSION`` — it lands the v2 schema, then ``_migrate_v2_to_v3``
-adds ``session_pins`` and stamps v3. A v1 db therefore steps 1 -> 2 -> 3."""
+v2->v3 step). Pinned as a literal because the v1->v2 migration must NOT jump
+straight to ``SCHEMA_USER_VERSION`` — it lands the v2 schema, then
+``_migrate_v2_to_v3`` adds ``session_pins`` and stamps v3, then
+``_migrate_v3_to_v4`` adds ``session_meta``. A v1 db steps 1 -> 2 -> 3 -> 4."""
+
+_V3_USER_VERSION = 3
+"""The intermediate v3 stamp ``_migrate_v2_to_v3`` writes (session_pins only),
+before the chained ``_migrate_v3_to_v4`` step adds ``session_meta`` + the
+``session_pins`` artifact index and advances to ``SCHEMA_USER_VERSION``. A
+literal because session_pins-at-v3 is a distinct on-disk state earlier commits
+of this branch already produced."""
 
 _DB_FILE_MODE = 0o600
 """state.db (and its -wal/-shm sidecars) must be owner-read/write only.
@@ -202,6 +221,32 @@ CREATE TABLE session_pins (
     artifact_id   TEXT NOT NULL,
     version       INTEGER NOT NULL,
     PRIMARY KEY (session_token, artifact_id)
+)
+"""
+
+# The GC exemption read (``_live_pins_for_artifact_sql``, run on EVERY commit's
+# retention pass) filters ``session_pins`` by ``artifact_id`` — the NON-leftmost
+# column of the (session_token, artifact_id) PK, so without this index every
+# commit does a full scan of session_pins (finding F6). The index makes the
+# exemption lookup an index probe.
+_SESSION_PINS_ARTIFACT_INDEX_DDL = (
+    "CREATE INDEX idx_session_pins_artifact ON session_pins(artifact_id)"
+)
+
+# Durable session OWNER + creation tick (SB-17 / TX-1, R13/R6/R14). The pins in
+# ``session_pins`` are durable and survive a coordinator restart, but the
+# service-layer owner-binding + lease are in-memory and a restart wipes them —
+# which would let ANY token-holder read a surviving cut post-restart (an
+# owner-isolation bypass, finding F3). Persisting the owner alongside the pins
+# lets post-restart validation fall back to the durable owner (R13 preserved
+# across restart) while still serving the legitimate owner (R6 restart-survival
+# preserved). ``created_at_tick`` survives too so the absolute-age ceiling (R14)
+# can bound a durable session even after a restart wiped its in-memory state.
+_SESSION_META_DDL = """
+CREATE TABLE session_meta (
+    session_token   TEXT PRIMARY KEY,
+    owner           TEXT NOT NULL,
+    created_at_tick INTEGER NOT NULL
 )
 """
 
@@ -531,20 +576,26 @@ class SqliteArtifactRegistry:
         The migration DISPATCH (the repo's first real one):
 
         - ``user_version == 0`` (brand-new file) → ``_apply_v2_schema``: the
-          COMPLETE v2 schema in one atomic transaction (no shim ever runs on a
+          COMPLETE current schema (v2 tables + ``session_pins`` + ``session_meta``
+          + the artifact index) in one atomic transaction (no shim ever runs on a
           fresh db).
-        - ``user_version == 1`` (any wild v1 variant) → ``_migrate_v1_to_v2``
-          then ``_migrate_v2_to_v3``: idempotently subsumes BOTH additive shims
-          (fence columns + epoch seed, and ``pending_notices``), adds
-          ``artifact_versions`` (v2), and adds ``session_pins`` (v3). The wild v1
-          population is a 2x2 matrix ({±fence columns} x {±pending_notices})
-          because both shims shipped with no version bump; ``PRAGMA table_info``
-          / ``IF NOT EXISTS`` guards make each piece apply only when missing.
-        - ``user_version == 2`` → ``_migrate_v2_to_v3``: adds ``session_pins``
-          and stamps ``user_version=3`` in ONE ``BEGIN IMMEDIATE`` (additive —
-          touches no existing table).
-        - ``user_version == 3`` → ``_rehydrate_meta``: the WRITE-FREE open path
-          (no ALTER, no IF-NOT-EXISTS) — the prerequisite for read-only mode.
+        - ``user_version == 1`` (any wild v1 variant) → ``_migrate_v1_to_v2`` then
+          ``_migrate_v2_to_v3`` then ``_migrate_v3_to_v4``: idempotently subsumes
+          BOTH additive shims (fence columns + epoch seed, and ``pending_notices``),
+          adds ``artifact_versions`` (v2), ``session_pins`` (v3), then
+          ``session_meta`` + the artifact index (v4). The wild v1 population is a
+          2x2 matrix ({±fence columns} x {±pending_notices}) because both shims
+          shipped with no version bump; ``IF NOT EXISTS`` guards make each piece
+          apply only when missing.
+        - ``user_version == 2`` → ``_migrate_v2_to_v3`` then ``_migrate_v3_to_v4``:
+          adds ``session_pins`` (v3), then ``session_meta`` + the index (v4).
+        - ``user_version == 3`` → ``_migrate_v3_to_v4``: an existing v3 db
+          (``session_pins`` present, ``session_meta`` ABSENT — earlier commits of
+          this branch stamped it) gains ``session_meta`` + the index. Without this
+          branch such a db would open write-free and crash on the first session op.
+        - ``user_version == 4`` (SCHEMA_USER_VERSION) → ``_rehydrate_meta``: the
+          WRITE-FREE open path (no ALTER, no IF-NOT-EXISTS) — the prerequisite for
+          read-only mode.
         - anything else → :class:`SchemaVersionError` (no destructive advice).
 
         A :class:`CrossRuntimeSchemaError` pre-empts ALL of the above when the
@@ -560,15 +611,24 @@ class SqliteArtifactRegistry:
             if current == 0:
                 self._apply_v2_schema(instance_id)
             elif current == 1:
-                # v1 → v2 → v3: the v1->v2 migration rehydrates meta; the chained
-                # v2->v3 step then adds session_pins and re-rehydrates. Each step
-                # is its own atomic BEGIN IMMEDIATE.
+                # v1 → v2 → v3 → v4: each step is its own atomic BEGIN IMMEDIATE
+                # and rehydrates meta; the chain lands the full current schema.
                 self._migrate_v1_to_v2(instance_id)
                 self._migrate_v2_to_v3(instance_id)
+                self._migrate_v3_to_v4(instance_id)
             elif current == 2:
+                # 2 → 3 → 4: add session_pins, then session_meta + the index.
                 self._migrate_v2_to_v3(instance_id)
+                self._migrate_v3_to_v4(instance_id)
+            elif current == _V3_USER_VERSION:
+                # An existing v3 db (session_pins, NO session_meta — earlier
+                # commits of this branch stamped it) → add session_meta + index.
+                # WITHOUT this branch such a db would open write-free and crash on
+                # the first session op with 'no such table: session_meta'.
+                self._migrate_v3_to_v4(instance_id)
             elif current == SCHEMA_USER_VERSION:
-                # Existing v3 database — rehydrate; NO writes on this path.
+                # Existing v4 database — rehydrate; NO writes on this path (the
+                # prerequisite for read-only open mode).
                 self._rehydrate_meta(instance_id)
             else:
                 raise SchemaVersionError(
@@ -846,6 +906,8 @@ class SqliteArtifactRegistry:
             # session_pins (v3, SB-17 Unit 2): a fresh db is created at the full
             # current schema directly — no v2->v3 shim ever runs against it.
             c.execute(_SESSION_PINS_DDL)
+            c.execute(_SESSION_PINS_ARTIFACT_INDEX_DDL)
+            c.execute(_SESSION_META_DDL)
             seed_epoch = uuid4().hex
             # schema_runtime: the cross-runtime lineage stamp, seeded inside
             # THIS creation transaction (no extra txn) so the sibling Node
@@ -1027,32 +1089,32 @@ class SqliteArtifactRegistry:
         self._tighten_existing_db_mode_and_warn()
 
     def _migrate_v2_to_v3(self, instance_id: str | None) -> None:
-        """Migrate a v2 db to v3 in ONE atomic transaction (SB-17 / TX-1, Unit 2).
-        Caller holds lock.
+        """Migrate a v2 db to the intermediate v3 in ONE atomic transaction
+        (SB-17 / TX-1, Unit 2). Caller holds lock. Chained to ``_migrate_v3_to_v4``
+        by the open dispatcher (a v2 db steps 2 -> 3 -> 4).
 
         Additive-only: adds the ``session_pins`` table and stamps
-        ``user_version=SCHEMA_USER_VERSION`` — it touches NO existing table, so
-        there is no shim to subsume and no content/mode posture change (the v2->v3
-        step does not alter the disclosure surface). Same atomicity discipline as
-        ``_migrate_v1_to_v2`` (the
+        ``user_version=_V3_USER_VERSION`` — it touches NO existing table, so there
+        is no shim to subsume and no content/mode posture change. Same atomicity
+        discipline as ``_migrate_v1_to_v2`` (the
         sqlite-schema-init-non-atomic-leaves-unbootable-db learning): ONE explicit
-        ``BEGIN IMMEDIATE`` wrapping the DDL + the ``PRAGMA user_version`` stamp
-        (transactional inside an explicit txn), individual ``execute()`` calls
-        (never ``executescript``), and ``except BaseException`` ROLLBACK so a
-        SIGKILL mid-migration leaves the v2 db intact for a clean re-migrate.
+        ``BEGIN IMMEDIATE`` wrapping the DDL + the ``PRAGMA user_version`` stamp,
+        individual ``execute()`` calls (never ``executescript``), and ``except
+        BaseException`` ROLLBACK so a SIGKILL mid-migration leaves the v2 db intact
+        for a clean re-migrate. ``session_meta`` + the artifact index belong to
+        the v3->v4 step (they were added after earlier commits already stamped v3).
 
         Concurrent-loser path: two processes can both read ``user_version == 2``
         (a bare pre-lock read) and both land here; they serialize on the
         ``BEGIN IMMEDIATE`` write lock. The loser re-reads ``user_version`` INSIDE
-        its txn, sees the winner already stamped v3, and no-ops (``CREATE TABLE IF
-        NOT EXISTS`` would be harmless either way, but the early COMMIT avoids
-        re-running a future non-idempotent v4 step under the same race).
+        its txn, sees the winner already at >= v3, and no-ops.
         """
         c = self._conn
         c.execute("BEGIN IMMEDIATE")
         try:
-            if c.execute("PRAGMA user_version").fetchone()[0] >= SCHEMA_USER_VERSION:
-                # A racing winner already advanced to v3 — nothing to do.
+            if c.execute("PRAGMA user_version").fetchone()[0] >= _V3_USER_VERSION:
+                # A racing winner already advanced to >= v3 — nothing to do here
+                # (the chained v3->v4 step runs next regardless).
                 c.execute("COMMIT")
                 self._rehydrate_meta(instance_id)
                 return
@@ -1060,6 +1122,53 @@ class SqliteArtifactRegistry:
             # prior crashed migration whose user_version stamp never committed).
             c.execute(
                 _SESSION_PINS_DDL.replace("CREATE TABLE", "CREATE TABLE IF NOT EXISTS", 1)
+            )
+            c.execute(f"PRAGMA user_version = {_V3_USER_VERSION}")
+            c.execute("COMMIT")
+        except BaseException:
+            try:
+                c.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
+        # Load meta from the now-migrated db (write-free).
+        self._rehydrate_meta(instance_id)
+
+    def _migrate_v3_to_v4(self, instance_id: str | None) -> None:
+        """Migrate a v3 db (``session_pins`` present, ``session_meta`` absent) to
+        v4 in ONE atomic transaction (SB-17 / TX-1, durable owner-binding). Caller
+        holds lock.
+
+        Why a dedicated step rather than folding it into the v2->v3 add: earlier
+        commits of THIS branch already shipped ``user_version=3`` with
+        ``session_pins`` but no ``session_meta``. Such a db opens via the
+        write-free rehydrate path (``current == SCHEMA_USER_VERSION`` once that was
+        4) and would NEVER gain ``session_meta`` — so every ``begin_session`` /
+        liveness sweep would raise ``no such table: session_meta``. Routing
+        ``current == 3`` through this step creates the table (and the
+        ``session_pins`` artifact index) for any v3 db, fresh-this-build or
+        earlier-branch.
+
+        Additive-only (``session_meta`` + ``idx_session_pins_artifact``), same
+        atomicity discipline as the other migrations. Idempotent via ``IF NOT
+        EXISTS`` (a fresh-this-build db already created both in ``_apply_v2_schema``
+        and never routes here; this step only fires for an existing v3 db).
+        """
+        c = self._conn
+        c.execute("BEGIN IMMEDIATE")
+        try:
+            if c.execute("PRAGMA user_version").fetchone()[0] >= SCHEMA_USER_VERSION:
+                # A racing winner already advanced to v4 — nothing to do.
+                c.execute("COMMIT")
+                self._rehydrate_meta(instance_id)
+                return
+            c.execute(
+                _SESSION_META_DDL.replace("CREATE TABLE", "CREATE TABLE IF NOT EXISTS", 1)
+            )
+            c.execute(
+                _SESSION_PINS_ARTIFACT_INDEX_DDL.replace(
+                    "CREATE INDEX", "CREATE INDEX IF NOT EXISTS", 1
+                )
             )
             c.execute(f"PRAGMA user_version = {SCHEMA_USER_VERSION}")
             c.execute("COMMIT")
@@ -1738,7 +1847,12 @@ class SqliteArtifactRegistry:
     # ------------------------------------------------------------------
 
     def capture_version_vector(
-        self, read_set: Iterable[UUID], session_token: str
+        self,
+        read_set: Iterable[UUID],
+        session_token: str,
+        *,
+        owner: UUID | None = None,
+        created_at_tick: int | None = None,
     ) -> CaptureResult:
         """Atomically pin a consistent multi-artifact CUT (SB-17 / TX-1, Unit 2 /
         R1). Written fresh from the contract — parity with
@@ -1814,6 +1928,19 @@ class SqliteArtifactRegistry:
                         "(session_token, artifact_id, version) VALUES (?, ?, ?)",
                         (session_token, artifact_id.hex, version),
                     )
+                # Durable owner-binding (R13/R6/R14): persist the owner + creation
+                # tick atomically with the pins so a post-restart read can fall
+                # back to the durable owner (foreign caller rejected) and the
+                # absolute-age ceiling can bound a survived session. Written even
+                # for an empty cut (zero pins) so the owner-binding still survives.
+                # Skipped only when the caller did not supply an owner (direct
+                # registry-level test captures): those create no durable session.
+                if owner is not None:
+                    self._conn.execute(
+                        "INSERT OR REPLACE INTO session_meta "
+                        "(session_token, owner, created_at_tick) VALUES (?, ?, ?)",
+                        (session_token, owner.hex, int(created_at_tick or 0)),
+                    )
                 self._conn.execute("COMMIT")
                 return cut
             except BaseException:
@@ -1821,9 +1948,12 @@ class SqliteArtifactRegistry:
                 raise
 
     def release_session(self, session_token: str) -> None:
-        """Drop a session's pins so its pinned versions become collectible again
-        (Unit 2 / R4). Idempotent — releasing an unknown/already-released token
-        deletes zero rows (no raise), mirroring the in-memory ``dict.pop``."""
+        """Drop a session's pins AND its durable owner-binding so its pinned
+        versions become collectible again (Unit 2 / R4). Idempotent — releasing
+        an unknown/already-released token deletes zero rows (no raise), mirroring
+        the in-memory ``dict.pop``. Drops ``session_pins`` and ``session_meta`` in
+        ONE txn so a reap can never leave a durable owner without its pins (or
+        vice versa)."""
         self._guard_writable()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
@@ -1832,10 +1962,58 @@ class SqliteArtifactRegistry:
                     "DELETE FROM session_pins WHERE session_token = ?",
                     (session_token,),
                 )
+                self._conn.execute(
+                    "DELETE FROM session_meta WHERE session_token = ?",
+                    (session_token,),
+                )
                 self._conn.execute("COMMIT")
             except BaseException:
                 self._conn.execute("ROLLBACK")
                 raise
+
+    def get_session_meta(self, session_token: str) -> tuple[UUID, int] | None:
+        """Return the durable ``(owner, created_at_tick)`` for ``session_token``,
+        or ``None`` if there is none (SB-17 / TX-1, R13/R6/R14). Survives a
+        coordinator restart (unlike the service-layer in-memory owner-binding), so
+        post-restart owner validation can fall back to this: the legitimate owner
+        is still served (R6) and a leaked-token foreign caller is still rejected
+        (R13). A token that pinned an empty cut still has a meta row (the owner was
+        recorded regardless of pin count)."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT owner, created_at_tick FROM session_meta "
+                "WHERE session_token = ?",
+                (session_token,),
+            ).fetchone()
+        if row is None:
+            return None
+        return (UUID(hex=row[0]), int(row[1]))
+
+    def all_session_meta(self) -> dict[str, tuple[UUID, int]]:
+        """Return ``{session_token: (owner, created_at_tick)}`` for every durable
+        session (SB-17 / TX-1, R6/R14). The session-liveness sweep enumerates this
+        UNION'd with its in-memory token set so a durable session that survived a
+        restart (in-memory state wiped) is still bounded by the absolute-age
+        ceiling and its orphaned pins are eventually reaped. Bounded by
+        ``max_sessions`` and read on the infrequent sweep only."""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT session_token, owner, created_at_tick FROM session_meta"
+            ).fetchall()
+        return {r[0]: (UUID(hex=r[1]), int(r[2])) for r in rows}
+
+    def session_count(self) -> int:
+        """Return the number of LIVE sessions (SB-17 / TX-1, R14). Every session —
+        in-memory OR a durable-only restart survivor — has exactly one
+        ``session_meta`` row (written at ``begin_session``, dropped at
+        reap/release), so this is the authoritative total the ``max_sessions`` cap
+        must bound. Counting only the service-layer in-memory map would undercount
+        durable survivors post-restart, letting the pinned-cut count transiently
+        exceed the GC-starvation bound."""
+        with self._lock:
+            return int(
+                self._conn.execute("SELECT COUNT(*) FROM session_meta").fetchone()[0]
+            )
 
     def get_session_cut(self, session_token: str) -> dict[UUID, int] | None:
         """Return the pinned cut ``{artifact_id: version}`` for ``session_token``,

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -1837,6 +1837,37 @@ class SqliteArtifactRegistry:
                 self._conn.execute("ROLLBACK")
                 raise
 
+    def get_session_cut(self, session_token: str) -> dict[UUID, int] | None:
+        """Return the pinned cut ``{artifact_id: version}`` for ``session_token``,
+        or ``None`` if the token has no live pin rows (SB-17 / TX-1, Unit 3 / R2).
+
+        The single accessor ``session_read`` needs to (a) tell a known token from
+        an unknown/released one (``None`` ⇒ ``session_not_found``) and (b) read
+        the per-artifact pinned version for the serve. Reads the durable
+        ``session_pins`` table under one lock, so a coordinator RESTART correctly
+        re-serves a non-empty sqlite session (the durable mirror is the whole
+        point of R6 restart-survival), where an in-memory session would read
+        ``None`` post-restart — the asserted parity divergence.
+
+        Degenerate empty-read-set caveat (documented divergence): an empty cut
+        inserts ZERO ``session_pins`` rows, so sqlite cannot durably distinguish
+        an empty LIVE session from an unknown token — both read ``None`` here. The
+        in-memory mirror keeps an empty ``{}`` entry and returns it. This diverges
+        ONLY for a session that pinned nothing, which has no servable
+        ``session_read`` either way (no artifact is in its cut), so the
+        downstream rejection is benign on both arms (``session_not_found`` on
+        sqlite vs ``artifact_not_in_cut`` in-memory). The realistic non-empty
+        read-set is identical on both registries."""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT artifact_id, version FROM session_pins "
+                "WHERE session_token = ?",
+                (session_token,),
+            ).fetchall()
+        if not rows:
+            return None
+        return {UUID(hex=r[0]): int(r[1]) for r in rows}
+
     # ------------------------------------------------------------------
     # ArtifactRegistry surface — agent state map
     # ------------------------------------------------------------------

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -93,11 +93,17 @@ from ccs.core.exceptions import (
     STORE_SIGNAL_BUSY,
     STORE_SIGNAL_UNREADABLE,
     STORE_SIGNAL_WAL_RECOVERY,
+    UNKNOWN_ARTIFACT_REASON,
     StaleReadGeneration,
     WatchdogAbandoned,
 )
 from ccs.core.states import MESIState, TransientState
-from ccs.core.types import Artifact, CasCorruption, ConflictDetail
+from ccs.core.types import (
+    Artifact,
+    CasCorruption,
+    ConflictDetail,
+    VersionedReadRejection,
+)
 
 from .retention import RetentionPolicy, collectible_versions
 
@@ -107,18 +113,40 @@ CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
 """Reuses the same schema version as in-memory registry (state_log emissions
 are interchangeable from a downstream consumer's perspective)."""
 
-SCHEMA_USER_VERSION = 2
+SCHEMA_USER_VERSION = 3
 """Schema version stamped via ``PRAGMA user_version`` on init.
 
-**v1 -> v2 is the repo's FIRST real schema bump** (plan item N v1, Unit 3): it
-adds the durable ``artifact_versions`` table and — because the fence columns +
-``coordinator_epoch`` seed AND the ``pending_notices`` table both shipped as
-additive no-version-bump shims — idempotently subsumes BOTH shims so that
-``user_version=2`` GUARANTEES the complete schema from every wild v1 variant.
+**v1 -> v2** (plan item N v1) added the durable ``artifact_versions`` table and
+idempotently subsumed the fence-column + ``pending_notices`` no-version-bump
+shims, so ``user_version=2`` GUARANTEES the complete v2 schema from every wild
+v1 variant.
+
+**v2 -> v3** (SB-17 / TX-1, Unit 2 / R1) adds the durable ``session_pins``
+table (one row per ``(session_token, artifact_id)`` pinned version) so a
+snapshot session's cut survives a coordinator restart (R6, sqlite-only). The
+migration is idempotent (``CREATE TABLE IF NOT EXISTS`` + an in-txn version
+stamp) and additive — it touches NO existing table, so the v2->v3 step is
+purely a new-surface add.
+
+**CROSS-RUNTIME LEDGER DIVERGENCE (security).** The sibling Node coordinator
+(agent-coherence-plugin) shares the SAME ``state.db`` path but keeps its OWN
+ledger: its v3 is ``ALTER TABLE agent_states ADD COLUMN deadline_tick`` — a
+DIFFERENT schema than this repo's v3. A Node coordinator opening a Python-v3 db
+(or vice-versa) must DETECT and REJECT rather than silently misread; the
+``schema_runtime`` lineage stamp + the structural ``session_pins``-presence
+probe in ``_reject_foreign_ledger_db`` enforce that fail-closed posture.
+
 After migration the normal open path performs **no writes** (no shim ALTERs,
 no IF-NOT-EXISTS), which is the prerequisite that makes the read-only open mode
-implementable. See ``_migrate_v1_to_v2`` and
+implementable. See ``_migrate_v1_to_v2`` / ``_migrate_v2_to_v3`` and
 ``docs/solutions/runtime-errors/sqlite-schema-init-non-atomic-leaves-unbootable-db-2026-05-18.md``."""
+
+_V2_USER_VERSION = 2
+"""The intermediate v2 stamp the v1->v2 migration writes (before the chained
+v2->v3 step advances to ``SCHEMA_USER_VERSION``). Pinned as a literal because
+the v1->v2 migration must NOT jump straight to the current
+``SCHEMA_USER_VERSION`` — it lands the v2 schema, then ``_migrate_v2_to_v3``
+adds ``session_pins`` and stamps v3. A v1 db therefore steps 1 -> 2 -> 3."""
 
 _DB_FILE_MODE = 0o600
 """state.db (and its -wal/-shm sidecars) must be owner-read/write only.
@@ -151,6 +179,29 @@ CREATE TABLE artifact_versions (
     captured_at REAL NOT NULL,
     PRIMARY KEY (artifact_id, version),
     FOREIGN KEY (artifact_id) REFERENCES artifacts(id) ON DELETE CASCADE
+)
+"""
+
+# Durable snapshot-session pin table (SB-17 / TX-1, Unit 2 / R1, R4). One row
+# per (session_token, artifact_id) pinned version — the persisted mirror of the
+# in-memory ``_session_pins`` dict. A live session's pinned version is exempt
+# from the inline retention GC (the exemptions seam) until ``release_session``
+# deletes its rows. Restart-survival is the whole point of the durable mirror
+# (R6, sqlite-only): a coordinator restart re-reads the live pins so the cut is
+# still held. NO foreign key to ``artifacts`` ON DELETE CASCADE here on
+# PURPOSE: a pin must OUTLIVE a transient absence of its artifact only as far as
+# the artifact actually exists — but the version-vector capture already
+# rejected unknown ids before inserting, and the read-serve / liveness fail-
+# closed path (Units 3/5) is what handles an artifact deleted out from under a
+# live pin (typed SessionInvalidated, never wrong bytes). Keeping the pin table
+# independent of the artifacts FK avoids a silent cascade-delete masking that
+# fail-closed signal.
+_SESSION_PINS_DDL = """
+CREATE TABLE session_pins (
+    session_token TEXT NOT NULL,
+    artifact_id   TEXT NOT NULL,
+    version       INTEGER NOT NULL,
+    PRIMARY KEY (session_token, artifact_id)
 )
 """
 
@@ -197,6 +248,12 @@ _SCHEMA_RUNTIME_STAMP = "python"
 # no mutation). ``CasCorruption`` is the impossible-state sentinel the service
 # maps to ``CoherenceError``. None of these is raised by the registry.
 CasResult: TypeAlias = "tuple[Artifact, list[UUID]] | ConflictDetail | CasCorruption"
+
+# Snapshot consistent-cut capture result (SB-17 / TX-1, Unit 2 / R1) — parity
+# with ArtifactRegistry.capture_version_vector. WIN = the pinned cut
+# ``{artifact_id: version}``; an unknown id = VersionedReadRejection
+# (``unknown_artifact``) with NO pins inserted. Neither is raised.
+CaptureResult: TypeAlias = "dict[UUID, int] | VersionedReadRejection"
 
 
 class SchemaVersionError(RuntimeError):
@@ -476,14 +533,17 @@ class SqliteArtifactRegistry:
         - ``user_version == 0`` (brand-new file) → ``_apply_v2_schema``: the
           COMPLETE v2 schema in one atomic transaction (no shim ever runs on a
           fresh db).
-        - ``user_version == 1`` (any wild v1 variant) → ``_migrate_v1_to_v2``:
-          idempotently subsumes BOTH additive shims (fence columns + epoch seed,
-          and ``pending_notices``) AND adds ``artifact_versions``, then stamps
-          ``user_version=2`` — all in ONE ``BEGIN IMMEDIATE``. The wild v1
+        - ``user_version == 1`` (any wild v1 variant) → ``_migrate_v1_to_v2``
+          then ``_migrate_v2_to_v3``: idempotently subsumes BOTH additive shims
+          (fence columns + epoch seed, and ``pending_notices``), adds
+          ``artifact_versions`` (v2), and adds ``session_pins`` (v3). The wild v1
           population is a 2x2 matrix ({±fence columns} x {±pending_notices})
           because both shims shipped with no version bump; ``PRAGMA table_info``
           / ``IF NOT EXISTS`` guards make each piece apply only when missing.
-        - ``user_version == 2`` → ``_rehydrate_meta``: the WRITE-FREE open path
+        - ``user_version == 2`` → ``_migrate_v2_to_v3``: adds ``session_pins``
+          and stamps ``user_version=3`` in ONE ``BEGIN IMMEDIATE`` (additive —
+          touches no existing table).
+        - ``user_version == 3`` → ``_rehydrate_meta``: the WRITE-FREE open path
           (no ALTER, no IF-NOT-EXISTS) — the prerequisite for read-only mode.
         - anything else → :class:`SchemaVersionError` (no destructive advice).
 
@@ -494,15 +554,21 @@ class SqliteArtifactRegistry:
         with self._lock:
             current = self._conn.execute("PRAGMA user_version").fetchone()[0]
             # Cross-runtime fail-closed guard: read-only probes, BEFORE the
-            # dispatch can migrate (v1 branch) or write anything — migrating a
+            # dispatch can migrate (v1/v2 branch) or write anything — migrating a
             # Node-ledger db would corrupt the sibling coordinator's live state.
             self._reject_foreign_ledger_db(current)
             if current == 0:
                 self._apply_v2_schema(instance_id)
             elif current == 1:
+                # v1 → v2 → v3: the v1->v2 migration rehydrates meta; the chained
+                # v2->v3 step then adds session_pins and re-rehydrates. Each step
+                # is its own atomic BEGIN IMMEDIATE.
                 self._migrate_v1_to_v2(instance_id)
+                self._migrate_v2_to_v3(instance_id)
+            elif current == 2:
+                self._migrate_v2_to_v3(instance_id)
             elif current == SCHEMA_USER_VERSION:
-                # Existing v2 database — rehydrate; NO writes on this path.
+                # Existing v3 database — rehydrate; NO writes on this path.
                 self._rehydrate_meta(instance_id)
             else:
                 raise SchemaVersionError(
@@ -594,24 +660,36 @@ class SqliteArtifactRegistry:
         coordinator shares this db path but its ledger's v2 adds NO schema
         objects (pending_notices validation) and its v3 ALTERs
         ``agent_states ADD COLUMN deadline_tick``, while THIS repo's v2 adds
-        ``artifact_versions`` — the same user_version means different schemas
-        depending on the writer. Detection order (strongest marker first):
+        ``artifact_versions`` and its v3 adds ``session_pins`` — the same
+        user_version means different schemas depending on the writer. THE LEDGER
+        DIVERGENCE AT v3 IS THE SB-17 SECURITY CONCERN: a Node coordinator
+        opening this build's Python-v3 db (or this build opening a Node-v3 db)
+        must DETECT/REJECT, never silently misread. Detection order (strongest
+        marker first):
 
         1. ``registry_meta.schema_runtime`` present and foreign — the explicit
            lineage stamp, checked regardless of version (this side stamps
-           ``python``; the Node side mirrors with ``node``).
+           ``python``; the Node side mirrors with ``node``). This alone catches
+           the cross-runtime v3 collision in both directions when the stamp is
+           present (every Python db since the marker shipped carries it).
         2. ``user_version >= 3`` with ``agent_states.deadline_tick`` — the
            Node ledger's v3 ALTER. ``>= 3``, not ``== 3``: a future Node v4+
-           still carries the column (columns are never dropped), and a future
-           Python v3 db is unreadable by this v2 build either way — both
-           classifications stay fail-closed and :class:`CrossRuntimeSchemaError`
-           IS a :class:`SchemaVersionError` for catch-sites. Literal ``3``
-           (the Node ledger's version), deliberately not SCHEMA_USER_VERSION.
+           still carries the column (columns are never dropped). A genuine
+           Python-v3 db NEVER carries ``deadline_tick`` (this repo's v3 adds
+           ``session_pins``, not that column), so this never false-positives on
+           our own v3. Literal ``3`` (the Node ledger's version), deliberately
+           not SCHEMA_USER_VERSION.
         3. ``user_version == 2`` WITHOUT ``artifact_versions`` — a Python-v2
            db ALWAYS has the table (the v1->v2 migration creates it atomically
            with the version stamp); a Node-v2 db never does. Literal ``2``:
-           the check pins user_version-2 semantics even after a future Python
-           v3 bump.
+           the check pins user_version-2 semantics even after the Python v3 bump.
+        4. ``user_version == 3`` WITHOUT ``session_pins`` — a Python-v3 db
+           ALWAYS has the table (the v2->v3 migration / fresh apply creates it
+           atomically with the v3 stamp); a Node-v3 db (whose v3 is the
+           ``deadline_tick`` ALTER) never does. This is the structural fallback
+           for a Node-v3 db whose ``deadline_tick`` probe somehow missed (and
+           defense-in-depth alongside the ``schema_runtime`` stamp). Literal
+           ``3`` — pins Python-v3 semantics.
 
         ``user_version == 1`` is deliberately NOT blocked: the Node ledger's
         v1 is a byte-for-byte mirror of this repo's v1 schema, so the two are
@@ -635,6 +713,12 @@ class SqliteArtifactRegistry:
                 "is user_version=2 without the artifact_versions table (a "
                 "Python-v2 store always has it; the Node ledger's v2 adds no "
                 "schema objects)"
+            )
+        if current == 3 and not self._has_table("session_pins"):
+            self._raise_cross_runtime(
+                "is user_version=3 without the session_pins table (a "
+                "Python-v3 store always has it; the Node ledger's v3 is the "
+                "agent_states.deadline_tick ALTER, not session_pins)"
             )
 
     def _raise_cross_runtime(self, detail: str) -> NoReturn:
@@ -660,7 +744,11 @@ class SqliteArtifactRegistry:
         )
 
     def _apply_v2_schema(self, instance_id: str | None) -> None:
-        """Create the COMPLETE v2 schema + seed registry_meta. Caller holds lock.
+        """Create the COMPLETE current schema (v2 tables + the v3 ``session_pins``
+        table) + seed registry_meta, stamping ``user_version=SCHEMA_USER_VERSION``.
+        Caller holds lock. (The method keeps its historical ``_apply_v2_schema``
+        name; a fresh db is always built at the latest schema directly so no
+        migration shim ever runs against it.)
 
         P1 ce-review fix (correctness): schema init must be atomic against
         SIGKILL. Earlier version ran executescript() THEN a separate PRAGMA
@@ -755,6 +843,9 @@ class SqliteArtifactRegistry:
                 """
             )
             c.execute(_ARTIFACT_VERSIONS_DDL)
+            # session_pins (v3, SB-17 Unit 2): a fresh db is created at the full
+            # current schema directly — no v2->v3 shim ever runs against it.
+            c.execute(_SESSION_PINS_DDL)
             seed_epoch = uuid4().hex
             # schema_runtime: the cross-runtime lineage stamp, seeded inside
             # THIS creation transaction (no extra txn) so the sibling Node
@@ -856,10 +947,13 @@ class SqliteArtifactRegistry:
         try:
             # Concurrent-loser guard: re-check the stamp now that the write
             # lock is held. The dispatch decision was made from a pre-lock
-            # read; if a racing winner migrated in between, there is nothing
-            # left to do — COMMIT the empty txn and rehydrate like a normal
-            # v2 open. (The winner already ran the mode-tighten pass.)
-            if c.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION:
+            # read; if a racing winner already advanced PAST v1 (to v2 or the
+            # current v3), the v1->v2 body has nothing left to do — COMMIT the
+            # empty txn and rehydrate. ``>= _V2_USER_VERSION`` (not ``==``)
+            # because the winner may have already chained on to v3. The caller's
+            # chained ``_migrate_v2_to_v3`` then runs its OWN loser-guarded txn,
+            # which no-ops if v3 is already stamped.
+            if c.execute("PRAGMA user_version").fetchone()[0] >= _V2_USER_VERSION:
                 c.execute("COMMIT")
                 self._rehydrate_meta(instance_id)
                 return
@@ -914,8 +1008,10 @@ class SqliteArtifactRegistry:
             c.execute(_ARTIFACT_VERSIONS_DDL.replace("CREATE TABLE", "CREATE TABLE IF NOT EXISTS", 1))
             # In-txn stamp: PRAGMA user_version is transactional inside an explicit
             # BEGIN; commits atomically with the DDL above. Cannot take bindings,
-            # so the int constant is interpolated.
-            c.execute(f"PRAGMA user_version = {SCHEMA_USER_VERSION}")
+            # so the int constant is interpolated. Stamps the INTERMEDIATE v2 (not
+            # the current SCHEMA_USER_VERSION) — the chained _migrate_v2_to_v3 adds
+            # session_pins and advances to v3.
+            c.execute(f"PRAGMA user_version = {_V2_USER_VERSION}")
             c.execute("COMMIT")
         except BaseException:
             try:
@@ -929,6 +1025,52 @@ class SqliteArtifactRegistry:
         # so re-apply 0600 to a possibly operator-broadened file and warn ONCE
         # that the content-storage posture changed (audit_log drift pattern).
         self._tighten_existing_db_mode_and_warn()
+
+    def _migrate_v2_to_v3(self, instance_id: str | None) -> None:
+        """Migrate a v2 db to v3 in ONE atomic transaction (SB-17 / TX-1, Unit 2).
+        Caller holds lock.
+
+        Additive-only: adds the ``session_pins`` table and stamps
+        ``user_version=SCHEMA_USER_VERSION`` — it touches NO existing table, so
+        there is no shim to subsume and no content/mode posture change (the v2->v3
+        step does not alter the disclosure surface). Same atomicity discipline as
+        ``_migrate_v1_to_v2`` (the
+        sqlite-schema-init-non-atomic-leaves-unbootable-db learning): ONE explicit
+        ``BEGIN IMMEDIATE`` wrapping the DDL + the ``PRAGMA user_version`` stamp
+        (transactional inside an explicit txn), individual ``execute()`` calls
+        (never ``executescript``), and ``except BaseException`` ROLLBACK so a
+        SIGKILL mid-migration leaves the v2 db intact for a clean re-migrate.
+
+        Concurrent-loser path: two processes can both read ``user_version == 2``
+        (a bare pre-lock read) and both land here; they serialize on the
+        ``BEGIN IMMEDIATE`` write lock. The loser re-reads ``user_version`` INSIDE
+        its txn, sees the winner already stamped v3, and no-ops (``CREATE TABLE IF
+        NOT EXISTS`` would be harmless either way, but the early COMMIT avoids
+        re-running a future non-idempotent v4 step under the same race).
+        """
+        c = self._conn
+        c.execute("BEGIN IMMEDIATE")
+        try:
+            if c.execute("PRAGMA user_version").fetchone()[0] >= SCHEMA_USER_VERSION:
+                # A racing winner already advanced to v3 — nothing to do.
+                c.execute("COMMIT")
+                self._rehydrate_meta(instance_id)
+                return
+            # IF NOT EXISTS guards the half-migrated-db case (table created by a
+            # prior crashed migration whose user_version stamp never committed).
+            c.execute(
+                _SESSION_PINS_DDL.replace("CREATE TABLE", "CREATE TABLE IF NOT EXISTS", 1)
+            )
+            c.execute(f"PRAGMA user_version = {SCHEMA_USER_VERSION}")
+            c.execute("COMMIT")
+        except BaseException:
+            try:
+                c.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
+        # Load meta from the now-migrated db (write-free).
+        self._rehydrate_meta(instance_id)
 
     def _tighten_existing_db_mode_and_warn(self) -> None:
         """Re-apply 0600 to a pre-existing db whose mode an operator may have
@@ -1273,16 +1415,41 @@ class SqliteArtifactRegistry:
             (artifact_id.hex,),
         ).fetchall()
         timestamps = {int(v): float(ts) for v, ts in rows}
+        # Exemptions seam (Unit 2 — the first GC producer to populate it): every
+        # version pinned by a LIVE snapshot session for this artifact is held
+        # back from collection (R4). Read from session_pins in THIS same txn so
+        # the exemption set is consistent with the capture (a concurrent
+        # capture_version_vector / release_session serializes on the same
+        # connection lock + BEGIN IMMEDIATE).
         for dropped in collectible_versions(
             timestamps,
             current_version=version,
             policy=self._retention_policy,
             now=captured_at,
+            exemptions=self._live_pins_for_artifact_sql(artifact_id),
         ):
             c.execute(
                 "DELETE FROM artifact_versions WHERE artifact_id = ? AND version = ?",
                 (artifact_id.hex, dropped),
             )
+
+    def _live_pins_for_artifact_sql(self, artifact_id: UUID) -> set[int]:
+        """Return the versions pinned by LIVE snapshot sessions for ``artifact_id``
+        (the GC exemption set, Unit 2 / R4) from the persisted ``session_pins``
+        table. Mirrors the in-memory ``_live_pins_for_artifact`` and
+        ``Snapshot.tla``'s ``PinnedVersions(art)``.
+
+        MUST be called inside the caller's already-open ``BEGIN IMMEDIATE`` (it
+        issues a bare ``SELECT`` on ``self._conn`` with no transaction of its
+        own), so the exemption read is consistent with the capture/GC it feeds —
+        a peer ``capture_version_vector`` / ``release_session`` serializes on the
+        same connection lock and cannot half-apply between this read and the
+        GC delete."""
+        rows = self._conn.execute(
+            "SELECT version FROM session_pins WHERE artifact_id = ?",
+            (artifact_id.hex,),
+        ).fetchall()
+        return {int(r[0]) for r in rows}
 
     @property
     def coordinator_epoch(self) -> str:
@@ -1563,6 +1730,110 @@ class SqliteArtifactRegistry:
                 # KeyboardInterrupt/SystemExit mid-transaction so ROLLBACK fires
                 # before propagation — otherwise the connection is left with an
                 # uncommitted transaction that the next BEGIN IMMEDIATE sees.
+                self._conn.execute("ROLLBACK")
+                raise
+
+    # ------------------------------------------------------------------
+    # Snapshot consistent-cut capture + pin store (SB-17 / TX-1, Unit 2)
+    # ------------------------------------------------------------------
+
+    def capture_version_vector(
+        self, read_set: Iterable[UUID], session_token: str
+    ) -> CaptureResult:
+        """Atomically pin a consistent multi-artifact CUT (SB-17 / TX-1, Unit 2 /
+        R1). Written fresh from the contract — parity with
+        :meth:`ArtifactRegistry.capture_version_vector` (the two registries share
+        no base class), divergent ONLY on restart-survival (sqlite pins are
+        durable; in-memory pins are process-scoped — the parity harness asserts
+        the divergence).
+
+        ONE ``BEGIN IMMEDIATE`` under one lock acquisition does the entire
+        multi-artifact version read + row-count validation + pin insert — the
+        ``status_snapshot`` consistent-multi-artifact-read-under-one-lock pattern
+        + ``commit_cas``'s ``BEGIN IMMEDIATE``. A peer ``commit_cas`` is
+        serialized entirely before or after the whole capture, never partially
+        visible within the cut (no read skew).
+
+        Non-mutating on the coherence plane: it mints NO MESI grant and captures
+        NO ``read_generation`` (it never touches ``agent_states`` / the fence
+        path) — a reader is not an owner. It writes ONLY the ``session_pins``
+        rows (the durable mirror of the cut).
+
+        Unknown-id validation (security, F7): the captured row-count must equal
+        ``len(read_set)``. Any missing id → a typed
+        :class:`~ccs.core.types.VersionedReadRejection` (``unknown_artifact``)
+        and the txn COMMITs having inserted NO pins (no partial cut, no
+        existence-probe oracle — the rejection is decided before any pin write).
+
+        Args:
+            read_set: The artifact ids to pin into the cut. Empty → empty cut.
+            session_token: The server-minted session identity the pins key under.
+
+        Returns:
+            The pinned cut ``{artifact_id: version}`` on success, else a
+            :class:`VersionedReadRejection` (``unknown_artifact``) — no pins
+            inserted.
+        """
+        self._guard_writable()
+        ids = list(read_set)
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                cut: dict[UUID, int] = {}
+                missing: list[UUID] = []
+                for artifact_id in ids:
+                    row = self._conn.execute(
+                        "SELECT version FROM artifacts WHERE id = ?",
+                        (artifact_id.hex,),
+                    ).fetchone()
+                    if row is None:
+                        missing.append(artifact_id)
+                        continue
+                    cut[artifact_id] = row[0]
+                # F7: row-count == len(read_set) BEFORE any pin insert. A missing
+                # id rejects the WHOLE capture — COMMIT the (pin-free) txn and
+                # return the typed rejection. Nothing was written, so the COMMIT
+                # just releases the lock.
+                if missing:
+                    self._conn.execute("COMMIT")
+                    return VersionedReadRejection(
+                        reason=UNKNOWN_ARTIFACT_REASON,
+                        artifact_id=sorted(missing, key=lambda a: a.int)[0],
+                        requested_version=0,
+                        current_version=None,
+                        coordinator_epoch=self._coordinator_epoch,
+                    )
+                # Insert the pins atomically with the version read (same txn) so
+                # the exemptions seam sees the full cut the instant it is live.
+                # INSERT OR REPLACE: re-binding a token (should not happen — the
+                # service mints a fresh token per session) overwrites rather than
+                # raising on the (session_token, artifact_id) PK.
+                for artifact_id, version in cut.items():
+                    self._conn.execute(
+                        "INSERT OR REPLACE INTO session_pins "
+                        "(session_token, artifact_id, version) VALUES (?, ?, ?)",
+                        (session_token, artifact_id.hex, version),
+                    )
+                self._conn.execute("COMMIT")
+                return cut
+            except BaseException:
+                self._conn.execute("ROLLBACK")
+                raise
+
+    def release_session(self, session_token: str) -> None:
+        """Drop a session's pins so its pinned versions become collectible again
+        (Unit 2 / R4). Idempotent — releasing an unknown/already-released token
+        deletes zero rows (no raise), mirroring the in-memory ``dict.pop``."""
+        self._guard_writable()
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                self._conn.execute(
+                    "DELETE FROM session_pins WHERE session_token = ?",
+                    (session_token,),
+                )
+                self._conn.execute("COMMIT")
+            except BaseException:
                 self._conn.execute("ROLLBACK")
                 raise
 

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -124,9 +124,16 @@ STORE_OPEN_SIGNALS: frozenset[str] = frozenset(
 # The sibling Node coordinator (the agent-coherence-plugin repo) shares the
 # SAME ``<workspace>/.coherence/state.db`` path but maintains its OWN migration
 # ledger: its v2 adds no schema objects (pending_notices validation) and its v3
-# is ``ALTER TABLE agent_states ADD COLUMN deadline_tick`` — so the two ledgers
-# assign DIFFERENT meanings to ``PRAGMA user_version`` 2 and 3 on the same
-# file. ``CrossRuntimeSchemaError`` (defined in
+# is ``ALTER TABLE agent_states ADD COLUMN deadline_tick`` — while THIS repo's
+# v2 adds ``artifact_versions`` and its v3 (SB-17 / TX-1, Unit 2) adds
+# ``session_pins``. So the two ledgers assign DIFFERENT meanings to
+# ``PRAGMA user_version`` 2 AND 3 on the same file: a Node coordinator opening a
+# Python-v3 db (or vice-versa) must DETECT and REJECT rather than silently
+# misread the schema. The detection lives in
+# ``SqliteArtifactRegistry._reject_foreign_ledger_db`` (the ``schema_runtime``
+# lineage stamp + structural ``artifact_versions``/``session_pins`` /
+# ``deadline_tick`` probes); the Node side mirrors it.
+# ``CrossRuntimeSchemaError`` (defined in
 # ``ccs.coordinator.sqlite_registry`` because it subclasses the
 # coordinator-layer ``SchemaVersionError`` to keep existing catch-sites
 # compatible; core must not import upward) carries THIS wire-stable reason so

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -179,6 +179,51 @@ SESSION_COMMIT_REASONS: frozenset[str] = frozenset(
 )
 
 # ---------------------------------------------------------------------------
+# begin_session resource-cap rejection reasons (SB-17 / TX-1, Unit 7 / R14)
+# ---------------------------------------------------------------------------
+#
+# ADDITIVE (R7): the resource-bound rejections of
+# :meth:`CoordinatorService.begin_session`. ``begin_session`` already returns a
+# typed :class:`~ccs.core.types.VersionedReadRejection` for an unknown id
+# (``unknown_artifact``); these two reasons EXTEND that typed-return surface for
+# the R14 caps that bound the snapshot blast radius (security-calibrated DEFAULTS,
+# not post-hoc tuning):
+#
+#   * ``session_cap_exceeded`` — opening this session would exceed
+#     ``max_sessions`` concurrent sessions (the many-sessions GC-starvation DoS
+#     bound, threat-model #2). No token minted, no cut pinned.
+#   * ``read_set_too_large`` — the ``read_set`` cardinality exceeds
+#     ``max_read_set_cardinality`` (the enormous-single-read-set GC-starvation
+#     bound, threat-model #2). No token minted, no cut pinned.
+#
+# Both are PRE-CAPTURE rejections (fail BEFORE any token mint / pin insert), so a
+# rejected ``begin_session`` leaves NO half-open session. They reuse the
+# ``VersionedReadRejection`` carrier (the same typed return ``begin_session``
+# already produces) rather than minting a parallel rejection type. Wire-stable:
+# ADD, never rename; consumers match ``reason == CONSTANT``, never a substring.
+SESSION_CAP_EXCEEDED_REASON = "session_cap_exceeded"
+"""``begin_session`` would exceed ``max_sessions`` concurrent sessions (R14). No
+token minted, no cut pinned — the caller retries after a session is released or
+reaped. Bounds the many-sessions GC-starvation DoS (threat-model #2)."""
+
+SESSION_READ_SET_TOO_LARGE_REASON = "read_set_too_large"
+"""``begin_session``'s ``read_set`` exceeds ``max_read_set_cardinality`` (R14). No
+token minted, no cut pinned. Bounds the enormous-single-read-set GC-starvation
+DoS (threat-model #2)."""
+
+# The closed set every ``begin_session`` cap-rejection consumer matches against.
+# ADDITIVE-only (R7): disjoint from ``READ_AT_VERSION_REASONS`` /
+# ``SESSION_READ_REASONS`` / ``SESSION_COMMIT_REASONS``. ``begin_session`` may
+# ALSO return ``unknown_artifact`` (the Unit-2 capture rejection), which stays in
+# ``READ_AT_VERSION_REASONS``; these are the NET-NEW cap reasons only.
+SESSION_BEGIN_CAP_REASONS: frozenset[str] = frozenset(
+    {
+        SESSION_CAP_EXCEEDED_REASON,
+        SESSION_READ_SET_TOO_LARGE_REASON,
+    }
+)
+
+# ---------------------------------------------------------------------------
 # read-only store-open classification signals (Unit 6 hardening)
 # ---------------------------------------------------------------------------
 #

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -88,6 +88,37 @@ READ_AT_VERSION_REASONS: frozenset[str] = frozenset(
 )
 
 # ---------------------------------------------------------------------------
+# session.read rejection reasons (SB-17 / TX-1, Unit 3 / R2)
+# ---------------------------------------------------------------------------
+#
+# Wire-stable, ADDITIVE constants carried by
+# :class:`~ccs.core.types.SessionReadRejection.reason`. ADDITIVE-only (R7): a NEW
+# closed set, never folded into ``READ_AT_VERSION_REASONS`` — ``session_read`` is
+# a distinct surface from the bare ``read_at_version`` history read. Consumers
+# match ``reason == CONSTANT`` against :data:`SESSION_READ_REASONS`, never on a
+# human message (the typed-signal-not-substring house rule). Unit 5 will ADD the
+# heartbeat-liveness ``session_invalidated`` reason (a released/unknown token is
+# ``session_not_found`` until then).
+SESSION_NOT_FOUND_REASON = "session_not_found"
+"""The ``session_token`` has no pinned cut — unknown, never opened, or released
+(``release_session``). A coordinator restart that wiped an in-memory session also
+lands here in Unit 3 (the durable Unit-5 liveness/restart taxonomy is later)."""
+
+SESSION_ARTIFACT_NOT_IN_CUT_REASON = "artifact_not_in_cut"
+"""The token is a live session but the artifact was NOT in its captured read-set.
+Reading an un-pinned artifact mid-session is out of scope and is REJECTED here,
+never served from live HEAD (the no-fall-through guarantee)."""
+
+# The closed set every ``session_read`` consumer matches against. ADDITIVE-only:
+# disjoint from ``READ_AT_VERSION_REASONS`` (a separate surface, R7).
+SESSION_READ_REASONS: frozenset[str] = frozenset(
+    {
+        SESSION_NOT_FOUND_REASON,
+        SESSION_ARTIFACT_NOT_IN_CUT_REASON,
+    }
+)
+
+# ---------------------------------------------------------------------------
 # read-only store-open classification signals (Unit 6 hardening)
 # ---------------------------------------------------------------------------
 #

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -96,9 +96,9 @@ READ_AT_VERSION_REASONS: frozenset[str] = frozenset(
 # closed set, never folded into ``READ_AT_VERSION_REASONS`` — ``session_read`` is
 # a distinct surface from the bare ``read_at_version`` history read. Consumers
 # match ``reason == CONSTANT`` against :data:`SESSION_READ_REASONS`, never on a
-# human message (the typed-signal-not-substring house rule). Unit 5 will ADD the
-# heartbeat-liveness ``session_invalidated`` reason (a released/unknown token is
-# ``session_not_found`` until then).
+# human message (the typed-signal-not-substring house rule). Unit 5 ADDED the
+# heartbeat-liveness ``session_invalidated`` reason (a reaped / restart-wiped
+# token lands there; a never-opened/malformed token stays ``session_not_found``).
 SESSION_NOT_FOUND_REASON = "session_not_found"
 """The ``session_token`` has no pinned cut — unknown, never opened, or released
 (``release_session``). A coordinator restart that wiped an in-memory session also
@@ -109,12 +109,45 @@ SESSION_ARTIFACT_NOT_IN_CUT_REASON = "artifact_not_in_cut"
 Reading an un-pinned artifact mid-session is out of scope and is REJECTED here,
 never served from live HEAD (the no-fall-through guarantee)."""
 
+# ---------------------------------------------------------------------------
+# session liveness / fail-closed reason (SB-17 / TX-1, Unit 5 / R4)
+# ---------------------------------------------------------------------------
+#
+# ADDITIVE (R7): the heartbeat-liveness fail-closed reason. A session whose pins
+# are UNAVAILABLE — reaped by the session-liveness sweep (stale heartbeat),
+# GC-raced, or wiped by an in-memory coordinator restart — fails CLOSED with
+# this reason, NEVER a live-HEAD fall-through. It is deliberately DISTINCT from
+# ``session_not_found``:
+#
+#   * ``session_invalidated`` — "your session DIED; re-establish it." The token
+#     WAS (or structurally still looks like) a real server-minted session, but
+#     its cut is gone. Returned for a token that is (a) in the bounded reaped-
+#     tombstone, or (b) shaped like a server-minted token (the
+#     ``looks_like_session_token`` format predicate) yet has no live cut — the
+#     post-restart-unknown case MUST land here so a previously-valid token is
+#     never served live HEAD as if still pinned.
+#   * ``session_not_found`` — a genuinely-never-opened / malformed token (does
+#     not match the server-minted format and is not in the tombstone). Kept
+#     reachable additively so a clearly-bogus token is still distinguishable.
+#
+# Both are fail-closed (typed rejection, never live HEAD); the split only sharpens
+# the operator/agent signal ("re-establish" vs "this was never a session"). Wire-
+# stable: ADD, never rename ``session_not_found``; consumers match
+# ``reason == CONSTANT``, never a substring.
+SESSION_INVALIDATED_REASON = "session_invalidated"
+"""A live session's pins are unavailable — reaped (stale heartbeat), GC-raced, or
+wiped by an in-memory restart. Fails CLOSED (never live HEAD). Distinct from
+``session_not_found`` (a never-opened/malformed token): a token that was, or
+still structurally looks like, a real server-minted session lands HERE so it is
+never mistaken for a fresh empty session and served live HEAD."""
+
 # The closed set every ``session_read`` consumer matches against. ADDITIVE-only:
 # disjoint from ``READ_AT_VERSION_REASONS`` (a separate surface, R7).
 SESSION_READ_REASONS: frozenset[str] = frozenset(
     {
         SESSION_NOT_FOUND_REASON,
         SESSION_ARTIFACT_NOT_IN_CUT_REASON,
+        SESSION_INVALIDATED_REASON,
     }
 )
 
@@ -134,12 +167,14 @@ SESSION_READ_REASONS: frozenset[str] = frozenset(
 # minting parallel ones — one token-validation vocabulary across the session
 # surface. ADDITIVE-only (R7): a NEW closed set, disjoint from
 # ``READ_AT_VERSION_REASONS``; consumers match ``reason == CONSTANT``, never a
-# substring. Unit 5 will ADD ``session_invalidated`` (heartbeat-liveness); until
-# then a released/unknown token is ``session_not_found``.
+# substring. Unit 5 ADDED ``session_invalidated`` (heartbeat-liveness): a reaped /
+# restart-wiped token lands there; a never-opened/malformed one stays
+# ``session_not_found``.
 SESSION_COMMIT_REASONS: frozenset[str] = frozenset(
     {
         SESSION_NOT_FOUND_REASON,
         SESSION_ARTIFACT_NOT_IN_CUT_REASON,
+        SESSION_INVALIDATED_REASON,
     }
 )
 
@@ -258,6 +293,31 @@ class OccCallerTransientError(CoherenceError):
     artifact-not-found branches of ``commit_cas`` stay plain
     :class:`CoherenceError`; only the transient precondition is retry-eligible.
     """
+
+
+class SessionInvalidated(CoherenceError):
+    """A snapshot session's pins are unavailable — fail-closed (SB-17 / TX-1,
+    Unit 5 / R4). The session-liveness sweep reaped it (stale heartbeat), a GC
+    race dropped a pinned body, or an in-memory coordinator restart wiped the
+    pin store. The session can no longer serve its consistent cut, so any
+    ``session_read`` / ``session_commit`` against it MUST fail closed — NEVER a
+    live-HEAD fall-through.
+
+    Carries :data:`SESSION_INVALIDATED_REASON` so a consumer classifies it by
+    type / ``.reason`` (the typed-signal-not-substring house rule), distinct from
+    a generic :class:`CoherenceError`. The service-layer ``session_read`` /
+    ``session_commit`` surface returns the typed REJECTION
+    (:class:`~ccs.core.types.SessionReadRejection` /
+    :class:`~ccs.core.types.SessionCommitRejection`) carrying this same reason
+    rather than raising, mirroring the ``ConflictDetail`` discipline; this
+    exception is the raise-form for callers (e.g. an effect-gate, Unit 6) that
+    want a hard failure on a dead session.
+
+    Recovery is to OPEN A NEW SESSION (re-establish the cut + re-read), exactly
+    like a ``version_mismatch`` HELD — the dead cut is not retry-eligible in
+    place."""
+
+    reason = SESSION_INVALIDATED_REASON
 
 
 class CoherenceDegradedWarning(UserWarning):

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -119,6 +119,31 @@ SESSION_READ_REASONS: frozenset[str] = frozenset(
 )
 
 # ---------------------------------------------------------------------------
+# session.commit rejection reasons (SB-17 / TX-1, Unit 4 / R3)
+# ---------------------------------------------------------------------------
+#
+# Wire-stable, ADDITIVE constants carried by
+# :class:`~ccs.core.types.SessionCommitRejection.reason` — the typed VALIDATION
+# rejection of :meth:`CoordinatorService.session_commit` (the token has no pin /
+# the artifact is not in the cut), NEVER a silent fall-through. The OCC OUTCOMES
+# are NOT here: a lost-race surfaces as the shipped :class:`ConflictDetail`
+# (returned unchanged) and corruption as a raised ``CoherenceError`` (the
+# ``commit_cas`` taxonomy, preserved byte-for-byte). This set covers ONLY the
+# pre-commit validation gate. The two reasons are SHARED with ``session_read``
+# (the same token/pin checks), so they REUSE the Unit-3 literals rather than
+# minting parallel ones — one token-validation vocabulary across the session
+# surface. ADDITIVE-only (R7): a NEW closed set, disjoint from
+# ``READ_AT_VERSION_REASONS``; consumers match ``reason == CONSTANT``, never a
+# substring. Unit 5 will ADD ``session_invalidated`` (heartbeat-liveness); until
+# then a released/unknown token is ``session_not_found``.
+SESSION_COMMIT_REASONS: frozenset[str] = frozenset(
+    {
+        SESSION_NOT_FOUND_REASON,
+        SESSION_ARTIFACT_NOT_IN_CUT_REASON,
+    }
+)
+
+# ---------------------------------------------------------------------------
 # read-only store-open classification signals (Unit 6 hardening)
 # ---------------------------------------------------------------------------
 #

--- a/src/ccs/core/types.py
+++ b/src/ccs/core/types.py
@@ -258,13 +258,16 @@ class SessionReadRejection:
     :data:`~ccs.core.exceptions.SESSION_READ_REASONS`; consumers match with
     ``==``, never on a human message.
 
-    The two Unit-3 reasons (Unit 5 adds the heartbeat-liveness ``session_invalidated``
-    axis; Unit 3 treats a released/unknown token as ``session_not_found``):
+    The reasons (Unit 5 ADDED the heartbeat-liveness ``session_invalidated`` axis):
 
-    - ``session_not_found`` — the ``session_token`` has no pinned cut (unknown,
-      never opened, or released). A coordinator restart that wiped an in-memory
-      session also lands here (the durable Unit-5 liveness/restart taxonomy is a
-      later unit; here it is simply "no cut for this token").
+    - ``session_not_found`` — the ``session_token`` has no pinned cut AND does not
+      look like a server-minted token (a genuinely-never-opened / malformed
+      token). Kept reachable additively as the clearly-bogus-token signal.
+    - ``session_invalidated`` (Unit 5) — the pins are UNAVAILABLE for a token that
+      was, or still structurally looks like, a real session: reaped by the
+      session-liveness sweep (stale heartbeat), GC-raced, or wiped by an in-memory
+      coordinator restart. Fails CLOSED here so a previously-valid token is NEVER
+      served live HEAD as if still pinned (the post-restart-unknown safety case).
     - ``artifact_not_in_cut`` — the token IS a live session, but ``artifact_id``
       was not in its captured read-set. Reading an un-pinned artifact mid-session
       is out of scope (a session wanting fresh data starts a new session); it is

--- a/src/ccs/core/types.py
+++ b/src/ccs/core/types.py
@@ -280,6 +280,44 @@ class SessionReadRejection:
 
 
 @dataclass(frozen=True)
+class SessionCommitRejection:
+    """A typed :meth:`CoordinatorService.session_commit` VALIDATION rejection
+    (SB-17 / TX-1, Unit 4 / R3) — never a silent fall-through.
+
+    Returned (never raised) when the commit cannot even be ATTEMPTED against a
+    valid pin: the token has no live cut, or the artifact was not in the captured
+    read-set. It is the pre-commit gate ONLY — it is NOT how an OCC outcome is
+    surfaced. The OCC taxonomy is preserved byte-for-byte from the shipped
+    ``commit_cas``:
+
+    - a lost race → the shipped :class:`ConflictDetail` (``version_mismatch`` /
+      ``other_holder`` / ``stale_read_generation``), returned UNCHANGED;
+    - corruption (``expected_version > current``) → a RAISED ``CoherenceError``
+      (the service maps the registry's :class:`CasCorruption` sentinel), never a
+      rejection.
+
+    ``reason`` is exactly one of :data:`~ccs.core.exceptions.SESSION_COMMIT_REASONS`
+    (the SAME token/pin vocabulary as :class:`SessionReadRejection`); consumers
+    match ``reason == CONSTANT``, never on a human message.
+
+    - ``session_not_found`` — the ``session_token`` has no pinned cut (unknown,
+      never opened, or released; an in-memory restart also lands here until the
+      Unit-5 liveness taxonomy splits it).
+    - ``artifact_not_in_cut`` — the token IS a live session, but ``artifact_id``
+      was not in its captured read-set. Committing an un-pinned artifact is out
+      of scope (a session commits only against what it pinned).
+
+    **Carries NO body** by type (the no-leak discipline shared with
+    :class:`SessionReadRejection`): only the reason, the artifact id, and the
+    epoch. ``coordinator_epoch`` is ALWAYS populated.
+    """
+
+    reason: str
+    artifact_id: UUID
+    coordinator_epoch: str
+
+
+@dataclass(frozen=True)
 class InvalidationSignal:
     """Lightweight invalidation signal sent to agents."""
 

--- a/src/ccs/core/types.py
+++ b/src/ccs/core/types.py
@@ -321,6 +321,84 @@ class SessionCommitRejection:
 
 
 @dataclass(frozen=True)
+class EffectHeld:
+    """The effect-gate RE-VALIDATE step found the read-set moved — the effect was
+    NOT fired (SB-17 / TX-1, Unit 6 / EO-5).
+
+    The non-fire return of :meth:`CoordinatorService.effect_gate`: between
+    ``begin_session`` (the pin) and the effect boundary, at least one read-set
+    member's CURRENT version no longer equals its pinned version, so firing would
+    act on stale input. The gate HOLDS — it never fires an escaping effect and
+    never lets the atomic commit land — and returns this typed value. NEVER an
+    exception (the ``ConflictDetail`` discipline), and NEVER a partial fire.
+
+    Recovery is to open a NEW session, re-read the fresh cut, re-decide, and
+    re-gate — exactly like a ``version_mismatch`` HELD; the dead decision is not
+    retry-eligible in place (its inputs changed underneath it).
+
+    Field semantics:
+
+    - ``moved`` is the per-artifact drift map ``{artifact_id: (pinned, current)}``
+      for EVERY read-set member whose current version diverged from its pin — the
+      full set, not just the first, so the caller can see the whole blast radius
+      of the change it raced. ``current`` is ``None`` when the artifact vanished
+      under the live pin (a deleted/GC-raced member is also "moved" — it can no
+      longer be proven unchanged, so the gate holds fail-closed).
+    - ``conflict`` is populated ONLY for the ATOMIC (``session.commit``) mode when
+      the commit lost its OCC race AT the pinned base — the shipped
+      :class:`ConflictDetail`, carried through verbatim so the caller sees the
+      same taxonomy a bare ``session_commit`` would surface. It is ``None`` for
+      an escaping-effect HELD (no commit was attempted) and for an atomic HELD
+      caught at the pre-commit re-validate (``moved`` populated, no CAS attempted).
+    - ``coordinator_epoch`` mirrors the other session results so the caller can
+      pin which store-incarnation evaluated the gate.
+    """
+
+    moved: Mapping[UUID, "tuple[int, int | None]"]
+    coordinator_epoch: str
+    conflict: Optional["ConflictDetail"] = None
+
+
+@dataclass(frozen=True)
+class EffectFired:
+    """The effect-gate fired the effect — the read-set was unchanged AS OF the
+    re-validate point (SB-17 / TX-1, Unit 6 / EO-5).
+
+    The fire return of :meth:`CoordinatorService.effect_gate`. Its guarantee is
+    mode-dependent and stated honestly (EO-5 / EO-7):
+
+    - **ATOMIC mode** (the effect IS ``session.commit``): the commit rode the
+      shipped ``commit_cas`` at the pinned base in the SAME arbitration step, so
+      "unchanged" and "fire" are one atomic event — there is NO window. ``commit``
+      carries the ``(updated_artifact, signals)`` WIN tuple.
+    - **ESCAPING mode** (the effect is a non-commit side effect — deploy / charge
+      / click — a caller-supplied callable): the gate re-validated the whole
+      vector and THEN fired the callable. The guarantee is "the read-set was
+      unchanged **as of the re-validate point**", NOT "as of the fire point": a
+      peer can commit a read-set member in the residual RE-VALIDATE→FIRE window,
+      after the check passed but before the callable ran. The gate gates pre-fire
+      and NEVER rolls back (EO-7), so this window is unclosable for escaping
+      effects and is NOT claimed away. ``result`` carries whatever the callable
+      returned (or ``None``).
+
+    Field semantics:
+
+    - ``revalidated_cut`` is the per-artifact version map ``{artifact_id: version}``
+      proven equal to the pin at the re-validate point — the exact vector the fire
+      decision was justified against.
+    - ``commit`` is the ``session.commit`` WIN tuple in ATOMIC mode, else ``None``.
+    - ``result`` is the escaping callable's return value in ESCAPING mode, else
+      ``None``.
+    - ``coordinator_epoch`` mirrors the other session results.
+    """
+
+    revalidated_cut: Mapping[UUID, int]
+    coordinator_epoch: str
+    commit: Optional["tuple[Artifact, list[InvalidationSignal]]"] = None
+    result: object = None
+
+
+@dataclass(frozen=True)
 class InvalidationSignal:
     """Lightweight invalidation signal sent to agents."""
 

--- a/src/ccs/core/types.py
+++ b/src/ccs/core/types.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal, Optional
+from typing import Literal, Mapping, Optional
 from uuid import UUID, uuid4
 
 from .states import MESIState, TransientState
@@ -153,6 +153,56 @@ class VersionedReadRejection:
     requested_version: int
     current_version: int | None
     coordinator_epoch: str
+
+
+@dataclass(frozen=True)
+class SnapshotSession:
+    """A consistent multi-artifact snapshot session (SB-17 / TX-1, Unit 2 / R1).
+
+    The WIN return of :meth:`CoordinatorService.begin_session` — a frozen value
+    object (the ``VersionedContent`` typed-return discipline) that pins a
+    coherent CUT of the read-set: a ``{artifact_id: version}`` vector captured at
+    ONE linearization point so no peer commit is *partially* visible within the
+    set (no cross-artifact read skew). The capture is non-mutating (it mints no
+    MESI grant and captures no ``read_generation`` — a reader is not an owner).
+
+    **R11 BINDING CONSTRAINT — the cut is an INSPECTABLE per-artifact map, NOT
+    an opaque handle.** ``cut`` exposes every pinned ``(artifact_id, version)``
+    pair by design: the paper SB-18 atomic multi-publish signature
+    (``commit_all(session_token, writes) -> MultiCommitResult``) is constructible
+    from v1 *only* because each artifact's ``expected_version`` can be read out
+    of this map. An opaque token that hid the per-artifact versions would leave
+    SB-18 no public way to obtain the expected-versions vector → foreclosed.
+    Unit 2 freezes this inspectable shape; Unit 9's harness re-checks it
+    mechanically. Do NOT replace ``cut`` with an opaque handle.
+
+    Field semantics:
+
+    - ``session_token`` is the server-minted, owner-bound session identity
+      (``secrets.token_urlsafe``; R13). It is NOT a snapshot handle — the cut is
+      carried inspectably in ``cut`` — it identifies the SESSION (for later
+      ``session.read`` / ``session.commit`` / heartbeat / release calls) and is
+      bound to the creating caller's identity at mint time.
+    - ``cut`` is the pinned version-vector ``{artifact_id: version}`` — the
+      consistent cut, one entry per read-set member, captured atomically. This is
+      the load-bearing inspectable surface (see the R11 note above).
+    - ``coordinator_epoch`` is the store's epoch, stamped to mirror
+      :class:`VersionedContent` / :class:`VersionedReadRejection` so a consumer
+      can pin which store-incarnation captured the cut (a durable sqlite session
+      survives restart only within the same epoch; an in-memory session does
+      not survive at all — R6).
+    - ``retain_versions`` is the deployment branch indicator: ``True`` when the
+      store retains bodies durably (the LAZY serve branch — Unit 3 serves pinned
+      bytes from ``artifact_versions``); ``False`` for the ``content=None`` /
+      retention-off ICP (the EAGER serve branch is resolved at the serve layer
+      in Unit 3, not here). Unit 2 records the branch; it captures the
+      version-MAP only and does NOT capture bytes in the coordinator.
+    """
+
+    session_token: str
+    cut: Mapping[UUID, int]
+    coordinator_epoch: str
+    retain_versions: bool
 
 
 @dataclass(frozen=True)

--- a/src/ccs/core/types.py
+++ b/src/ccs/core/types.py
@@ -206,6 +206,80 @@ class SnapshotSession:
 
 
 @dataclass(frozen=True)
+class DataPlaneDeferredRead:
+    """A pinned-version read the COORDINATOR cannot serve bytes for — the bytes
+    live in the data plane (SB-17 / TX-1, Unit 3 / R2, the EAGER branch).
+
+    The honest, typed signal of :meth:`CoordinatorService.session_read` when the
+    session pins a real version but the coordinator holds NO body for it: the
+    ``retain_versions=False`` / ``commit_cas(content=None)`` ICP, where bodies
+    are never persisted in ``artifact_versions`` and the canonical bytes live in
+    the CoherentVolume data plane. This is NOT an error and NOT a crash — it
+    carries the pinned ``version`` + ``coordinator_epoch`` (+ ``content_hash`` if
+    the registry knows it) so the caller can fetch the exact pinned bytes from
+    the data plane. The actual data-plane byte serve is **Unit 6
+    (CoherentVolume)** — this result is the boundary signal "coordinator pinned
+    the version; ask the data plane for the bytes."
+
+    **Carries NO body** by type (mirrors the :class:`VersionedReadRejection`
+    no-leak discipline): only the pinned coordinates a data-plane fetch needs.
+    The distinction from a rejection is deliberate — a rejection means "no valid
+    pin"; this means "valid pin, bytes elsewhere".
+
+    Field semantics:
+
+    - ``artifact_id`` / ``version`` are the PINNED coordinates (the cut entry),
+      not the current ones — the data plane must be asked for exactly this
+      version's bytes.
+    - ``content_hash`` is the pinned version's hash when the registry knows it
+      (the artifact metadata carries a hash even when the body is not retained),
+      else ``None`` — a hint the data-plane fetch can verify against; never a
+      body.
+    - ``coordinator_epoch`` is the store's epoch, stamped to mirror
+      :class:`VersionedContent` / :class:`SnapshotSession` so the caller can pin
+      which store-incarnation captured the cut.
+    """
+
+    artifact_id: UUID
+    version: int
+    content_hash: str | None
+    coordinator_epoch: str
+
+
+@dataclass(frozen=True)
+class SessionReadRejection:
+    """A typed :meth:`CoordinatorService.session_read` rejection (SB-17 / TX-1,
+    Unit 3 / R2) — never a live-HEAD fall-through.
+
+    The non-serve return when the call cannot be honored against a valid pin: a
+    typed RETURN (the ``ConflictDetail`` / ``VersionedReadRejection`` discipline),
+    never an exception and NEVER the current bytes served as if pinned. ``reason``
+    is exactly one of the wire-stable constants in
+    :data:`~ccs.core.exceptions.SESSION_READ_REASONS`; consumers match with
+    ``==``, never on a human message.
+
+    The two Unit-3 reasons (Unit 5 adds the heartbeat-liveness ``session_invalidated``
+    axis; Unit 3 treats a released/unknown token as ``session_not_found``):
+
+    - ``session_not_found`` — the ``session_token`` has no pinned cut (unknown,
+      never opened, or released). A coordinator restart that wiped an in-memory
+      session also lands here (the durable Unit-5 liveness/restart taxonomy is a
+      later unit; here it is simply "no cut for this token").
+    - ``artifact_not_in_cut`` — the token IS a live session, but ``artifact_id``
+      was not in its captured read-set. Reading an un-pinned artifact mid-session
+      is out of scope (a session wanting fresh data starts a new session); it is
+      rejected here, NOT served from live HEAD.
+
+    **Carries NO body** by type (the no-leak discipline): only the reason, the
+    artifact id, and the epoch. ``coordinator_epoch`` is ALWAYS populated.
+    """
+
+    reason: str
+    artifact_id: UUID
+    coordinator_epoch: str
+
+
+@dataclass(frozen=True)
 class InvalidationSignal:
     """Lightweight invalidation signal sent to agents."""
 

--- a/src/ccs/simulation/engine.py
+++ b/src/ccs/simulation/engine.py
@@ -212,6 +212,16 @@ class SimulationEngine:
                         max_hold_ticks=self._crash_recovery.max_hold_ticks,
                     )
                 )
+                # SB-17 / TX-1 Unit 5 / R4: the session-liveness sweep is a NEW
+                # axis (the grant sweep above can't see a grantless snapshot
+                # session). Gated by the SAME ``crash_recovery.enabled`` flag and
+                # the SAME heartbeat-staleness knob. The simulation engine opens
+                # no snapshot sessions, so this is a no-op here (zero sessions) —
+                # wired for parity with the live coordinator sweep cadence.
+                self._coordinator.enforce_session_liveness(
+                    current_tick=now,
+                    heartbeat_timeout_ticks=self._crash_recovery.heartbeat_timeout_ticks,
+                )
             self._clock.advance()
 
         # Drain messages that become due exactly at final tick.

--- a/tests/adapters/test_session_audit.py
+++ b/tests/adapters/test_session_audit.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for the content-free snapshot-session audit log (SB-17 / TX-1,
+Unit 8 / R10a).
+
+Mirrors the KTD-V bounded-payload discipline of
+``test_audit_log_payload_bounded_no_user_content`` (in
+``tests/test_claude_code_strict_mode_telemetry.py``) for the SEPARATE
+session-audit module: begin / commit / invalidate events carry only
+session id (a hash of the token), read-set artifact ids, pinned versions,
+and timestamps — NEVER content bytes, body hashes, or user prose.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+from datetime import datetime
+from pathlib import Path
+from uuid import uuid4
+
+from ccs.adapters.claude_code.session_audit_log import (
+    _REQUIRED_MODE,
+    _resolve_session_audit_log_path,
+    append_session_begin,
+    append_session_commit,
+    append_session_invalidate,
+)
+
+
+def _read_records(coordinator_root: Path) -> list[dict]:
+    path = _resolve_session_audit_log_path(coordinator_root)
+    lines = path.read_text().strip().splitlines()
+    return [json.loads(line) for line in lines]
+
+
+# The forbidden field set — adding any of these would leak more surface than
+# R10a scopes. ``content_hash`` is forbidden too: the audit log records NO
+# hashes of bodies (the session-token HASH is recorded under the ``session``
+# key, which is allowed and is not a body hash).
+_FORBIDDEN = {
+    "content",
+    "content_hash",
+    "body",
+    "bytes",
+    "command",
+    "tool_input",
+    "additionalContext",
+    "user_message",
+    "prose",
+    "token",  # the RAW session token must never appear
+    "session_token",
+}
+
+
+def test_session_begin_record_bounded_fields(tmp_path: Path) -> None:
+    (tmp_path / ".coherence").mkdir(mode=0o700)
+    a1, a2 = uuid4(), uuid4()
+    token = "tok-begin-xyz"
+    assert append_session_begin(tmp_path, session_token=token, cut={a1: 42, a2: 7})
+    record = _read_records(tmp_path)[0]
+    # EXACT bounded field set (like test_audit_log_payload_bounded_no_user_content).
+    assert set(record.keys()) == {"ts", "event", "session", "cut"}
+    assert record["event"] == "session_begin"
+    # session is the SHA-256 hash of the token, never the raw token.
+    assert record["session"] == hashlib.sha256(token.encode()).hexdigest()
+    assert token not in json.dumps(record)
+    # cut carries ids + versions only.
+    assert record["cut"] == {str(a1): 42, str(a2): 7}
+    datetime.fromisoformat(record["ts"])
+
+
+def test_session_commit_record_bounded_fields(tmp_path: Path) -> None:
+    (tmp_path / ".coherence").mkdir(mode=0o700)
+    artifact = uuid4()
+    token = "tok-commit-abc"
+    assert append_session_commit(
+        tmp_path,
+        session_token=token,
+        artifact_id=artifact,
+        pinned_version=42,
+        committed_version=43,
+    )
+    record = _read_records(tmp_path)[0]
+    assert set(record.keys()) == {
+        "ts", "event", "session", "artifact", "pinned_version", "committed_version",
+    }
+    assert record["event"] == "session_commit"
+    assert record["artifact"] == str(artifact)
+    assert record["pinned_version"] == 42
+    assert record["committed_version"] == 43
+    assert not (set(record.keys()) & _FORBIDDEN)
+
+
+def test_session_invalidate_record_bounded_fields(tmp_path: Path) -> None:
+    (tmp_path / ".coherence").mkdir(mode=0o700)
+    token = "tok-inv-123"
+    assert append_session_invalidate(
+        tmp_path, session_token=token, reason="session_invalidated",
+    )
+    record = _read_records(tmp_path)[0]
+    assert set(record.keys()) == {"ts", "event", "session", "reason"}
+    assert record["event"] == "session_invalidate"
+    # reason is a machine token, never prose.
+    assert record["reason"] == "session_invalidated"
+    assert not (set(record.keys()) & _FORBIDDEN)
+
+
+def test_all_three_events_no_forbidden_fields_no_content(tmp_path: Path) -> None:
+    """The exact-field-set guard like the KTD-V counterpart: across all three
+    event kinds, no forbidden (content/prose/raw-token) field ever appears."""
+    (tmp_path / ".coherence").mkdir(mode=0o700)
+    artifact = uuid4()
+    token = "tok-secret-never-logged"
+    secret_prose = "the user's confidential plan body"
+    append_session_begin(tmp_path, session_token=token, cut={artifact: 1})
+    append_session_commit(
+        tmp_path, session_token=token, artifact_id=artifact,
+        pinned_version=1, committed_version=2,
+    )
+    append_session_invalidate(tmp_path, session_token=token, reason="session_invalidated")
+    raw = _resolve_session_audit_log_path(tmp_path).read_text()
+    # The raw token and any prose must never appear anywhere in the log bytes.
+    assert token not in raw
+    assert secret_prose not in raw
+    for record in _read_records(tmp_path):
+        assert not (set(record.keys()) & _FORBIDDEN), (
+            f"forbidden field leaked: {set(record.keys()) & _FORBIDDEN}"
+        )
+
+
+def test_session_audit_file_mode_0600(tmp_path: Path) -> None:
+    (tmp_path / ".coherence").mkdir(mode=0o700)
+    append_session_begin(tmp_path, session_token="t", cut={uuid4(): 1})
+    path = _resolve_session_audit_log_path(tmp_path)
+    assert stat.S_IMODE(path.stat().st_mode) == _REQUIRED_MODE
+
+
+def test_session_audit_required_mode_constant() -> None:
+    """R10a locked: the required mode is 0o600 (owner-only)."""
+    assert _REQUIRED_MODE == 0o600
+
+
+def test_session_audit_o_nofollow_refuses_symlink(tmp_path: Path) -> None:
+    """O_NOFOLLOW: a symlink planted at the audit path must NOT be followed —
+    the append fails closed (returns False), never redirects elsewhere."""
+    (tmp_path / ".coherence").mkdir(mode=0o700)
+    audit_path = _resolve_session_audit_log_path(tmp_path)
+    target = tmp_path / "elsewhere.log"
+    target.write_text("")
+    audit_path.symlink_to(target)
+    ok = append_session_begin(tmp_path, session_token="t", cut={uuid4(): 1})
+    assert ok is False
+    # The symlink target must be untouched (nothing written through the link).
+    assert target.read_text() == ""
+
+
+def test_session_audit_append_failure_does_not_raise(tmp_path: Path) -> None:
+    """No .coherence/ dir → os.open fails; the helper swallows the OSError
+    (the coordinator transaction has already committed)."""
+    ok = append_session_begin(tmp_path, session_token="t", cut={uuid4(): 1})
+    assert ok is False

--- a/tests/test_effect_gate.py
+++ b/tests/test_effect_gate.py
@@ -1,0 +1,673 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Unit 6 — the effect-gate wrapper (EO-5): "fire effect E iff read-set R
+unchanged" (SB-17 / TX-1).
+
+Plan: ``docs/plans/2026-06-26-002-feat-read-side-transaction-snapshot-plan.md``
+Unit 6. Requirement trace: **EO-5** (the ergonomic EO-4 = SB-17 user surface).
+Builds on Units 2-5: ``begin_session`` / cut-capture (U2), ``session_read`` (U3),
+``session_commit`` (U4), the heartbeat lease + session-liveness sweep + fail-closed
+``SessionInvalidated`` (U5). The gate COMPOSES those primitives; it re-implements
+none of them.
+
+``CoordinatorService.effect_gate`` is a PURE IN-PROCESS coordinator method (not the
+CoherentVolume HTTP path), so fail-closed is enforced by the typed session results
+directly — a dead session at any step RAISES ``SessionInvalidated``, never fires.
+
+The two modes under test:
+
+- **ATOMIC** (``commit=(artifact_id, content)``) — routed through ``session_commit``
+  so ``commit_cas`` arbitrates at the pinned base in the SAME step: NO
+  re-validate->fire window. A raced peer commit loses the CAS cleanly (HELD with the
+  shipped ``ConflictDetail`` carried through verbatim).
+- **ESCAPING** (``effect=callable``) — re-validate, then fire the callable. The
+  guarantee is "unchanged AS OF the re-validate point", NOT "as of the fire point":
+  the residual re-validate->fire window is unclosable (EO-7) and is OBSERVED here,
+  not asserted away.
+
+Timing is exercised with FIXED-STALE BUFFERS (a peer commit driven explicitly at a
+chosen point), never counters or wall-clock sleeps — the institutional steer for
+the multi-read window (a protocol proof bounds the registry, not the integration).
+Reason matching is ALWAYS ``reason == CONSTANT`` against the imported wire-stable
+constant, never a substring of a human message.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.retention import RetentionPolicy
+from ccs.coordinator.service import CoordinatorService, SessionView
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.exceptions import (
+    SESSION_INVALIDATED_REASON,
+    VERSION_MISMATCH_REASON,
+    CoherenceError,
+    SessionInvalidated,
+)
+from ccs.core.states import MESIState
+from ccs.core.types import (
+    Artifact,
+    ConflictDetail,
+    DataPlaneDeferredRead,
+    EffectFired,
+    EffectHeld,
+    VersionedContent,
+)
+
+_HB_TIMEOUT = 120
+
+
+# ---------------------------------------------------------------------------
+# Builders — mirror tests/test_session_commit.py / test_session_lifetime.py.
+# ---------------------------------------------------------------------------
+
+
+def _register(reg, artifact_id: UUID, name: str, body: str, version: int = 1) -> None:
+    art = Artifact(id=artifact_id, name=name, version=version, content_hash="h1")
+    reg.register_artifact(art, content=body)
+
+
+def _peer_commit_cas(
+    reg, artifact_id: UUID, writer: UUID, expected: int, body: str | None
+) -> None:
+    """A PEER OCC commit via the registry ``commit_cas`` WIN — advances current
+    past the pin so a subsequent gate at the captured version is HELD."""
+    reg.set_agent_state(artifact_id, writer, MESIState.SHARED, tick=1)
+    reg.commit_cas(
+        artifact_id,
+        writer,
+        expected_version=expected,
+        content_hash="h2",
+        content=body,
+        tick=2,
+    )
+
+
+def _lazy_registries(tmp_path: Path):
+    """An (in_memory, sqlite) LAZY pair — ``retain_versions=True`` (bodies in
+    history) so ``session_read`` serves concrete pinned bytes on both arms."""
+    pol = RetentionPolicy(max_versions=8)
+    mem = ArtifactRegistry(retain_versions=True, retention_policy=pol)
+    sql = SqliteArtifactRegistry(
+        tmp_path / "gate_lazy.db", retain_versions=True, retention_policy=pol
+    )
+    return mem, sql
+
+
+def _eager_registries(tmp_path: Path):
+    """An (in_memory, sqlite) EAGER pair — ``retain_versions=False`` (the
+    ``content=None`` ICP); ``session_read`` returns ``DataPlaneDeferredRead``."""
+    mem = ArtifactRegistry(retain_versions=False)
+    sql = SqliteArtifactRegistry(tmp_path / "gate_eager.db", retain_versions=False)
+    return mem, sql
+
+
+# ===========================================================================
+# A — Happy path: read-set unchanged through re-validate -> effect fires.
+# ===========================================================================
+
+
+class TestHappyPathFires:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_escaping_effect_fires_when_unchanged(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            a, b = uuid4(), uuid4()
+            _register(reg, a, "plan.md", "PLAN-V1")
+            _register(reg, b, "budget.md", "BUDGET-V1")
+
+            fired: list[object] = []
+
+            def decide(view: SessionView) -> str:
+                plan = view.read(a)
+                budget = view.read(b)
+                assert isinstance(plan, VersionedContent)
+                assert isinstance(budget, VersionedContent)
+                return f"{plan.content}+{budget.content}"
+
+            def effect(decision: object) -> str:
+                fired.append(decision)
+                return "DEPLOYED"
+
+            outcome = svc.effect_gate(
+                read_set=[a, b], owner=owner, decide=decide, effect=effect
+            )
+
+            assert isinstance(outcome, EffectFired)
+            # The callable fired EXACTLY once with the decision computed off the cut.
+            assert fired == ["PLAN-V1+BUDGET-V1"]
+            assert outcome.result == "DEPLOYED"
+            assert outcome.revalidated_cut == {a: 1, b: 1}
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_atomic_commit_wins_when_unchanged(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "PLAN-V1")
+
+            def decide(view: SessionView) -> object:
+                return view.read(a)
+
+            outcome = svc.effect_gate(
+                read_set=[a],
+                owner=owner,
+                decide=decide,
+                commit=(a, "PLAN-V2"),
+            )
+
+            assert isinstance(outcome, EffectFired)
+            assert outcome.commit is not None
+            updated_artifact, signals = outcome.commit
+            assert updated_artifact.version == 2  # pinned 1 -> 2
+            assert isinstance(signals, list)
+            # The registry advanced.
+            assert reg.get_artifact(a).version == 2
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# B — HELD: a peer advances a read-set member after capture -> NEVER fires.
+# ===========================================================================
+
+
+class TestHeldOnDrift:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_escaping_effect_held_when_member_moved(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            a, b = uuid4(), uuid4()
+            _register(reg, a, "plan.md", "PLAN-V1")
+            _register(reg, b, "budget.md", "BUDGET-V1")
+
+            fired: list[object] = []
+
+            def decide(view: SessionView) -> str:
+                # A peer commits a READ-SET MEMBER between the pin and the effect
+                # boundary — driven explicitly (a fixed-stale buffer, not a sleep)
+                # from inside decide so the drift is deterministic.
+                _peer_commit_cas(reg, b, uuid4(), expected=1, body="BUDGET-V2")
+                return "decision-on-stale-budget"
+
+            def effect(decision: object) -> str:
+                fired.append(decision)
+                return "DEPLOYED"
+
+            outcome = svc.effect_gate(
+                read_set=[a, b], owner=owner, decide=decide, effect=effect
+            )
+
+            assert isinstance(outcome, EffectHeld)
+            # The effect was NEVER invoked — no fire on stale input.
+            assert fired == []
+            # The drift map names the moved member (pinned 1 -> current 2).
+            assert outcome.moved == {b: (1, 2)}
+            # No commit conflict for an escaping HELD (no CAS was attempted).
+            assert outcome.conflict is None
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_atomic_commit_held_returns_conflict_when_target_moved(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "PLAN-V1")
+
+            def decide(view: SessionView) -> object:
+                # A peer advances the COMMIT TARGET after the pin.
+                _peer_commit_cas(reg, a, uuid4(), expected=1, body="PLAN-V2-PEER")
+                return view  # decision value unused for atomic mode
+
+            outcome = svc.effect_gate(
+                read_set=[a],
+                owner=owner,
+                decide=decide,
+                commit=(a, "PLAN-V2-MINE"),
+            )
+
+            assert isinstance(outcome, EffectHeld)
+            # The fast pre-CAS re-validate short-circuits here, so no commit was
+            # attempted -> the drift map names the moved target, conflict is None.
+            assert outcome.moved == {a: (1, 2)}
+            # The registry still carries the PEER's bytes (mine never landed).
+            assert reg.get_artifact(a).version == 2
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_atomic_commit_conflict_surfaced_when_cas_loses(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """An OTHER read-set member moved (not the commit target), so the fast
+        pre-CAS re-validate does NOT short-circuit the target — the CAS runs and
+        loses at the pinned base, surfacing the shipped ``ConflictDetail`` verbatim
+        inside ``EffectHeld.conflict``."""
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            a, b = uuid4(), uuid4()
+            _register(reg, a, "plan.md", "PLAN-V1")
+            _register(reg, b, "budget.md", "BUDGET-V1")
+
+            def decide(view: SessionView) -> object:
+                # Move the COMMIT TARGET 'a' so the CAS at the pinned base loses,
+                # AND the pre-CAS short-circuit fires too. To exercise the CAS
+                # losing path itself, move 'a' but assert the conflict shape.
+                _peer_commit_cas(reg, a, uuid4(), expected=1, body="PLAN-PEER")
+                return view
+
+            outcome = svc.effect_gate(
+                read_set=[a, b],
+                owner=owner,
+                decide=decide,
+                commit=(a, "PLAN-MINE"),
+            )
+
+            assert isinstance(outcome, EffectHeld)
+            # Either path (pre-CAS short-circuit or CAS loss) HOLDS and names 'a'.
+            assert a in outcome.moved
+            assert outcome.moved[a] == (1, 2)
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# C — Fail-closed: the session is reaped mid-gate -> SessionInvalidated, no fire.
+# ===========================================================================
+
+
+class TestFailClosed:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_reaped_session_in_decide_fails_closed(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "PLAN-V1")
+
+            fired: list[object] = []
+
+            def decide(view: SessionView) -> object:
+                # Reap THIS session mid-gate: drive the liveness sweep past the
+                # heartbeat window (fixed ticks, no sleep). The session's pins are
+                # released, so the subsequent read fails closed.
+                reaped = svc.enforce_session_liveness(
+                    current_tick=_HB_TIMEOUT + 1,
+                    heartbeat_timeout_ticks=_HB_TIMEOUT,
+                )
+                assert reaped == 1
+                return view.read(a)  # fails closed here
+
+            def effect(decision: object) -> str:
+                fired.append(decision)
+                return "DEPLOYED"
+
+            with pytest.raises(SessionInvalidated) as exc:
+                svc.effect_gate(
+                    read_set=[a],
+                    owner=owner,
+                    decide=decide,
+                    effect=effect,
+                    created_at_tick=0,
+                )
+            assert exc.value.reason == SESSION_INVALIDATED_REASON
+            assert fired == []  # the effect NEVER ran
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_reaped_session_at_atomic_commit_fails_closed(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "PLAN-V1")
+
+            def decide(view: SessionView) -> object:
+                # Reap after the decision read but before the commit fires.
+                svc.session_read(view._token, a)  # a valid pinned read first
+                svc.enforce_session_liveness(
+                    current_tick=_HB_TIMEOUT + 1,
+                    heartbeat_timeout_ticks=_HB_TIMEOUT,
+                )
+                return view
+
+            with pytest.raises(SessionInvalidated) as exc:
+                svc.effect_gate(
+                    read_set=[a],
+                    owner=owner,
+                    decide=decide,
+                    commit=(a, "PLAN-V2"),
+                    created_at_tick=0,
+                )
+            assert exc.value.reason == SESSION_INVALIDATED_REASON
+            # The commit NEVER landed — the artifact stays at v1.
+            assert reg.get_artifact(a).version == 1
+        finally:
+            sql.close()
+
+    def test_unknown_artifact_in_read_set_fails_closed(self, tmp_path: Path) -> None:
+        mem, _sql = _lazy_registries(tmp_path)
+        svc = CoordinatorService(mem)
+        a = uuid4()
+        _register(mem, a, "plan.md", "PLAN-V1")
+        ghost = uuid4()  # never registered
+
+        with pytest.raises(SessionInvalidated):
+            svc.effect_gate(
+                read_set=[a, ghost],
+                owner=uuid4(),
+                decide=lambda view: None,
+                effect=lambda d: "DEPLOYED",
+            )
+
+
+# ===========================================================================
+# D — Atomic vs escaping: the residual re-validate->fire window (EO-7).
+# ===========================================================================
+
+
+class TestRevalidateFireWindow:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_escaping_window_is_observed_not_asserted_away(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """A peer commit landing in the RE-VALIDATE->FIRE window for an ESCAPING
+        effect: the effect FIRES on a vector that was valid at re-validate but
+        moved before the fire completed. The window is OBSERVED (the gate fired
+        AND the member moved), NOT asserted away. This is the honest EO-5 / EO-7
+        bound — atomic-iff holds ONLY for ``session.commit``."""
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "PLAN-V1")
+
+            # The side effect itself lands a peer commit on a read-set member as
+            # its FIRST action — i.e. exactly inside the unclosable window, after
+            # the gate's re-validate already passed. This is the deterministic
+            # stand-in for a concurrent peer commit racing the fire (a fixed-stale
+            # buffer, not a sleep): the gate cannot have seen it, because it fires
+            # the callable only after re-validate.
+            window_fired: list[bool] = []
+
+            def decide(view: SessionView) -> object:
+                return view.read(a)
+
+            def escaping_effect(decision: object) -> str:
+                # A peer moves the pinned member DURING the fire.
+                _peer_commit_cas(reg, a, uuid4(), expected=1, body="PLAN-V2-RACED")
+                window_fired.append(True)
+                return "DEPLOYED-ON-NOW-STALE-VECTOR"
+
+            outcome = svc.effect_gate(
+                read_set=[a], owner=owner, decide=decide, effect=escaping_effect
+            )
+
+            # The gate FIRED (re-validate passed before the callable ran) ...
+            assert isinstance(outcome, EffectFired)
+            assert window_fired == [True]
+            assert outcome.result == "DEPLOYED-ON-NOW-STALE-VECTOR"
+            # ... yet the member MOVED inside the window: the effect fired on a
+            # vector that is no longer current. The gate does NOT roll back (EO-7);
+            # the residual window is real and is documented, not claimed away.
+            assert reg.get_artifact(a).version == 2  # moved during fire
+            assert outcome.revalidated_cut == {a: 1}  # what was proven at re-validate
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_atomic_mode_closes_the_window(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """The ATOMIC counterpart: the SAME race that an escaping effect cannot
+        catch is caught by ``commit_cas`` arbitration — when the commit target is
+        moved by a peer, the atomic commit HOLDS (no fire), proving the window is
+        closed for ``session.commit`` (the strong guarantee)."""
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "PLAN-V1")
+
+            def decide(view: SessionView) -> object:
+                _peer_commit_cas(reg, a, uuid4(), expected=1, body="PLAN-V2-PEER")
+                return view
+
+            outcome = svc.effect_gate(
+                read_set=[a], owner=owner, decide=decide, commit=(a, "PLAN-V2-MINE")
+            )
+
+            # Atomic mode HELD — the peer's commit is the only one that landed.
+            assert isinstance(outcome, EffectHeld)
+            assert reg.get_artifact(a).version == 2
+            # The pinned-base CAS would surface version_mismatch had the pre-CAS
+            # short-circuit not caught it first; either way nothing of mine landed.
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# E — Classification on exact reason constant, not substring.
+# ===========================================================================
+
+
+class TestReasonClassification:
+    def test_held_carries_shipped_conflict_reason_exactly(
+        self, tmp_path: Path
+    ) -> None:
+        """When the atomic CAS loses (rather than the pre-CAS short-circuit), the
+        carried ``ConflictDetail.reason`` is the shipped ``version_mismatch``
+        constant verbatim — matched with ``==``, never a substring. Driven by
+        moving the target so the CAS arbitrates at the pinned base."""
+        mem, _sql = _lazy_registries(tmp_path)
+        svc = CoordinatorService(mem)
+        owner = uuid4()
+        a = uuid4()
+        _register(mem, a, "plan.md", "PLAN-V1")
+
+        # Bypass the gate's pre-CAS short-circuit to exercise the CAS-loss path
+        # directly: call _effect_gate_atomic with a cut whose target is already
+        # advanced. We pin at v1, advance to v2, then commit -> CAS loses.
+        session = svc.begin_session(read_set=[a], owner=owner)
+        _peer_commit_cas(mem, a, uuid4(), expected=1, body="PLAN-PEER")
+
+        # The session's cut still pins v1; session_commit at pin 1 vs current 2
+        # returns the shipped ConflictDetail(version_mismatch).
+        result = svc.session_commit(session.session_token, a, "PLAN-MINE")
+        assert isinstance(result, ConflictDetail)
+        assert result.reason == VERSION_MISMATCH_REASON  # exact constant, not substring
+
+    def test_fail_closed_reason_is_exact_constant(self, tmp_path: Path) -> None:
+        mem, _sql = _lazy_registries(tmp_path)
+        svc = CoordinatorService(mem)
+        a = uuid4()
+        _register(mem, a, "plan.md", "PLAN-V1")
+
+        def decide(view: SessionView) -> object:
+            svc.enforce_session_liveness(
+                current_tick=_HB_TIMEOUT + 1, heartbeat_timeout_ticks=_HB_TIMEOUT
+            )
+            return view.read(a)
+
+        with pytest.raises(SessionInvalidated) as exc:
+            svc.effect_gate(
+                read_set=[a], owner=uuid4(), decide=decide, effect=lambda d: None
+            )
+        assert exc.value.reason == SESSION_INVALIDATED_REASON
+
+
+# ===========================================================================
+# F — Caller-misuse + eager-branch + cleanup edges.
+# ===========================================================================
+
+
+class TestEdges:
+    def test_requires_exactly_one_effect_mode(self, tmp_path: Path) -> None:
+        mem, _sql = _lazy_registries(tmp_path)
+        svc = CoordinatorService(mem)
+        a = uuid4()
+        _register(mem, a, "plan.md", "PLAN-V1")
+
+        # Neither effect nor commit.
+        with pytest.raises(ValueError):
+            svc.effect_gate(read_set=[a], owner=uuid4(), decide=lambda v: None)
+
+        # Both effect and commit.
+        with pytest.raises(ValueError):
+            svc.effect_gate(
+                read_set=[a],
+                owner=uuid4(),
+                decide=lambda v: None,
+                effect=lambda d: None,
+                commit=(a, "X"),
+            )
+
+    def test_decide_reading_unpinned_artifact_is_hard_error(
+        self, tmp_path: Path
+    ) -> None:
+        mem, _sql = _lazy_registries(tmp_path)
+        svc = CoordinatorService(mem)
+        a, b = uuid4(), uuid4()
+        _register(mem, a, "plan.md", "PLAN-V1")
+        _register(mem, b, "budget.md", "BUDGET-V1")
+
+        def decide(view: SessionView) -> object:
+            return view.read(b)  # b is NOT in the read-set
+
+        with pytest.raises(CoherenceError):
+            svc.effect_gate(
+                read_set=[a], owner=uuid4(), decide=decide, effect=lambda d: None
+            )
+
+    def test_eager_branch_decide_gets_data_plane_deferred(
+        self, tmp_path: Path
+    ) -> None:
+        """On the EAGER (``content=None`` / retain-off) branch the coordinator
+        holds no body, so the decide view gets a ``DataPlaneDeferredRead``. The
+        gate still re-validates by VERSION (byte-source-independent) and fires."""
+        mem, sql = _eager_registries(tmp_path)
+        try:
+            svc = CoordinatorService(mem)
+            owner = uuid4()
+            a = uuid4()
+            _register(mem, a, "plan.md", "PLAN-V1")
+
+            seen: list[object] = []
+
+            def decide(view: SessionView) -> object:
+                r = view.read(a)
+                seen.append(r)
+                return r
+
+            def effect(decision: object) -> str:
+                return "FIRED"
+
+            outcome = svc.effect_gate(
+                read_set=[a], owner=owner, decide=decide, effect=effect
+            )
+            assert isinstance(outcome, EffectFired)
+            assert len(seen) == 1
+            assert isinstance(seen[0], DataPlaneDeferredRead)
+            assert seen[0].version == 1
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_release_on_exit_drops_the_pin(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "PLAN-V1")
+
+            captured_token: list[str] = []
+
+            def decide(view: SessionView) -> object:
+                captured_token.append(view._token)
+                return view.read(a)
+
+            svc.effect_gate(
+                read_set=[a], owner=owner, decide=decide, effect=lambda d: "X"
+            )
+            # After the gate, the pin is released by default — the cut is gone.
+            tok = captured_token[0]
+            assert reg.get_session_cut(tok) is None
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_keep_session_when_release_disabled(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "PLAN-V1")
+
+            captured_token: list[str] = []
+
+            def decide(view: SessionView) -> object:
+                captured_token.append(view._token)
+                return view.read(a)
+
+            svc.effect_gate(
+                read_set=[a],
+                owner=owner,
+                decide=decide,
+                effect=lambda d: "X",
+                release_on_exit=False,
+            )
+            tok = captured_token[0]
+            assert reg.get_session_cut(tok) is not None  # still live
+        finally:
+            sql.close()

--- a/tests/test_effect_gate.py
+++ b/tests/test_effect_gate.py
@@ -268,37 +268,58 @@ class TestHeldOnDrift:
     def test_atomic_commit_conflict_surfaced_when_cas_loses(
         self, tmp_path: Path, arm: str
     ) -> None:
-        """An OTHER read-set member moved (not the commit target), so the fast
-        pre-CAS re-validate does NOT short-circuit the target — the CAS runs and
-        loses at the pinned base, surfacing the shipped ``ConflictDetail`` verbatim
-        inside ``EffectHeld.conflict``."""
+        """The TRUE CAS-loss branch (finding F8): the pre-CAS re-validate sees the
+        commit target as UNCHANGED (so it does NOT short-circuit), the CAS then
+        RUNS and LOSES at the pinned base, and the shipped ``ConflictDetail`` is
+        surfaced verbatim inside ``EffectHeld.conflict``. ``conflict is not None``
+        is exactly what distinguishes this from the pre-CAS short-circuit path
+        (which the prior version of this test actually exercised, leaving the CAS
+        loss branch uncovered).
+
+        Determinism: the TOCTOU window between the pre-CAS re-validate and the CAS
+        is simulated by stubbing the FIRST ``_revalidate_cut`` to report no drift,
+        then letting the REAL CAS lose against the peer-moved target."""
         mem, sql = _lazy_registries(tmp_path)
         reg = mem if arm == "in_memory" else sql
         try:
             svc = CoordinatorService(reg)
             owner = uuid4()
-            a, b = uuid4(), uuid4()
+            a = uuid4()
             _register(reg, a, "plan.md", "PLAN-V1")
-            _register(reg, b, "budget.md", "BUDGET-V1")
+
+            real_revalidate = svc._revalidate_cut
+            calls = {"n": 0}
+
+            def fake_revalidate(cut):
+                calls["n"] += 1
+                # 1st call = the pre-CAS short-circuit check: hide the drift so the
+                # CAS actually runs. Later calls (post-conflict) are the REAL drift.
+                if calls["n"] == 1:
+                    return {}
+                return real_revalidate(cut)
+
+            svc._revalidate_cut = fake_revalidate
 
             def decide(view: SessionView) -> object:
-                # Move the COMMIT TARGET 'a' so the CAS at the pinned base loses,
-                # AND the pre-CAS short-circuit fires too. To exercise the CAS
-                # losing path itself, move 'a' but assert the conflict shape.
-                _peer_commit_cas(reg, a, uuid4(), expected=1, body="PLAN-PEER")
+                # The peer moves the commit target after the pin; the stubbed
+                # pre-CAS check hides it, so the CAS at pinned base v1 loses to v2.
+                _peer_commit_cas(reg, a, uuid4(), expected=1, body="PLAN-PEER-V2")
                 return view
 
             outcome = svc.effect_gate(
-                read_set=[a, b],
-                owner=owner,
-                decide=decide,
-                commit=(a, "PLAN-MINE"),
+                read_set=[a], owner=owner, decide=decide, commit=(a, "PLAN-MINE"),
             )
 
+            assert calls["n"] == 2  # pre-CAS (hidden) THEN post-conflict (real)
             assert isinstance(outcome, EffectHeld)
-            # Either path (pre-CAS short-circuit or CAS loss) HOLDS and names 'a'.
-            assert a in outcome.moved
-            assert outcome.moved[a] == (1, 2)
+            # DISTINGUISHING assertion: the CAS ran and lost, so the shipped
+            # ConflictDetail is carried through verbatim (short-circuit → None).
+            assert outcome.conflict is not None
+            assert outcome.conflict.reason == "version_mismatch"
+            # The post-conflict re-validate names the moved target.
+            assert outcome.moved.get(a) == (1, 2)
+            # The peer's bytes stand; mine never landed (no phantom write).
+            assert reg.get_artifact(a).version == 2
         finally:
             sql.close()
 

--- a/tests/test_effect_gate.py
+++ b/tests/test_effect_gate.py
@@ -365,7 +365,7 @@ class TestFailClosed:
 
             def decide(view: SessionView) -> object:
                 # Reap after the decision read but before the commit fires.
-                svc.session_read(view._token, a)  # a valid pinned read first
+                svc.session_read(view._token, a, caller=owner)  # a valid pinned read first
                 svc.enforce_session_liveness(
                     current_tick=_HB_TIMEOUT + 1,
                     heartbeat_timeout_ticks=_HB_TIMEOUT,
@@ -518,7 +518,7 @@ class TestReasonClassification:
 
         # The session's cut still pins v1; session_commit at pin 1 vs current 2
         # returns the shipped ConflictDetail(version_mismatch).
-        result = svc.session_commit(session.session_token, a, "PLAN-MINE")
+        result = svc.session_commit(session.session_token, a, "PLAN-MINE", caller=owner)
         assert isinstance(result, ConflictDetail)
         assert result.reason == VERSION_MISMATCH_REASON  # exact constant, not substring
 

--- a/tests/test_retention_parity.py
+++ b/tests/test_retention_parity.py
@@ -67,11 +67,13 @@ from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
 from ccs.core.exceptions import (
     CURRENT_VERSION_REASON,
     NOT_RETAINED_REASON,
+    SESSION_INVALIDATED_REASON,
     UNKNOWN_ARTIFACT_REASON,
 )
 from ccs.core.states import MESIState
 from ccs.core.types import (
     Artifact,
+    SessionReadRejection,
     SnapshotSession,
     VersionedContent,
     VersionedReadRejection,
@@ -723,3 +725,168 @@ def _commit_cas(reg, artifact_id: UUID, writer: UUID, expected: int, body: str) 
         content=body,
         tick=2,
     )
+
+
+# ===========================================================================
+# E — Snapshot SESSION parity through the SERVICE surface (Unit 9 / R5, R6)
+# ===========================================================================
+#
+# Section D (above, Unit 2) exercised ``capture_version_vector`` at the REGISTRY
+# level. Unit 9 adds the parity that rides the SERVICE surface a real session
+# uses — ``begin_session`` / ``session_read`` / ``get_session_cut`` — and pins
+# the in-memory↔sqlite divergence (restart-survival, R6) on BOTH arms so it is
+# ASSERTED, never masked. R5 (concurrent overlapping sessions hold independent
+# immutable cuts) is exercised identically across the two registries.
+
+
+def _register(reg, artifact_id: UUID, name: str, body: str) -> None:
+    art = Artifact(id=artifact_id, name=name, version=1, content_hash="h")
+    reg.register_artifact(art, content=body)
+
+
+class TestSnapshotSessionParityThroughService:
+    """``begin_session`` + ``session_read`` behave IDENTICALLY on both registries
+    on the NON-restart paths (capture, serve, overlap, release); the ONE
+    divergence — restart-survival — is asserted explicitly on BOTH arms (sqlite
+    survives, in-memory wiped). The success criterion + R6: divergence ASSERTED,
+    not hidden."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_begin_and_serve_identical_on_both_arms(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        # The non-restart happy path is registry-agnostic: begin a session over a
+        # retained store, serve the pinned bytes, and read back the cut via the
+        # service — same observable result on both arms.
+        mem, sql = _snap_pair(
+            tmp_path, "sess_serve.db", RetentionPolicy(max_versions=8)
+        )
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "PINNED-V1")
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
+            assert isinstance(session, SnapshotSession)
+            assert dict(session.cut) == {a: 1}
+            # The pinned bytes serve identically (lazy / retain on).
+            served = svc.session_read(session.session_token, a, caller=owner)
+            assert isinstance(served, VersionedContent)
+            assert served.version == 1
+            assert served.content == "PINNED-V1"
+            # The durable/ephemeral pin is readable back through the registry on
+            # both arms while live.
+            assert svc.registry.get_session_cut(session.session_token) == {a: 1}
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_overlapping_sessions_hold_independent_immutable_cuts_R5(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        # R5: two concurrent overlapping sessions over the SAME artifact hold
+        # INDEPENDENT immutable cuts — the second session pins the moved version,
+        # the first stays at its captured version. Identical on both arms.
+        mem, sql = _snap_pair(
+            tmp_path, "sess_overlap.db", RetentionPolicy(max_versions=8)
+        )
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "V1")
+            owner = uuid4()
+            s1 = svc.begin_session(read_set=[a], owner=owner)  # pins {a:1}
+            writer = uuid4()
+            _commit_cas(reg, a, writer, 1, "V2")  # current → 2
+            s2 = svc.begin_session(read_set=[a], owner=owner)  # pins {a:2}
+
+            assert isinstance(s1, SnapshotSession) and isinstance(s2, SnapshotSession)
+            # Independent immutable cuts: s1 still at v1, s2 at v2.
+            assert dict(s1.cut) == {a: 1}
+            assert dict(s2.cut) == {a: 2}
+            # Each serves ITS OWN pinned version (no read skew, no cross-leak).
+            r1 = svc.session_read(s1.session_token, a, caller=owner)
+            r2 = svc.session_read(s2.session_token, a, caller=owner)
+            assert isinstance(r1, VersionedContent) and r1.version == 1
+            assert r1.content == "V1"
+            assert isinstance(r2, VersionedContent) and r2.version == 2
+            assert r2.content == "V2"
+
+            # Releasing s1 must NOT disturb s2's independent cut.
+            reg.release_session(s1.session_token)
+            assert svc.registry.get_session_cut(s2.session_token) == {a: 2}
+        finally:
+            sql.close()
+
+    def test_restart_survival_divergence_both_arms_asserted(
+        self, tmp_path: Path
+    ) -> None:
+        # THE Unit-9 divergence (R6), through the SERVICE surface and asserted on
+        # BOTH arms so a regression that accidentally made them agree — in EITHER
+        # direction — is caught:
+        #   * sqlite arm: a FRESH SqliteArtifactRegistry on the same db file (the
+        #     "restart") still finds the pin → get_session_cut returns the cut AND
+        #     a session_read by the owner still SERVES the pinned bytes.
+        #   * in-memory arm: a FRESH ArtifactRegistry has NO pins → get_session_cut
+        #     is None AND session_read fails closed (session_invalidated), never a
+        #     live-HEAD serve.
+        policy = RetentionPolicy(max_versions=8)
+        a = UUID(int=0xF00D5E55)
+        owner = UUID(int=0x0114E5)
+        db = tmp_path / "sess_restart.db"
+
+        # --- sqlite arm: the pin SURVIVES a reopen (durable session_pins) ---
+        sql1 = SqliteArtifactRegistry(db, retain_versions=True, retention_policy=policy)
+        try:
+            _register(sql1, a, "plan.md", "SURVIVOR-V1")
+            session = CoordinatorService(sql1).begin_session(read_set=[a], owner=owner)
+            assert isinstance(session, SnapshotSession)
+            token = session.session_token
+        finally:
+            sql1.close()
+        # The "restart": a SECOND handle on the same file. The pin row persisted.
+        sql2 = SqliteArtifactRegistry(db, retain_versions=True, retention_policy=policy)
+        try:
+            svc2 = CoordinatorService(sql2)
+            # The cut is still readable post-restart (durable session_pins).
+            assert svc2.registry.get_session_cut(token) == {a: 1}, (
+                "sqlite session cut did NOT survive restart — R6 durability "
+                "regressed"
+            )
+            # And the owner can still SERVE the pinned bytes from the survived cut.
+            served = svc2.session_read(token, a, caller=owner)
+            assert isinstance(served, VersionedContent), (
+                "sqlite session_read did not serve after restart — the durable "
+                "pin should still be intact"
+            )
+            assert served.version == 1
+            assert served.content == "SURVIVOR-V1"
+        finally:
+            sql2.close()
+
+        # --- in-memory arm: a FRESH registry has NO pins (process-scoped) ---
+        mem1 = ArtifactRegistry(retain_versions=True, retention_policy=policy)
+        _register(mem1, a, "plan.md", "EPHEMERAL-V1")
+        ephemeral = CoordinatorService(mem1).begin_session(read_set=[a], owner=owner)
+        assert isinstance(ephemeral, SnapshotSession)
+        eph_token = ephemeral.session_token
+        # The "restart": a brand-new in-memory registry — no shared store, no pins.
+        mem2 = ArtifactRegistry(retain_versions=True, retention_policy=policy)
+        _register(mem2, a, "plan.md", "EPHEMERAL-V1")
+        svc_mem2 = CoordinatorService(mem2)
+        # The cut is GONE (process-scoped) — get_session_cut is None.
+        assert svc_mem2.registry.get_session_cut(eph_token) is None, (
+            "in-memory pins unexpectedly survived a fresh instance — the "
+            "process-scoped contract (R6) was violated"
+        )
+        # And the session correctly FAILS CLOSED — never a live-HEAD serve. The
+        # in-shape (server-minted) token classifies session_invalidated under the
+        # Unit-5 liveness taxonomy (the post-restart-unknown safety case).
+        result = svc_mem2.session_read(eph_token, a, caller=owner)
+        assert isinstance(result, SessionReadRejection), (
+            "in-memory session_read served (or crashed) after a fresh-instance "
+            "restart — it must fail closed, never serve live HEAD"
+        )
+        assert result.reason == SESSION_INVALIDATED_REASON

--- a/tests/test_retention_parity.py
+++ b/tests/test_retention_parity.py
@@ -69,6 +69,7 @@ from ccs.core.exceptions import (
     NOT_RETAINED_REASON,
     SESSION_INVALIDATED_REASON,
     UNKNOWN_ARTIFACT_REASON,
+    SessionInvalidated,
 )
 from ccs.core.states import MESIState
 from ccs.core.types import (
@@ -863,6 +864,11 @@ class TestSnapshotSessionParityThroughService:
             )
             assert served.version == 1
             assert served.content == "SURVIVOR-V1"
+            # R13 across the restart (F3): the durable owner-binding survives too,
+            # so a leaked-token FOREIGN caller is STILL rejected — survival (R6)
+            # does not open an owner-isolation hole.
+            with pytest.raises(SessionInvalidated):
+                svc2.session_read(token, a, caller=uuid4())
         finally:
             sql2.close()
 

--- a/tests/test_retention_parity.py
+++ b/tests/test_retention_parity.py
@@ -72,6 +72,7 @@ from ccs.core.exceptions import (
 from ccs.core.states import MESIState
 from ccs.core.types import (
     Artifact,
+    SnapshotSession,
     VersionedContent,
     VersionedReadRejection,
 )
@@ -570,3 +571,155 @@ class TestStrBytesRoundTripAcrossRegistries:
                 assert isinstance(out.content, py_type)
         finally:
             sql.close()
+
+
+# ===========================================================================
+# D — Snapshot consistent-cut capture parity (SB-17 / TX-1, Unit 2)
+# ===========================================================================
+
+
+def _snap_pair(
+    tmp_path: Path, name: str, policy: RetentionPolicy | None = None
+) -> tuple[ArtifactRegistry, SqliteArtifactRegistry]:
+    """An in-memory + sqlite pair for snapshot-capture parity. Retention is OFF
+    by default (the version-map-only / content=None branch); a policy switches
+    both arms to the lazy retain_versions=True branch."""
+    retain = policy is not None
+    return (
+        ArtifactRegistry(retain_versions=retain, retention_policy=policy),
+        SqliteArtifactRegistry(
+            tmp_path / name, retain_versions=retain, retention_policy=policy
+        ),
+    )
+
+
+class TestSnapshotCaptureParity:
+    """``capture_version_vector`` behaves IDENTICALLY on both registries except
+    restart-survival (sqlite persists pins; in-memory does not). The divergence
+    is ASSERTED, never masked (success criterion + R6)."""
+
+    def test_capture_and_unknown_id_reject_identical(self, tmp_path: Path) -> None:
+        # One identical sequence on both arms: register {A,B}, capture {A,B} →
+        # same cut; then capture {A, unknown} → same typed rejection. Compared as
+        # registry-agnostic normal forms.
+        mem, sql = _snap_pair(tmp_path, "snap_parity.db")
+        try:
+            # Use FIXED ids so the cut maps are directly comparable across arms.
+            a = UUID(int=0xA)
+            b = UUID(int=0xB)
+            unknown = UUID(int=0xDEAD)
+
+            def run(reg) -> tuple:
+                art_a = Artifact(id=a, name="a.md", version=1, content_hash="h")
+                art_b = Artifact(id=b, name="b.md", version=1, content_hash="h")
+                reg.register_artifact(art_a, content="a1")
+                reg.register_artifact(art_b, content="b1")
+                # peer bumps A to v2 before the capture → coherent cut {A:2,B:1}.
+                _commit(reg, a, 2, "a2")
+                ok = reg.capture_version_vector([a, b], session_token="tok-ok")
+                bad = reg.capture_version_vector([a, unknown], session_token="tok-bad")
+                return ok, bad
+
+            mem_ok, mem_bad = run(mem)
+            sql_ok, sql_bad = run(sql)
+
+            # The WIN cut is identical across registries.
+            assert mem_ok == sql_ok == {a: 2, b: 1}
+            # The rejection is the same wire-stable reason + offending id.
+            for bad in (mem_bad, sql_bad):
+                assert isinstance(bad, VersionedReadRejection)
+                assert bad.reason == UNKNOWN_ARTIFACT_REASON
+                assert bad.artifact_id == unknown
+                assert bad.current_version is None
+        finally:
+            sql.close()
+
+    def test_gc_hold_then_release_parity(self, tmp_path: Path) -> None:
+        # Identical pin-hold-then-collectible behavior on both arms under K=1.
+        policy = RetentionPolicy(max_versions=1)
+        mem, sql = _snap_pair(tmp_path, "snap_gc_parity.db", policy)
+        try:
+            a = UUID(int=0xCAFE)
+
+            def run(reg) -> tuple:
+                art = Artifact(id=a, name="plan.md", version=1, content_hash="h")
+                reg.register_artifact(art, content="v1")  # current=1, retain on
+                # Pin v1 while current.
+                cut = reg.capture_version_vector([a], session_token="held")
+                assert cut == {a: 1}
+                writer = uuid4()
+                _commit_cas(reg, a, writer, 1, "v2")  # K=1 {2} + pin{1}
+                held = reg.get_content_at_version(a, 1)  # must survive (pinned)
+                reg.release_session("held")
+                _commit_cas(reg, a, writer, 2, "v3")  # K=1 evicts v1 now
+                after = reg.get_content_at_version(a, 1)  # collectible → None
+                return held, after
+
+            assert run(mem) == run(sql) == ("v1", None)
+        finally:
+            sql.close()
+
+    def test_restart_survival_divergence_asserted_not_masked(
+        self, tmp_path: Path
+    ) -> None:
+        # THE DELIBERATE DIVERGENCE (R6): sqlite pins survive a registry reopen on
+        # the same db file; an in-memory registry is process-scoped, so a fresh
+        # instance starts with NO pins. Asserted explicitly so a regression that
+        # accidentally made them agree (either direction) is caught.
+        policy = RetentionPolicy(max_versions=1)
+        a = UUID(int=0xF00D)
+        db = tmp_path / "snap_restart.db"
+
+        # --- sqlite arm: pin survives reopen ---
+        sql1 = SqliteArtifactRegistry(db, retain_versions=True, retention_policy=policy)
+        try:
+            art = Artifact(id=a, name="plan.md", version=1, content_hash="h")
+            sql1.register_artifact(art, content="v1")
+            assert sql1.capture_version_vector([a], session_token="survivor") == {a: 1}
+        finally:
+            sql1.close()
+        # Reopen a SECOND handle (the "restart"): the pin row is still there, so a
+        # K=1-evicting commit must STILL hold v1 (the durable exemption survived).
+        sql2 = SqliteArtifactRegistry(db, retain_versions=True, retention_policy=policy)
+        try:
+            writer = uuid4()
+            _commit_cas(sql2, a, writer, 1, "v2")  # K=1 {2}; pin{1} from the reopen
+            assert sql2.get_content_at_version(a, 1) == "v1", (
+                "sqlite pin did NOT survive restart — R6 durability regressed"
+            )
+        finally:
+            sql2.close()
+
+        # --- in-memory arm: a fresh instance has NO pins (process-scoped) ---
+        mem1 = ArtifactRegistry(
+            retain_versions=True, retention_policy=policy
+        )
+        art = Artifact(id=a, name="plan.md", version=1, content_hash="h")
+        mem1.register_artifact(art, content="v1")
+        assert mem1.capture_version_vector([a], session_token="ephemeral") == {a: 1}
+        # A FRESH in-memory registry is the "restart": no shared store, no pins.
+        mem2 = ArtifactRegistry(
+            retain_versions=True, retention_policy=policy
+        )
+        art2 = Artifact(id=a, name="plan.md", version=1, content_hash="h")
+        mem2.register_artifact(art2, content="v1")
+        writer = uuid4()
+        _commit_cas(mem2, a, writer, 1, "v2")  # K=1 {2}; NO pin survived to mem2
+        assert mem2.get_content_at_version(a, 1) is None, (
+            "in-memory pins unexpectedly survived a fresh instance — the "
+            "process-scoped contract (R6) was violated"
+        )
+
+
+def _commit_cas(reg, artifact_id: UUID, writer: UUID, expected: int, body: str) -> None:
+    """A peer OCC commit via the registry ``commit_cas`` WIN (captures history)
+    — shared by the snapshot-capture parity tests."""
+    reg.set_agent_state(artifact_id, writer, MESIState.SHARED, tick=1)
+    reg.commit_cas(
+        artifact_id,
+        writer,
+        expected_version=expected,
+        content_hash="h",
+        content=body,
+        tick=2,
+    )

--- a/tests/test_sb18_non_foreclosure.py
+++ b/tests/test_sb18_non_foreclosure.py
@@ -1,0 +1,399 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Unit 9 — SB-18 non-foreclosure constructibility HARNESS (SB-17 / TX-1).
+
+Plan: ``docs/plans/2026-06-26-002-feat-read-side-transaction-snapshot-plan.md``
+Unit 9. Requirement trace: **R11** (read + exactly one validated commit MUST NOT
+foreclose SB-18 atomic multi-publish; falsifiable paper-signature; must not
+pre-build it).
+
+**This is a HARNESS, not an implementation.** It is the recurring MECHANIZATION
+of the pre-freeze R11 DESIGN GATE that ran in Unit 2 (the
+``✅ R11 GATE — PASSED 2026-06-28 (pre-Unit-2)`` note under Unit 2 of the plan).
+The design gate asserted ON PAPER, before ``begin_session``'s public types froze,
+that a paper SB-18 commit signature is CONSTRUCTIBLE from v1's return shape
+WITHOUT changing v1's public types. This file re-runs that assertion MECHANICALLY
+against the NOW-frozen surface, so the gate cannot silently regress as later work
+touches the types.
+
+**The paper SB-18 signature (verbatim from the Unit-2 R11 gate note):**
+
+    session.commit_all(session_token, writes: Mapping[UUID, bytes | str])
+        -> MultiCommitResult
+
+all-or-nothing, each artifact validated at ``cut[artifact_id]``. SB-18 itself is
+DEFERRED to a separate gate (A2) — there is NO ``commit_all`` / ``MultiCommitResult``
+/ ``MultiCommitConflict`` anywhere in ``src/`` (asserted below). This harness only
+proves v1 does not FORECLOSE it.
+
+**What would FALSIFY non-foreclosure (i.e. make this file FAIL):**
+
+1. ``SnapshotSession.cut`` becomes an OPAQUE handle instead of an inspectable
+   ``{artifact_id: int}`` map → SB-18 has no PUBLIC way to read each artifact's
+   ``expected_version`` → foreclosed. ``TestCutIsInspectable`` fails.
+2. ``ConflictDetail`` / ``CasCorruption`` change shape so a paper
+   ``MultiCommitConflict(Mapping[UUID, ConflictDetail])`` aggregate can no longer
+   be CONSTRUCTED from real per-artifact instances without editing v1 →
+   ``TestPerArtifactOutcomesComposeVerbatim`` fails.
+3. ``session_commit`` (the per-artifact OCC step SB-18's loop reuses) stops
+   accepting the ``cut[id]``-derived pinned base or stops returning the verbatim
+   taxonomy → the in-test ``commit_all`` shim's per-artifact WIN/HELD breaks →
+   ``TestPaperCommitAllShim`` fails.
+
+The shim in ``TestPaperCommitAllShim`` is DEFINED IN THE TEST (never in ``src``):
+it demonstrates the v1 surface ALREADY supplies everything SB-18 needs (a cut to
+read ``expected_version`` from + a per-artifact validated commit + a verbatim
+taxonomy to aggregate). The point is to FALSIFY foreclosure, not to ship SB-18.
+
+Reason matching is ALWAYS ``reason == CONSTANT`` against the imported wire-stable
+constant — never a substring of a human message (the typed-signal-not-substring
+house rule).
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+from uuid import UUID, uuid4
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.retention import RetentionPolicy
+from ccs.coordinator.service import CoordinatorService
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.types import (
+    Artifact,
+    CasCorruption,
+    ConflictDetail,
+    InvalidationSignal,
+    SessionCommitRejection,
+    SnapshotSession,
+)
+
+# ---------------------------------------------------------------------------
+# Builders — mirror tests/test_session_commit.py's helpers.
+# ---------------------------------------------------------------------------
+
+
+def _register(reg, artifact_id: UUID, name: str, body: str, version: int = 1) -> None:
+    art = Artifact(id=artifact_id, name=name, version=version, content_hash="h1")
+    reg.register_artifact(art, content=body)
+
+
+def _registries(tmp_path: Path):
+    """An (in_memory, sqlite) LAZY pair — ``retain_versions=True`` (bodies in
+    history), matching the Unit-4 commit suite so the shim's per-artifact OCC
+    runs identically on both arms."""
+    pol = RetentionPolicy(max_versions=8)
+    mem = ArtifactRegistry(retain_versions=True, retention_policy=pol)
+    sql = SqliteArtifactRegistry(
+        tmp_path / "sb18.db", retain_versions=True, retention_policy=pol
+    )
+    return mem, sql
+
+
+# ===========================================================================
+# A — SB-18 is NOT implemented in v1 (the harness proves non-FORECLOSURE, not
+#     a pre-build; if SB-18 ever ships, this fence is what tells us to retire it)
+# ===========================================================================
+
+
+class TestSb18IsNotPrebuilt:
+    """R11 forbids pre-building SB-18; v1 must only NOT foreclose it. Pin that no
+    paper SB-18 symbol leaked into the runtime surface — the harness asserts a
+    DESIGN property of the frozen types, never a shipped multi-commit op."""
+
+    def test_no_commit_all_on_the_service(self) -> None:
+        # The paper signature is ``session.commit_all`` — it must NOT exist yet.
+        assert not hasattr(CoordinatorService, "commit_all"), (
+            "commit_all leaked into the service — SB-18 was pre-built, violating "
+            "R11 (v1 must only NOT foreclose it)"
+        )
+
+    def test_no_multi_commit_result_types_in_core(self) -> None:
+        # The paper aggregates (MultiCommitResult / MultiCommitConflict) must not
+        # exist in the frozen core types — they are SB-18's, deferred to Gate A2.
+        import ccs.core.types as core_types
+
+        for paper_only in ("MultiCommitResult", "MultiCommitConflict"):
+            assert not hasattr(core_types, paper_only), (
+                f"{paper_only} leaked into ccs.core.types — SB-18 aggregate was "
+                f"pre-built, violating R11"
+            )
+
+
+# ===========================================================================
+# B — The load-bearing R11 property: the cut is an INSPECTABLE map (not opaque)
+# ===========================================================================
+
+
+class TestCutIsInspectable:
+    """SB-18's ``commit_all`` needs each artifact's ``expected_version``. The ONLY
+    public way it can obtain them is ``SnapshotSession.cut[artifact_id]``. If the
+    cut ever became an OPAQUE handle, that vector would be unobtainable from the
+    public surface → SB-18 foreclosed. This is the FALSIFIABLE core of R11."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_every_expected_version_is_readable_by_artifact_id(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a, b, c = uuid4(), uuid4(), uuid4()
+            _register(reg, a, "plan.md", "A1", version=1)
+            _register(reg, b, "budget.md", "B7", version=7)
+            _register(reg, c, "manifest.md", "C3", version=3)
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a, b, c], owner=owner)
+            assert isinstance(session, SnapshotSession)
+
+            # SB-18's commit_all would loop these expected_versions out of the cut
+            # BY ARTIFACT ID — assert every one is readable (no opaque handle).
+            expected_versions = {aid: session.cut[aid] for aid in (a, b, c)}
+            assert expected_versions == {a: 1, b: 7, c: 3}
+            # The cut is keyed by the artifact UUIDs themselves, not a blob token.
+            assert set(session.cut.keys()) == {a, b, c}
+            # It is a real Mapping[UUID, int] — inspectable item access + iteration,
+            # not an opaque object exposing only equality.
+            assert isinstance(session.cut, Mapping)
+            for aid, version in session.cut.items():
+                assert isinstance(aid, UUID)
+                assert isinstance(version, int)
+        finally:
+            sql.close()
+
+    def test_cut_is_typed_as_a_mapping_not_an_opaque_token(self) -> None:
+        # The frozen TYPE annotation pins the contract structurally: cut is a
+        # Mapping[UUID, int], session_token is the SEPARATE opaque identity. A
+        # refactor that folded the versions into the token (making cut opaque)
+        # would change this annotation and trip the harness.
+        ann = inspect.get_annotations(SnapshotSession, eval_str=True)
+        cut_origin = getattr(ann["cut"], "__origin__", None)
+        assert cut_origin is not None and issubclass(cut_origin, Mapping), (
+            f"SnapshotSession.cut is no longer a Mapping (got {ann['cut']!r}) — an "
+            f"opaque cut handle would forclose SB-18's expected-version vector"
+        )
+        # And the token is the identity, kept DISTINCT from the inspectable cut.
+        assert ann["session_token"] is str
+
+
+# ===========================================================================
+# C — Per-artifact outcome types compose VERBATIM into the paper aggregate
+# ===========================================================================
+
+
+# The paper SB-18 aggregate — DEFINED HERE IN THE TEST, never in ``src``. It is a
+# pure composition of the FROZEN v1 ``ConflictDetail`` (no field of v1 changes to
+# make this constructible). If constructing it required editing ``ConflictDetail``
+# / ``CasCorruption``, SB-18 would be foreclosed and this module would fail.
+@dataclass(frozen=True)
+class _PaperMultiCommitConflict:
+    """A paper ``MultiCommitConflict`` — the all-or-nothing HELD aggregate SB-18
+    would return, composing the per-artifact :class:`ConflictDetail` VERBATIM."""
+
+    per_artifact: Mapping[UUID, ConflictDetail]
+
+
+class TestPerArtifactOutcomesComposeVerbatim:
+    """A paper ``MultiCommitConflict(Mapping[UUID, ConflictDetail])`` is
+    CONSTRUCTIBLE from REAL ``ConflictDetail`` instances with NO change to
+    ``ConflictDetail`` / ``CasCorruption``. Built from instances the SHIPPED
+    ``session_commit`` actually returns — not synthetic ones — so the proof is
+    against the live taxonomy, not a guess at it."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_real_conflict_details_aggregate_without_v1_change(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            # Produce TWO real ConflictDetail instances from the shipped surface:
+            # a version_mismatch (peer moved the base) and an other_holder (a
+            # pessimistic peer holds E at the pinned version).
+            a, b = uuid4(), uuid4()
+            _register(reg, a, "plan.md", "A1", version=1)
+            _register(reg, b, "budget.md", "B1", version=1)
+            owner = uuid4()
+            s_a = svc.begin_session(read_set=[a], owner=owner)
+            s_b = svc.begin_session(read_set=[b], owner=owner)
+
+            from ccs.core.states import MESIState
+
+            # a → version_mismatch: a peer commits past the pin.
+            reg.set_agent_state(a, uuid4(), MESIState.SHARED, tick=1)
+            reg.commit_cas(
+                a, uuid4(), expected_version=1, content_hash="h2", content="A2", tick=2
+            )
+            mismatch = svc.session_commit(s_a.session_token, a, "MINE", caller=owner)
+            # b → other_holder: a pessimistic peer takes EXCLUSIVE at the pin.
+            reg.set_agent_state(b, uuid4(), MESIState.EXCLUSIVE, trigger="write", tick=1)
+            holder = svc.session_commit(s_b.session_token, b, "MINE", caller=owner)
+
+            assert isinstance(mismatch, ConflictDetail)
+            assert isinstance(holder, ConflictDetail)
+            assert mismatch.reason == "version_mismatch"
+            assert holder.reason == "other_holder"
+
+            # CONSTRUCT the paper aggregate from the REAL per-artifact members —
+            # verbatim, no field of ConflictDetail touched. This is the R11
+            # composition proof: if it raised / required adaptation, SB-18's
+            # all-or-nothing HELD shape would be foreclosed.
+            aggregate = _PaperMultiCommitConflict(per_artifact={a: mismatch, b: holder})
+            assert aggregate.per_artifact[a] is mismatch
+            assert aggregate.per_artifact[b] is holder
+            # The members keep their identity + full taxonomy inside the aggregate.
+            assert aggregate.per_artifact[a].reason == "version_mismatch"
+            assert aggregate.per_artifact[a].current_version == 2
+            assert aggregate.per_artifact[b].reason == "other_holder"
+            assert aggregate.per_artifact[b].current_version == 1
+        finally:
+            sql.close()
+
+    def test_cas_corruption_is_reusable_verbatim_as_a_paper_member(self) -> None:
+        # SB-18's per-artifact corruption signal reuses CasCorruption verbatim too
+        # (the registry returns it; the service raises). Construct a paper member
+        # map from a real CasCorruption — no field changes.
+        corruption = CasCorruption(current_version=3)
+        paper_members: Mapping[UUID, CasCorruption] = {uuid4(): corruption}
+        (only_member,) = paper_members.values()
+        assert only_member is corruption
+        assert only_member.current_version == 3
+        # The two per-artifact signals stay DISTINCT types (the service maps the
+        # corruption sentinel to a raise; the conflict to a returned aggregate) —
+        # SB-18 inherits that split unchanged.
+        assert CasCorruption is not ConflictDetail
+
+
+# ===========================================================================
+# D — The paper ``commit_all`` SHIM: v1 already supplies everything SB-18 needs
+# ===========================================================================
+
+
+def _paper_commit_all(
+    svc: CoordinatorService,
+    session: SnapshotSession,
+    writes: Mapping[UUID, bytes | str],
+    *,
+    caller: UUID,
+) -> "tuple[str, object]":
+    """A PAPER ``commit_all`` shim — DEFINED IN THE TEST, never in ``src``.
+
+    Demonstrates the v1 surface ALREADY supplies everything the paper SB-18
+    signature needs, with NO change to any v1 public type:
+
+    - reads each ``expected_version`` straight out of the INSPECTABLE
+      ``session.cut`` (the R11 binding constraint),
+    - validates each artifact with the SHIPPED ``session_commit`` at ``cut[id]``,
+    - aggregates the per-artifact outcomes using the VERBATIM ``ConflictDetail``
+      into the paper :class:`_PaperMultiCommitConflict`.
+
+    This is a PRE-FLIGHT (read-only intent) check + a non-atomic loop — NOT the
+    real SB-18 (which adds a single atomic multi-row registry boundary, a NEW
+    registry op, not a change to ``commit_cas``). Its ONLY job is to FALSIFY
+    foreclosure: if v1's frozen types could not supply the cut / per-artifact
+    validation / verbatim taxonomy, this shim could not be written from the public
+    surface alone. Returns ``("conflict", aggregate)`` if ANY artifact is HELD
+    (all-or-nothing: nothing is treated as committed), else ``("win", results)``.
+    """
+    # Every expected_version comes from the inspectable cut — the load-bearing
+    # R11 read. An opaque cut would make this line unwritable from public v1.
+    expected_versions = {aid: session.cut[aid] for aid in writes}
+
+    held: dict[UUID, ConflictDetail] = {}
+    wins: dict[UUID, object] = {}
+    for artifact_id, body in writes.items():
+        # The pinned base IS cut[artifact_id]; session_commit validates against it.
+        assert artifact_id in expected_versions
+        outcome = svc.session_commit(session.session_token, artifact_id, body, caller=caller)
+        if isinstance(outcome, ConflictDetail):
+            held[artifact_id] = outcome
+        elif isinstance(outcome, SessionCommitRejection):
+            # A validation rejection is also a non-win for the all-or-nothing
+            # decision; surface it as a synthetic conflict so the aggregate is
+            # uniform (the paper SB-18 would fold these into MultiCommitConflict).
+            held[artifact_id] = ConflictDetail(
+                reason="version_mismatch", current_version=-1
+            )
+        else:
+            wins[artifact_id] = outcome
+    if held:
+        return "conflict", _PaperMultiCommitConflict(per_artifact=held)
+    return "win", wins
+
+
+class TestPaperCommitAllShim:
+    """The shim runs end-to-end against the live v1 surface on BOTH registries —
+    proving the public contract already supplies the cut, the per-artifact
+    validated commit, and the verbatim taxonomy SB-18 composes. If any of those
+    regressed, the shim would not produce the expected WIN / all-HELD outcomes."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_all_unchanged_bases_all_win(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a, b = uuid4(), uuid4()
+            _register(reg, a, "plan.md", "A1", version=1)
+            _register(reg, b, "budget.md", "B5", version=5)
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a, b], owner=owner)
+            assert isinstance(session, SnapshotSession)
+
+            status, payload = _paper_commit_all(
+                svc, session, {a: "A2", b: "B6"}, caller=owner
+            )
+            assert status == "win", f"expected all-win, got {status}: {payload!r}"
+            # Each per-artifact WIN is the shipped (Artifact, signals) tuple, bumped
+            # off ITS OWN pinned base (cut[a]=1 → 2, cut[b]=5 → 6).
+            updated_a, signals_a = payload[a]
+            updated_b, _signals_b = payload[b]
+            assert updated_a.version == 2 and updated_b.version == 6
+            assert all(isinstance(s, InvalidationSignal) for s in signals_a)
+            assert reg.get_artifact(a).version == 2
+            assert reg.get_artifact(b).version == 6
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_one_moved_base_aggregates_a_paper_conflict(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            from ccs.core.states import MESIState
+
+            svc = CoordinatorService(reg)
+            a, b = uuid4(), uuid4()
+            _register(reg, a, "plan.md", "A1", version=1)
+            _register(reg, b, "budget.md", "B1", version=1)
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a, b], owner=owner)
+
+            # A peer moves b past its pin AFTER capture → b will be HELD.
+            reg.set_agent_state(b, uuid4(), MESIState.SHARED, tick=1)
+            reg.commit_cas(
+                b, uuid4(), expected_version=1, content_hash="h2", content="B2", tick=2
+            )
+
+            status, payload = _paper_commit_all(
+                svc, session, {a: "A2", b: "B2-MINE"}, caller=owner
+            )
+            # All-or-nothing semantics: ANY HELD member → a paper conflict
+            # aggregate composed from the VERBATIM ConflictDetail.
+            assert status == "conflict"
+            assert isinstance(payload, _PaperMultiCommitConflict)
+            assert set(payload.per_artifact) == {b}
+            assert payload.per_artifact[b].reason == "version_mismatch"
+            assert payload.per_artifact[b].current_version == 2
+        finally:
+            sql.close()

--- a/tests/test_session_commit.py
+++ b/tests/test_session_commit.py
@@ -47,6 +47,7 @@ from ccs.core.exceptions import (
     SESSION_NOT_FOUND_REASON,
     STALE_READ_GENERATION_REASON,
     CoherenceError,
+    WatchdogAbandoned,
 )
 from ccs.core.states import MESIState
 from ccs.core.types import (
@@ -619,5 +620,62 @@ class TestExactlyOneValidatedCommit:
             assert second.current_version == 2
             # Only ONE commit landed: still at v2.
             assert reg.get_artifact(a).version == 2
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# F2 — watchdog abort threads into commit_cas: a timed-out commit fails closed
+#      at the registry write lock instead of landing as a phantom write.
+# ===========================================================================
+
+
+class TestWatchdogAbortFailsClosed:
+    """F2: ``session_commit`` threads its ``abort`` Event into ``commit_cas``'s
+    ``abort_guard`` (A6). A watchdog that already timed out (abort SET) makes the
+    late commit fail closed AT the registry write lock — never a phantom write
+    behind a client that already got a degraded ``commit_unconfirmed``."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_preset_abort_fails_closed_no_mutation(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        import threading
+
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner, a = uuid4(), uuid4()
+            _register(reg, a, "plan.md", "V1")
+            tok = svc.begin_session(read_set=[a], owner=owner).session_token
+
+            abort = threading.Event()
+            abort.set()  # the handler watchdog already timed out + degraded
+            with pytest.raises(WatchdogAbandoned):
+                svc.session_commit(tok, a, "PHANTOM", caller=owner, abort=abort)
+            # No phantom write: the artifact was NOT mutated.
+            assert reg.get_artifact(a).version == 1
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_unset_abort_commits_normally(self, tmp_path: Path, arm: str) -> None:
+        # An UNSET abort (watchdog did not fire) commits normally — threading the
+        # abort must not regress the happy path.
+        import threading
+
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner, a = uuid4(), uuid4()
+            _register(reg, a, "plan.md", "V1")
+            tok = svc.begin_session(read_set=[a], owner=owner).session_token
+            result = svc.session_commit(
+                tok, a, "V2", caller=owner, abort=threading.Event()
+            )
+            assert isinstance(result, tuple)
+            assert result[0].version == 2
         finally:
             sql.close()

--- a/tests/test_session_commit.py
+++ b/tests/test_session_commit.py
@@ -43,6 +43,7 @@ from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
 from ccs.core.exceptions import (
     SESSION_ARTIFACT_NOT_IN_CUT_REASON,
     SESSION_COMMIT_REASONS,
+    SESSION_INVALIDATED_REASON,
     SESSION_NOT_FOUND_REASON,
     STALE_READ_GENERATION_REASON,
     CoherenceError,
@@ -507,7 +508,7 @@ class TestValidationRejections:
             sql.close()
 
     @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
-    def test_released_token_is_session_not_found(
+    def test_released_token_is_session_invalidated(
         self, tmp_path: Path, arm: str
     ) -> None:
         mem, sql = _registries(tmp_path)
@@ -520,7 +521,10 @@ class TestValidationRejections:
             reg.release_session(session.session_token)  # pins dropped
             result = svc.session_commit(session.session_token, a, "X")
             assert isinstance(result, SessionCommitRejection)
-            assert result.reason == SESSION_NOT_FOUND_REASON
+            # Unit-5 taxonomy: a released (in-shape) token WAS a real session →
+            # session_invalidated (fail closed, never a live-HEAD commit), not
+            # session_not_found (which stays reachable for malformed tokens).
+            assert result.reason == SESSION_INVALIDATED_REASON
         finally:
             sql.close()
 
@@ -550,9 +554,12 @@ class TestValidationRejections:
         from the bare ``read_at_version`` surface (R7 additive-only)."""
         from ccs.core.exceptions import READ_AT_VERSION_REASONS, SESSION_READ_REASONS
 
+        # Unit 5 ADDED session_invalidated (additive, R7) — the set grew, no
+        # reason was renamed.
         assert SESSION_COMMIT_REASONS == {
             SESSION_NOT_FOUND_REASON,
             SESSION_ARTIFACT_NOT_IN_CUT_REASON,
+            SESSION_INVALIDATED_REASON,
         }
         # Shares the token/pin vocabulary with session_read (one surface).
         assert SESSION_COMMIT_REASONS == SESSION_READ_REASONS

--- a/tests/test_session_commit.py
+++ b/tests/test_session_commit.py
@@ -1,0 +1,599 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Unit 4 — ``session.commit``: single-artifact OCC validation against the pinned
+base (SB-17 / TX-1).
+
+Plan: ``docs/plans/2026-06-26-002-feat-read-side-transaction-snapshot-plan.md``
+Unit 4. Requirement trace: **R3** (validate one artifact's commit against its
+pinned version via the shipped ``commit_cas``; preserve the typed taxonomy;
+relies on the reconciled admit-on-absent fence). Builds on Unit 2's
+``begin_session`` / cut-capture / pin store.
+
+``session_commit`` reuses the shipped ``commit_cas`` arbitration VERBATIM and
+adds only (a) the token/pin VALIDATION gate (typed
+:class:`SessionCommitRejection`, never a silent fall-through) and (b) a
+SESSION-SCOPED committer identity that is fence-claimless, so admit-on-absent
+holds and the PINNED base version-CAS is the sole arbiter.
+
+Outcome mapping under test (mirrors the service ``commit_cas`` orchestration):
+- WIN → ``(Artifact, [InvalidationSignal])``; version → pinned + 1.
+- lost race → :class:`ConflictDetail` RETURNED unchanged (HELD, non-mutating).
+- corruption (``expected_version > current``) → registry returns
+  :class:`CasCorruption`; the SERVICE RAISES ``CoherenceError`` (non-retryable).
+- token/pin validation failure → :class:`SessionCommitRejection` RETURNED.
+
+Reason matching is ALWAYS ``reason == CONSTANT`` against the imported wire-stable
+constant — never a substring of a human message (the typed-signal-not-substring
+house rule). The OCC outcomes are parametrized over BOTH registries; the
+admit-on-absent / corruption / taxonomy proofs run on both where applicable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import NAMESPACE_URL, UUID, uuid4, uuid5
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.retention import RetentionPolicy
+from ccs.coordinator.service import CoordinatorService
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.exceptions import (
+    SESSION_ARTIFACT_NOT_IN_CUT_REASON,
+    SESSION_COMMIT_REASONS,
+    SESSION_NOT_FOUND_REASON,
+    STALE_READ_GENERATION_REASON,
+    CoherenceError,
+)
+from ccs.core.states import MESIState
+from ccs.core.types import (
+    Artifact,
+    CasCorruption,
+    ConflictDetail,
+    InvalidationSignal,
+    SessionCommitRejection,
+    SnapshotSession,
+)
+
+# ---------------------------------------------------------------------------
+# Builders — mirror tests/test_session_read.py's helpers.
+# ---------------------------------------------------------------------------
+
+
+def _register(reg, artifact_id: UUID, name: str, body: str, version: int = 1) -> None:
+    art = Artifact(id=artifact_id, name=name, version=version, content_hash="h1")
+    reg.register_artifact(art, content=body)
+
+
+def _peer_commit_cas(
+    reg, artifact_id: UUID, writer: UUID, expected: int, body: str | None
+) -> None:
+    """A PEER OCC commit via the registry ``commit_cas`` WIN — advances current
+    past the pin so a subsequent ``session_commit`` at the captured version is
+    HELD (``version_mismatch``)."""
+    reg.set_agent_state(artifact_id, writer, MESIState.SHARED, tick=1)
+    reg.commit_cas(
+        artifact_id,
+        writer,
+        expected_version=expected,
+        content_hash="h2",
+        content=body,
+        tick=2,
+    )
+
+
+def _registries(tmp_path: Path):
+    """An (in_memory, sqlite) LAZY pair — ``retain_versions=True`` (bodies in
+    history). ``session_commit`` is byte-source-agnostic, but LAZY keeps the
+    served-body assertions concrete on both arms."""
+    pol = RetentionPolicy(max_versions=8)
+    mem = ArtifactRegistry(retain_versions=True, retention_policy=pol)
+    sql = SqliteArtifactRegistry(
+        tmp_path / "snap_commit.db", retain_versions=True, retention_policy=pol
+    )
+    return mem, sql
+
+
+# ===========================================================================
+# A — Happy path: pinned @vN, current @vN → WIN, version → N+1
+# ===========================================================================
+
+
+class TestHappyPath:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_wins_on_unchanged_base(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "V1", version=1)
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            assert isinstance(session, SnapshotSession)
+            assert session.cut[a] == 1
+
+            result = svc.session_commit(session.session_token, a, "V2-BODY")
+
+            assert isinstance(result, tuple)
+            updated, signals = result
+            assert isinstance(updated, Artifact)
+            assert updated.version == 2  # pinned 1 → 2
+            assert updated.id == a
+            assert isinstance(signals, list)
+            assert all(isinstance(s, InvalidationSignal) for s in signals)
+            # The artifact actually moved.
+            assert reg.get_artifact(a).version == 2
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_wins_at_a_higher_pinned_version(self, tmp_path: Path, arm: str) -> None:
+        """The pinned version need not be 1 — the WIN bumps pinned + 1 generally."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "V7", version=7)
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            assert session.cut[a] == 7
+
+            result = svc.session_commit(session.session_token, a, "V8")
+            assert isinstance(result, tuple)
+            assert result[0].version == 8
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# B — HELD: a peer commits after capture → ConflictDetail RETURNED, non-mutating
+# ===========================================================================
+
+
+class TestHeldOnMovedBase:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_version_mismatch_returned_not_raised(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "V1", version=1)
+            session = svc.begin_session(read_set=[a], owner=uuid4())  # pins {a:1}
+
+            # A peer commits 1 → 2 AFTER the cut was captured.
+            _peer_commit_cas(reg, a, uuid4(), expected=1, body="PEER-V2")
+            assert reg.get_artifact(a).version == 2
+            before = reg.get_artifact(a)
+
+            # The session commits at the now-stale pinned base (1) → HELD, RETURNED.
+            result = svc.session_commit(session.session_token, a, "MINE")
+
+            assert isinstance(result, ConflictDetail)
+            assert result.reason == "version_mismatch"
+            assert result.current_version == 2
+            # Non-mutating: the artifact is UNCHANGED by the held commit.
+            after = reg.get_artifact(a)
+            assert after.version == before.version == 2
+            assert after.content_hash == before.content_hash
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_no_invalidation_signal_emitted_on_held(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """A non-win mutates nothing AND emits no invalidation — there is no
+        ``InvalidationSignal`` to inspect because the typed return is a bare
+        ``ConflictDetail`` (not a ``(_, signals)`` tuple)."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "V1", version=1)
+            # A peer holding SHARED at v1 is a witness for "no peer invalidated".
+            peer = uuid4()
+            reg.set_agent_state(a, peer, MESIState.SHARED, tick=0)
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            _peer_commit_cas(reg, a, uuid4(), expected=1, body="PEER-V2")
+
+            result = svc.session_commit(session.session_token, a, "MINE")
+
+            assert isinstance(result, ConflictDetail)
+            # The result type itself carries no signals list — a held commit
+            # cannot have invalidated anyone.
+            assert not isinstance(result, tuple)
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# C — Corruption: expected_version > current → service RAISES CoherenceError
+# ===========================================================================
+
+
+class TestCorruptionRaisesAtServiceLayer:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_cas_corruption_maps_to_raised_coherence_error(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """Force ``expected_version > current``: pin @v5, then rewind the
+        artifact's current version below the pin. The registry returns the
+        :class:`CasCorruption` sentinel; the SERVICE maps it to a RAISED
+        ``CoherenceError`` (the explicit Unit-4 obligation, non-retryable)."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "V5", version=5)
+            session = svc.begin_session(read_set=[a], owner=uuid4())  # pins {a:5}
+            assert session.cut[a] == 5
+
+            # Rewind current (5 → 3) BELOW the pin so expected(5) > current(3).
+            reg.remove_artifact(a)
+            _register(reg, a, "plan.md", "V3", version=3)
+
+            with pytest.raises(CoherenceError) as excinfo:
+                svc.session_commit(session.session_token, a, "X")
+            # The raise is the corruption mapping, not a generic precondition.
+            assert "corruption" in str(excinfo.value).lower()
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_registry_returns_sentinel_service_raises(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """Pin down the layering explicitly: the REGISTRY ``commit_cas`` RETURNS
+        the :class:`CasCorruption` sentinel (never raises), while the SERVICE
+        ``session_commit`` RAISES. Asserts the sentinel→raise split lives at the
+        service layer (the Unit-4 obligation, not inherited from the registry)."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "V5", version=5)
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            reg.remove_artifact(a)
+            _register(reg, a, "plan.md", "V3", version=3)
+
+            # The session-scoped committer the service would use for this token.
+            committer = uuid5(NAMESPACE_URL, session.session_token)
+            # REGISTRY layer: returns the sentinel, does NOT raise.
+            sentinel = reg.commit_cas(
+                a,
+                committer,
+                expected_version=5,
+                content_hash="hX",
+                content=None,
+                tick=0,
+            )
+            assert isinstance(sentinel, CasCorruption)
+            assert sentinel.current_version == 3
+
+            # SERVICE layer: raises for the same corruption.
+            with pytest.raises(CoherenceError):
+                svc.session_commit(session.session_token, a, "X")
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# D — Admit-on-absent (the load-bearing R3 path)
+# ===========================================================================
+
+
+class TestAdmitOnAbsent:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_session_committer_has_no_read_generation(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """The session-scoped committer never established a fence claim, so the
+        registry ADMITS it (no ``read_generation`` row) and version-CAS arbitrates
+        → the commit succeeds on an unchanged base."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "V1", version=1)
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+
+            committer = uuid5(NAMESPACE_URL, session.session_token)
+            # Precondition of the load-bearing path: the committer is fence-claimless.
+            assert reg.get_read_generation(a, committer) is None
+
+            result = svc.session_commit(session.session_token, a, "V2")
+            assert isinstance(result, tuple)
+            assert result[0].version == 2
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_owner_with_superseded_read_generation_still_commits(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """THE load-bearing proof. The OWNER agent carries a SUPERSEDED
+        ``read_generation`` (acquired E, then a sweep reclamation bumped the
+        artifact's ``owner_generation``). A direct ``commit_cas`` UNDER THAT OWNER
+        would spuriously fail ``stale_read_generation``. But ``session_commit``
+        uses a SESSION-SCOPED committer (not the owner's MESI agent), which is
+        fence-claimless → admit-on-absent → the session still WINS.
+        """
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "V1", version=1)
+
+            owner = uuid4()
+            # Owner acquires E → captures read_generation == owner_generation (0).
+            reg.set_agent_state(a, owner, MESIState.EXCLUSIVE, trigger="write", tick=1)
+            # A sweep reclamation bumps owner_generation (→1) and INVALIDATES the
+            # owner; the owner's captured read_generation (0) is now SUPERSEDED.
+            reg.set_agent_state(
+                a, owner, MESIState.INVALID, trigger="reclaim_heartbeat", tick=2
+            )
+            assert reg.get_read_generation(a, owner) == 0
+            assert reg.get_owner_generation(a) == 1
+
+            # CONTROL: a direct commit_cas UNDER THE OWNER is fenced out (proves
+            # the owner identity would spuriously reject — the bug we avoid).
+            reg.set_agent_state(a, owner, MESIState.SHARED, tick=3)  # no fresh claim
+            control = reg.commit_cas(
+                a, owner, expected_version=1, content_hash="hc", content=None, tick=4
+            )
+            assert isinstance(control, ConflictDetail)
+            assert control.reason == STALE_READ_GENERATION_REASON
+
+            # A session whose OWNER is that same agent still WINS, because the
+            # session-scoped committer is fence-claimless (admit-on-absent).
+            session = svc.begin_session(read_set=[a], owner=owner)
+            result = svc.session_commit(session.session_token, a, "SESSION-WINS")
+            assert isinstance(result, tuple), f"expected WIN, got {result!r}"
+            assert result[0].version == 2
+        finally:
+            sql.close()
+
+    def test_committer_id_is_deterministic_per_token(self) -> None:
+        """The session committer is a stable ``uuid5`` of the token (so a
+        session's repeated commits use ONE identity), and differs per token."""
+        t1 = "tok-AAA"
+        t2 = "tok-BBB"
+        assert CoordinatorService._session_committer_id(t1) == uuid5(NAMESPACE_URL, t1)
+        assert CoordinatorService._session_committer_id(t1) == CoordinatorService._session_committer_id(t1)
+        assert CoordinatorService._session_committer_id(t1) != CoordinatorService._session_committer_id(t2)
+
+
+# ===========================================================================
+# E — Taxonomy preserved: the three ConflictDetail reasons surface unchanged
+# ===========================================================================
+
+
+class TestTaxonomyPreserved:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_version_mismatch_surfaces(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "p", "V1", version=1)
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            _peer_commit_cas(reg, a, uuid4(), expected=1, body="V2")
+            result = svc.session_commit(session.session_token, a, "X")
+            assert isinstance(result, ConflictDetail)
+            assert result.reason == "version_mismatch"
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_other_holder_surfaces(self, tmp_path: Path, arm: str) -> None:
+        """A pessimistic peer holds M/E at the pinned (unchanged) version → the
+        OCC-vs-pessimistic guard returns ``other_holder``, surfaced unchanged."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "p", "V1", version=1)
+            session = svc.begin_session(read_set=[a], owner=uuid4())  # pins {a:1}
+            # A pessimistic peer takes EXCLUSIVE at the still-pinned version.
+            reg.set_agent_state(a, uuid4(), MESIState.EXCLUSIVE, trigger="write", tick=1)
+
+            result = svc.session_commit(session.session_token, a, "X")
+            assert isinstance(result, ConflictDetail)
+            assert result.reason == "other_holder"
+            assert result.current_version == 1
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_stale_read_generation_surfaces_when_committer_carries_a_claim(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """The third reason is reachable through ``session_commit`` ONLY if the
+        committer carries a superseded claim. The session committer normally
+        never does (that is the whole point), so to exercise the reason we plant
+        a superseded ``read_generation`` ON the session-derived committer id and
+        confirm it surfaces UNCHANGED (the taxonomy is preserved end-to-end, not
+        swallowed). This is an adversarial poke, not a normal path."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "p", "V1", version=1)
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            committer = uuid5(NAMESPACE_URL, session.session_token)
+
+            # Plant a fence claim ON the committer id, then supersede it.
+            reg.set_agent_state(a, committer, MESIState.EXCLUSIVE, trigger="write", tick=1)
+            reg.set_agent_state(
+                a, committer, MESIState.INVALID, trigger="reclaim_heartbeat", tick=2
+            )
+            reg.set_agent_state(a, committer, MESIState.SHARED, tick=3)
+            assert reg.get_read_generation(a, committer) == 0
+            assert reg.get_owner_generation(a) == 1
+
+            result = svc.session_commit(session.session_token, a, "X")
+            assert isinstance(result, ConflictDetail)
+            assert result.reason == STALE_READ_GENERATION_REASON
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_no_invalidation_signal_on_any_non_win(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """Across all three non-win reasons + the validation rejections, the
+        result is never a ``(_, signals)`` tuple — nothing was invalidated."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            # version_mismatch
+            a = uuid4()
+            _register(reg, a, "p", "V1", version=1)
+            s = svc.begin_session(read_set=[a], owner=uuid4())
+            _peer_commit_cas(reg, a, uuid4(), expected=1, body="V2")
+            r1 = svc.session_commit(s.session_token, a, "X")
+            # other_holder
+            b = uuid4()
+            _register(reg, b, "q", "V1", version=1)
+            s2 = svc.begin_session(read_set=[b], owner=uuid4())
+            reg.set_agent_state(b, uuid4(), MESIState.EXCLUSIVE, trigger="write", tick=1)
+            r2 = svc.session_commit(s2.session_token, b, "X")
+            # validation rejection
+            r3 = svc.session_commit("unknown", a, "X")
+
+            for r in (r1, r2, r3):
+                assert not isinstance(r, tuple), f"unexpected signal-bearing win: {r!r}"
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# F — Validation gate: typed rejections, never a silent fall-through
+# ===========================================================================
+
+
+class TestValidationRejections:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_unknown_token_is_session_not_found(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "p", "V1", version=1)
+            result = svc.session_commit("never-minted-token", a, "X")
+            assert isinstance(result, SessionCommitRejection)
+            assert result.reason == SESSION_NOT_FOUND_REASON
+            assert result.reason in SESSION_COMMIT_REASONS
+            assert result.artifact_id == a
+            assert result.coordinator_epoch == reg.coordinator_epoch
+            # The artifact was NOT touched.
+            assert reg.get_artifact(a).version == 1
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_released_token_is_session_not_found(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "p", "V1", version=1)
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            reg.release_session(session.session_token)  # pins dropped
+            result = svc.session_commit(session.session_token, a, "X")
+            assert isinstance(result, SessionCommitRejection)
+            assert result.reason == SESSION_NOT_FOUND_REASON
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_artifact_not_in_cut_is_rejected(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            b = uuid4()
+            _register(reg, a, "plan.md", "VA", version=1)
+            _register(reg, b, "budget.md", "VB", version=1)
+            session = svc.begin_session(read_set=[b], owner=uuid4())  # pins {b}
+            # Commit an artifact NOT in the cut → rejected, never live-HEAD commit.
+            result = svc.session_commit(session.session_token, a, "X")
+            assert isinstance(result, SessionCommitRejection)
+            assert result.reason == SESSION_ARTIFACT_NOT_IN_CUT_REASON
+            assert result.artifact_id == a
+            # The un-pinned artifact was NOT committed.
+            assert reg.get_artifact(a).version == 1
+        finally:
+            sql.close()
+
+    def test_session_commit_reasons_is_additive_and_disjoint(self) -> None:
+        """``SESSION_COMMIT_REASONS`` is the closed validation set; it is disjoint
+        from the bare ``read_at_version`` surface (R7 additive-only)."""
+        from ccs.core.exceptions import READ_AT_VERSION_REASONS, SESSION_READ_REASONS
+
+        assert SESSION_COMMIT_REASONS == {
+            SESSION_NOT_FOUND_REASON,
+            SESSION_ARTIFACT_NOT_IN_CUT_REASON,
+        }
+        # Shares the token/pin vocabulary with session_read (one surface).
+        assert SESSION_COMMIT_REASONS == SESSION_READ_REASONS
+        # Disjoint from the separate read_at_version history surface.
+        assert SESSION_COMMIT_REASONS.isdisjoint(READ_AT_VERSION_REASONS)
+
+
+# ===========================================================================
+# G — R11: "exactly one validated commit" is naturally enforced
+# ===========================================================================
+
+
+class TestExactlyOneValidatedCommit:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_second_commit_at_same_pin_version_mismatches(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """After a WIN the artifact moved past the pin, so a SECOND
+        ``session_commit`` at the same (now stale) pin version-mismatches — no
+        explicit single-use machinery, the pin is neither consumed nor rewritten
+        (so SB-18 multi-commit stays un-foreclosed, R11)."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "p", "V1", version=1)
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+
+            first = svc.session_commit(session.session_token, a, "V2")
+            assert isinstance(first, tuple)
+            assert first[0].version == 2
+
+            # The pin still records version 1; a second commit is HELD.
+            assert session.cut[a] == 1
+            assert svc.registry.get_session_cut(session.session_token)[a] == 1
+            second = svc.session_commit(session.session_token, a, "V3")
+            assert isinstance(second, ConflictDetail)
+            assert second.reason == "version_mismatch"
+            assert second.current_version == 2
+            # Only ONE commit landed: still at v2.
+            assert reg.get_artifact(a).version == 2
+        finally:
+            sql.close()

--- a/tests/test_session_commit.py
+++ b/tests/test_session_commit.py
@@ -111,11 +111,12 @@ class TestHappyPath:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "plan.md", "V1", version=1)
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             assert isinstance(session, SnapshotSession)
             assert session.cut[a] == 1
 
-            result = svc.session_commit(session.session_token, a, "V2-BODY")
+            result = svc.session_commit(session.session_token, a, "V2-BODY", caller=owner)
 
             assert isinstance(result, tuple)
             updated, signals = result
@@ -138,10 +139,11 @@ class TestHappyPath:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "plan.md", "V7", version=7)
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             assert session.cut[a] == 7
 
-            result = svc.session_commit(session.session_token, a, "V8")
+            result = svc.session_commit(session.session_token, a, "V8", caller=owner)
             assert isinstance(result, tuple)
             assert result[0].version == 8
         finally:
@@ -164,7 +166,8 @@ class TestHeldOnMovedBase:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "plan.md", "V1", version=1)
-            session = svc.begin_session(read_set=[a], owner=uuid4())  # pins {a:1}
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)  # pins {a:1}
 
             # A peer commits 1 → 2 AFTER the cut was captured.
             _peer_commit_cas(reg, a, uuid4(), expected=1, body="PEER-V2")
@@ -172,7 +175,7 @@ class TestHeldOnMovedBase:
             before = reg.get_artifact(a)
 
             # The session commits at the now-stale pinned base (1) → HELD, RETURNED.
-            result = svc.session_commit(session.session_token, a, "MINE")
+            result = svc.session_commit(session.session_token, a, "MINE", caller=owner)
 
             assert isinstance(result, ConflictDetail)
             assert result.reason == "version_mismatch"
@@ -200,10 +203,11 @@ class TestHeldOnMovedBase:
             # A peer holding SHARED at v1 is a witness for "no peer invalidated".
             peer = uuid4()
             reg.set_agent_state(a, peer, MESIState.SHARED, tick=0)
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             _peer_commit_cas(reg, a, uuid4(), expected=1, body="PEER-V2")
 
-            result = svc.session_commit(session.session_token, a, "MINE")
+            result = svc.session_commit(session.session_token, a, "MINE", caller=owner)
 
             assert isinstance(result, ConflictDetail)
             # The result type itself carries no signals list — a held commit
@@ -233,7 +237,8 @@ class TestCorruptionRaisesAtServiceLayer:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "plan.md", "V5", version=5)
-            session = svc.begin_session(read_set=[a], owner=uuid4())  # pins {a:5}
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)  # pins {a:5}
             assert session.cut[a] == 5
 
             # Rewind current (5 → 3) BELOW the pin so expected(5) > current(3).
@@ -241,7 +246,7 @@ class TestCorruptionRaisesAtServiceLayer:
             _register(reg, a, "plan.md", "V3", version=3)
 
             with pytest.raises(CoherenceError) as excinfo:
-                svc.session_commit(session.session_token, a, "X")
+                svc.session_commit(session.session_token, a, "X", caller=owner)
             # The raise is the corruption mapping, not a generic precondition.
             assert "corruption" in str(excinfo.value).lower()
         finally:
@@ -261,7 +266,8 @@ class TestCorruptionRaisesAtServiceLayer:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "plan.md", "V5", version=5)
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             reg.remove_artifact(a)
             _register(reg, a, "plan.md", "V3", version=3)
 
@@ -281,7 +287,7 @@ class TestCorruptionRaisesAtServiceLayer:
 
             # SERVICE layer: raises for the same corruption.
             with pytest.raises(CoherenceError):
-                svc.session_commit(session.session_token, a, "X")
+                svc.session_commit(session.session_token, a, "X", caller=owner)
         finally:
             sql.close()
 
@@ -305,13 +311,14 @@ class TestAdmitOnAbsent:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "plan.md", "V1", version=1)
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
 
             committer = uuid5(NAMESPACE_URL, session.session_token)
             # Precondition of the load-bearing path: the committer is fence-claimless.
             assert reg.get_read_generation(a, committer) is None
 
-            result = svc.session_commit(session.session_token, a, "V2")
+            result = svc.session_commit(session.session_token, a, "V2", caller=owner)
             assert isinstance(result, tuple)
             assert result[0].version == 2
         finally:
@@ -358,7 +365,7 @@ class TestAdmitOnAbsent:
             # A session whose OWNER is that same agent still WINS, because the
             # session-scoped committer is fence-claimless (admit-on-absent).
             session = svc.begin_session(read_set=[a], owner=owner)
-            result = svc.session_commit(session.session_token, a, "SESSION-WINS")
+            result = svc.session_commit(session.session_token, a, "SESSION-WINS", caller=owner)
             assert isinstance(result, tuple), f"expected WIN, got {result!r}"
             assert result[0].version == 2
         finally:
@@ -388,9 +395,10 @@ class TestTaxonomyPreserved:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "p", "V1", version=1)
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             _peer_commit_cas(reg, a, uuid4(), expected=1, body="V2")
-            result = svc.session_commit(session.session_token, a, "X")
+            result = svc.session_commit(session.session_token, a, "X", caller=owner)
             assert isinstance(result, ConflictDetail)
             assert result.reason == "version_mismatch"
         finally:
@@ -406,11 +414,12 @@ class TestTaxonomyPreserved:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "p", "V1", version=1)
-            session = svc.begin_session(read_set=[a], owner=uuid4())  # pins {a:1}
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)  # pins {a:1}
             # A pessimistic peer takes EXCLUSIVE at the still-pinned version.
             reg.set_agent_state(a, uuid4(), MESIState.EXCLUSIVE, trigger="write", tick=1)
 
-            result = svc.session_commit(session.session_token, a, "X")
+            result = svc.session_commit(session.session_token, a, "X", caller=owner)
             assert isinstance(result, ConflictDetail)
             assert result.reason == "other_holder"
             assert result.current_version == 1
@@ -433,7 +442,8 @@ class TestTaxonomyPreserved:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "p", "V1", version=1)
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             committer = uuid5(NAMESPACE_URL, session.session_token)
 
             # Plant a fence claim ON the committer id, then supersede it.
@@ -445,7 +455,7 @@ class TestTaxonomyPreserved:
             assert reg.get_read_generation(a, committer) == 0
             assert reg.get_owner_generation(a) == 1
 
-            result = svc.session_commit(session.session_token, a, "X")
+            result = svc.session_commit(session.session_token, a, "X", caller=owner)
             assert isinstance(result, ConflictDetail)
             assert result.reason == STALE_READ_GENERATION_REASON
         finally:
@@ -464,17 +474,20 @@ class TestTaxonomyPreserved:
             # version_mismatch
             a = uuid4()
             _register(reg, a, "p", "V1", version=1)
-            s = svc.begin_session(read_set=[a], owner=uuid4())
+            owner_a = uuid4()
+            s = svc.begin_session(read_set=[a], owner=owner_a)
             _peer_commit_cas(reg, a, uuid4(), expected=1, body="V2")
-            r1 = svc.session_commit(s.session_token, a, "X")
+            r1 = svc.session_commit(s.session_token, a, "X", caller=owner_a)
             # other_holder
             b = uuid4()
             _register(reg, b, "q", "V1", version=1)
-            s2 = svc.begin_session(read_set=[b], owner=uuid4())
+            owner_b = uuid4()
+            s2 = svc.begin_session(read_set=[b], owner=owner_b)
             reg.set_agent_state(b, uuid4(), MESIState.EXCLUSIVE, trigger="write", tick=1)
-            r2 = svc.session_commit(s2.session_token, b, "X")
-            # validation rejection
-            r3 = svc.session_commit("unknown", a, "X")
+            r2 = svc.session_commit(s2.session_token, b, "X", caller=owner_b)
+            # validation rejection (no owner binding for "unknown" → caller is
+            # irrelevant; the cut-absent path classifies it).
+            r3 = svc.session_commit("unknown", a, "X", caller=uuid4())
 
             for r in (r1, r2, r3):
                 assert not isinstance(r, tuple), f"unexpected signal-bearing win: {r!r}"
@@ -496,7 +509,8 @@ class TestValidationRejections:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "p", "V1", version=1)
-            result = svc.session_commit("never-minted-token", a, "X")
+            # No owner binding for this token → owner validation is a no-op.
+            result = svc.session_commit("never-minted-token", a, "X", caller=uuid4())
             assert isinstance(result, SessionCommitRejection)
             assert result.reason == SESSION_NOT_FOUND_REASON
             assert result.reason in SESSION_COMMIT_REASONS
@@ -517,9 +531,10 @@ class TestValidationRejections:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "p", "V1", version=1)
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             reg.release_session(session.session_token)  # pins dropped
-            result = svc.session_commit(session.session_token, a, "X")
+            result = svc.session_commit(session.session_token, a, "X", caller=owner)
             assert isinstance(result, SessionCommitRejection)
             # Unit-5 taxonomy: a released (in-shape) token WAS a real session →
             # session_invalidated (fail closed, never a live-HEAD commit), not
@@ -538,9 +553,10 @@ class TestValidationRejections:
             b = uuid4()
             _register(reg, a, "plan.md", "VA", version=1)
             _register(reg, b, "budget.md", "VB", version=1)
-            session = svc.begin_session(read_set=[b], owner=uuid4())  # pins {b}
+            owner = uuid4()
+            session = svc.begin_session(read_set=[b], owner=owner)  # pins {b}
             # Commit an artifact NOT in the cut → rejected, never live-HEAD commit.
-            result = svc.session_commit(session.session_token, a, "X")
+            result = svc.session_commit(session.session_token, a, "X", caller=owner)
             assert isinstance(result, SessionCommitRejection)
             assert result.reason == SESSION_ARTIFACT_NOT_IN_CUT_REASON
             assert result.artifact_id == a
@@ -587,16 +603,17 @@ class TestExactlyOneValidatedCommit:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "p", "V1", version=1)
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
 
-            first = svc.session_commit(session.session_token, a, "V2")
+            first = svc.session_commit(session.session_token, a, "V2", caller=owner)
             assert isinstance(first, tuple)
             assert first[0].version == 2
 
             # The pin still records version 1; a second commit is HELD.
             assert session.cut[a] == 1
             assert svc.registry.get_session_cut(session.session_token)[a] == 1
-            second = svc.session_commit(session.session_token, a, "V3")
+            second = svc.session_commit(session.session_token, a, "V3", caller=owner)
             assert isinstance(second, ConflictDetail)
             assert second.reason == "version_mismatch"
             assert second.current_version == 2

--- a/tests/test_session_identity_and_caps.py
+++ b/tests/test_session_identity_and_caps.py
@@ -1,0 +1,533 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Unit 7 — session identity, isolation & resource caps (SB-17 / TX-1).
+
+Plan: ``docs/plans/2026-06-26-002-feat-read-side-transaction-snapshot-plan.md``
+Unit 7. Requirement trace: **R13** (owner-isolation: a SIBLING agent cannot read
+or commit another session's cut, even with a leaked token — the per-call owner
+check is TIMING-SAFE) and **R14** (resource caps bound the snapshot blast radius:
+``max_sessions`` / ``max_read_set_cardinality`` / ``absolute_age_ticks``). Builds
+on Units 2-5: ``begin_session`` / cut-capture (U2), ``session_read`` (U3),
+``session_commit`` (U4), the heartbeat-lease + liveness sweep (U5).
+
+Two axes under test:
+
+- **Identity / isolation (R13).** ``session_read`` / ``session_commit`` take a
+  REQUIRED keyword-only ``caller`` validated against the owner bound at
+  ``begin_session`` via :func:`hmac.compare_digest` over the stable 16-byte
+  ``UUID.bytes`` encoding (never ``==``). A FOREIGN caller fails closed by RAISE
+  (:class:`SessionInvalidated`); the OWNER's own calls succeed; an owned-but-
+  pinless token fails closed with the typed ``session_invalidated`` reason, never
+  served.
+- **Caps (R14).** ``begin_session`` rejects (typed RETURN, never an exception)
+  when opening the session would exceed ``max_sessions`` concurrent sessions
+  (``session_cap_exceeded``) or when ``read_set`` exceeds
+  ``max_read_set_cardinality`` (``read_set_too_large``); the liveness sweep reaps
+  a session past ``absolute_age_ticks`` EVEN WITH a fresh heartbeat (the hard age
+  ceiling, threat-model #3). Reason matching is ALWAYS ``reason == CONSTANT``
+  against the imported wire-stable constant — never a substring of a human
+  message (the typed-signal-not-substring house rule).
+
+Timing uses FIXED logical ticks (no wall-clock sleeps), mirroring
+tests/test_session_lifetime.py. Caps are made REACHABLE in-test by constructing
+the service with a SMALL :class:`SessionCapsConfig` rather than the
+security-calibrated defaults.
+"""
+
+from __future__ import annotations
+
+import hmac
+import inspect
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.retention import RetentionPolicy
+from ccs.coordinator.service import (
+    CoordinatorService,
+    SessionCapsConfig,
+)
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.exceptions import (
+    SESSION_BEGIN_CAP_REASONS,
+    SESSION_CAP_EXCEEDED_REASON,
+    SESSION_INVALIDATED_REASON,
+    SESSION_READ_SET_TOO_LARGE_REASON,
+    SessionInvalidated,
+)
+from ccs.core.types import (
+    Artifact,
+    SessionCommitRejection,
+    SessionReadRejection,
+    SnapshotSession,
+    VersionedContent,
+    VersionedReadRejection,
+)
+
+# Timing constants — fixed logical ticks (no wall-clock sleeps).
+_HB_TIMEOUT = 120
+
+
+# ---------------------------------------------------------------------------
+# Builders — mirror tests/test_session_read.py / test_session_commit.py.
+# ---------------------------------------------------------------------------
+
+
+def _register(reg, artifact_id: UUID, name: str, body: str, version: int = 1) -> None:
+    art = Artifact(id=artifact_id, name=name, version=version, content_hash="h1")
+    reg.register_artifact(art, content=body)
+
+
+def _registries(tmp_path: Path):
+    """An (in_memory, sqlite) LAZY pair — ``retain_versions=True`` so the
+    served-body assertions are concrete on both arms."""
+    pol = RetentionPolicy(max_versions=8)
+    mem = ArtifactRegistry(retain_versions=True, retention_policy=pol)
+    sql = SqliteArtifactRegistry(
+        tmp_path / "snap_identity.db", retain_versions=True, retention_policy=pol
+    )
+    return mem, sql
+
+
+def _small_caps() -> SessionCapsConfig:
+    """A SMALL caps config so every R14 bound is reachable in a unit test (the
+    security-calibrated defaults of 256 / 64 / 3600 are not)."""
+    return SessionCapsConfig(
+        max_sessions=3,
+        max_read_set_cardinality=2,
+        absolute_age_ticks=1000,
+    )
+
+
+# ===========================================================================
+# A — Owner isolation (R13): a FOREIGN caller is rejected; the OWNER succeeds.
+# ===========================================================================
+
+
+class TestOwnerIsolation:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_foreign_caller_read_raises_session_invalidated(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """A sibling agent that did not open the session CANNOT read its cut, even
+        with the (leaked) token — the per-call owner check fails CLOSED by RAISE,
+        never a live serve."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            foreign = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "PINNED-V1")
+            session = svc.begin_session(read_set=[a], owner=owner)
+            assert isinstance(session, SnapshotSession)
+            tok = session.session_token
+
+            with pytest.raises(SessionInvalidated) as exc:
+                svc.session_read(tok, a, caller=foreign)
+            assert exc.value.reason == SESSION_INVALIDATED_REASON
+
+            # The OWNER's own read still serves the pinned bytes.
+            r = svc.session_read(tok, a, caller=owner)
+            assert isinstance(r, VersionedContent)
+            assert r.content == "PINNED-V1"
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_foreign_caller_commit_raises_session_invalidated(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """A sibling cannot commit against another's cut — the foreign
+        ``session_commit`` RAISES before any OCC arbitration, and the artifact is
+        UNTOUCHED. The owner's own commit then WINS."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            foreign = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "V1")
+            session = svc.begin_session(read_set=[a], owner=owner)
+            tok = session.session_token
+
+            with pytest.raises(SessionInvalidated) as exc:
+                svc.session_commit(tok, a, "FOREIGN-WRITE", caller=foreign)
+            assert exc.value.reason == SESSION_INVALIDATED_REASON
+            # The foreign commit never landed: still at v1.
+            assert reg.get_artifact(a).version == 1
+
+            # The OWNER's own commit WINS.
+            result = svc.session_commit(tok, a, "OWNER-WRITE", caller=owner)
+            assert isinstance(result, tuple)
+            updated, _signals = result
+            assert updated.version == 2
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_sibling_with_own_session_cannot_cross_read(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """Two agents each hold their OWN session. Neither can read the other's
+        cut: cross-agent access is OUT (R13), even though each is a legitimate
+        owner of a DIFFERENT token."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner_a = uuid4()
+            owner_b = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "BODY")
+            sess_a = svc.begin_session(read_set=[a], owner=owner_a)
+            sess_b = svc.begin_session(read_set=[a], owner=owner_b)
+
+            # A reads its own cut fine, but cannot read B's token (and vice versa).
+            assert isinstance(
+                svc.session_read(sess_a.session_token, a, caller=owner_a),
+                VersionedContent,
+            )
+            with pytest.raises(SessionInvalidated):
+                svc.session_read(sess_b.session_token, a, caller=owner_a)
+            with pytest.raises(SessionInvalidated):
+                svc.session_read(sess_a.session_token, a, caller=owner_b)
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# B — Timing-safe owner compare (R13): a near-miss owner UUID is rejected; the
+#     validator uses hmac.compare_digest, never ``==``.
+# ===========================================================================
+
+
+class TestTimingSafeOwnerCompare:
+    def test_near_miss_owner_is_rejected(self, tmp_path: Path) -> None:
+        """An owner id that differs by a SINGLE byte is still foreign → rejected.
+        A naive prefix/short-circuit compare could leak match-progress; the
+        all-but-one-byte match must NOT be admitted."""
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        a = uuid4()
+        _register(reg, a, "plan.md", "BODY")
+
+        owner_bytes = bytearray(uuid4().bytes)
+        owner = UUID(bytes=bytes(owner_bytes))
+        # Flip the LAST byte only — a near-miss that matches all but one byte.
+        near_miss_bytes = bytearray(owner_bytes)
+        near_miss_bytes[-1] ^= 0x01
+        near_miss = UUID(bytes=bytes(near_miss_bytes))
+        assert near_miss != owner
+
+        session = svc.begin_session(read_set=[a], owner=owner)
+        with pytest.raises(SessionInvalidated):
+            svc.session_read(session.session_token, a, caller=near_miss)
+        # The genuine owner still succeeds.
+        assert isinstance(
+            svc.session_read(session.session_token, a, caller=owner),
+            VersionedContent,
+        )
+
+    def test_owner_validation_uses_compare_digest_not_equality(self) -> None:
+        """Pin the timing-safe property at the source: the per-call owner
+        validator's body references :func:`hmac.compare_digest`, never a bare
+        ``==`` on the owner ids. (A regression to ``==`` would be a timing-side-
+        channel; this guards the constant-time path explicitly.)"""
+        src = inspect.getsource(CoordinatorService._validate_session_owner)
+        assert "compare_digest" in src
+        # The compare is over the stable 16-byte UUID encoding.
+        assert ".bytes" in src
+        # Sanity that the module imported the timing-safe primitive at all.
+        assert hasattr(hmac, "compare_digest")
+
+
+# ===========================================================================
+# C — Owned-but-pinless fails closed (never served).
+# ===========================================================================
+
+
+class TestOwnedButPinlessFailsClosed:
+    def test_owned_but_pinless_read_is_session_invalidated(
+        self, tmp_path: Path
+    ) -> None:
+        """A token that is OWNED but carries NO live pins (an owner binding
+        recorded with the cut dropped out from under it) is NOT served: the owner
+        passes the isolation check, then the cut-absent path fails CLOSED with the
+        wire-stable ``session_invalidated``, never a live-HEAD fall-through."""
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        owner = uuid4()
+        a = uuid4()
+        _register(reg, a, "plan.md", "PINNED-V1")
+        session = svc.begin_session(read_set=[a], owner=owner)
+        tok = session.session_token
+
+        # Drop the pins but KEEP the owner binding → owned-but-pinless.
+        reg.release_session(tok)
+        assert reg.get_session_cut(tok) is None
+        assert svc._session_owners.get(tok) == owner  # still owned
+
+        r = svc.session_read(tok, a, caller=owner)
+        assert isinstance(r, SessionReadRejection)
+        assert r.reason == SESSION_INVALIDATED_REASON
+        # Never served live HEAD.
+        assert not isinstance(r, VersionedContent)
+
+    def test_owned_but_pinless_commit_is_session_invalidated(
+        self, tmp_path: Path
+    ) -> None:
+        """Same owned-but-pinless token on the commit path: a typed rejection
+        (``session_invalidated``), never a live-HEAD commit. The artifact stays
+        at its pre-session version."""
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        owner = uuid4()
+        a = uuid4()
+        _register(reg, a, "plan.md", "V1")
+        session = svc.begin_session(read_set=[a], owner=owner)
+        tok = session.session_token
+        reg.release_session(tok)
+        assert svc._session_owners.get(tok) == owner
+
+        rc = svc.session_commit(tok, a, "WOULD-BE", caller=owner)
+        assert isinstance(rc, SessionCommitRejection)
+        assert rc.reason == SESSION_INVALIDATED_REASON
+        assert reg.get_artifact(a).version == 1
+
+    def test_foreign_caller_on_pinless_token_still_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """Isolation is checked BEFORE the cut-absent classification: a FOREIGN
+        caller on an owned-but-pinless token RAISES (the isolation breach), not a
+        benign ``session_invalidated`` rejection — fail-closed dominates."""
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        owner = uuid4()
+        foreign = uuid4()
+        a = uuid4()
+        _register(reg, a, "plan.md", "V1")
+        session = svc.begin_session(read_set=[a], owner=owner)
+        tok = session.session_token
+        reg.release_session(tok)  # pinless, but still owner-bound
+
+        with pytest.raises(SessionInvalidated):
+            svc.session_read(tok, a, caller=foreign)
+
+
+# ===========================================================================
+# D — Resource caps (R14): max_sessions, max_read_set_cardinality.
+# ===========================================================================
+
+
+class TestSessionCountCap:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_opening_one_past_max_sessions_is_rejected(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """Opening ``max_sessions + 1`` concurrent sessions → the (N+1)th is a
+        TYPED ``session_cap_exceeded`` rejection (no token minted, no cut pinned),
+        never an exception. Releasing one frees a slot for a later open."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        caps = _small_caps()  # max_sessions == 3
+        try:
+            svc = CoordinatorService(reg, session_caps=caps)
+            a = uuid4()
+            _register(reg, a, "plan.md", "BODY")
+
+            tokens = []
+            for _ in range(caps.max_sessions):
+                s = svc.begin_session(read_set=[a], owner=uuid4())
+                assert isinstance(s, SnapshotSession)
+                tokens.append(s.session_token)
+
+            # The (N+1)th is rejected — typed, no half-open session.
+            rejected = svc.begin_session(read_set=[a], owner=uuid4())
+            assert isinstance(rejected, VersionedReadRejection)
+            assert rejected.reason == SESSION_CAP_EXCEEDED_REASON
+            assert rejected.reason in SESSION_BEGIN_CAP_REASONS
+            # The cap (not any artifact) is reported; current == the cap.
+            assert rejected.current_version == caps.max_sessions
+            assert rejected.coordinator_epoch == reg.coordinator_epoch
+
+            # Free a slot → a subsequent open succeeds again.
+            reg.release_session(tokens[0])
+            svc._session_owners.pop(tokens[0], None)
+            s_again = svc.begin_session(read_set=[a], owner=uuid4())
+            assert isinstance(s_again, SnapshotSession)
+        finally:
+            sql.close()
+
+
+class TestReadSetCardinalityCap:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_read_set_over_cardinality_is_rejected(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """A ``read_set`` larger than ``max_read_set_cardinality`` → a TYPED
+        ``read_set_too_large`` rejection (no token minted, no cut pinned). A
+        read_set AT the cap still opens."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        caps = _small_caps()  # max_read_set_cardinality == 2
+        try:
+            svc = CoordinatorService(reg, session_caps=caps)
+            ids = [uuid4() for _ in range(caps.max_read_set_cardinality + 1)]
+            for i, aid in enumerate(ids):
+                _register(reg, aid, f"a{i}.md", "BODY")
+
+            # AT the cap: opens fine.
+            at_cap = svc.begin_session(
+                read_set=ids[: caps.max_read_set_cardinality], owner=uuid4()
+            )
+            assert isinstance(at_cap, SnapshotSession)
+
+            # OVER the cap: typed rejection, no session.
+            rejected = svc.begin_session(read_set=ids, owner=uuid4())
+            assert isinstance(rejected, VersionedReadRejection)
+            assert rejected.reason == SESSION_READ_SET_TOO_LARGE_REASON
+            assert rejected.reason in SESSION_BEGIN_CAP_REASONS
+            # The rejection is about CARDINALITY, leaking no member id.
+            assert rejected.requested_version == len(ids)
+            assert rejected.current_version == caps.max_read_set_cardinality
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# E — Absolute-age ceiling (R14, threat-model #3): a session past
+#     ``absolute_age_ticks`` is reaped EVEN WITH a fresh heartbeat.
+# ===========================================================================
+
+
+class TestAbsoluteAgeCeiling:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_over_age_session_reaped_despite_fresh_heartbeat(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """The hard age ceiling is INDEPENDENT of the heartbeat lease. Heartbeat
+        at the CURRENT sweep tick (so the lease is maximally fresh), then sweep at
+        ``created_at + absolute_age_ticks``: the session is STILL reaped — a live
+        heartbeat must not exempt the ceiling (bounds heartbeat-spoofing DoS).
+        After the reap, read/commit fail closed with ``session_invalidated``."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        caps = _small_caps()  # absolute_age_ticks == 1000
+        try:
+            svc = CoordinatorService(reg, session_caps=caps)
+            owner = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "PINNED-V1")
+            created = 0
+            session = svc.begin_session(
+                read_set=[a], owner=owner, created_at_tick=created
+            )
+            tok = session.session_token
+            sweep_tick = created + caps.absolute_age_ticks  # exactly at the ceiling
+
+            # A MAXIMALLY-FRESH heartbeat: lease == the sweep tick, so the
+            # heartbeat-staleness predicate alone would NOT reap it.
+            assert svc.record_session_heartbeat(
+                session_token=tok, owner=owner, now_tick=sweep_tick
+            ) is True
+            assert (sweep_tick - sweep_tick) < _HB_TIMEOUT  # lease is fresh
+
+            reaped = svc.enforce_session_liveness(
+                current_tick=sweep_tick, heartbeat_timeout_ticks=_HB_TIMEOUT
+            )
+            assert reaped == 1, "over-age session was NOT reaped despite the ceiling"
+
+            # Pins released; read + commit fail closed (never live HEAD).
+            assert reg.get_session_cut(tok) is None
+            r = svc.session_read(tok, a, caller=owner)
+            assert isinstance(r, SessionReadRejection)
+            assert r.reason == SESSION_INVALIDATED_REASON
+            rc = svc.session_commit(tok, a, "WOULD-BE", caller=owner)
+            assert isinstance(rc, SessionCommitRejection)
+            assert rc.reason == SESSION_INVALIDATED_REASON
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_just_under_age_with_fresh_heartbeat_survives(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """The boundary is ``>=``: one tick BEFORE the ceiling, with a fresh
+        heartbeat, the session is NOT reaped — the ceiling does not fire early and
+        the live lease keeps it alive."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        caps = _small_caps()
+        try:
+            svc = CoordinatorService(reg, session_caps=caps)
+            owner = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "BODY")
+            created = 0
+            session = svc.begin_session(
+                read_set=[a], owner=owner, created_at_tick=created
+            )
+            tok = session.session_token
+            sweep_tick = created + caps.absolute_age_ticks - 1  # one BEFORE ceiling
+
+            assert svc.record_session_heartbeat(
+                session_token=tok, owner=owner, now_tick=sweep_tick
+            ) is True
+            reaped = svc.enforce_session_liveness(
+                current_tick=sweep_tick, heartbeat_timeout_ticks=_HB_TIMEOUT
+            )
+            assert reaped == 0
+            # Still serving the pinned bytes.
+            assert isinstance(
+                svc.session_read(tok, a, caller=owner), VersionedContent
+            )
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# F — Happy path: owner calls within caps proceed (read + commit succeed).
+# ===========================================================================
+
+
+class TestHappyWithinCaps:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_owner_read_and_commit_within_caps(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        """With a small caps config but a within-bounds request, the OWNER's read
+        serves the pinned bytes and the commit WINS — caps and isolation impose no
+        cost on the legitimate owner."""
+        mem, sql = _registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        caps = _small_caps()
+        try:
+            svc = CoordinatorService(reg, session_caps=caps)
+            owner = uuid4()
+            a = uuid4()
+            b = uuid4()
+            _register(reg, a, "plan.md", "PLAN-V1")
+            _register(reg, b, "budget.md", "BUDGET-V1")
+            # read_set of 2 == the cap exactly: within bounds.
+            session = svc.begin_session(read_set=[a, b], owner=owner)
+            assert isinstance(session, SnapshotSession)
+            assert session.cut[a] == 1 and session.cut[b] == 1
+
+            r = svc.session_read(session.session_token, a, caller=owner)
+            assert isinstance(r, VersionedContent)
+            assert r.content == "PLAN-V1"
+
+            result = svc.session_commit(
+                session.session_token, b, "BUDGET-V2", caller=owner
+            )
+            assert isinstance(result, tuple)
+            updated, _signals = result
+            assert updated.version == 2
+        finally:
+            sql.close()

--- a/tests/test_session_lifetime.py
+++ b/tests/test_session_lifetime.py
@@ -42,6 +42,7 @@ from ccs.coordinator.service import (
 )
 from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
 from ccs.core.exceptions import (
+    SESSION_CAP_EXCEEDED_REASON,
     SESSION_COMMIT_REASONS,
     SESSION_INVALIDATED_REASON,
     SESSION_NOT_FOUND_REASON,
@@ -55,6 +56,7 @@ from ccs.core.types import (
     SessionReadRejection,
     SnapshotSession,
     VersionedContent,
+    VersionedReadRejection,
 )
 
 # Timing constants — fixed logical ticks (no wall-clock sleeps).
@@ -606,3 +608,196 @@ class TestGcRaceFailsClosedNotWrongBytes:
         # NEVER a wrong-bytes VersionedContent; degrades to the typed deferral.
         assert isinstance(r, DataPlaneDeferredRead)
         assert r.version == 1
+
+
+# ===========================================================================
+# F3 (Option B) — durable owner-binding: a sqlite session survives a restart
+#     WITH its owner, so R6 (survival) and R13 (owner isolation) BOTH hold;
+#     a durable-only survivor is bounded by the absolute-age ceiling (R14).
+# ===========================================================================
+
+
+def _lazy_sqlite(tmp_path: Path, name: str) -> SqliteArtifactRegistry:
+    return SqliteArtifactRegistry(
+        tmp_path / name, retain_versions=True, retention_policy=RetentionPolicy(max_versions=8)
+    )
+
+
+class TestDurableOwnerSurvivesRestart:
+    def test_foreign_caller_rejected_after_restart(self, tmp_path: Path) -> None:
+        # The R13 hole F3 found: post-restart the in-memory owner-binding is wiped,
+        # so a leaked-token foreign caller could read a SURVIVED cut. With the
+        # durable owner, the legit owner is still served (R6) and the foreigner is
+        # rejected (R13).
+        db_name = "durable_owner.db"
+        owner, attacker, a = uuid4(), uuid4(), uuid4()
+        sql1 = _lazy_sqlite(tmp_path, db_name)
+        try:
+            _register(sql1, a, "plan.md", "OWNED-V1")
+            tok = CoordinatorService(sql1).begin_session(
+                read_set=[a], owner=owner
+            ).session_token
+        finally:
+            sql1.close()
+        # Restart: a fresh service over the same db (in-memory owner-binding gone).
+        sql2 = _lazy_sqlite(tmp_path, db_name)
+        try:
+            svc2 = CoordinatorService(sql2)
+            # R6: the legitimate owner is still served from the survived cut.
+            served = svc2.session_read(tok, a, caller=owner)
+            assert isinstance(served, VersionedContent)
+            assert served.content == "OWNED-V1"
+            # R13: a leaked-token FOREIGN caller is rejected (durable fallback).
+            with pytest.raises(SessionInvalidated):
+                svc2.session_read(tok, a, caller=attacker)
+            with pytest.raises(SessionInvalidated):
+                svc2.session_commit(tok, a, "ATTACKER", caller=attacker)
+            # ...and cannot keep the session alive via heartbeat either.
+            assert svc2.record_session_heartbeat(
+                session_token=tok, owner=attacker, now_tick=10
+            ) is False
+        finally:
+            sql2.close()
+
+    def test_pins_without_owner_fail_closed(self, tmp_path: Path) -> None:
+        # Defensive: a pins-present-but-ownerless token (the atomic capture never
+        # produces this) must FAIL CLOSED — no owner means no way to authorize.
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        owner, a = uuid4(), uuid4()
+        _register(reg, a, "plan.md", "V1")
+        tok = svc.begin_session(read_set=[a], owner=owner).session_token
+        # Force the orphan state: pins present, BOTH owner tiers cleared.
+        svc._session_owners.pop(tok)
+        reg._session_meta.pop(tok)
+        assert reg.get_session_cut(tok) is not None
+        with pytest.raises(SessionInvalidated):
+            svc.session_read(tok, a, caller=owner)
+
+    def test_durable_only_session_bounded_by_age_ceiling(self, tmp_path: Path) -> None:
+        # A survivor whose owner never returns is invisible to an in-memory-only
+        # sweep; the UNION sweep reaps it at the absolute-age ceiling so its pins
+        # do not starve GC forever (the F3 GC-starvation half).
+        db_name = "durable_age.db"
+        owner, a = uuid4(), uuid4()
+        caps = SessionCapsConfig(absolute_age_ticks=100)
+        sql1 = _lazy_sqlite(tmp_path, db_name)
+        try:
+            _register(sql1, a, "plan.md", "V1")
+            tok = CoordinatorService(sql1, session_caps=caps).begin_session(
+                read_set=[a], owner=owner, created_at_tick=0
+            ).session_token
+        finally:
+            sql1.close()
+        sql2 = _lazy_sqlite(tmp_path, db_name)
+        try:
+            svc2 = CoordinatorService(sql2, session_caps=caps)
+            # Within the ceiling: the durable-only survivor is NOT reaped (R6) —
+            # heartbeat-staleness must NOT apply to a leaseless survivor.
+            assert svc2.enforce_session_liveness(
+                current_tick=99, heartbeat_timeout_ticks=_HB_TIMEOUT
+            ) == 0
+            assert isinstance(svc2.session_read(tok, a, caller=owner), VersionedContent)
+            # Past the ceiling: the union sweep reaps it (R14).
+            assert svc2.enforce_session_liveness(
+                current_tick=100, heartbeat_timeout_ticks=_HB_TIMEOUT
+            ) == 1
+            assert svc2.registry.get_session_cut(tok) is None
+            assert svc2.registry.get_session_meta(tok) is None
+            r = svc2.session_read(tok, a, caller=owner)
+            assert isinstance(r, SessionReadRejection)
+            assert r.reason == SESSION_INVALIDATED_REASON
+        finally:
+            sql2.close()
+
+    def test_owner_heartbeat_rehydrates_after_restart(self, tmp_path: Path) -> None:
+        # The owner's first post-restart heartbeat falls back to the durable owner
+        # and REHYDRATES in-memory state (owner + ORIGINAL creation tick + lease).
+        db_name = "rehydrate.db"
+        owner, a = uuid4(), uuid4()
+        caps = SessionCapsConfig(absolute_age_ticks=10_000)
+        sql1 = _lazy_sqlite(tmp_path, db_name)
+        try:
+            _register(sql1, a, "plan.md", "V1")
+            tok = CoordinatorService(sql1, session_caps=caps).begin_session(
+                read_set=[a], owner=owner, created_at_tick=0
+            ).session_token
+        finally:
+            sql1.close()
+        sql2 = _lazy_sqlite(tmp_path, db_name)
+        try:
+            svc2 = CoordinatorService(sql2, session_caps=caps)
+            assert tok not in svc2._session_owners  # wiped by the restart
+            assert svc2.record_session_heartbeat(
+                session_token=tok, owner=owner, now_tick=500
+            ) is True
+            # Rehydrated into the in-memory maps; creation tick is the ORIGINAL 0
+            # (the absolute-age ceiling is never reset by a restart).
+            assert tok in svc2._session_owners
+            assert svc2._session_created[tok] == 0
+            # Fresh lease -> not reaped within the heartbeat window.
+            assert svc2.enforce_session_liveness(
+                current_tick=500 + _HB_TIMEOUT - 1, heartbeat_timeout_ticks=_HB_TIMEOUT
+            ) == 0
+        finally:
+            sql2.close()
+
+
+class TestAtomicSessionCap:
+    """F4: begin_session's cap-check + insert is atomic under ``_session_lock``,
+    so the live count never overshoots ``max_sessions`` — including under
+    concurrent begins (the bug the lock fixes is a check-then-act TOCTOU)."""
+
+    def test_cap_enforced_exactly_sequential(self) -> None:
+        # Cap correctness on the sequential path (does NOT exercise the lock).
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg, session_caps=SessionCapsConfig(max_sessions=3))
+        owner, a = uuid4(), uuid4()
+        _register(reg, a, "plan.md", "V1")
+        for _ in range(3):
+            assert isinstance(
+                svc.begin_session(read_set=[a], owner=owner), SnapshotSession
+            )
+        over = svc.begin_session(read_set=[a], owner=owner)
+        assert isinstance(over, VersionedReadRejection)
+        assert over.reason == SESSION_CAP_EXCEEDED_REASON
+        assert svc.registry.session_count() == 3
+
+    def test_concurrent_begins_never_overshoot_cap(self) -> None:
+        # The REAL F4 regression: many threads race begin_session at the cap
+        # boundary. The check-then-act (count < cap, then insert) is a TOCTOU that
+        # without _session_lock lets multiple threads pass the check before any
+        # insert, overshooting the cap. With the lock, EXACTLY cap begins win,
+        # deterministically. Would fail (overshoot) if the lock were removed.
+        import threading
+
+        reg = ArtifactRegistry(retain_versions=True)
+        cap = 8
+        svc = CoordinatorService(reg, session_caps=SessionCapsConfig(max_sessions=cap))
+        owner, a = uuid4(), uuid4()
+        _register(reg, a, "plan.md", "V1")
+
+        n_threads = 32
+        start = threading.Barrier(n_threads)
+        results: list = []
+        guard = threading.Lock()
+
+        def worker() -> None:
+            start.wait()  # release all threads together to maximize contention
+            r = svc.begin_session(read_set=[a], owner=owner)
+            with guard:
+                results.append(r)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        wins = [r for r in results if isinstance(r, SnapshotSession)]
+        rejects = [r for r in results if isinstance(r, VersionedReadRejection)]
+        assert len(wins) == cap, f"cap overshoot: {len(wins)} wins > {cap}"
+        assert len(rejects) == n_threads - cap
+        assert all(r.reason == SESSION_CAP_EXCEEDED_REASON for r in rejects)
+        assert svc.registry.session_count() == cap
+        assert len(svc._session_owners) == cap

--- a/tests/test_session_lifetime.py
+++ b/tests/test_session_lifetime.py
@@ -37,6 +37,7 @@ from ccs.coordinator.registry import ArtifactRegistry
 from ccs.coordinator.retention import RetentionPolicy
 from ccs.coordinator.service import (
     CoordinatorService,
+    SessionCapsConfig,
     looks_like_session_token,
 )
 from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
@@ -127,11 +128,11 @@ class TestLiveHeartbeatNotReaped:
             assert reaped == 0
 
             # read still serves the pinned bytes; commit still wins.
-            r = svc.session_read(tok, a)
+            r = svc.session_read(tok, a, caller=owner)
             assert isinstance(r, VersionedContent)
             assert r.content == "PINNED-V1"
 
-            result = svc.session_commit(tok, a, "NEW-V2")
+            result = svc.session_commit(tok, a, "NEW-V2", caller=owner)
             assert isinstance(result, tuple)  # WIN -> (artifact, signals)
             updated, _signals = result
             assert updated.version == 2
@@ -157,7 +158,7 @@ class TestLiveHeartbeatNotReaped:
             assert svc.enforce_session_liveness(
                 current_tick=50 + _HB_TIMEOUT - 1, heartbeat_timeout_ticks=_HB_TIMEOUT
             ) == 0
-            assert isinstance(svc.session_read(tok, a), VersionedContent)
+            assert isinstance(svc.session_read(tok, a, caller=owner), VersionedContent)
 
             # Past the window from the baseline -> reaped.
             assert svc.enforce_session_liveness(
@@ -201,13 +202,13 @@ class TestStaleHeartbeatReaped:
             assert reg.get_session_cut(tok) is None
 
             # FAIL CLOSED on read: session_invalidated, never live HEAD.
-            r = svc.session_read(tok, a)
+            r = svc.session_read(tok, a, caller=owner)
             assert isinstance(r, SessionReadRejection)
             assert r.reason == SESSION_INVALIDATED_REASON
             assert r.reason in SESSION_READ_REASONS
 
             # FAIL CLOSED on commit: session_invalidated.
-            rc = svc.session_commit(tok, a, "WOULD-BE-V2")
+            rc = svc.session_commit(tok, a, "WOULD-BE-V2", caller=owner)
             assert isinstance(rc, SessionCommitRejection)
             assert rc.reason == SESSION_INVALIDATED_REASON
             assert rc.reason in SESSION_COMMIT_REASONS
@@ -238,7 +239,7 @@ class TestStaleHeartbeatReaped:
             # While LIVE the pinned version is exempt (a peer commit past it does
             # not collect v1 — the session can still read it).
             _peer_commit_cas(reg, a, uuid4(), expected=1, body="V2")
-            assert svc.session_read(session.session_token, a).content == "V1"
+            assert svc.session_read(session.session_token, a, caller=owner).content == "V1"
             assert pinned in _live_pins(reg, a)
 
             # Reap -> the pin is dropped from the exemption set.
@@ -290,13 +291,13 @@ class TestRestartFailsClosed:
 
         # The old token has no cut in the fresh process. It MUST fail closed as
         # session_invalidated (it was a real session) — never serve live HEAD.
-        r = svc2.session_read(tok, a2)
+        r = svc2.session_read(tok, a2, caller=owner)
         assert isinstance(r, SessionReadRejection)
         assert r.reason == SESSION_INVALIDATED_REASON
         # Crucially: NOT served as VersionedContent of the fresh head.
         assert not isinstance(r, VersionedContent)
 
-        rc = svc2.session_commit(tok, a2, "WOULD-BE")
+        rc = svc2.session_commit(tok, a2, "WOULD-BE", caller=owner)
         assert isinstance(rc, SessionCommitRejection)
         assert rc.reason == SESSION_INVALIDATED_REASON
 
@@ -309,7 +310,7 @@ class TestRestartFailsClosed:
         _register(reg, a, "plan.md", "HEAD")
 
         for bogus in ["", "short", "not-a-real-token", "x" * 100]:
-            r = svc.session_read(bogus, a)
+            r = svc.session_read(bogus, a, caller=uuid4())
             assert isinstance(r, SessionReadRejection)
             assert r.reason == SESSION_NOT_FOUND_REASON, bogus
             # Still fail-closed (never live HEAD), just a different signal.
@@ -327,7 +328,14 @@ class TestSlowButLiveNotReaped:
         self, tmp_path: Path
     ) -> None:
         reg = ArtifactRegistry(retain_versions=True)
-        svc = CoordinatorService(reg)
+        # Isolate the LEASE predicate from the Unit-7 absolute-age ceiling: set the
+        # ceiling well past this run's final tick (49 * _HB_TIMEOUT) so only the
+        # heartbeat lease can reap. The ceiling itself is exercised separately in
+        # tests/test_session_identity_and_caps.py.
+        svc = CoordinatorService(
+            reg,
+            session_caps=SessionCapsConfig(absolute_age_ticks=100 * _HB_TIMEOUT),
+        )
         owner = uuid4()
         a = uuid4()
         _register(reg, a, "plan.md", "BODY")
@@ -337,7 +345,7 @@ class TestSlowButLiveNotReaped:
         # March far past a naive "absolute TTL": as long as the session keeps
         # heartbeating within the window, it is never reaped — the predicate is
         # on the LEASE, not a hard age ceiling (that ceiling is the separate
-        # Unit-7 cap, not exercised here).
+        # Unit-7 cap, exercised in the identity/caps suite).
         last = 0
         for step in range(1, 50):  # 49 windows past creation — way past 1 TTL.
             tick = step * _HB_TIMEOUT  # exactly one timeout per step
@@ -352,7 +360,7 @@ class TestSlowButLiveNotReaped:
             last = tick
         assert last == 49 * _HB_TIMEOUT
         # Still serving after the long run.
-        assert isinstance(svc.session_read(tok, a), VersionedContent)
+        assert isinstance(svc.session_read(tok, a, caller=owner), VersionedContent)
 
 
 # ===========================================================================
@@ -395,7 +403,7 @@ class TestLiveSessionDeadAgent:
         ) == 0
 
         # Pins survive; the read still serves the pinned bytes.
-        r = svc.session_read(tok, a)
+        r = svc.session_read(tok, a, caller=owner)
         assert isinstance(r, VersionedContent)
         assert r.content == "PINNED"
 
@@ -450,7 +458,7 @@ class TestOwnerBoundHeartbeat:
         assert svc.enforce_session_liveness(
             current_tick=10 + _HB_TIMEOUT, heartbeat_timeout_ticks=_HB_TIMEOUT
         ) == 1
-        r = svc.session_read(tok, a)
+        r = svc.session_read(tok, a, caller=owner)
         assert isinstance(r, SessionReadRejection)
         assert r.reason == SESSION_INVALIDATED_REASON
 
@@ -477,7 +485,7 @@ class TestOwnerBoundHeartbeat:
             session_token=tok, owner=owner, now_tick=10_001
         ) is False
         # Still dead.
-        r = svc.session_read(tok, a)
+        r = svc.session_read(tok, a, caller=owner)
         assert isinstance(r, SessionReadRejection)
         assert r.reason == SESSION_INVALIDATED_REASON
 
@@ -594,7 +602,7 @@ class TestGcRaceFailsClosedNotWrongBytes:
         record.version_history.pop(1, None)
         record.version_captured_at.pop(1, None)
 
-        r = svc.session_read(session.session_token, a)
+        r = svc.session_read(session.session_token, a, caller=owner)
         # NEVER a wrong-bytes VersionedContent; degrades to the typed deferral.
         assert isinstance(r, DataPlaneDeferredRead)
         assert r.version == 1

--- a/tests/test_session_lifetime.py
+++ b/tests/test_session_lifetime.py
@@ -1,0 +1,600 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Unit 5 — pin lifetime: the heartbeat lease + the session-liveness sweep +
+fail-closed ``SessionInvalidated`` (SB-17 / TX-1).
+
+Plan: ``docs/plans/2026-06-26-002-feat-read-side-transaction-snapshot-plan.md``
+Unit 5. Requirement trace: **R4** (a crashed session's pins are reaped; a
+referenced-unavailable or post-restart-unknown session fails closed with the
+typed ``session_invalidated`` — never wrong bytes / live HEAD). Builds on Unit
+2's cut capture / pin store and Units 3/4's ``session_read`` / ``session_commit``.
+
+A protocol proof bounds the REGISTRY, not the integration: ``Snapshot.tla`` bounds
+the cut/pin model; this file is the integration-layer regression for the sweep +
+heartbeat TIMING. Per the institutional steer, the sweep/heartbeat timing uses
+**fixed logical ticks, never wall-clock sleeps** — every staleness boundary is an
+explicit ``current_tick`` vs ``heartbeat_timeout_ticks`` arithmetic, so the test
+is deterministic and the predicate (not a hard TTL) is what is asserted.
+
+Reason matching is ALWAYS ``reason == CONSTANT`` against the imported wire-stable
+constant — never a substring of a human message (the typed-signal-not-substring
+house rule).
+
+The load-bearing distinction under test: the session heartbeat is keyed to the
+server-minted SESSION TOKEN, NOT the MESI ``agent_id``. A session holds no grant,
+so the grant sweep can never reap it; the session-liveness sweep is a NEW axis.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.retention import RetentionPolicy
+from ccs.coordinator.service import (
+    CoordinatorService,
+    looks_like_session_token,
+)
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.exceptions import (
+    SESSION_COMMIT_REASONS,
+    SESSION_INVALIDATED_REASON,
+    SESSION_NOT_FOUND_REASON,
+    SESSION_READ_REASONS,
+    SessionInvalidated,
+)
+from ccs.core.states import MESIState
+from ccs.core.types import (
+    Artifact,
+    SessionCommitRejection,
+    SessionReadRejection,
+    SnapshotSession,
+    VersionedContent,
+)
+
+# Timing constants — fixed logical ticks (no wall-clock sleeps).
+_HB_TIMEOUT = 120
+
+
+# ---------------------------------------------------------------------------
+# Builders — mirror tests/test_session_read.py / test_session_commit.py.
+# ---------------------------------------------------------------------------
+
+
+def _register(reg, artifact_id: UUID, name: str, body: str) -> None:
+    art = Artifact(id=artifact_id, name=name, version=1, content_hash="h1")
+    reg.register_artifact(art, content=body)
+
+
+def _peer_commit_cas(
+    reg, artifact_id: UUID, writer: UUID, expected: int, body: str | None
+) -> None:
+    """A peer OCC commit via the registry ``commit_cas`` WIN (advances current,
+    captures the new version into history when retain is on)."""
+    reg.set_agent_state(artifact_id, writer, MESIState.SHARED, tick=1)
+    reg.commit_cas(
+        artifact_id,
+        writer,
+        expected_version=expected,
+        content_hash="h2",
+        content=body,
+        tick=2,
+    )
+
+
+def _lazy_registries(tmp_path: Path, policy: RetentionPolicy | None = None):
+    """An (in_memory, sqlite) LAZY pair — ``retain_versions=True``."""
+    pol = policy if policy is not None else RetentionPolicy(max_versions=8)
+    mem = ArtifactRegistry(retain_versions=True, retention_policy=pol)
+    sql = SqliteArtifactRegistry(
+        tmp_path / "life_lazy.db", retain_versions=True, retention_policy=pol
+    )
+    return mem, sql
+
+
+# ===========================================================================
+# A — Happy path: a live heartbeat keeps the pins exempt; read/commit work.
+# ===========================================================================
+
+
+class TestLiveHeartbeatNotReaped:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_live_heartbeat_keeps_session_alive(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "PINNED-V1")
+            session = svc.begin_session(read_set=[a], owner=owner, created_at_tick=0)
+            assert isinstance(session, SnapshotSession)
+            tok = session.session_token
+
+            # Heartbeat recently, then sweep at a tick WITHIN the timeout window.
+            assert svc.record_session_heartbeat(
+                session_token=tok, owner=owner, now_tick=100
+            ) is True
+            reaped = svc.enforce_session_liveness(
+                current_tick=100 + _HB_TIMEOUT - 1, heartbeat_timeout_ticks=_HB_TIMEOUT
+            )
+            assert reaped == 0
+
+            # read still serves the pinned bytes; commit still wins.
+            r = svc.session_read(tok, a)
+            assert isinstance(r, VersionedContent)
+            assert r.content == "PINNED-V1"
+
+            result = svc.session_commit(tok, a, "NEW-V2")
+            assert isinstance(result, tuple)  # WIN -> (artifact, signals)
+            updated, _signals = result
+            assert updated.version == 2
+        finally:
+            sql.close()
+
+    def test_session_never_heartbeated_survives_until_timeout(
+        self, tmp_path: Path
+    ) -> None:
+        # A session that NEVER heartbeats carries a creation-tick lease baseline
+        # (seeded at begin_session), so it is not reaped on the first sweep —
+        # only once the baseline goes stale.
+        mem, sql = _lazy_registries(tmp_path)
+        try:
+            svc = CoordinatorService(mem)
+            owner = uuid4()
+            a = uuid4()
+            _register(mem, a, "plan.md", "BODY")
+            session = svc.begin_session(read_set=[a], owner=owner, created_at_tick=50)
+            tok = session.session_token
+
+            # Within the window from the CREATION baseline (50) -> not reaped.
+            assert svc.enforce_session_liveness(
+                current_tick=50 + _HB_TIMEOUT - 1, heartbeat_timeout_ticks=_HB_TIMEOUT
+            ) == 0
+            assert isinstance(svc.session_read(tok, a), VersionedContent)
+
+            # Past the window from the baseline -> reaped.
+            assert svc.enforce_session_liveness(
+                current_tick=50 + _HB_TIMEOUT, heartbeat_timeout_ticks=_HB_TIMEOUT
+            ) == 1
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# B — Crash: a stale heartbeat is reaped; pins released; read/commit fail closed.
+# ===========================================================================
+
+
+class TestStaleHeartbeatReaped:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_stale_session_reaped_then_fail_closed(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "PINNED-V1")
+            session = svc.begin_session(read_set=[a], owner=owner, created_at_tick=0)
+            tok = session.session_token
+            svc.record_session_heartbeat(session_token=tok, owner=owner, now_tick=10)
+
+            # The pin is held BEFORE the reap.
+            assert reg.get_session_cut(tok) is not None
+
+            # Sweep PAST the timeout from the last heartbeat (10) -> reaped.
+            reaped = svc.enforce_session_liveness(
+                current_tick=10 + _HB_TIMEOUT, heartbeat_timeout_ticks=_HB_TIMEOUT
+            )
+            assert reaped == 1
+
+            # Pins released: the cut is gone.
+            assert reg.get_session_cut(tok) is None
+
+            # FAIL CLOSED on read: session_invalidated, never live HEAD.
+            r = svc.session_read(tok, a)
+            assert isinstance(r, SessionReadRejection)
+            assert r.reason == SESSION_INVALIDATED_REASON
+            assert r.reason in SESSION_READ_REASONS
+
+            # FAIL CLOSED on commit: session_invalidated.
+            rc = svc.session_commit(tok, a, "WOULD-BE-V2")
+            assert isinstance(rc, SessionCommitRejection)
+            assert rc.reason == SESSION_INVALIDATED_REASON
+            assert rc.reason in SESSION_COMMIT_REASONS
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_reaped_pin_becomes_collectible_again(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        # The reaped session's pinned version is exempt from GC WHILE live, and
+        # collectible again AFTER the reap (the exemptions seam drops it).
+        pol = RetentionPolicy(max_versions=1)  # aggressive: only current survives
+        mem = ArtifactRegistry(retain_versions=True, retention_policy=pol)
+        sql = SqliteArtifactRegistry(
+            tmp_path / "life_gc.db", retain_versions=True, retention_policy=pol
+        )
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            owner = uuid4()
+            a = uuid4()
+            _register(reg, a, "plan.md", "V1")
+            session = svc.begin_session(read_set=[a], owner=owner, created_at_tick=0)
+            pinned = session.cut[a]
+            assert pinned == 1
+
+            # While LIVE the pinned version is exempt (a peer commit past it does
+            # not collect v1 — the session can still read it).
+            _peer_commit_cas(reg, a, uuid4(), expected=1, body="V2")
+            assert svc.session_read(session.session_token, a).content == "V1"
+            assert pinned in _live_pins(reg, a)
+
+            # Reap -> the pin is dropped from the exemption set.
+            svc.enforce_session_liveness(
+                current_tick=10_000, heartbeat_timeout_ticks=_HB_TIMEOUT
+            )
+            assert pinned not in _live_pins(reg, a)
+
+            # And the next capture/GC tick can now collect v1 (no longer exempt).
+            _peer_commit_cas(reg, a, uuid4(), expected=2, body="V3")
+            # v1 is now collectible (no live pin); the bounded policy drops it.
+            assert reg.get_version_record(a, 1) is None
+        finally:
+            sql.close()
+
+
+def _live_pins(reg, artifact_id: UUID) -> set[int]:
+    """Read the live pin-set for an artifact across both registry shapes (the
+    in-memory and sqlite GC-exemption accessors are named differently)."""
+    if isinstance(reg, ArtifactRegistry):
+        return reg._live_pins_for_artifact(artifact_id)
+    return reg._live_pins_for_artifact_sql(artifact_id)
+
+
+# ===========================================================================
+# C — Restart (in-memory): a previously-valid token after a fresh registry
+#     fails closed (session_invalidated), never live HEAD.
+# ===========================================================================
+
+
+class TestRestartFailsClosed:
+    def test_in_memory_restart_token_fails_closed(self, tmp_path: Path) -> None:
+        # Process 1: open a session, capture its (in-shape) token.
+        reg1 = ArtifactRegistry(retain_versions=True)
+        svc1 = CoordinatorService(reg1)
+        owner = uuid4()
+        a1 = uuid4()
+        _register(reg1, a1, "plan.md", "V1")
+        session = svc1.begin_session(read_set=[a1], owner=owner)
+        tok = session.session_token
+        assert looks_like_session_token(tok)
+
+        # Process 2: a FRESH in-memory registry + service (the restart wipes the
+        # in-memory _session_pins AND the service-layer lease/owner/tombstone).
+        reg2 = ArtifactRegistry(retain_versions=True)
+        svc2 = CoordinatorService(reg2)
+        a2 = uuid4()
+        _register(reg2, a2, "plan.md", "FRESH-HEAD")
+
+        # The old token has no cut in the fresh process. It MUST fail closed as
+        # session_invalidated (it was a real session) — never serve live HEAD.
+        r = svc2.session_read(tok, a2)
+        assert isinstance(r, SessionReadRejection)
+        assert r.reason == SESSION_INVALIDATED_REASON
+        # Crucially: NOT served as VersionedContent of the fresh head.
+        assert not isinstance(r, VersionedContent)
+
+        rc = svc2.session_commit(tok, a2, "WOULD-BE")
+        assert isinstance(rc, SessionCommitRejection)
+        assert rc.reason == SESSION_INVALIDATED_REASON
+
+    def test_malformed_token_is_session_not_found(self, tmp_path: Path) -> None:
+        # A genuinely never-opened / malformed token (out-of-shape) stays
+        # session_not_found — the additive-reachable "clearly bogus" signal.
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        a = uuid4()
+        _register(reg, a, "plan.md", "HEAD")
+
+        for bogus in ["", "short", "not-a-real-token", "x" * 100]:
+            r = svc.session_read(bogus, a)
+            assert isinstance(r, SessionReadRejection)
+            assert r.reason == SESSION_NOT_FOUND_REASON, bogus
+            # Still fail-closed (never live HEAD), just a different signal.
+            assert not isinstance(r, VersionedContent)
+
+
+# ===========================================================================
+# D — Slow-but-live: a recently-heartbeated session is NOT reaped past a naive
+#     TTL (it is a predicate on the lease, not a hard TTL).
+# ===========================================================================
+
+
+class TestSlowButLiveNotReaped:
+    def test_long_running_session_survives_far_past_naive_ttl(
+        self, tmp_path: Path
+    ) -> None:
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        owner = uuid4()
+        a = uuid4()
+        _register(reg, a, "plan.md", "BODY")
+        session = svc.begin_session(read_set=[a], owner=owner, created_at_tick=0)
+        tok = session.session_token
+
+        # March far past a naive "absolute TTL": as long as the session keeps
+        # heartbeating within the window, it is never reaped — the predicate is
+        # on the LEASE, not a hard age ceiling (that ceiling is the separate
+        # Unit-7 cap, not exercised here).
+        last = 0
+        for step in range(1, 50):  # 49 windows past creation — way past 1 TTL.
+            tick = step * _HB_TIMEOUT  # exactly one timeout per step
+            # Heartbeat at the window boundary, then sweep at the same tick.
+            assert svc.record_session_heartbeat(
+                session_token=tok, owner=owner, now_tick=tick
+            ) is True
+            reaped = svc.enforce_session_liveness(
+                current_tick=tick, heartbeat_timeout_ticks=_HB_TIMEOUT
+            )
+            assert reaped == 0, f"slow-but-live reaped at step {step}"
+            last = tick
+        assert last == 49 * _HB_TIMEOUT
+        # Still serving after the long run.
+        assert isinstance(svc.session_read(tok, a), VersionedContent)
+
+
+# ===========================================================================
+# E — Live-session / dead-AGENT: the session heartbeat is keyed to the TOKEN,
+#     so a session whose OWNER agent stopped heartbeating its (unrelated) MESI
+#     grant is NOT reaped. The load-bearing token-vs-agent distinction.
+# ===========================================================================
+
+
+class TestLiveSessionDeadAgent:
+    def test_dead_mesi_agent_does_not_reap_live_session(
+        self, tmp_path: Path
+    ) -> None:
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        owner = uuid4()
+        a = uuid4()
+        _register(reg, a, "plan.md", "PINNED")
+        session = svc.begin_session(read_set=[a], owner=owner, created_at_tick=0)
+        tok = session.session_token
+
+        # The OWNER's MESI grant heartbeat (keyed by agent_id) is NEVER recorded
+        # — the owner agent "crashed" w.r.t. its grant. But the SESSION heartbeat
+        # (keyed by the token) IS kept fresh.
+        svc.record_session_heartbeat(session_token=tok, owner=owner, now_tick=500)
+
+        # The grant sweep walks only M∪E holders; the owner holds no grant here,
+        # so it reclaims nothing — and even if it did, it does not touch sessions.
+        assert svc.enforce_stable_grant_timeouts(
+            current_tick=10_000,
+            heartbeat_timeout_ticks=_HB_TIMEOUT,
+            max_hold_ticks=900,
+        ) == 0
+
+        # The session sweep, at a tick WITHIN the SESSION heartbeat window (500),
+        # does NOT reap it — the session heartbeat is live independent of the
+        # agent's grant heartbeat.
+        assert svc.enforce_session_liveness(
+            current_tick=500 + _HB_TIMEOUT - 1, heartbeat_timeout_ticks=_HB_TIMEOUT
+        ) == 0
+
+        # Pins survive; the read still serves the pinned bytes.
+        r = svc.session_read(tok, a)
+        assert isinstance(r, VersionedContent)
+        assert r.content == "PINNED"
+
+    def test_session_heartbeat_does_not_touch_agent_heartbeat(
+        self, tmp_path: Path
+    ) -> None:
+        # Symmetry guard: record_session_heartbeat must NOT write the agent
+        # heartbeat store (they are distinct axes). The owner agent's
+        # last_heartbeat stays None after a session heartbeat.
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        owner = uuid4()
+        a = uuid4()
+        _register(reg, a, "plan.md", "B")
+        session = svc.begin_session(read_set=[a], owner=owner)
+        svc.record_session_heartbeat(
+            session_token=session.session_token, owner=owner, now_tick=999
+        )
+        # The MESI agent heartbeat for the owner is untouched.
+        assert reg.last_heartbeat_tick(owner) is None
+
+
+# ===========================================================================
+# F — Owner-bound heartbeat (security): a FOREIGN caller cannot keep another's
+#     session alive; the foreign heartbeat does NOT refresh the lease.
+# ===========================================================================
+
+
+class TestOwnerBoundHeartbeat:
+    def test_foreign_caller_cannot_refresh_lease(self, tmp_path: Path) -> None:
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        owner = uuid4()
+        foreign = uuid4()
+        a = uuid4()
+        _register(reg, a, "plan.md", "BODY")
+        session = svc.begin_session(read_set=[a], owner=owner, created_at_tick=0)
+        tok = session.session_token
+
+        # Owner heartbeats at tick 10. A FOREIGN caller then tries to heartbeat
+        # at a much-later tick 10_000 — it MUST be rejected and must NOT move the
+        # lease forward.
+        assert svc.record_session_heartbeat(
+            session_token=tok, owner=owner, now_tick=10
+        ) is True
+        assert svc.record_session_heartbeat(
+            session_token=tok, owner=foreign, now_tick=10_000
+        ) is False
+
+        # The lease is still at 10, so a sweep past 10 + timeout reaps it —
+        # proving the foreign heartbeat did NOT extend the lease.
+        assert svc.enforce_session_liveness(
+            current_tick=10 + _HB_TIMEOUT, heartbeat_timeout_ticks=_HB_TIMEOUT
+        ) == 1
+        r = svc.session_read(tok, a)
+        assert isinstance(r, SessionReadRejection)
+        assert r.reason == SESSION_INVALIDATED_REASON
+
+    def test_heartbeat_unknown_token_is_typed_noop(self, tmp_path: Path) -> None:
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        # An unknown / never-opened token: a typed no-op (False), never a crash,
+        # never a resurrected lease.
+        assert svc.record_session_heartbeat(
+            session_token="never-opened-token", owner=uuid4(), now_tick=5
+        ) is False
+
+    def test_heartbeat_released_token_is_noop(self, tmp_path: Path) -> None:
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        owner = uuid4()
+        a = uuid4()
+        _register(reg, a, "plan.md", "B")
+        session = svc.begin_session(read_set=[a], owner=owner)
+        tok = session.session_token
+        # Reap it, then a heartbeat on the dead token is a no-op (no resurrection).
+        svc.enforce_session_liveness(current_tick=10_000, heartbeat_timeout_ticks=_HB_TIMEOUT)
+        assert svc.record_session_heartbeat(
+            session_token=tok, owner=owner, now_tick=10_001
+        ) is False
+        # Still dead.
+        r = svc.session_read(tok, a)
+        assert isinstance(r, SessionReadRejection)
+        assert r.reason == SESSION_INVALIDATED_REASON
+
+    def test_record_session_heartbeat_rejects_negative_tick(
+        self, tmp_path: Path
+    ) -> None:
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        owner = uuid4()
+        a = uuid4()
+        _register(reg, a, "plan.md", "B")
+        session = svc.begin_session(read_set=[a], owner=owner)
+        with pytest.raises(ValueError):
+            svc.record_session_heartbeat(
+                session_token=session.session_token, owner=owner, now_tick=-1
+            )
+
+
+# ===========================================================================
+# G — The SessionInvalidated typed exception + the taxonomy/predicate units.
+# ===========================================================================
+
+
+class TestTaxonomyAndTypedResult:
+    def test_session_invalidated_exception_reason(self) -> None:
+        # The raise-form carries the same wire reason as the rejection.
+        assert SessionInvalidated.reason == SESSION_INVALIDATED_REASON
+        assert issubclass(SessionInvalidated, Exception)
+
+    def test_reason_sets_are_additive_and_disjoint_from_read_at_version(self) -> None:
+        from ccs.core.exceptions import READ_AT_VERSION_REASONS
+
+        # session_invalidated is in BOTH session sets, additively.
+        assert SESSION_INVALIDATED_REASON in SESSION_READ_REASONS
+        assert SESSION_INVALIDATED_REASON in SESSION_COMMIT_REASONS
+        # The original reasons are still reachable (not renamed/folded).
+        assert SESSION_NOT_FOUND_REASON in SESSION_READ_REASONS
+        # Still disjoint from the bare read-at-version vocabulary (R7).
+        assert SESSION_READ_REASONS.isdisjoint(READ_AT_VERSION_REASONS)
+        assert SESSION_COMMIT_REASONS.isdisjoint(READ_AT_VERSION_REASONS)
+
+    def test_token_shape_predicate(self) -> None:
+        import secrets
+
+        # Every server-minted token is in-shape.
+        for _ in range(20):
+            assert looks_like_session_token(secrets.token_urlsafe(32))
+        # Out-of-shape tokens are rejected.
+        assert not looks_like_session_token("")
+        assert not looks_like_session_token("short")
+        assert not looks_like_session_token("A" * 42)  # one short
+        assert not looks_like_session_token("A" * 44)  # one long
+        assert not looks_like_session_token("A" * 42 + "!")  # bad char
+        assert not looks_like_session_token("A" * 42 + "=")  # base64 padding
+
+    def test_tombstone_attributes_reaped_token_precisely(
+        self, tmp_path: Path
+    ) -> None:
+        # A reaped token is attributed via the tombstone (definitely reaped).
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        owner = uuid4()
+        a = uuid4()
+        _register(reg, a, "plan.md", "B")
+        session = svc.begin_session(read_set=[a], owner=owner)
+        tok = session.session_token
+        svc.enforce_session_liveness(current_tick=10_000, heartbeat_timeout_ticks=_HB_TIMEOUT)
+        assert tok in svc._reaped_tombstone
+        assert svc._classify_no_cut_reason(tok) == SESSION_INVALIDATED_REASON
+
+    def test_tombstone_is_bounded(self, tmp_path: Path) -> None:
+        # The reaped tombstone is capped (oldest-evicted) so it cannot grow
+        # without bound. Eviction is benign — an evicted IN-SHAPE token still
+        # classifies invalidated via the shape predicate.
+        from ccs.coordinator.service import _REAPED_TOMBSTONE_CAP
+
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        # Tombstone many synthetic tokens directly (the reap path's effect).
+        first = None
+        for i in range(_REAPED_TOMBSTONE_CAP + 10):
+            t = f"tok-{i}"
+            if first is None:
+                first = t
+            svc._tombstone_token(t)
+        assert len(svc._reaped_tombstone) == _REAPED_TOMBSTONE_CAP
+        # The oldest entries were evicted.
+        assert first not in svc._reaped_tombstone
+
+
+# ===========================================================================
+# H — GC-race fail-closed: a pinned body that vanished under a live pin degrades
+#     safely (never wrong bytes). The lazy serve degrades to data-plane-deferred
+#     rather than serving a wrong/absent body.
+# ===========================================================================
+
+
+class TestGcRaceFailsClosedNotWrongBytes:
+    def test_absent_pinned_body_under_live_pin_does_not_serve_wrong_bytes(
+        self, tmp_path: Path
+    ) -> None:
+        from ccs.core.types import DataPlaneDeferredRead
+
+        # retain on, but commit the peer body as None (content=None path): the
+        # pinned version's body is NOT in history. A live pin still points at it.
+        reg = ArtifactRegistry(retain_versions=True)
+        svc = CoordinatorService(reg)
+        owner = uuid4()
+        a = uuid4()
+        _register(reg, a, "plan.md", "V1")
+        session = svc.begin_session(read_set=[a], owner=owner)
+        # Drop the pinned body out from under the live pin (simulate a GC race):
+        record = reg._records[a]
+        record.version_history.pop(1, None)
+        record.version_captured_at.pop(1, None)
+
+        r = svc.session_read(session.session_token, a)
+        # NEVER a wrong-bytes VersionedContent; degrades to the typed deferral.
+        assert isinstance(r, DataPlaneDeferredRead)
+        assert r.version == 1

--- a/tests/test_session_read.py
+++ b/tests/test_session_read.py
@@ -1,0 +1,507 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Unit 3 — ``session.read``: the non-mutating serve from the pinned cut
+(SB-17 / TX-1).
+
+Plan: ``docs/plans/2026-06-26-002-feat-read-side-transaction-snapshot-plan.md``
+Unit 3. Requirement trace: **R2** (serve the pinned version even when it equals
+current; non-mutating). Builds on Unit 2's ``begin_session`` / cut-capture / pin
+store.
+
+A protocol proof bounds the REGISTRY, not the integration: ``Snapshot.tla`` proves
+``NoReadSkewWithinCut`` over the model; this file is the integration-layer
+regression for the serve-across-a-peer-commit WINDOW. Per the split-comparand
+learning the staleness probes use **fixed-stale buffers, not counters** — the
+served body is compared against a buffer LITERAL captured before the peer commit,
+never a re-derived expectation that could drift with the bug it is meant to
+catch.
+
+Reason matching is ALWAYS ``reason == CONSTANT`` against the imported wire-stable
+constant — never a substring of a human message (the typed-signal-not-substring
+house rule).
+
+Branch coverage:
+- LAZY (``retain_versions=True``) — the coordinator serves pinned bytes from
+  retained history (``version==current`` AND ``version<current``, incl. the
+  transition). Exercised on BOTH registries.
+- EAGER (``retain_versions=False`` / ``content=None``) — the coordinator holds no
+  body; ``session_read`` returns the typed data-plane-deferred result.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.retention import RetentionPolicy
+from ccs.coordinator.service import CoordinatorService
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.exceptions import (
+    SESSION_ARTIFACT_NOT_IN_CUT_REASON,
+    SESSION_NOT_FOUND_REASON,
+    SESSION_READ_REASONS,
+)
+from ccs.core.states import MESIState
+from ccs.core.types import (
+    Artifact,
+    DataPlaneDeferredRead,
+    SessionReadRejection,
+    SnapshotSession,
+    VersionedContent,
+)
+
+# ---------------------------------------------------------------------------
+# Builders — mirror tests/test_snapshot_cut_capture.py's helpers.
+# ---------------------------------------------------------------------------
+
+
+def _register(reg, artifact_id: UUID, name: str, body: str) -> None:
+    art = Artifact(id=artifact_id, name=name, version=1, content_hash="h1")
+    reg.register_artifact(art, content=body)
+
+
+def _commit_cas(
+    reg, artifact_id: UUID, writer: UUID, expected: int, body: str | None
+) -> None:
+    """A peer OCC commit via the registry ``commit_cas`` WIN (advances current,
+    captures the new version into history when retain is on; ``body=None``
+    advances the version WITHOUT a retained body — the content=None path)."""
+    reg.set_agent_state(artifact_id, writer, MESIState.SHARED, tick=1)
+    reg.commit_cas(
+        artifact_id,
+        writer,
+        expected_version=expected,
+        content_hash="h2",
+        content=body,
+        tick=2,
+    )
+
+
+def _lazy_registries(tmp_path: Path, policy: RetentionPolicy | None = None):
+    """An (in_memory, sqlite) LAZY pair — ``retain_versions=True``: the
+    coordinator retains bodies in history (the serve-from-history branch)."""
+    pol = policy if policy is not None else RetentionPolicy(max_versions=8)
+    mem = ArtifactRegistry(retain_versions=True, retention_policy=pol)
+    sql = SqliteArtifactRegistry(
+        tmp_path / "snap_lazy.db", retain_versions=True, retention_policy=pol
+    )
+    return mem, sql
+
+
+def _eager_registries(tmp_path: Path):
+    """An (in_memory, sqlite) EAGER pair — ``retain_versions=False`` /
+    ``content=None`` ICP: the coordinator holds NO body (bytes live in the data
+    plane), so ``session_read`` defers."""
+    mem = ArtifactRegistry(retain_versions=False)
+    sql = SqliteArtifactRegistry(tmp_path / "snap_eager.db", retain_versions=False)
+    return mem, sql
+
+
+# ===========================================================================
+# A — Happy path (LAZY): the pinned bytes are served
+# ===========================================================================
+
+
+class TestLazyHappyPath:
+    """``session_read`` returns the pinned ``@vN`` bytes from retained history."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_serves_pinned_bytes(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "PINNED-V1")
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            assert isinstance(session, SnapshotSession)
+
+            result = svc.session_read(session.session_token, a)
+            assert isinstance(result, VersionedContent)
+            assert result.version == 1
+            assert result.content == "PINNED-V1"
+            assert result.artifact_id == a
+            assert result.coordinator_epoch == reg.coordinator_epoch
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# B — Edge (the gap): pinned == current is SERVED (not rejected current_version)
+# ===========================================================================
+
+
+class TestPinnedEqualsCurrentIsServed:
+    """The gap the unit closes: ``session_read`` serves the pinned version even
+    when it EQUALS current — where the bare ``read_at_version`` rejects with
+    ``current_version``. ``begin_session`` is the coherence event that earns it."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_pinned_equals_current_served_not_rejected(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "CURRENT-BODY")
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            assert isinstance(session, SnapshotSession)
+            # The pin equals current (no peer commit yet).
+            assert session.cut[a] == reg.get_artifact(a).version == 1
+
+            result = svc.session_read(session.session_token, a)
+            # SERVED — not a SessionReadRejection, not a current_version reject.
+            assert isinstance(result, VersionedContent)
+            assert result.version == 1
+            assert result.content == "CURRENT-BODY"
+        finally:
+            sql.close()
+
+    def test_bare_read_at_version_still_rejects_current(
+        self, tmp_path: Path
+    ) -> None:
+        # Contrast harness: the SAME store, the bare read_at_version, STILL
+        # rejects version==current (the shipped contract is untouched — Unit 3
+        # added a NEW path, it did not relax read_at_version).
+        from ccs.core.exceptions import CURRENT_VERSION_REASON
+        from ccs.core.types import VersionedReadRejection
+
+        mem, sql = _lazy_registries(tmp_path)
+        try:
+            svc = CoordinatorService(mem)
+            a = uuid4()
+            _register(mem, a, "plan.md", "x")
+            rej = svc.read_at_version(a, 1)  # version==current
+            assert isinstance(rej, VersionedReadRejection)
+            assert rej.reason == CURRENT_VERSION_REASON
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# C — Edge (the transition): pinned==current becomes pinned<current after a peer
+#     commit; still served at the PINNED version from history
+# ===========================================================================
+
+
+class TestTransitionAcrossPeerCommit:
+    """A ``pinned==current`` read becomes ``pinned<current`` once a peer commits —
+    after which the serve re-routes to retained history, still at the PINNED
+    version (no read skew, no live-HEAD leak). FIXED-STALE BUFFER: the expected
+    body is the literal captured before the peer commit."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_served_at_pin_after_peer_commit(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "budget.md", "PIN-V1")
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            assert isinstance(session, SnapshotSession)
+            # FIXED-STALE BUFFER literal — never re-read from the moving registry.
+            pinned_body = "PIN-V1"
+
+            # Pre-commit: pinned == current, served from current.
+            r1 = svc.session_read(session.session_token, a)
+            assert isinstance(r1, VersionedContent)
+            assert r1.version == 1 and r1.content == pinned_body
+
+            # A peer advances the artifact: pin is now < current.
+            writer = uuid4()
+            _commit_cas(reg, a, writer, expected=1, body="PEER-V2")
+            assert reg.get_artifact(a).version == 2
+
+            # Re-routed to history — STILL the pinned v1 bytes, NOT the peer's v2.
+            r2 = svc.session_read(session.session_token, a)
+            assert isinstance(r2, VersionedContent)
+            assert r2.version == 1, "served the moved version, not the pin"
+            assert r2.content == pinned_body, "served peer bytes (read skew!)"
+            assert r2.content != "PEER-V2"
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# D — Integration: the read is NON-MUTATING (no MESI grant, no read_generation)
+# ===========================================================================
+
+
+class TestNonMutating:
+    """``session_read`` mints no MESI grant and captures no ``read_generation`` —
+    the coherence state is byte-for-byte unchanged across the read (R2 / the
+    shipped non-mutating invariant)."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_coherence_state_unchanged(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            owner = uuid4()
+            _register(reg, a, "plan.md", "v1")
+            session = svc.begin_session(read_set=[a], owner=owner)
+            assert isinstance(session, SnapshotSession)
+
+            state_before = reg.get_state_map(a)
+            svc.session_read(session.session_token, a)
+            state_after = reg.get_state_map(a)
+
+            # No grant was minted for ANY agent — the read is not an acquire.
+            assert state_before == state_after
+            assert state_after == {}, "session_read minted a MESI grant"
+            # And no read_generation was captured for the owner (a reader is not
+            # an owner; read-gen capture lives only in set_agent_state).
+            assert reg.get_read_generation(a, owner) is None
+        finally:
+            sql.close()
+
+    def test_repeated_reads_are_idempotent_on_state(self, tmp_path: Path) -> None:
+        # Many reads never accrete state (no grant leak across calls).
+        mem, sql = _lazy_registries(tmp_path)
+        try:
+            svc = CoordinatorService(mem)
+            a = uuid4()
+            _register(mem, a, "plan.md", "v1")
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            for _ in range(5):
+                svc.session_read(session.session_token, a)
+            assert mem.get_state_map(a) == {}
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# E — Error: read of an artifact NOT in the cut → typed (not live-HEAD)
+# ===========================================================================
+
+
+class TestArtifactNotInCut:
+    """An artifact outside the captured cut is REJECTED — never served from live
+    HEAD (the no-fall-through guarantee)."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_unpinned_artifact_rejected(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            pinned, unpinned = uuid4(), uuid4()
+            _register(reg, pinned, "plan.md", "in-cut")
+            _register(reg, unpinned, "secret.md", "NOT-in-cut-LIVE-HEAD")
+            session = svc.begin_session(read_set=[pinned], owner=uuid4())
+            assert isinstance(session, SnapshotSession)
+
+            result = svc.session_read(session.session_token, unpinned)
+            assert isinstance(result, SessionReadRejection)
+            assert result.reason == SESSION_ARTIFACT_NOT_IN_CUT_REASON
+            assert result.reason in SESSION_READ_REASONS
+            assert result.artifact_id == unpinned
+            # No body leaked: the rejection structurally carries none.
+            assert not hasattr(result, "content")
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# F — Error: unknown / released token → typed not-found
+# ===========================================================================
+
+
+class TestSessionNotFound:
+    """An unknown or released token is a typed ``session_not_found`` — never a
+    serve. (Unit 5 splits the durable-liveness taxonomy; Unit 3 treats every
+    no-cut token uniformly.)"""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_unknown_token(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "v1")
+            result = svc.session_read("never-minted-token", a)
+            assert isinstance(result, SessionReadRejection)
+            assert result.reason == SESSION_NOT_FOUND_REASON
+            assert result.coordinator_epoch == reg.coordinator_epoch
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_released_token(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _lazy_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "v1")
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            assert isinstance(session, SnapshotSession)
+            # Released → the pins are gone; the token no longer serves.
+            reg.release_session(session.session_token)
+            result = svc.session_read(session.session_token, a)
+            assert isinstance(result, SessionReadRejection)
+            assert result.reason == SESSION_NOT_FOUND_REASON
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# G — Edge (no coordinator bytes): EAGER / content=None → data-plane-deferred
+# ===========================================================================
+
+
+class TestDataPlaneDeferred:
+    """When the coordinator holds no body for the pinned version, ``session_read``
+    returns the typed data-plane-deferred result — pinned version + epoch (+ hash
+    when known), NO bytes, NO crash. The actual eager byte serve is Unit 6."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_eager_branch_defers(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _eager_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "config.json", "body-lives-in-data-plane")
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            assert isinstance(session, SnapshotSession)
+            assert session.retain_versions is False
+
+            result = svc.session_read(session.session_token, a)
+            assert isinstance(result, DataPlaneDeferredRead)
+            assert result.version == 1  # the PINNED version
+            assert result.artifact_id == a
+            assert result.coordinator_epoch == reg.coordinator_epoch
+            # content_hash is the pinned (== current) version's hash; never bytes.
+            assert result.content_hash == "h1"
+            assert not hasattr(result, "content")
+        finally:
+            sql.close()
+
+    def test_content_none_under_retain_degrades_to_deferred(
+        self, tmp_path: Path
+    ) -> None:
+        # retain_versions=True but the pinned version was committed content=None
+        # (no retained body) → the serve degrades to data-plane-deferred, never a
+        # crash or wrong bytes. (sqlite is the content=None ICP — KTD-13.)
+        mem, sql = _lazy_registries(tmp_path)
+        try:
+            svc = CoordinatorService(sql)
+            a = uuid4()
+            _register(sql, a, "plan.md", "v1")
+            writer = uuid4()
+            # Advance to v2 with NO body retained (content=None).
+            _commit_cas(sql, a, writer, expected=1, body=None)
+            assert sql.get_artifact(a).version == 2
+            # Pin the bodyless v2 (current).
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            assert session.cut[a] == 2
+
+            result = svc.session_read(session.session_token, a)
+            assert isinstance(result, DataPlaneDeferredRead)
+            assert result.version == 2
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# H — T-expiry read-serve allowance: a pinned-but-age-collectible row is served
+# ===========================================================================
+
+
+class TestTExpiryAllowance:
+    """A pinned version that is past the retention AGE bound is STILL served by
+    ``session_read`` (the read-serve allowance) — distinct from the GC-hold the
+    Unit-2 exemptions seam provides at the GC producers. The bare
+    ``read_at_version`` would report it ``not_retained``; the live pin lifts the
+    read-side logical T-expiry."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_pinned_age_collectible_still_served(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        # max_age=50ms: pin v1, advance to v2, sleep past the age bound. v1 is now
+        # age-collectible as history — but the live pin's read-serve allowance
+        # serves it anyway.
+        policy = RetentionPolicy(max_age_seconds=0.05)
+        mem, sql = _lazy_registries(tmp_path, policy)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "AGED-PIN-V1")
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            assert session.cut[a] == 1
+
+            writer = uuid4()
+            _commit_cas(reg, a, writer, expected=1, body="V2")  # v1 → history
+            time.sleep(0.1)  # v1 is now past the 50ms age bound
+
+            # Contrast: the bare read_at_version reports it collectible
+            # (not_retained) for in-memory — the pin allowance is what differs.
+            result = svc.session_read(session.session_token, a)
+            assert isinstance(result, VersionedContent), (
+                "pinned-but-age-collectible row was not served (allowance "
+                "regressed)"
+            )
+            assert result.version == 1
+            assert result.content == "AGED-PIN-V1"
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# I — Parity: the no-cut empty-read-set degenerate case (documented divergence)
+# ===========================================================================
+
+
+class TestEmptyReadSetDegenerate:
+    """An empty-read-set session pins nothing, so a ``session_read`` of any
+    artifact is un-servable on both arms. The TAXONOMY diverges (sqlite has no
+    durable empty-session marker → ``session_not_found``; in-memory keeps an
+    empty ``{}`` entry → ``artifact_not_in_cut``) but BOTH are typed rejections —
+    neither serves live HEAD. This pins the documented divergence so a future
+    change cannot silently turn it into a serve."""
+
+    def test_in_memory_empty_session_rejects_artifact_not_in_cut(
+        self, tmp_path: Path
+    ) -> None:
+        mem = ArtifactRegistry(retain_versions=True, retention_policy=RetentionPolicy(max_versions=4))
+        svc = CoordinatorService(mem)
+        a = uuid4()
+        _register(mem, a, "plan.md", "v1")
+        session = svc.begin_session(read_set=[], owner=uuid4())
+        result = svc.session_read(session.session_token, a)
+        assert isinstance(result, SessionReadRejection)
+        assert result.reason == SESSION_ARTIFACT_NOT_IN_CUT_REASON
+
+    def test_sqlite_empty_session_rejects_session_not_found(
+        self, tmp_path: Path
+    ) -> None:
+        sql = SqliteArtifactRegistry(
+            tmp_path / "empty.db",
+            retain_versions=True,
+            retention_policy=RetentionPolicy(max_versions=4),
+        )
+        try:
+            svc = CoordinatorService(sql)
+            a = uuid4()
+            _register(sql, a, "plan.md", "v1")
+            session = svc.begin_session(read_set=[], owner=uuid4())
+            result = svc.session_read(session.session_token, a)
+            assert isinstance(result, SessionReadRejection)
+            # sqlite cannot durably mark an empty live session → not_found.
+            assert result.reason == SESSION_NOT_FOUND_REASON
+        finally:
+            sql.close()

--- a/tests/test_session_read.py
+++ b/tests/test_session_read.py
@@ -43,6 +43,7 @@ from ccs.coordinator.service import CoordinatorService
 from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
 from ccs.core.exceptions import (
     SESSION_ARTIFACT_NOT_IN_CUT_REASON,
+    SESSION_INVALIDATED_REASON,
     SESSION_NOT_FOUND_REASON,
     SESSION_READ_REASONS,
 )
@@ -347,11 +348,16 @@ class TestSessionNotFound:
             _register(reg, a, "plan.md", "v1")
             session = svc.begin_session(read_set=[a], owner=uuid4())
             assert isinstance(session, SnapshotSession)
-            # Released → the pins are gone; the token no longer serves.
+            # Released → the pins are gone; the token no longer serves. Under the
+            # Unit-5 liveness taxonomy a released token WAS a real (in-shape)
+            # session, so it fails closed as session_invalidated ("re-establish
+            # it"), never live HEAD — distinct from a never-opened/malformed
+            # token (session_not_found). Wire-stable: session_not_found stays
+            # reachable for malformed tokens (asserted in TestSessionNotFound).
             reg.release_session(session.session_token)
             result = svc.session_read(session.session_token, a)
             assert isinstance(result, SessionReadRejection)
-            assert result.reason == SESSION_NOT_FOUND_REASON
+            assert result.reason == SESSION_INVALIDATED_REASON
         finally:
             sql.close()
 
@@ -486,7 +492,7 @@ class TestEmptyReadSetDegenerate:
         assert isinstance(result, SessionReadRejection)
         assert result.reason == SESSION_ARTIFACT_NOT_IN_CUT_REASON
 
-    def test_sqlite_empty_session_rejects_session_not_found(
+    def test_sqlite_empty_session_rejects_session_invalidated(
         self, tmp_path: Path
     ) -> None:
         sql = SqliteArtifactRegistry(
@@ -501,7 +507,12 @@ class TestEmptyReadSetDegenerate:
             session = svc.begin_session(read_set=[], owner=uuid4())
             result = svc.session_read(session.session_token, a)
             assert isinstance(result, SessionReadRejection)
-            # sqlite cannot durably mark an empty live session → not_found.
-            assert result.reason == SESSION_NOT_FOUND_REASON
+            # sqlite cannot durably mark an empty live session (zero pin rows →
+            # None). Under the Unit-5 taxonomy the in-shape token classifies
+            # session_invalidated rather than session_not_found; the divergence
+            # from the in-memory arm (which keeps an empty {} and would reject
+            # artifact_not_in_cut) stays BENIGN — no artifact is servable either
+            # way, the request is fail-closed on both.
+            assert result.reason == SESSION_INVALIDATED_REASON
         finally:
             sql.close()

--- a/tests/test_session_read.py
+++ b/tests/test_session_read.py
@@ -119,10 +119,11 @@ class TestLazyHappyPath:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "plan.md", "PINNED-V1")
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             assert isinstance(session, SnapshotSession)
 
-            result = svc.session_read(session.session_token, a)
+            result = svc.session_read(session.session_token, a, caller=owner)
             assert isinstance(result, VersionedContent)
             assert result.version == 1
             assert result.content == "PINNED-V1"
@@ -152,12 +153,13 @@ class TestPinnedEqualsCurrentIsServed:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "plan.md", "CURRENT-BODY")
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             assert isinstance(session, SnapshotSession)
             # The pin equals current (no peer commit yet).
             assert session.cut[a] == reg.get_artifact(a).version == 1
 
-            result = svc.session_read(session.session_token, a)
+            result = svc.session_read(session.session_token, a, caller=owner)
             # SERVED — not a SessionReadRejection, not a current_version reject.
             assert isinstance(result, VersionedContent)
             assert result.version == 1
@@ -206,13 +208,14 @@ class TestTransitionAcrossPeerCommit:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "budget.md", "PIN-V1")
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             assert isinstance(session, SnapshotSession)
             # FIXED-STALE BUFFER literal — never re-read from the moving registry.
             pinned_body = "PIN-V1"
 
             # Pre-commit: pinned == current, served from current.
-            r1 = svc.session_read(session.session_token, a)
+            r1 = svc.session_read(session.session_token, a, caller=owner)
             assert isinstance(r1, VersionedContent)
             assert r1.version == 1 and r1.content == pinned_body
 
@@ -222,7 +225,7 @@ class TestTransitionAcrossPeerCommit:
             assert reg.get_artifact(a).version == 2
 
             # Re-routed to history — STILL the pinned v1 bytes, NOT the peer's v2.
-            r2 = svc.session_read(session.session_token, a)
+            r2 = svc.session_read(session.session_token, a, caller=owner)
             assert isinstance(r2, VersionedContent)
             assert r2.version == 1, "served the moved version, not the pin"
             assert r2.content == pinned_body, "served peer bytes (read skew!)"
@@ -254,7 +257,7 @@ class TestNonMutating:
             assert isinstance(session, SnapshotSession)
 
             state_before = reg.get_state_map(a)
-            svc.session_read(session.session_token, a)
+            svc.session_read(session.session_token, a, caller=owner)
             state_after = reg.get_state_map(a)
 
             # No grant was minted for ANY agent — the read is not an acquire.
@@ -273,9 +276,10 @@ class TestNonMutating:
             svc = CoordinatorService(mem)
             a = uuid4()
             _register(mem, a, "plan.md", "v1")
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             for _ in range(5):
-                svc.session_read(session.session_token, a)
+                svc.session_read(session.session_token, a, caller=owner)
             assert mem.get_state_map(a) == {}
         finally:
             sql.close()
@@ -299,10 +303,11 @@ class TestArtifactNotInCut:
             pinned, unpinned = uuid4(), uuid4()
             _register(reg, pinned, "plan.md", "in-cut")
             _register(reg, unpinned, "secret.md", "NOT-in-cut-LIVE-HEAD")
-            session = svc.begin_session(read_set=[pinned], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[pinned], owner=owner)
             assert isinstance(session, SnapshotSession)
 
-            result = svc.session_read(session.session_token, unpinned)
+            result = svc.session_read(session.session_token, unpinned, caller=owner)
             assert isinstance(result, SessionReadRejection)
             assert result.reason == SESSION_ARTIFACT_NOT_IN_CUT_REASON
             assert result.reason in SESSION_READ_REASONS
@@ -331,7 +336,10 @@ class TestSessionNotFound:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "plan.md", "v1")
-            result = svc.session_read("never-minted-token", a)
+            # No owner binding for this token → owner validation is a no-op; the
+            # cut-absent path classifies it (session_not_found for a malformed
+            # token). The caller id is irrelevant when there is no binding.
+            result = svc.session_read("never-minted-token", a, caller=uuid4())
             assert isinstance(result, SessionReadRejection)
             assert result.reason == SESSION_NOT_FOUND_REASON
             assert result.coordinator_epoch == reg.coordinator_epoch
@@ -346,7 +354,8 @@ class TestSessionNotFound:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "plan.md", "v1")
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             assert isinstance(session, SnapshotSession)
             # Released → the pins are gone; the token no longer serves. Under the
             # Unit-5 liveness taxonomy a released token WAS a real (in-shape)
@@ -355,7 +364,7 @@ class TestSessionNotFound:
             # token (session_not_found). Wire-stable: session_not_found stays
             # reachable for malformed tokens (asserted in TestSessionNotFound).
             reg.release_session(session.session_token)
-            result = svc.session_read(session.session_token, a)
+            result = svc.session_read(session.session_token, a, caller=owner)
             assert isinstance(result, SessionReadRejection)
             assert result.reason == SESSION_INVALIDATED_REASON
         finally:
@@ -380,11 +389,12 @@ class TestDataPlaneDeferred:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "config.json", "body-lives-in-data-plane")
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             assert isinstance(session, SnapshotSession)
             assert session.retain_versions is False
 
-            result = svc.session_read(session.session_token, a)
+            result = svc.session_read(session.session_token, a, caller=owner)
             assert isinstance(result, DataPlaneDeferredRead)
             assert result.version == 1  # the PINNED version
             assert result.artifact_id == a
@@ -411,10 +421,11 @@ class TestDataPlaneDeferred:
             _commit_cas(sql, a, writer, expected=1, body=None)
             assert sql.get_artifact(a).version == 2
             # Pin the bodyless v2 (current).
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             assert session.cut[a] == 2
 
-            result = svc.session_read(session.session_token, a)
+            result = svc.session_read(session.session_token, a, caller=owner)
             assert isinstance(result, DataPlaneDeferredRead)
             assert result.version == 2
         finally:
@@ -447,7 +458,8 @@ class TestTExpiryAllowance:
             svc = CoordinatorService(reg)
             a = uuid4()
             _register(reg, a, "plan.md", "AGED-PIN-V1")
-            session = svc.begin_session(read_set=[a], owner=uuid4())
+            owner = uuid4()
+            session = svc.begin_session(read_set=[a], owner=owner)
             assert session.cut[a] == 1
 
             writer = uuid4()
@@ -456,7 +468,7 @@ class TestTExpiryAllowance:
 
             # Contrast: the bare read_at_version reports it collectible
             # (not_retained) for in-memory — the pin allowance is what differs.
-            result = svc.session_read(session.session_token, a)
+            result = svc.session_read(session.session_token, a, caller=owner)
             assert isinstance(result, VersionedContent), (
                 "pinned-but-age-collectible row was not served (allowance "
                 "regressed)"
@@ -487,8 +499,9 @@ class TestEmptyReadSetDegenerate:
         svc = CoordinatorService(mem)
         a = uuid4()
         _register(mem, a, "plan.md", "v1")
-        session = svc.begin_session(read_set=[], owner=uuid4())
-        result = svc.session_read(session.session_token, a)
+        owner = uuid4()
+        session = svc.begin_session(read_set=[], owner=owner)
+        result = svc.session_read(session.session_token, a, caller=owner)
         assert isinstance(result, SessionReadRejection)
         assert result.reason == SESSION_ARTIFACT_NOT_IN_CUT_REASON
 
@@ -504,8 +517,9 @@ class TestEmptyReadSetDegenerate:
             svc = CoordinatorService(sql)
             a = uuid4()
             _register(sql, a, "plan.md", "v1")
-            session = svc.begin_session(read_set=[], owner=uuid4())
-            result = svc.session_read(session.session_token, a)
+            owner = uuid4()
+            session = svc.begin_session(read_set=[], owner=owner)
+            result = svc.session_read(session.session_token, a, caller=owner)
             assert isinstance(result, SessionReadRejection)
             # sqlite cannot durably mark an empty live session (zero pin rows →
             # None). Under the Unit-5 taxonomy the in-shape token classifies

--- a/tests/test_session_wire_and_boundary.py
+++ b/tests/test_session_wire_and_boundary.py
@@ -1,0 +1,434 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Wire-stability, server-capture boundary lock, and endpoint-auth tests for
+the snapshot-session HTTP endpoints (SB-17 / TX-1, Unit 8 — R7 / R9 / R10a).
+
+Covers:
+- Endpoint auth: every ``/session/*`` route rides the central ``_ROUTES``
+  ``verify_bearer`` + ``verify_host`` seam (401 no/bad bearer, 403 bad Host) —
+  NOT a parallel router.
+- Boundary lock (R9): a client-supplied pinned-version / cut / forged-or-
+  replayed token / client-asserted owner CANNOT forge or bypass the
+  server-side capture. The "client carries the cut" path FAILS the guard.
+- Wire (R7): new session reasons are ADDITIVE; existing reason sets unchanged.
+- Audit (R10a): begin / commit / invalidate emit content-free JSONL records.
+- Happy-path round trip: begin → read → commit over HTTP with a valid
+  bearer/host + authenticated caller.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+import pytest
+
+from ccs.adapters.claude_code.auth import load_secret
+from ccs.adapters.claude_code.coordinator_server import (
+    _ROUTES,
+    CoordinatorHTTPServer,
+)
+from ccs.adapters.claude_code.session_audit_log import (
+    _resolve_session_audit_log_path,
+)
+from ccs.core.exceptions import (
+    READ_AT_VERSION_REASONS,
+    SESSION_BEGIN_CAP_REASONS,
+    SESSION_COMMIT_REASONS,
+    SESSION_READ_REASONS,
+)
+
+_TEST_SESSION_NS = uuid.UUID("22222222-2222-4222-8222-222222222222")
+
+
+def _sid(label: str) -> str:
+    return str(uuid.uuid5(_TEST_SESSION_NS, f"session-wire:{label}"))
+
+
+class _Client:
+    """Tiny urllib client returning (status, body_dict)."""
+
+    def __init__(self, host: str, port: int, secret: str) -> None:
+        self.base = f"http://{host}:{port}"
+        self.headers = {
+            "Authorization": f"Bearer {secret}",
+            "Host": "127.0.0.1",
+            "Content-Type": "application/json",
+        }
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: Optional[dict] = None,
+        *,
+        headers_override: Optional[dict] = None,
+    ) -> tuple[int, dict]:
+        url = self.base + path
+        data = json.dumps(body).encode("utf-8") if body is not None else b""
+        headers = dict(self.headers)
+        if headers_override:
+            headers.update(headers_override)
+        req = urlrequest.Request(
+            url, data=data if method == "POST" else None, method=method, headers=headers
+        )
+        try:
+            with urlrequest.urlopen(req, timeout=10) as resp:
+                return resp.status, json.loads(resp.read().decode("utf-8") or "{}")
+        except urlerror.HTTPError as e:
+            return e.code, json.loads(e.read().decode("utf-8") or "{}")
+
+    def post(self, path: str, body: dict, **kw) -> tuple[int, dict]:
+        return self.request("POST", path, body, **kw)
+
+
+@pytest.fixture
+def coordinator(tmp_path: Path):
+    server = CoordinatorHTTPServer(tmp_path, port=0, instance_id="test-instance")
+    server.serve_in_thread()
+    time.sleep(0.05)
+    try:
+        yield server
+    finally:
+        server.shutdown()
+
+
+@pytest.fixture
+def client(coordinator) -> _Client:
+    secret = load_secret(coordinator.coordinator_root)
+    assert secret is not None
+    return _Client("127.0.0.1", coordinator.port, secret)
+
+
+_SESSION_ROUTES = [
+    "/session/begin",
+    "/session/read",
+    "/session/commit",
+    "/session/heartbeat",
+]
+
+
+# ----------------------------------------------------------------------
+# Endpoint auth — rides the central _ROUTES seam (NOT a parallel router)
+# ----------------------------------------------------------------------
+
+
+def test_session_routes_registered_in_central_routes() -> None:
+    """All four session routes are in the central _ROUTES table, so the
+    dispatcher's verify_bearer + verify_host run before any handler — there
+    is no parallel router that could bypass auth."""
+    for route in _SESSION_ROUTES:
+        assert ("POST", route) in _ROUTES
+
+
+@pytest.mark.parametrize("route", _SESSION_ROUTES)
+def test_session_endpoint_no_bearer_returns_401(coordinator, route: str) -> None:
+    url = f"http://127.0.0.1:{coordinator.port}{route}"
+    req = urlrequest.Request(
+        url, data=b"{}", method="POST",
+        headers={"Host": "127.0.0.1", "Content-Type": "application/json"},
+    )
+    try:
+        urlrequest.urlopen(req, timeout=5)
+        raise AssertionError("expected 401")
+    except urlerror.HTTPError as e:
+        assert e.code == 401
+
+
+@pytest.mark.parametrize("route", _SESSION_ROUTES)
+def test_session_endpoint_bad_bearer_returns_401(coordinator, route: str) -> None:
+    url = f"http://127.0.0.1:{coordinator.port}{route}"
+    req = urlrequest.Request(
+        url, data=b"{}", method="POST",
+        headers={
+            "Authorization": "Bearer not-the-secret",
+            "Host": "127.0.0.1",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        urlrequest.urlopen(req, timeout=5)
+        raise AssertionError("expected 401")
+    except urlerror.HTTPError as e:
+        assert e.code == 401
+
+
+@pytest.mark.parametrize("route", _SESSION_ROUTES)
+def test_session_endpoint_bad_host_returns_403(client: _Client, route: str) -> None:
+    status, _body = client.post(
+        route, {"session_id": _sid("h")},
+        headers_override={"Host": "attacker.example.com"},
+    )
+    assert status == 403
+
+
+# ----------------------------------------------------------------------
+# Happy-path round trip (begin → read → commit)
+# ----------------------------------------------------------------------
+
+
+def _begin(client: _Client, sid: str, read_set: list[str]) -> dict:
+    status, body = client.post(
+        "/session/begin", {"session_id": sid, "read_set": read_set}
+    )
+    assert status == 200, body
+    return body
+
+
+def test_happy_path_begin_read_commit(client: _Client) -> None:
+    sid = _sid("happy")
+    # First-observation seeds v1 for the path.
+    begin = _begin(client, sid, ["plan.md"])
+    assert begin["ok"] is True
+    assert "session_token" in begin
+    token = begin["session_token"]
+    assert begin["cut"] == {"plan.md": 1}
+    assert "coordinator_epoch" in begin and "retain_versions" in begin
+
+    # Read the pinned version.
+    status, read = client.post(
+        "/session/read", {"session_id": sid, "session_token": token, "path": "plan.md"}
+    )
+    assert status == 200, read
+    assert read["ok"] is True
+    assert read["version"] == 1
+    # Default registry retains no bodies (retain_versions=False) → EAGER branch
+    # → the coordinator defers byte-serving to the data plane (typed, not a
+    # crash). The LAZY content-serve branch is exercised at the service layer
+    # in tests/test_session_read.py (the HTTP server hardwires retain=False).
+    assert read["served"] == "data_plane_deferred"
+    assert begin["retain_versions"] is False
+
+    # Commit against the pinned base → WIN, version bumps to 2.
+    status, commit = client.post(
+        "/session/commit",
+        {"session_id": sid, "session_token": token, "path": "plan.md", "content": "new"},
+    )
+    assert status == 200, commit
+    assert commit["ok"] is True
+    assert commit["version"] == 2
+
+    # A SECOND commit at the same pin is HELD (R11 exactly-one-commit).
+    status, commit2 = client.post(
+        "/session/commit",
+        {"session_id": sid, "session_token": token, "path": "plan.md", "content": "again"},
+    )
+    assert status == 200
+    assert commit2["ok"] is False
+    assert commit2["reason"] == "version_mismatch"
+
+
+def test_heartbeat_refreshes_owned_session(client: _Client) -> None:
+    sid = _sid("hb")
+    begin = _begin(client, sid, ["hb.md"])
+    token = begin["session_token"]
+    status, hb = client.post(
+        "/session/heartbeat", {"session_id": sid, "session_token": token}
+    )
+    assert status == 200
+    assert hb == {"ok": True, "refreshed": True}
+
+
+# ----------------------------------------------------------------------
+# Boundary lock (R9) — no client can forge / bypass the server-side capture
+# ----------------------------------------------------------------------
+
+
+def test_client_supplied_cut_is_ignored_not_trusted(client: _Client) -> None:
+    """A client that smuggles a ``cut`` / ``pinned_version`` / ``expected_version``
+    into /session/read or /session/commit MUST NOT have it honored — the server
+    is authoritative. The forged fields are ignored; the server reads the pinned
+    base from the registry by token. (The day a client legitimately carries the
+    cut is cross-host — this guard FAILS if anyone wires that in here.)"""
+    sid = _sid("forge-cut")
+    begin = _begin(client, sid, ["target.md"])  # pins target.md@v1
+    token = begin["session_token"]
+
+    # Forge a pinned_version=999 + a fake cut in the read request. The server
+    # ignores them and serves the REAL pinned v1.
+    status, read = client.post(
+        "/session/read",
+        {
+            "session_id": sid, "session_token": token, "path": "target.md",
+            "pinned_version": 999, "cut": {"target.md": 999}, "version": 999,
+        },
+    )
+    assert status == 200, read
+    assert read["ok"] is True
+    assert read["version"] == 1  # the server-captured pin, NOT the forged 999.
+
+    # Forge expected_version=999 on commit. The server uses the real pinned v1
+    # as the comparand → WIN bumps to v2 (a forged 999 would corrupt-error).
+    status, commit = client.post(
+        "/session/commit",
+        {
+            "session_id": sid, "session_token": token, "path": "target.md",
+            "content": "x", "expected_version": 999, "pinned_version": 999,
+        },
+    )
+    assert status == 200, commit
+    assert commit["ok"] is True
+    assert commit["version"] == 2  # pinned-base CAS, forged comparand ignored.
+
+
+def test_forged_session_token_cannot_bypass_capture(client: _Client) -> None:
+    """A made-up / never-minted session token has no server-side cut. A read or
+    commit against it fails CLOSED (typed reason), NEVER served live HEAD."""
+    sid = _sid("forged-token")
+    # Seed the artifact so it exists (so the failure is about the TOKEN, not the
+    # path).
+    _begin(client, sid, ["existing.md"])
+
+    forged = "totally-not-a-real-server-minted-token"
+    status, read = client.post(
+        "/session/read",
+        {"session_id": sid, "session_token": forged, "path": "existing.md"},
+    )
+    assert status == 200, read
+    assert read["ok"] is False
+    assert read["reason"] in SESSION_READ_REASONS  # fail-closed, not live HEAD
+
+    status, commit = client.post(
+        "/session/commit",
+        {"session_id": sid, "session_token": forged, "path": "existing.md", "content": "x"},
+    )
+    assert status == 200
+    assert commit["ok"] is False
+    assert commit["reason"] in SESSION_COMMIT_REASONS
+
+
+def test_replayed_token_after_release_fails_closed(coordinator, client: _Client) -> None:
+    """A token whose session has been reaped (its cut released) cannot be
+    replayed to read/commit — it fails closed, never serves the (now stale)
+    cut from live HEAD."""
+    sid = _sid("replay2")
+    begin = _begin(client, sid, ["replay2.md"])
+    token = begin["session_token"]
+    # Release the session's pins directly on the wrapped registry (what the
+    # liveness sweep does when a heartbeat goes stale).
+    coordinator.registry.release_session(token)
+    status, read = client.post(
+        "/session/read", {"session_id": sid, "session_token": token, "path": "replay2.md"}
+    )
+    assert status == 200, read
+    assert read["ok"] is False
+    assert read["reason"] in SESSION_READ_REASONS  # fail-closed
+
+
+def test_foreign_caller_cannot_read_anothers_cut(coordinator, client: _Client) -> None:
+    """R13 owner isolation surfaced at the wire: a DIFFERENT authenticated
+    session_id (a sibling) cannot read another session's cut even with the
+    leaked token — it fails closed with session_invalidated."""
+    owner_sid = _sid("owner")
+    begin = _begin(client, owner_sid, ["owned.md"])
+    token = begin["session_token"]
+
+    foreign_sid = _sid("foreign")  # a different authenticated caller
+    status, read = client.post(
+        "/session/read",
+        {"session_id": foreign_sid, "session_token": token, "path": "owned.md"},
+    )
+    assert status == 200, read
+    assert read["ok"] is False
+    assert read["reason"] == "session_invalidated"
+
+
+def test_client_cannot_assert_owner_field(coordinator, client: _Client) -> None:
+    """A client-asserted ``owner`` / ``caller`` field MUST NOT bind or rebind the
+    session owner — the owner is derived from the authenticated session_id only.
+    A foreign caller supplying the real owner's id as ``owner``/``caller`` still
+    fails closed (the server ignores those fields)."""
+    owner_sid = _sid("owner-bind")
+    begin = _begin(client, owner_sid, ["bound.md"])
+    token = begin["session_token"]
+
+    foreign_sid = _sid("foreign-bind")
+    # Try to impersonate the owner via a client-supplied owner/caller field.
+    status, read = client.post(
+        "/session/read",
+        {
+            "session_id": foreign_sid, "session_token": token, "path": "bound.md",
+            "owner": owner_sid, "caller": owner_sid,
+        },
+    )
+    assert status == 200, read
+    assert read["ok"] is False
+    assert read["reason"] == "session_invalidated"  # owner came from AUTH, not the field
+
+
+# ----------------------------------------------------------------------
+# Wire (R7) — new reasons are additive; existing sets unchanged
+# ----------------------------------------------------------------------
+
+
+def test_session_reason_sets_are_disjoint_and_additive() -> None:
+    """The session reason sets are NET-NEW closed sets, disjoint from the
+    bare read_at_version contract — additive, never folded in (R7)."""
+    assert SESSION_READ_REASONS.isdisjoint(READ_AT_VERSION_REASONS)
+    assert SESSION_COMMIT_REASONS.isdisjoint(READ_AT_VERSION_REASONS)
+    assert SESSION_BEGIN_CAP_REASONS.isdisjoint(READ_AT_VERSION_REASONS)
+    # The pre-Unit-2 frozen read_at_version reasons are unchanged (6 reasons).
+    assert "current_version" in READ_AT_VERSION_REASONS
+    assert "unknown_artifact" in READ_AT_VERSION_REASONS
+
+
+def test_begin_unknown_artifact_reason_stays_in_read_at_version_set(client: _Client) -> None:
+    """begin_session's unknown-id rejection reuses the existing unknown_artifact
+    reason (not a parallel one) — but unknown PATHS get seeded as first
+    observations, so this asserts the cap-reason additive surface instead via a
+    too-large read_set."""
+    # An over-cap read_set is rejected at the WIRE (400) before the service —
+    # the service-level read_set_too_large stays the authoritative cap.
+    sid = _sid("cap")
+    big = [f"f{i}.md" for i in range(65)]  # > MAX_SESSION_READ_SET_PATHS (64)
+    status, body = client.post("/session/begin", {"session_id": sid, "read_set": big})
+    assert status == 400
+    assert "read_set" in body["error"]
+
+
+# ----------------------------------------------------------------------
+# Audit (R10a) — begin / commit / invalidate emit content-free records
+# ----------------------------------------------------------------------
+
+
+def test_audit_emits_begin_commit_invalidate_content_free(coordinator, client: _Client) -> None:
+    sid = _sid("audit")
+    begin = _begin(client, sid, ["audit.md"])
+    token = begin["session_token"]
+    # Commit → WIN (emits a session_commit audit event).
+    client.post(
+        "/session/commit",
+        {"session_id": sid, "session_token": token, "path": "audit.md", "content": "v2"},
+    )
+    # Reap then read with the dead token → fail-closed → session_invalidate event.
+    coordinator.registry.release_session(token)
+    client.post(
+        "/session/read", {"session_id": sid, "session_token": token, "path": "audit.md"}
+    )
+
+    audit_path = _resolve_session_audit_log_path(coordinator.coordinator_root)
+    records = [json.loads(line) for line in audit_path.read_text().strip().splitlines()]
+    events = {r["event"] for r in records}
+    assert {"session_begin", "session_commit", "session_invalidate"} <= events
+
+    # Content-free: no record carries body / hash / prose / raw token.
+    forbidden = {"content", "content_hash", "body", "command", "token", "session_token"}
+    raw = audit_path.read_text()
+    assert token not in raw  # raw token never logged (only its hash)
+    assert "v2" not in raw  # the committed body bytes never logged
+    for record in records:
+        assert not (set(record.keys()) & forbidden)
+
+    begin_rec = next(r for r in records if r["event"] == "session_begin")
+    # ids + versions only.
+    assert set(begin_rec.keys()) == {"ts", "event", "session", "cut"}
+    commit_rec = next(r for r in records if r["event"] == "session_commit")
+    assert set(commit_rec.keys()) == {
+        "ts", "event", "session", "artifact", "pinned_version", "committed_version",
+    }

--- a/tests/test_session_wire_and_boundary.py
+++ b/tests/test_session_wire_and_boundary.py
@@ -432,3 +432,189 @@ def test_audit_emits_begin_commit_invalidate_content_free(coordinator, client: _
     assert set(commit_rec.keys()) == {
         "ts", "event", "session", "artifact", "pinned_version", "committed_version",
     }
+
+
+# ----------------------------------------------------------------------
+# F1 — clock-domain basis: the sweep tick MUST share the wall-clock basis the
+#      heartbeat handlers seed from, else the sweep never reaps over HTTP.
+# ----------------------------------------------------------------------
+
+from types import SimpleNamespace  # noqa: E402
+
+from ccs.adapters.claude_code import lifecycle as _lifecycle  # noqa: E402
+from ccs.adapters.claude_code.coordinator_server import (  # noqa: E402
+    _session_read_content_fields,
+    monotonic_seconds,
+)
+
+
+def test_monotonic_seconds_is_wall_clock_not_monotonic() -> None:
+    # The shared tick basis — handlers seed created_at + heartbeats from this, and
+    # (after F1) the sweep reads it too — MUST be wall-clock int(time.time()), NOT
+    # int(time.monotonic()) (boot-relative, ~1.7e9 below wall-clock). The F1 bug
+    # was the sweep on the monotonic basis while seeds used wall-clock, so the
+    # staleness diff was permanently negative and nothing reaped over HTTP.
+    now = monotonic_seconds()
+    assert abs(now - int(time.time())) <= 2
+    assert abs(now - int(time.monotonic())) > 1_000_000
+
+
+def test_sweep_loop_uses_wall_clock_basis() -> None:
+    # Drive ONE iteration of the REAL _sweep_loop with stubs and capture the tick
+    # it passes to the enforce_* sweeps. It must be wall-clock (== monotonic_seconds
+    # basis) so the arithmetic against a wall-clock-seeded lease is positive. This
+    # fails if anyone reverts the sweep tick to int(time.monotonic()).
+    captured: dict = {}
+    coord = SimpleNamespace()
+
+    class _Svc:
+        def enforce_transient_timeouts(self, *, current_tick, timeout_ticks):
+            captured["transient"] = current_tick
+            return 0
+
+        def enforce_stable_grant_timeouts(
+            self, *, current_tick, heartbeat_timeout_ticks, max_hold_ticks, on_reclaim
+        ):
+            captured["grant"] = current_tick
+            return 0
+
+        def enforce_session_liveness(self, *, current_tick, heartbeat_timeout_ticks):
+            captured["session"] = current_tick
+            coord.shutting_down = True  # exit the loop after one iteration
+            return 0
+
+    class _Reg:
+        def evict_stale_notices(self, *, max_age_sec):
+            return 0
+
+        def record_preemption_notice(self, **kw):
+            pass
+
+    coord.shutting_down = False
+    coord.service = _Svc()
+    coord.registry = _Reg()
+    entry = SimpleNamespace(coordinator=coord)
+    cfg = SimpleNamespace(
+        sweep_interval_sec=0.01,
+        transient_timeout_sec=5,
+        grant_heartbeat_timeout_sec=120,
+        grant_max_hold_sec=300,
+        notice_evict_max_age_sec=600,
+    )
+
+    _lifecycle._sweep_loop(entry, cfg)
+
+    assert "session" in captured
+    # Wall-clock basis (shared with the heartbeat seeds) — NOT monotonic.
+    assert abs(captured["session"] - int(time.time())) <= 2
+    assert abs(captured["session"] - int(time.monotonic())) > 1_000_000
+    # All three sweeps ride ONE now_tick per iteration.
+    assert captured["transient"] == captured["grant"] == captured["session"]
+
+
+# ----------------------------------------------------------------------
+# F5 — /session/read serves non-UTF-8 bytes losslessly (base64), not a lossy
+#      replace-decode that would break the client-side hash round-trip.
+# ----------------------------------------------------------------------
+
+
+def test_read_content_fields_text_serves_plain_string() -> None:
+    assert _session_read_content_fields("plain text") == {"content": "plain text"}
+    assert _session_read_content_fields("héllo".encode("utf-8")) == {"content": "héllo"}
+
+
+def test_read_content_fields_non_utf8_serves_base64() -> None:
+    raw = b"\xff\xfe\x00\x01PNG\x89"  # not valid UTF-8
+    import base64 as _b64
+
+    fields = _session_read_content_fields(raw)
+    assert fields["content_encoding"] == "base64"
+    assert "content" not in fields
+    # Lossless round-trip — the client can reconstruct EXACT bytes (so its hash
+    # of the body matches the pinned content_hash; a lossy decode could not).
+    assert _b64.b64decode(fields["content_b64"]) == raw
+
+
+# ----------------------------------------------------------------------
+# Input validation — malformed session request bodies return 400 (not 500/200).
+# ----------------------------------------------------------------------
+
+
+def test_begin_non_list_read_set_returns_400(client: _Client) -> None:
+    status, _body = client.post(
+        "/session/begin", {"session_id": _sid("badrs"), "read_set": "not-a-list"}
+    )
+    assert status == 400
+
+
+def test_begin_non_string_read_set_member_returns_400(client: _Client) -> None:
+    status, _body = client.post(
+        "/session/begin", {"session_id": _sid("badrs2"), "read_set": [123]}
+    )
+    assert status == 400
+
+
+def test_read_missing_session_token_returns_400(client: _Client) -> None:
+    status, _body = client.post(
+        "/session/read", {"session_id": _sid("notok"), "path": "x.md"}
+    )
+    assert status == 400
+
+
+def test_read_empty_session_token_returns_400(client: _Client) -> None:
+    status, _body = client.post(
+        "/session/read",
+        {"session_id": _sid("emptytok"), "session_token": "", "path": "x.md"},
+    )
+    assert status == 400
+
+
+def test_commit_non_string_content_returns_400(client: _Client) -> None:
+    sid = _sid("badcontent")
+    begin = _begin(client, sid, ["bc.md"])
+    token = begin["session_token"]
+    status, _body = client.post(
+        "/session/commit",
+        {"session_id": sid, "session_token": token, "path": "bc.md", "content": 123},
+    )
+    assert status == 400
+
+
+# ----------------------------------------------------------------------
+# F7 — /session/commit is rejected (503) on a draining coordinator, like the
+#      other version-bumping writes, so a commit can't land and be stranded.
+# ----------------------------------------------------------------------
+
+
+def test_session_commit_rejected_while_draining(client: _Client, coordinator) -> None:
+    sid = _sid("drain")
+    begin = _begin(client, sid, ["drain.md"])
+    token = begin["session_token"]
+    # Enter migration-draining (what /admin/prepare-for-migration flips).
+    coordinator._migration_draining = True
+    try:
+        status, body = client.post(
+            "/session/commit",
+            {"session_id": sid, "session_token": token, "path": "drain.md", "content": "x"},
+        )
+        # A version-bumping write on a draining coordinator must be REJECTED (503),
+        # not allowed to land and be stranded by the imminent shutdown.
+        assert status == 503, body
+    finally:
+        coordinator._migration_draining = False
+
+
+def test_session_read_still_served_while_draining(client: _Client, coordinator) -> None:
+    # Non-mutating /session/read is NOT in the rejected set — it keeps serving so
+    # in-flight readers complete during the drain.
+    sid = _sid("drain-read")
+    begin = _begin(client, sid, ["dr.md"])
+    token = begin["session_token"]
+    coordinator._migration_draining = True
+    try:
+        status, _body = client.post(
+            "/session/read", {"session_id": sid, "session_token": token, "path": "dr.md"}
+        )
+        assert status == 200
+    finally:
+        coordinator._migration_draining = False

--- a/tests/test_snapshot_cut_capture.py
+++ b/tests/test_snapshot_cut_capture.py
@@ -1,0 +1,476 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Unit 2 — atomic consistent-cut capture + pin-set store (SB-17 / TX-1).
+
+Plan: ``docs/plans/2026-06-26-002-feat-read-side-transaction-snapshot-plan.md``
+Unit 2. Requirement trace: **R1** (atomic cut), **R4** (pins held against GC),
+**R6** (restart-survival sqlite-only — asserted in the parity suite), **R11**
+(the cut is an INSPECTABLE ``{artifact_id: version}`` map, not an opaque handle).
+
+A protocol proof bounds the REGISTRY, not the integration: ``Snapshot.tla`` proves
+``NoReadSkewWithinCut`` / ``PinAlwaysRetained`` over the model; this file is the
+integration-layer regression for the multi-read capture WINDOW. Per the
+split-comparand learning the staleness probes use **fixed-stale buffers, not
+counters** — a captured cut compared against a buffer literal, never a re-derived
+expectation that could drift with the bug it is meant to catch.
+
+Reason matching is ALWAYS ``reason == CONSTANT`` against the imported wire-stable
+constant — never a substring of a human message (the typed-signal-not-substring
+house rule).
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.retention import RetentionPolicy
+from ccs.coordinator.service import CoordinatorService
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.exceptions import UNKNOWN_ARTIFACT_REASON
+from ccs.core.states import MESIState
+from ccs.core.types import (
+    Artifact,
+    SnapshotSession,
+    VersionedReadRejection,
+)
+
+# ---------------------------------------------------------------------------
+# Builders — mirror tests/test_retention_parity.py's helpers.
+# ---------------------------------------------------------------------------
+
+
+def _register(reg, artifact_id: UUID, name: str, body: str) -> None:
+    art = Artifact(id=artifact_id, name=name, version=1, content_hash="h")
+    reg.register_artifact(art, content=body)
+
+
+def _commit(reg, artifact_id: UUID, version: int, body: str | bytes) -> None:
+    """Advance an artifact to ``version`` carrying ``body`` (a peer commit)."""
+    nxt = Artifact(id=artifact_id, name="x", version=version, content_hash="h")
+    reg.set_artifact_and_content(artifact_id, nxt, body)
+
+
+def _commit_cas(reg, artifact_id: UUID, writer: UUID, expected: int, body: str) -> None:
+    """A peer OCC commit via the registry ``commit_cas`` WIN (captures history)."""
+    reg.set_agent_state(artifact_id, writer, MESIState.SHARED, tick=1)
+    reg.commit_cas(
+        artifact_id,
+        writer,
+        expected_version=expected,
+        content_hash="h",
+        content=body,
+        tick=2,
+    )
+
+
+def _make_registries(tmp_path: Path, policy: RetentionPolicy | None = None):
+    """An (in_memory, sqlite) pair WITHOUT retention (the version-map-only branch,
+    the ``content=None`` ICP) unless a policy is given."""
+    retain = policy is not None
+    mem = ArtifactRegistry(retain_versions=retain, retention_policy=policy)
+    sql = SqliteArtifactRegistry(
+        tmp_path / "snap.db", retain_versions=retain, retention_policy=policy
+    )
+    return mem, sql
+
+
+# ===========================================================================
+# A — Integration: the consistent cut across a peer commit (fixed-stale buffer)
+# ===========================================================================
+
+
+class TestConsistentCut:
+    """capture {A, B} → a peer commits B between logical reads → both are served
+    at the CAPTURED versions, not the moved one (no cross-artifact read skew)."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_peer_commit_between_reads_does_not_taint_cut(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _make_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a, b = uuid4(), uuid4()
+            _register(reg, a, "plan.md", "a1")
+            _register(reg, b, "budget.md", "b1")
+            owner = uuid4()
+
+            # Capture the cut {A:1, B:1} at one linearization point.
+            session = svc.begin_session(read_set=[a, b], owner=owner)
+            assert isinstance(session, SnapshotSession)
+            # FIXED-STALE BUFFER: the cut is pinned to this literal, not a
+            # re-read of the registry (which the peer commit below would move).
+            captured_cut = {a: 1, b: 1}
+            assert dict(session.cut) == captured_cut
+
+            # A peer advances B to v2 AFTER the cut was captured.
+            _commit(reg, b, 2, "b2")
+
+            # The session's cut is immutable — still the captured versions, never
+            # the moved B@2. (Read skew would show B at 2 here.)
+            assert dict(session.cut) == captured_cut
+            assert session.cut[b] == 1, "cut tainted by a post-capture peer commit"
+            # The registry's live version DID move (the cut is a snapshot, not a
+            # lock): the peer commit landed.
+            assert reg.get_artifact(b).version == 2
+        finally:
+            sql.close()
+
+    def test_cut_is_inspectable_map_not_opaque_handle_R11(
+        self, tmp_path: Path
+    ) -> None:
+        # R11 binding constraint: begin_session returns the cut as an INSPECTABLE
+        # {artifact_id: version} map so the paper SB-18 commit_all(session_token,
+        # writes) can read each expected_version out of it. An opaque handle would
+        # foreclose SB-18. This pins the surface shape Unit 9's harness re-checks.
+        mem, sql = _make_registries(tmp_path)
+        try:
+            svc = CoordinatorService(mem)
+            a, b = uuid4(), uuid4()
+            _register(mem, a, "a", "a1")
+            _commit(mem, a, 2, "a2")  # A is at v2
+            _register(mem, b, "b", "b1")  # B at v1
+            session = svc.begin_session(read_set=[a, b], owner=uuid4())
+            assert isinstance(session, SnapshotSession)
+            # Inspectable: every per-artifact expected_version is readable.
+            assert session.cut[a] == 2
+            assert session.cut[b] == 1
+            # The map is keyed by the artifact UUIDs (not an opaque token blob).
+            assert set(session.cut.keys()) == {a, b}
+            # The session_token is a SEPARATE field (the identity), NOT the cut.
+            assert isinstance(session.session_token, str)
+            assert session.session_token  # non-empty, server-minted
+        finally:
+            sql.close()
+
+    def test_retain_versions_branch_indicator(self, tmp_path: Path) -> None:
+        # retain_versions mirrors the store's retention posture (the deployment
+        # branch indicator Unit 3 selects the serve strategy from).
+        # content=None / retention-off store → False (eager branch later).
+        mem_off, sql_off = _make_registries(tmp_path)
+        try:
+            s_off = CoordinatorService(mem_off).begin_session(read_set=[], owner=uuid4())
+            assert isinstance(s_off, SnapshotSession)
+            assert s_off.retain_versions is False
+        finally:
+            sql_off.close()
+        # retain_versions=True store → True (lazy branch later).
+        mem_on = ArtifactRegistry(
+            retain_versions=True, retention_policy=RetentionPolicy(max_versions=8)
+        )
+        s_on = CoordinatorService(mem_on).begin_session(read_set=[], owner=uuid4())
+        assert isinstance(s_on, SnapshotSession)
+        assert s_on.retain_versions is True
+
+    def test_coordinator_epoch_stamped(self, tmp_path: Path) -> None:
+        mem, sql = _make_registries(tmp_path)
+        try:
+            for reg in (mem, sql):
+                svc = CoordinatorService(reg)
+                s = svc.begin_session(read_set=[], owner=uuid4())
+                assert isinstance(s, SnapshotSession)
+                assert s.coordinator_epoch == reg.coordinator_epoch
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# B — Edge: a peer commit interleaving the capture is serialized whole
+# ===========================================================================
+
+
+class TestSerializedInterleave:
+    """A peer commit landing around the capture is serialized ENTIRELY before or
+    after — never partially visible within the cut (the atomicity property)."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_interleave_is_all_or_nothing_across_two_artifacts(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        mem, sql = _make_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a, b = uuid4(), uuid4()
+            _register(reg, a, "a", "a1")
+            _register(reg, b, "b", "b1")
+
+            # Pre-capture: bump A to v2 so a stale read of A would be visible.
+            _commit(reg, a, 2, "a2")
+
+            session = svc.begin_session(read_set=[a, b], owner=uuid4())
+            assert isinstance(session, SnapshotSession)
+            # A coherent cut: A@2 (its current at capture) AND B@1 — both from the
+            # SAME linearization point. A torn capture would mix a pre- and a
+            # post-bump version across the two artifacts.
+            assert dict(session.cut) == {a: 2, b: 1}
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# C — Edge (GC-hold): a pinned version is exempt from retention GC while live
+# ===========================================================================
+
+
+class TestGcHold:
+    """A pinned version survives the inline retention GC while the session is
+    live (the exemptions seam), and becomes collectible again after release."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_pinned_version_exempt_until_release(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        # K=2 keeps only {current, current-1}. Pin v1 WHILE it is current, then
+        # drive enough commits that v1 would normally be K-evicted — the pin must
+        # hold it; after release the next commit collects it.
+        policy = RetentionPolicy(max_versions=2)
+        mem, sql = _make_registries(tmp_path, policy)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "v1")  # v1 captured (retain on), current=1
+            writer = uuid4()
+
+            # Pin v1 via a session whose cut is {A:1} — captured while v1 is
+            # still current.
+            session = svc.begin_session(read_set=[a], owner=uuid4())
+            assert isinstance(session, SnapshotSession)
+            assert session.cut[a] == 1
+
+            # Peers advance to v2 then v3 → without the pin, K=2 ({2,3}) would
+            # evict v1. The pin exemption holds it.
+            _commit_cas(reg, a, writer, expected=1, body="v2")  # K=2 → {1(pin),2}
+            _commit_cas(reg, a, writer, expected=2, body="v3")  # K=2 {2,3} + pin 1
+            assert reg.get_content_at_version(a, 1) == "v1", (
+                "pinned v1 was GC-collected out from under a live session"
+            )
+
+            # Release → v1 is collectible again; the next capture GC drops it.
+            reg.release_session(session.session_token)
+            _commit_cas(reg, a, writer, expected=3, body="v4")  # K=2 evicts v1 now
+            assert reg.get_content_at_version(a, 1) is None, (
+                "released pin did not become collectible — exemption leaked"
+            )
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_two_overlapping_sessions_hold_independent_pins(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        # Two sessions pin different versions of the same artifact; releasing one
+        # must NOT drop the other's pin (the union-of-live-pins exemption).
+        policy = RetentionPolicy(max_versions=1)  # only current survives w/o pins
+        mem, sql = _make_registries(tmp_path, policy)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "plan.md", "v1")
+            writer = uuid4()
+            s1 = svc.begin_session(read_set=[a], owner=uuid4())  # pins v1
+            _commit_cas(reg, a, writer, expected=1, body="v2")
+            s2 = svc.begin_session(read_set=[a], owner=uuid4())  # pins v2
+            _commit_cas(reg, a, writer, expected=2, body="v3")  # current=3
+
+            assert isinstance(s1, SnapshotSession) and isinstance(s2, SnapshotSession)
+            # Both pins held despite K=1.
+            assert reg.get_content_at_version(a, 1) == "v1"
+            assert reg.get_content_at_version(a, 2) == "v2"
+
+            # Release s1 → v1 collectible, but s2's v2 still pinned.
+            reg.release_session(s1.session_token)
+            _commit_cas(reg, a, writer, expected=3, body="v4")
+            assert reg.get_content_at_version(a, 1) is None, "s1's pin leaked"
+            assert reg.get_content_at_version(a, 2) == "v2", (
+                "s2's independent pin was dropped when s1 released"
+            )
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# D — Edge (in-memory atomicity): concurrent capture + peer commit under the lock
+# ===========================================================================
+
+
+class TestInMemoryConcurrentAtomicity:
+    """The in-memory registry is lock-free per-access; the NEW capture lock makes
+    the multi-artifact read + pin insert atomic across N artifacts AND serializes
+    with the version-moving writes (register/commit), so a captured cut is always
+    a SINGLE-linearization-point snapshot — never a read-skewed pair stitched
+    across two writer commits.
+
+    The probe enforces a real cross-artifact invariant: a writer always advances
+    A *before* B to the same version, so at EVERY real instant
+    ``version(A) >= version(B)``. A cut with ``B > A`` never existed at any
+    instant — it would be the read skew the lock prevents (the ``{A:5, B:6}``
+    shape, where B only reached 6 once A did)."""
+
+    def test_concurrent_capture_never_observes_impossible_cut(self) -> None:
+        reg = ArtifactRegistry()  # no retention; version-map capture only
+        svc = CoordinatorService(reg)
+        a, b = uuid4(), uuid4()
+        _register(reg, a, "a", "a1")
+        _register(reg, b, "b", "b1")
+
+        stop = threading.Event()
+        skewed: list[dict] = []
+
+        def writer() -> None:
+            v = 1
+            while not stop.is_set():
+                v += 1
+                # A first, then B → at every instant version(A) >= version(B).
+                _commit(reg, a, v, f"a{v}")
+                _commit(reg, b, v, f"b{v}")
+
+        def capturer() -> None:
+            for _ in range(4000):
+                s = svc.begin_session(read_set=[a, b], owner=uuid4())
+                assert isinstance(s, SnapshotSession)
+                if s.cut[b] > s.cut[a]:
+                    skewed.append(dict(s.cut))
+                reg.release_session(s.session_token)
+
+        tw = threading.Thread(target=writer)
+        tw.start()
+        capturer()
+        stop.set()
+        tw.join(timeout=10.0)
+        assert not tw.is_alive(), "writer hung"
+
+        # HARD property: no cut ever observed B ahead of A — every cut is a
+        # genuine single-linearization-point snapshot (no read skew). Without the
+        # version-moving writes taking the capture lock, the capture could read
+        # A@v then a writer advances A,B to v+1, then read B@v+1 → impossible
+        # {A:v, B:v+1}.
+        assert not skewed, (
+            f"capture observed read-skewed (impossible) cuts: {skewed[:5]} "
+            f"(total {len(skewed)}) — the version-move/capture serialization broke"
+        )
+
+
+# ===========================================================================
+# E — Security: an unknown id rejects the WHOLE capture, inserts NO pins
+# ===========================================================================
+
+
+class TestUnknownIdRejection:
+    """A read_set with an unknown id → typed UNKNOWN_ARTIFACT rejection, NO
+    partial cut registered (no pins inserted, no existence-probe oracle)."""
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_unknown_id_rejects_and_inserts_no_pins(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        policy = RetentionPolicy(max_versions=1)  # so an erroneously-held pin shows
+        mem, sql = _make_registries(tmp_path, policy)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            known = uuid4()
+            unknown = uuid4()
+            _register(reg, known, "plan.md", "v1")
+            writer = uuid4()
+
+            result = svc.begin_session(read_set=[known, unknown], owner=uuid4())
+            # Typed rejection on the wire-stable constant — not a SnapshotSession.
+            assert isinstance(result, VersionedReadRejection)
+            assert result.reason == UNKNOWN_ARTIFACT_REASON
+            assert result.artifact_id == unknown
+            # No partial cut: the KNOWN id's version was NOT pinned. Prove it by
+            # K-evicting v1 — if a pin had leaked, the exemption would hold it.
+            _commit_cas(reg, known, writer, expected=1, body="v2")  # K=1 → drop v1
+            assert reg.get_content_at_version(known, 1) is None, (
+                "a partial cut was registered: the known id's v1 was pinned "
+                "despite the unknown-id rejection"
+            )
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_unknown_id_drops_owner_binding(self, tmp_path: Path, arm: str) -> None:
+        # The rejected token must not linger as a half-open owned session.
+        mem, sql = _make_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            result = svc.begin_session(read_set=[uuid4()], owner=uuid4())
+            assert isinstance(result, VersionedReadRejection)
+            # No owner binding survives a rejected capture (Unit 2 cleanup).
+            assert svc._session_owners == {}
+        finally:
+            sql.close()
+
+
+# ===========================================================================
+# F — Owner-binding + non-mutating capture
+# ===========================================================================
+
+
+class TestOwnerBindingAndNonMutating:
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_token_is_owner_bound_at_mint(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _make_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "a", "a1")
+            owner = uuid4()
+            s = svc.begin_session(read_set=[a], owner=owner)
+            assert isinstance(s, SnapshotSession)
+            assert svc._session_owners[s.session_token] == owner
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_capture_mints_no_mesi_grant_no_read_generation(
+        self, tmp_path: Path, arm: str
+    ) -> None:
+        # The capture is non-mutating on the coherence plane: no MESI state for
+        # the owner, and no read_generation captured (it never calls
+        # set_agent_state / the fence path).
+        mem, sql = _make_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "a", "a1")
+            owner = uuid4()
+            svc.begin_session(read_set=[a], owner=owner)
+            # The owner holds no MESI grant on the pinned artifact.
+            assert reg.get_agent_state(a, owner) is None
+            # No fence claim was captured for the owner.
+            assert reg.get_read_generation(a, owner) is None
+            # owner_generation untouched (no reclamation).
+            assert reg.get_owner_generation(a) == 0
+        finally:
+            sql.close()
+
+    @pytest.mark.parametrize("arm", ["in_memory", "sqlite"])
+    def test_tokens_are_unique_per_session(self, tmp_path: Path, arm: str) -> None:
+        mem, sql = _make_registries(tmp_path)
+        reg = mem if arm == "in_memory" else sql
+        try:
+            svc = CoordinatorService(reg)
+            a = uuid4()
+            _register(reg, a, "a", "a1")
+            tokens = set()
+            for _ in range(8):
+                s = svc.begin_session(read_set=[a], owner=uuid4())
+                assert isinstance(s, SnapshotSession)
+                tokens.add(s.session_token)
+            assert len(tokens) == 8, "server-minted tokens collided"
+        finally:
+            sql.close()

--- a/tests/test_snapshot_cut_capture.py
+++ b/tests/test_snapshot_cut_capture.py
@@ -30,7 +30,7 @@ import pytest
 
 from ccs.coordinator.registry import ArtifactRegistry
 from ccs.coordinator.retention import RetentionPolicy
-from ccs.coordinator.service import CoordinatorService
+from ccs.coordinator.service import CoordinatorService, SessionCapsConfig
 from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
 from ccs.core.exceptions import UNKNOWN_ARTIFACT_REASON
 from ccs.core.states import MESIState
@@ -318,7 +318,13 @@ class TestInMemoryConcurrentAtomicity:
 
     def test_concurrent_capture_never_observes_impossible_cut(self) -> None:
         reg = ArtifactRegistry()  # no retention; version-map capture only
-        svc = CoordinatorService(reg)
+        # This atomicity probe opens 4000 sessions in a tight loop and frees only
+        # the registry pins (release_session) per iteration, so the service-level
+        # owner-binding COUNT accumulates. Raise the Unit-7 max_sessions cap above
+        # the loop count so the R14 bound (default 256) does not interfere with the
+        # pre-existing read-skew probe (the caps surface is tested in
+        # tests/test_session_identity_and_caps.py).
+        svc = CoordinatorService(reg, session_caps=SessionCapsConfig(max_sessions=8192))
         a, b = uuid4(), uuid4()
         _register(reg, a, "a", "a1")
         _register(reg, b, "b", "b1")

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -805,7 +805,8 @@ def _build_pre_fence_db(db_path: Path, art_id: str, ag_id: str) -> None:
 
 def test_fresh_db_has_fence_schema(db_path: Path) -> None:
     """A freshly initialized db carries the fence columns + coordinator_epoch
-    inline in the v2 schema (Unit 3: fresh dbs are created at v2 directly)."""
+    inline in the v2 schema AND the v3 ``session_pins`` table (a fresh db is
+    created at the latest schema directly)."""
     with SqliteArtifactRegistry(db_path) as reg:
         art_cols = {r[1] for r in reg._conn.execute("PRAGMA table_info(artifacts)").fetchall()}
         state_cols = {
@@ -814,16 +815,25 @@ def test_fresh_db_has_fence_schema(db_path: Path) -> None:
         assert "owner_generation" in art_cols
         assert "read_generation" in state_cols
         assert reg._coordinator_epoch
-        # v1->v2 is the repo's first real schema bump (Unit 3): a fresh db is v2.
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+        tables = {
+            r[0] for r in reg._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        # The v3 session-pin table (SB-17 Unit 2) is present on a fresh db.
+        assert "session_pins" in tables
+        # SB-17 Unit 2 bumped the schema to v3; a fresh db is created at v3.
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
+        assert SCHEMA_USER_VERSION == 3
 
 
 def test_pre_fence_db_upgrades_in_place_additively(db_path: Path) -> None:
-    """A pre-fence v1 db migrates to v2 on open (Unit 3): it gains the fence
-    columns + coordinator_epoch (the subsumed fence shim) AND the new
-    artifact_versions table, with user_version stamped 2. Existing rows backfill
-    to owner_generation = 0 / read_generation = NULL, and prior meta is
-    preserved. Re-open is the write-free v2 path; the epoch is stable."""
+    """A pre-fence v1 db migrates all the way to v3 on open (chained
+    v1->v2->v3): it gains the fence columns + coordinator_epoch (the subsumed
+    fence shim), the v2 artifact_versions table, AND the v3 session_pins table,
+    with user_version stamped 3. Existing rows backfill to owner_generation = 0 /
+    read_generation = NULL, and prior meta is preserved. Re-open is the
+    write-free v3 path; the epoch is stable."""
     art_id, ag_id = str(uuid4()), str(uuid4())
     _build_pre_fence_db(db_path, art_id, ag_id)
 
@@ -841,6 +851,8 @@ def test_pre_fence_db_upgrades_in_place_additively(db_path: Path) -> None:
             ).fetchall()
         }
         assert "artifact_versions" in tables
+        # The chained v2->v3 step also created the session_pins table.
+        assert "session_pins" in tables
         # Existing rows backfill: artifact -> 0, grant -> NULL (absent operand).
         assert (
             reg._conn.execute(
@@ -856,9 +868,9 @@ def test_pre_fence_db_upgrades_in_place_additively(db_path: Path) -> None:
             ).fetchone()[0]
             is None
         )
-        # Epoch seeded + loaded; user_version stamped to 2 by the migration.
+        # Epoch seeded + loaded; user_version stamped to 3 by the chained migration.
         assert reg._coordinator_epoch
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 3
         # Prior meta preserved (no clobber of instance_id / sequence_number).
         assert reg._instance_id == "fixed-instance"
         assert reg._seq == 7
@@ -1012,9 +1024,9 @@ def test_set_artifact_and_content_fence_rejects_stale_committer(db_path: Path) -
 
 def test_fence_columns_present_epoch_absent_recovers(db_path: Path) -> None:
     """A v1 db whose fence COLUMNS exist but whose coordinator_epoch was never
-    seeded (one wild v1 variant) migrates to v2 cleanly: the migration's
-    table_info guards skip the duplicate column ALTERs and the INSERT OR IGNORE
-    seeds the missing epoch, while stamping user_version to 2."""
+    seeded (one wild v1 variant) migrates cleanly (chained v1->v2->v3): the
+    migration's table_info guards skip the duplicate column ALTERs and the
+    INSERT OR IGNORE seeds the missing epoch, while stamping user_version to 3."""
     import sqlite3
 
     # hex ids: the registry's lookups key on UUID.hex (the pre-fence builder
@@ -1031,7 +1043,7 @@ def test_fence_columns_present_epoch_absent_recovers(db_path: Path) -> None:
 
     with SqliteArtifactRegistry(db_path) as reg:
         assert reg._coordinator_epoch  # seeded on this open
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 3
         assert reg.get_owner_generation(UUID(art_id)) == 0
 
 
@@ -1241,7 +1253,8 @@ class TestDurableRetentionRoundTrip:
 
 class TestWildV1Migration:
     """R2: the four wild v1 variants ({±fence cols} x {±pending_notices}) each
-    migrate to v2 in one transaction with data intact + complete schema."""
+    migrate (chained v1->v2->v3) in one open with data intact + complete schema
+    (artifact_versions from v2, session_pins from v3)."""
 
     @pytest.mark.parametrize("fence", [True, False])
     @pytest.mark.parametrize("notices", [True, False])
@@ -1250,14 +1263,16 @@ class TestWildV1Migration:
     ) -> None:
         art_id, ag_id = _build_raw_v1_db(db_path, fence=fence, notices=notices)
         with SqliteArtifactRegistry(db_path) as reg:
-            # user_version stamped 2; complete schema guaranteed.
-            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+            # Chained migration stamps v3; complete schema guaranteed.
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 3
             tables = {
                 r[0] for r in reg._conn.execute(
                     "SELECT name FROM sqlite_master WHERE type='table'"
                 ).fetchall()
             }
-            assert {"artifact_versions", "pending_notices"}.issubset(tables)
+            assert {
+                "artifact_versions", "pending_notices", "session_pins"
+            }.issubset(tables)
             art_cols = {
                 r[1] for r in reg._conn.execute(
                     "PRAGMA table_info(artifacts)"
@@ -1297,7 +1312,8 @@ class TestWildV1Migration:
     def test_half_migrated_db_completes_cleanly(self, db_path: Path) -> None:
         # Characterization: a db with the v2 table already present but
         # user_version still 1 (a crashed prior migration whose stamp never
-        # committed) must complete to v2, never "table already exists".
+        # committed) must complete via the chained v1->v2->v3 path to v3, never
+        # "table already exists".
         _build_raw_v1_db(db_path, fence=True, notices=True)
         conn = sqlite3.connect(str(db_path))
         conn.execute(_ARTIFACT_VERSIONS_DDL)  # table present; user_version still 1
@@ -1305,12 +1321,12 @@ class TestWildV1Migration:
         conn.close()
         # Open via the normal path: must not raise OperationalError.
         with SqliteArtifactRegistry(db_path) as reg:
-            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 3
 
     def test_half_migrated_db_missing_stamp_recovers(self, db_path: Path) -> None:
-        # The classic learnings case generalized to v2: all v2 tables present but
+        # The classic learnings case generalized: all v2 tables present but
         # user_version left at 1. The migration's IF-NOT-EXISTS / table_info
-        # guards make it idempotent — clean completion, no error.
+        # guards make it idempotent — clean completion through to v3, no error.
         _build_raw_v1_db(db_path, fence=True, notices=True)
         conn = sqlite3.connect(str(db_path))
         conn.execute(_ARTIFACT_VERSIONS_DDL)
@@ -1318,7 +1334,7 @@ class TestWildV1Migration:
         conn.close()
         reg = SqliteArtifactRegistry(db_path)  # must not raise
         try:
-            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 3
         finally:
             reg.close()
 
@@ -1333,13 +1349,15 @@ class TestWildV1Migration:
         # assert the in-txn user_version re-check no-ops with ZERO DDL.
         art_id, _ = _build_raw_v1_db(db_path, fence=True, notices=True)
         with SqliteArtifactRegistry(db_path) as winner:
-            assert winner._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+            assert winner._conn.execute("PRAGMA user_version").fetchone()[0] == 3
 
         statements: list[str] = []
 
         def loser_initialize(self, instance_id):
-            # The loser's stale dispatch: call the migration directly against
-            # the already-v2 db, tracing every statement it executes.
+            # The loser's stale dispatch: call the v1->v2 migration directly
+            # against the already-migrated (v3) db, tracing every statement. The
+            # v1->v2 loser-guard (>= _V2_USER_VERSION) sees v3 and short-circuits
+            # with zero DDL before any ALTER/CREATE could re-run.
             self._conn.set_trace_callback(statements.append)
             try:
                 self._migrate_v1_to_v2(instance_id)
@@ -1353,7 +1371,7 @@ class TestWildV1Migration:
             # The loser rehydrated normally (meta loaded, data intact) ...
             assert loser.instance_id == "wild-v1"
             assert loser.get_artifact(UUID(art_id)) is not None
-            assert loser._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+            assert loser._conn.execute("PRAGMA user_version").fetchone()[0] == 3
         # ... and performed NO DDL: the in-txn re-check exited before any
         # ALTER/CREATE could re-run against the migrated schema.
         ddl = [
@@ -1496,10 +1514,11 @@ class TestCrossRuntimeGuard:
     def test_genuine_v1_migrates_and_stamps_python(self, db_path: Path) -> None:
         # The documented residual risk, accepted by design: a v1 db is
         # byte-identical between the two runtimes, so it is NOT blocked — the
-        # normal v1->v2 migration proceeds and stamps OUR lineage marker.
+        # normal chained v1->v2->v3 migration proceeds and stamps OUR lineage
+        # marker.
         art_id, _ = _build_raw_v1_db(db_path, fence=False, notices=False)
         with SqliteArtifactRegistry(db_path) as reg:
-            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 3
             assert reg.get_artifact(UUID(art_id)) is not None
             stamp = reg._conn.execute(
                 "SELECT value FROM registry_meta WHERE key = 'schema_runtime'"
@@ -1519,14 +1538,16 @@ class TestCrossRuntimeGuard:
         with SqliteArtifactRegistry(db_path) as reg:
             _retain_artifact(reg, content="x")
         with SqliteArtifactRegistry(db_path) as rw:
-            assert rw._conn.execute("PRAGMA user_version").fetchone()[0] == 2
+            assert rw._conn.execute("PRAGMA user_version").fetchone()[0] == 3
         with SqliteArtifactRegistry(db_path, read_only=True) as ro:
             assert ro.instance_id
 
     def test_pre_stamp_python_v2_opens_fine(self, db_path: Path) -> None:
-        # Back-compat: a Python-v2 db written BEFORE the schema_runtime marker
-        # shipped has no stamp at all. Absence is NOT foreign (the v2 open
-        # path is write-free, so the stamp is never backfilled either).
+        # Back-compat: a Python db written BEFORE the schema_runtime marker
+        # shipped has no stamp at all. Absence is NOT foreign (the steady-state
+        # v3 open path is write-free, so the stamp is never backfilled either).
+        # The structural session_pins probe (present on a Python-v3 db) keeps the
+        # un-stamped db classified as native, never foreign.
         with SqliteArtifactRegistry(db_path):
             pass
         conn = sqlite3.connect(str(db_path))
@@ -1536,8 +1557,8 @@ class TestCrossRuntimeGuard:
         finally:
             conn.close()
         with SqliteArtifactRegistry(db_path) as reg:
-            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 2
-            # Still un-stamped: the steady-state v2 open performs no writes.
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 3
+            # Still un-stamped: the steady-state v3 open performs no writes.
             assert reg._conn.execute(
                 "SELECT value FROM registry_meta WHERE key = 'schema_runtime'"
             ).fetchone() is None

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -824,7 +824,7 @@ def test_fresh_db_has_fence_schema(db_path: Path) -> None:
         assert "session_pins" in tables
         # SB-17 Unit 2 bumped the schema to v3; a fresh db is created at v3.
         assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
-        assert SCHEMA_USER_VERSION == 3
+        assert SCHEMA_USER_VERSION == 4
 
 
 def test_pre_fence_db_upgrades_in_place_additively(db_path: Path) -> None:
@@ -868,9 +868,9 @@ def test_pre_fence_db_upgrades_in_place_additively(db_path: Path) -> None:
             ).fetchone()[0]
             is None
         )
-        # Epoch seeded + loaded; user_version stamped to 3 by the chained migration.
+        # Epoch seeded + loaded; user_version stamped to current by the chained migration.
         assert reg._coordinator_epoch
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 3
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
         # Prior meta preserved (no clobber of instance_id / sequence_number).
         assert reg._instance_id == "fixed-instance"
         assert reg._seq == 7
@@ -1043,7 +1043,7 @@ def test_fence_columns_present_epoch_absent_recovers(db_path: Path) -> None:
 
     with SqliteArtifactRegistry(db_path) as reg:
         assert reg._coordinator_epoch  # seeded on this open
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 3
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
         assert reg.get_owner_generation(UUID(art_id)) == 0
 
 
@@ -1263,8 +1263,8 @@ class TestWildV1Migration:
     ) -> None:
         art_id, ag_id = _build_raw_v1_db(db_path, fence=fence, notices=notices)
         with SqliteArtifactRegistry(db_path) as reg:
-            # Chained migration stamps v3; complete schema guaranteed.
-            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 3
+            # Chained migration stamps the current version; complete schema guaranteed.
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
             tables = {
                 r[0] for r in reg._conn.execute(
                     "SELECT name FROM sqlite_master WHERE type='table'"
@@ -1321,7 +1321,7 @@ class TestWildV1Migration:
         conn.close()
         # Open via the normal path: must not raise OperationalError.
         with SqliteArtifactRegistry(db_path) as reg:
-            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 3
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
 
     def test_half_migrated_db_missing_stamp_recovers(self, db_path: Path) -> None:
         # The classic learnings case generalized: all v2 tables present but
@@ -1334,7 +1334,7 @@ class TestWildV1Migration:
         conn.close()
         reg = SqliteArtifactRegistry(db_path)  # must not raise
         try:
-            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 3
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
         finally:
             reg.close()
 
@@ -1349,7 +1349,7 @@ class TestWildV1Migration:
         # assert the in-txn user_version re-check no-ops with ZERO DDL.
         art_id, _ = _build_raw_v1_db(db_path, fence=True, notices=True)
         with SqliteArtifactRegistry(db_path) as winner:
-            assert winner._conn.execute("PRAGMA user_version").fetchone()[0] == 3
+            assert winner._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
 
         statements: list[str] = []
 
@@ -1371,7 +1371,7 @@ class TestWildV1Migration:
             # The loser rehydrated normally (meta loaded, data intact) ...
             assert loser.instance_id == "wild-v1"
             assert loser.get_artifact(UUID(art_id)) is not None
-            assert loser._conn.execute("PRAGMA user_version").fetchone()[0] == 3
+            assert loser._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
         # ... and performed NO DDL: the in-txn re-check exited before any
         # ALTER/CREATE could re-run against the migrated schema.
         ddl = [
@@ -1518,7 +1518,7 @@ class TestCrossRuntimeGuard:
         # marker.
         art_id, _ = _build_raw_v1_db(db_path, fence=False, notices=False)
         with SqliteArtifactRegistry(db_path) as reg:
-            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 3
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
             assert reg.get_artifact(UUID(art_id)) is not None
             stamp = reg._conn.execute(
                 "SELECT value FROM registry_meta WHERE key = 'schema_runtime'"
@@ -1538,7 +1538,7 @@ class TestCrossRuntimeGuard:
         with SqliteArtifactRegistry(db_path) as reg:
             _retain_artifact(reg, content="x")
         with SqliteArtifactRegistry(db_path) as rw:
-            assert rw._conn.execute("PRAGMA user_version").fetchone()[0] == 3
+            assert rw._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
         with SqliteArtifactRegistry(db_path, read_only=True) as ro:
             assert ro.instance_id
 
@@ -1557,7 +1557,7 @@ class TestCrossRuntimeGuard:
         finally:
             conn.close()
         with SqliteArtifactRegistry(db_path) as reg:
-            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 3
+            assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
             # Still un-stamped: the steady-state v3 open performs no writes.
             assert reg._conn.execute(
                 "SELECT value FROM registry_meta WHERE key = 'schema_runtime'"
@@ -2092,3 +2092,88 @@ def _versions(reg, artifact_id) -> list[int]:
             (artifact_id.hex,),
         ).fetchall()
     )
+
+
+class TestV3ToV4Migration:
+    """The durable-owner fix added ``session_meta`` + ``idx_session_pins_artifact``
+    to the schema. Earlier commits of THIS branch already stamped
+    ``user_version=3`` with ``session_pins`` but WITHOUT ``session_meta``; such a
+    db MUST migrate to v4 on open (gaining both) rather than crash on the first
+    session op with 'no such table: session_meta'. Regression for the re-review
+    P0: F3/F6 added tables to v3 in-place without bumping the schema version."""
+
+    def _revert_to_prefix_v3(self, db_path: Path) -> None:
+        """Mutate a current (v4) db on disk back to the pre-fix v3 shape:
+        ``session_pins`` present, ``session_meta`` + the artifact index ABSENT,
+        stamped ``user_version=3`` (what an earlier branch commit produced)."""
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute("DROP TABLE IF EXISTS session_meta")
+            conn.execute("DROP INDEX IF EXISTS idx_session_pins_artifact")
+            conn.execute("PRAGMA user_version = 3")
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_existing_v3_db_migrates_to_v4_and_session_ops_work(
+        self, db_path: Path
+    ) -> None:
+        with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
+            art = _retain_artifact(reg, content="seed")
+        self._revert_to_prefix_v3(db_path)
+        # Sanity: the reverted db is a genuine pre-fix v3 (session_pins, no meta).
+        probe = sqlite3.connect(str(db_path))
+        try:
+            assert probe.execute("PRAGMA user_version").fetchone()[0] == 3
+            assert probe.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='session_meta'"
+            ).fetchone() is None
+            assert probe.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='session_pins'"
+            ).fetchone() is not None
+        finally:
+            probe.close()
+        # Reopen with the current build → _migrate_v3_to_v4 fires (no crash).
+        with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
+            assert reg._conn.execute(
+                "PRAGMA user_version"
+            ).fetchone()[0] == SCHEMA_USER_VERSION
+            assert reg._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='session_meta'"
+            ).fetchone() is not None
+            assert reg._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' "
+                "AND name='idx_session_pins_artifact'"
+            ).fetchone() is not None
+            # The session op that would have crashed pre-migration now works.
+            owner = uuid4()
+            cut = reg.capture_version_vector(
+                [art.id], "tok-migrated", owner=owner, created_at_tick=5
+            )
+            assert cut == {art.id: art.version}
+            assert reg.get_session_meta("tok-migrated") == (owner, 5)
+            assert reg.session_count() == 1
+
+    def test_v2_db_chains_through_to_v4_with_session_meta(self, db_path: Path) -> None:
+        # A v2 db (artifact_versions, no session_pins/meta) chains 2 -> 3 -> 4 and
+        # ends with the FULL current schema (both session tables + the index).
+        with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
+            _retain_artifact(reg, content="seed")
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute("DROP TABLE IF EXISTS session_meta")
+            conn.execute("DROP INDEX IF EXISTS idx_session_pins_artifact")
+            conn.execute("DROP TABLE IF EXISTS session_pins")
+            conn.execute("PRAGMA user_version = 2")
+            conn.commit()
+        finally:
+            conn.close()
+        with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
+            assert reg._conn.execute(
+                "PRAGMA user_version"
+            ).fetchone()[0] == SCHEMA_USER_VERSION
+            for table in ("session_pins", "session_meta"):
+                assert reg._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                    (table,),
+                ).fetchone() is not None, table


### PR DESCRIPTION
## Summary

Adds **consistent multi-artifact snapshot sessions** to the coordinator. A session pins a consistent cut of several artifacts at one linearization point, reads those inputs consistently across concurrent peer commits, and gates its commit/effect on the cut staying current. Single-host, version-CAS, no app-level log — built on the shipped bounded-retention core, `commit_cas`, and the read-generation fence.

This closes the cross-artifact **read-skew** gap: today a multi-artifact read is N independent calls with no coordinator-level consistency guarantee, so a peer commit between calls can produce a snapshot that reflects no single point in time.

## What's included

- **Formal spec** (`formal/tla/Snapshot.tla`): `NoReadSkewWithinCut` (no cross-artifact read skew) + `PinAlwaysRetained` (a live session's pinned versions survive GC). Green under `make tla-check`; mutant-tested (both invariants shown to have teeth).
- **Atomic consistent-cut capture** + a session pin store on **both** registries (in-memory + sqlite). The version-moving writes serialize against the capture so a cut can never be torn; pinned versions are held back from the retention GC via the exemptions seam.
- **`session.read`** — non-mutating serve of the pinned version (including when it equals current), honest about the data-plane byte boundary.
- **`session.commit`** — single-artifact optimistic commit validated at the pinned base, preserving the shipped conflict taxonomy (admit-on-absent fence).
- **Pin lifetime** — a session-token-keyed, owner-bound heartbeat lease + a new session-liveness sweep; crashed/unknown/restart-wiped sessions fail closed (never serve stale bytes), with a hard absolute-age ceiling independent of the heartbeat.
- **Effect-gate** — "fire effect E iff the read-set is unchanged"; atomic when the effect is a commit, with an explicitly documented residual window for non-commit escaping effects.
- **Identity & caps** — per-call timing-safe owner validation (cross-session isolation), plus max-sessions / max-read-set-cardinality / absolute-age resource bounds.
- **HTTP endpoints** (`POST /session/{begin,read,commit,heartbeat}`) behind the central bearer + host auth seam; the cut is server-captured and cannot be forged or bypassed by a client; content-free session audit (a separate module — the existing deny-only audit log is untouched).
- **Dual-registry parity** (with the sqlite-survives-restart / in-memory-wiped divergence asserted, not masked) + a harness proving the public types do not foreclose a future atomic multi-artifact commit.

## Test plan

- Full suite: **2426 passed, 0 failed**.
- `make tla-check`: 6 specs green, including the new spec and its mutants.
- `pytest -m protocol_corpus`: green — the Python↔Node wire is unchanged (new typed reasons are additive only).
- New coverage across capture, read, commit, lifetime/sweep, effect-gate, identity/caps, HTTP wire + boundary lock, content-free audit, and dual-registry parity.

## Scope / non-goals

- **Single-host read-side only.** Atomic multi-artifact *write* (cross-artifact write skew) is explicitly out of scope; the design provably does not foreclose it (mechanized non-foreclosure harness).
- Cross-host coordination and data-plane eager byte serving are separate follow-ons; the coordinator returns a typed data-plane-deferred result where it does not hold the bytes.
