### PR TITLE
refactor(coordinator): extract registry Protocol (RegistryBase + SqliteExtended)

### DIFF
--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -9,7 +9,7 @@ import threading
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Callable, Iterable, Iterator, Optional, TypeAlias
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Optional
 from uuid import UUID, uuid4
 
 from ccs.core.exceptions import (
@@ -26,11 +26,14 @@ from ccs.core.types import (
     VersionedReadRejection,
 )
 
+# The registry contract return types (ReclamationSlot / CasResult / CaptureResult)
+# live in the Protocol module (Phase 1 dedup); re-exported here so existing
+# `from .registry import CasResult` importers keep working.
+from .registry_protocol import CaptureResult, CasResult, ReclamationSlot
 from .retention import RetentionPolicy, collectible_versions
 
 CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
 
-ReclamationSlot: TypeAlias = tuple[str, int]  # (trigger, tick)
 _M_OR_E_STATES: frozenset[MESIState] = frozenset({MESIState.MODIFIED, MESIState.EXCLUSIVE})
 
 # The coordinator-side EVICTION triggers: the stable-grant sweep
@@ -53,18 +56,6 @@ RECLAIM_TRIGGERS: frozenset[str] = frozenset(
 # would silently disable capture on reads -- pinned equal across registries by
 # the parity test, same discipline as RECLAIM_TRIGGERS.
 CLAIM_CAPTURE_TRIGGERS: frozenset[str] = frozenset({"fetch"})
-
-# OCC commit-CAS result (plan Unit 2) — parity with SqliteArtifactRegistry.
-# WIN = (updated_artifact, invalidated_agent_ids); loss = ConflictDetail;
-# impossible state = CasCorruption. None is raised by the registry.
-CasResult: TypeAlias = "tuple[Artifact, list[UUID]] | ConflictDetail | CasCorruption"
-
-# Snapshot consistent-cut capture result (SB-17 / TX-1, Unit 2 / R1) — parity
-# with SqliteArtifactRegistry.capture_version_vector. WIN = the pinned cut
-# ``{artifact_id: version}``; a read_set with an unknown id =
-# VersionedReadRejection(reason=UNKNOWN_ARTIFACT) and NO pins inserted (no
-# partial cut, no existence-probe oracle). Neither is raised by the registry.
-CaptureResult: TypeAlias = "dict[UUID, int] | VersionedReadRejection"
 
 
 @dataclass
@@ -921,3 +912,14 @@ class ArtifactRegistry:
             for agent_id, state in self._records[artifact_id].state_by_agent.items()
             if state != MESIState.INVALID
         ]
+
+
+if TYPE_CHECKING:
+    # Static conformance assertion (Phase 1, zero runtime change): a type checker
+    # rejects this if ``ArtifactRegistry`` ever drifts from the ``RegistryBase``
+    # contract the service layer depends on. Structural (no runtime inheritance);
+    # no import cycle (registry_protocol imports only domain types).
+    from .registry_protocol import RegistryBase
+
+    def _conforms(r: ArtifactRegistry) -> RegistryBase:
+        return r

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -27,35 +27,20 @@ from ccs.core.types import (
 )
 
 # The registry contract return types (ReclamationSlot / CasResult / CaptureResult)
-# live in the Protocol module (Phase 1 dedup); re-exported here so existing
-# `from .registry import CasResult` importers keep working.
-from .registry_protocol import CaptureResult, CasResult, ReclamationSlot
+# live in the Protocol module (deduplicated there); re-exported here to keep
+# `ccs.coordinator.registry.CasResult` a stable public import path.
+from .registry_protocol import (
+    CLAIM_CAPTURE_TRIGGERS,
+    RECLAIM_TRIGGERS,
+    CaptureResult,
+    CasResult,
+    ReclamationSlot,
+)
 from .retention import RetentionPolicy, collectible_versions
 
 CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
 
 _M_OR_E_STATES: frozenset[MESIState] = frozenset({MESIState.MODIFIED, MESIState.EXCLUSIVE})
-
-# The coordinator-side EVICTION triggers: the stable-grant sweep
-# (CoordinatorService.enforce_stable_grant_timeouts -> reclaim_heartbeat /
-# reclaim_max_hold) and the transient-timeout fail-safe
-# (enforce_transient_timeouts -> "timeout"). An M/E -> INVALID transition
-# carrying one of these bumps the artifact's owner_generation (the
-# read-generation fence) -- the holder's claim was revoked WITHOUT a version
-# move, which is exactly what version-CAS cannot see. A peer-invalidation
-# INVALID (any other trigger) does NOT bump: that path moves the version, so
-# version-CAS already catches a stale write. Duplicated in
-# SqliteArtifactRegistry; pinned equal by the parity test.
-RECLAIM_TRIGGERS: frozenset[str] = frozenset(
-    {"reclaim_heartbeat", "reclaim_max_hold", "timeout"}
-)
-
-# Triggers that mark a GENUINE content read for read-generation capture (the
-# E/M-acquire capture is keyed on the state transition, not the trigger).
-# Service.fetch() emits "fetch"; a rename there without updating this constant
-# would silently disable capture on reads -- pinned equal across registries by
-# the parity test, same discipline as RECLAIM_TRIGGERS.
-CLAIM_CAPTURE_TRIGGERS: frozenset[str] = frozenset({"fetch"})
 
 
 @dataclass

--- a/src/ccs/coordinator/registry_protocol.py
+++ b/src/ccs/coordinator/registry_protocol.py
@@ -4,19 +4,19 @@
 """Structural Protocols for the coordinator's artifact registries.
 
 This module holds the registry CONTRACT the service layer depends on, extracted
-in Phase 1 of the cross-host production-HA journey (PURE REFACTOR — zero
-behavior change). Before this extraction the two registries
-(:class:`ccs.coordinator.registry.ArtifactRegistry` in-memory and
+as a pure refactor (zero behavior change). Before this extraction the two
+registries (:class:`ccs.coordinator.registry.ArtifactRegistry` in-memory and
 :class:`ccs.coordinator.sqlite_registry.SqliteArtifactRegistry` durable) were
 duck-typed with NO shared interface; their parity was asserted piecemeal in
 tests.
 
-The two Protocols below name that shared surface explicitly:
+The two Protocols below name that shared surface explicitly (the authoritative
+method set is the one pinned by ``tests/test_registry_protocol_parity.py``):
 
-- :class:`RegistryBase` — the 34 methods :class:`CoordinatorService` (the
-  service layer) depends on. ``ArtifactRegistry`` and ``SqliteArtifactRegistry``
-  both satisfy it.
-- :class:`SqliteExtended` — ``RegistryBase`` plus the 13 SQLite-backed methods
+- :class:`RegistryBase` — the methods :class:`CoordinatorService` (the service
+  layer) depends on. ``ArtifactRegistry`` and ``SqliteArtifactRegistry`` both
+  satisfy it.
+- :class:`SqliteExtended` — ``RegistryBase`` plus the SQLite-backed methods
   ``coordinator_server.py`` depends on (preemption notices, prefix lookups,
   ``resolve_or_register``, ``status_snapshot``, connection ``close``). Only
   ``SqliteArtifactRegistry`` satisfies it today.
@@ -46,34 +46,54 @@ from .retention import RetentionPolicy
 
 # Contract return types — DEFINED here in the contract module and re-exported by
 # the concrete registries (registry.py / sqlite_registry.py import them back).
-# They ARE part of the contract (the return types of its methods); Phase 1
+# They ARE part of the contract (the return types of its methods); this module
 # deduplicated them here (each registry previously defined its own identical copy).
 ReclamationSlot: TypeAlias = tuple[str, int]  # (trigger, tick)
 # WIN = (updated_artifact, invalidated_agent_ids); loss = ConflictDetail;
 # impossible state = CasCorruption. None is raised by the registry.
 CasResult: TypeAlias = "tuple[Artifact, list[UUID]] | ConflictDetail | CasCorruption"
-# Snapshot consistent-cut capture (SB-17 / TX-1): WIN = the pinned cut
+# Snapshot consistent-cut capture: WIN = the pinned cut
 # {artifact_id: version}; a read_set with an unknown id = VersionedReadRejection,
 # NO pins inserted. Neither is raised by the registry.
 CaptureResult: TypeAlias = "dict[UUID, int] | VersionedReadRejection"
+
+# Shared registry trigger constants — DEFINED here (canonical) and re-exported by
+# both registries, which previously each kept an identical copy pinned equal by
+# the dual-registry parity test.
+#
+# RECLAIM_TRIGGERS: the coordinator-side EVICTION triggers (the stable-grant
+# sweep's reclaim_heartbeat / reclaim_max_hold + the transient-timeout fail-safe
+# "timeout"). An M/E -> INVALID transition carrying one of these bumps the
+# artifact's owner_generation (the read-generation fence): the claim was revoked
+# WITHOUT a version move, which version-CAS cannot see. Any other
+# (peer-invalidation) INVALID does NOT bump — that path moves the version, so
+# version-CAS already catches a stale write.
+RECLAIM_TRIGGERS: frozenset[str] = frozenset(
+    {"reclaim_heartbeat", "reclaim_max_hold", "timeout"}
+)
+# CLAIM_CAPTURE_TRIGGERS: triggers marking a GENUINE content read for
+# read-generation capture (the E/M-acquire capture is keyed on the state
+# transition, not the trigger). Service.fetch() emits "fetch"; renaming it
+# without updating this would silently disable capture on reads.
+CLAIM_CAPTURE_TRIGGERS: frozenset[str] = frozenset({"fetch"})
 
 
 @runtime_checkable
 class RegistryBase(Protocol):
     """The registry contract the service layer (:class:`CoordinatorService`)
-    depends on — the 34 methods shared by both the in-memory and SQLite-backed
+    depends on — the methods shared by both the in-memory and SQLite-backed
     registries.
 
-    Extracted in Phase 1 as a PURE REFACTOR (no behavior change): it names the
+    Extracted as a pure refactor (no behavior change): it names the
     previously-implicit duck-type both registries already satisfied. The
     in-memory :class:`~ccs.coordinator.registry.ArtifactRegistry` is the
     canonical shape; the durable
     :class:`~ccs.coordinator.sqlite_registry.SqliteArtifactRegistry` mirrors it.
 
     Note on :meth:`get_content`: the in-memory registry returns ``Optional[str]``
-    while the SQLite registry returns ``Optional[bytes]`` (the KTD-13 contract
-    divergence — SQLite returns ``b""`` for known artifacts). The honest union
-    return type is therefore ``str | bytes | None``.
+    while the SQLite registry returns ``Optional[bytes]`` (it returns ``b""`` for
+    known artifacts). The honest union return type is therefore
+    ``str | bytes | None``.
     """
 
     def abort_guard(self, abort: "Event | None" = None) -> AbstractContextManager[None]:
@@ -230,14 +250,14 @@ class RegistryBase(Protocol):
 @runtime_checkable
 class SqliteExtended(RegistryBase, Protocol):
     """The extended registry surface ``coordinator_server.py`` depends on —
-    :class:`RegistryBase` plus the 13 methods that only the SQLite-backed
+    :class:`RegistryBase` plus the methods that only the SQLite-backed
     registry (:class:`~ccs.coordinator.sqlite_registry.SqliteArtifactRegistry`)
     provides today.
 
     These cover the durable-store-only concerns: connection ``close``, durable
     name/prefix lookups, the preemption-notice surface (record/peek/pop/evict),
     ``resolve_or_register`` first-observation seeding, and the ``status_snapshot``
-    batch. Extracted in Phase 1 as a PURE REFACTOR (no behavior change).
+    batch. Extracted as a pure refactor (no behavior change).
     """
 
     def artifact_names_under_prefix(self, prefix: str) -> list[str]:

--- a/src/ccs/coordinator/registry_protocol.py
+++ b/src/ccs/coordinator/registry_protocol.py
@@ -132,6 +132,16 @@ class RegistryBase(Protocol):
     ) -> CasResult:
         ...
 
+    @property
+    def coordinator_epoch(self) -> str:
+        """Fence token identifying this coordinator incarnation. A ``@property``
+        on both registries; read by :class:`CoordinatorService` on the read-fence
+        and session paths (``read_at_version`` / ``begin_session`` /
+        ``session_read`` / ``session_commit``). Declared here so a backend typed
+        against ``RegistryBase`` cannot omit it and pass ``isinstance`` yet fail
+        at the first fence read."""
+        ...
+
     def get_agent_state(self, artifact_id: UUID, agent_id: UUID) -> MESIState | None:
         ...
 

--- a/src/ccs/coordinator/registry_protocol.py
+++ b/src/ccs/coordinator/registry_protocol.py
@@ -1,0 +1,308 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Structural Protocols for the coordinator's artifact registries.
+
+This module holds the registry CONTRACT the service layer depends on, extracted
+in Phase 1 of the cross-host production-HA journey (PURE REFACTOR — zero
+behavior change). Before this extraction the two registries
+(:class:`ccs.coordinator.registry.ArtifactRegistry` in-memory and
+:class:`ccs.coordinator.sqlite_registry.SqliteArtifactRegistry` durable) were
+duck-typed with NO shared interface; their parity was asserted piecemeal in
+tests.
+
+The two Protocols below name that shared surface explicitly:
+
+- :class:`RegistryBase` — the 34 methods :class:`CoordinatorService` (the
+  service layer) depends on. ``ArtifactRegistry`` and ``SqliteArtifactRegistry``
+  both satisfy it.
+- :class:`SqliteExtended` — ``RegistryBase`` plus the 13 SQLite-backed methods
+  ``coordinator_server.py`` depends on (preemption notices, prefix lookups,
+  ``resolve_or_register``, ``status_snapshot``, connection ``close``). Only
+  ``SqliteArtifactRegistry`` satisfies it today.
+
+Both are :func:`~typing.runtime_checkable` so ``isinstance`` (structural
+presence-of-methods only) and the parity test can verify conformance. The
+registries do NOT inherit these Protocols at runtime — conformance is structural,
+backed by a ``TYPE_CHECKING``-guarded static assertion in each registry module
+and by ``tests/test_registry_protocol_parity.py``.
+
+To avoid an import cycle, this module imports ONLY domain types — never the
+registry classes themselves (the registries import this module's Protocols under
+``TYPE_CHECKING`` for the conformance assertion).
+"""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from threading import Event
+from typing import Any, Iterable, Optional, Protocol, TypeAlias, runtime_checkable
+from uuid import UUID
+
+from ccs.core.states import MESIState, TransientState
+from ccs.core.types import Artifact, CasCorruption, ConflictDetail, VersionedReadRejection
+
+from .retention import RetentionPolicy
+
+# Contract return types — DEFINED here in the contract module and re-exported by
+# the concrete registries (registry.py / sqlite_registry.py import them back).
+# They ARE part of the contract (the return types of its methods); Phase 1
+# deduplicated them here (each registry previously defined its own identical copy).
+ReclamationSlot: TypeAlias = tuple[str, int]  # (trigger, tick)
+# WIN = (updated_artifact, invalidated_agent_ids); loss = ConflictDetail;
+# impossible state = CasCorruption. None is raised by the registry.
+CasResult: TypeAlias = "tuple[Artifact, list[UUID]] | ConflictDetail | CasCorruption"
+# Snapshot consistent-cut capture (SB-17 / TX-1): WIN = the pinned cut
+# {artifact_id: version}; a read_set with an unknown id = VersionedReadRejection,
+# NO pins inserted. Neither is raised by the registry.
+CaptureResult: TypeAlias = "dict[UUID, int] | VersionedReadRejection"
+
+
+@runtime_checkable
+class RegistryBase(Protocol):
+    """The registry contract the service layer (:class:`CoordinatorService`)
+    depends on — the 34 methods shared by both the in-memory and SQLite-backed
+    registries.
+
+    Extracted in Phase 1 as a PURE REFACTOR (no behavior change): it names the
+    previously-implicit duck-type both registries already satisfied. The
+    in-memory :class:`~ccs.coordinator.registry.ArtifactRegistry` is the
+    canonical shape; the durable
+    :class:`~ccs.coordinator.sqlite_registry.SqliteArtifactRegistry` mirrors it.
+
+    Note on :meth:`get_content`: the in-memory registry returns ``Optional[str]``
+    while the SQLite registry returns ``Optional[bytes]`` (the KTD-13 contract
+    divergence — SQLite returns ``b""`` for known artifacts). The honest union
+    return type is therefore ``str | bytes | None``.
+    """
+
+    def abort_guard(self, abort: "Event | None" = None) -> AbstractContextManager[None]:
+        ...
+
+    def all_session_meta(self) -> "dict[str, tuple[UUID, int]]":
+        ...
+
+    def artifact_ids(self) -> list[UUID]:
+        ...
+
+    def capture_version_vector(
+        self,
+        read_set: "Iterable[UUID]",
+        session_token: str,
+        *,
+        owner: "UUID | None" = None,
+        created_at_tick: int | None = None,
+    ) -> CaptureResult:
+        ...
+
+    def clear_agent_transient(self, artifact_id: UUID, agent_id: UUID) -> None:
+        ...
+
+    def commit_cas(
+        self,
+        artifact_id: UUID,
+        agent_id: UUID,
+        *,
+        expected_version: int,
+        content_hash: str,
+        size_tokens: int | None = None,
+        content: bytes | str | None = None,
+        tick: int = 0,
+        trigger: str = "commit_cas",
+    ) -> CasResult:
+        ...
+
+    def get_agent_state(self, artifact_id: UUID, agent_id: UUID) -> MESIState | None:
+        ...
+
+    def get_agent_transient(self, artifact_id: UUID, agent_id: UUID) -> TransientState | None:
+        ...
+
+    def get_artifact(self, artifact_id: UUID) -> Optional[Artifact]:
+        ...
+
+    def get_content(self, artifact_id: UUID) -> str | bytes | None:
+        ...
+
+    def get_content_at_version(self, artifact_id: UUID, version: int) -> str | bytes | None:
+        ...
+
+    def get_last_reclamation(
+        self, agent_id: UUID, artifact_id: UUID
+    ) -> ReclamationSlot | None:
+        ...
+
+    def get_owner_generation(self, artifact_id: UUID) -> int:
+        ...
+
+    def get_read_generation(self, artifact_id: UUID, agent_id: UUID) -> int | None:
+        ...
+
+    def get_session_cut(self, session_token: str) -> dict[UUID, int] | None:
+        ...
+
+    def get_session_meta(self, session_token: str) -> "tuple[UUID, int] | None":
+        ...
+
+    def get_state_map(self, artifact_id: UUID) -> dict[UUID, MESIState]:
+        ...
+
+    def get_transient_map(self, artifact_id: UUID) -> dict[UUID, TransientState]:
+        ...
+
+    def get_transient_tick(self, artifact_id: UUID, agent_id: UUID) -> int | None:
+        ...
+
+    def get_version_record(
+        self, artifact_id: UUID, version: int
+    ) -> tuple[str | bytes, float] | None:
+        ...
+
+    def granted_at_tick(self, agent_id: UUID, artifact_id: UUID) -> int | None:
+        ...
+
+    def has_artifact(self, artifact_id: UUID) -> bool:
+        ...
+
+    def last_heartbeat_tick(self, agent_id: UUID) -> int | None:
+        ...
+
+    def record_heartbeat(self, agent_id: UUID, now_tick: int) -> None:
+        ...
+
+    def record_last_reclamation(
+        self, agent_id: UUID, artifact_id: UUID, trigger: str, tick: int
+    ) -> None:
+        ...
+
+    def register_artifact(self, artifact: Artifact, content: str) -> None:
+        ...
+
+    def release_session(self, session_token: str) -> None:
+        ...
+
+    def remove_artifact(self, artifact_id: UUID) -> None:
+        ...
+
+    def retention_meta(self) -> tuple[bool, RetentionPolicy | None]:
+        ...
+
+    def session_count(self) -> int:
+        ...
+
+    def set_agent_state(
+        self,
+        artifact_id: UUID,
+        agent_id: UUID,
+        state: MESIState,
+        *,
+        trigger: str = "unknown",
+        tick: int = 0,
+        content_hash: str | None = None,
+    ) -> None:
+        ...
+
+    def set_agent_transient(
+        self,
+        artifact_id: UUID,
+        agent_id: UUID,
+        transient_state: TransientState,
+        *,
+        entered_tick: int,
+    ) -> None:
+        ...
+
+    def set_artifact_and_content(
+        self,
+        artifact_id: UUID,
+        artifact: Artifact,
+        content: str,
+        *,
+        last_writer: Optional[UUID] = None,
+        fence_agent_id: Optional[UUID] = None,
+    ) -> None:
+        ...
+
+    def valid_holders(self, artifact_id: UUID) -> list[UUID]:
+        ...
+
+
+@runtime_checkable
+class SqliteExtended(RegistryBase, Protocol):
+    """The extended registry surface ``coordinator_server.py`` depends on —
+    :class:`RegistryBase` plus the 13 methods that only the SQLite-backed
+    registry (:class:`~ccs.coordinator.sqlite_registry.SqliteArtifactRegistry`)
+    provides today.
+
+    These cover the durable-store-only concerns: connection ``close``, durable
+    name/prefix lookups, the preemption-notice surface (record/peek/pop/evict),
+    ``resolve_or_register`` first-observation seeding, and the ``status_snapshot``
+    batch. Extracted in Phase 1 as a PURE REFACTOR (no behavior change).
+    """
+
+    def artifact_names_under_prefix(self, prefix: str) -> list[str]:
+        ...
+
+    def artifacts_held_by_agent(
+        self, agent_id: UUID, states: Iterable[MESIState]
+    ) -> list[UUID]:
+        ...
+
+    def close(self) -> None:
+        ...
+
+    def evict_stale_notices(
+        self, *, max_age_sec: float, now_unix: Optional[float] = None
+    ) -> int:
+        ...
+
+    def get_artifact_updated_at(self, artifact_id: UUID) -> Optional[float]:
+        ...
+
+    def last_writer_for(self, artifact_id: UUID) -> Optional[UUID]:
+        ...
+
+    def lookup_artifact_id_by_name(self, parent_rel_path: str) -> UUID | None:
+        ...
+
+    def peek_preemption_notice(
+        self, agent_id: UUID, artifact_id: UUID
+    ) -> Optional[tuple[UUID, float]]:
+        ...
+
+    def pop_pending_notices(
+        self, agent_id: UUID
+    ) -> list[tuple[UUID, UUID, float]]:
+        ...
+
+    def pop_preemption_notice(
+        self, agent_id: UUID, artifact_id: UUID
+    ) -> Optional[tuple[UUID, float]]:
+        ...
+
+    def record_preemption_notice(
+        self,
+        *,
+        victim_agent_id: UUID,
+        artifact_id: UUID,
+        preempter_agent_id: UUID,
+        preempted_at_unix_ts: float,
+    ) -> None:
+        ...
+
+    def resolve_or_register(
+        self,
+        parent_rel_path: str,
+        content_hash: str,
+        *,
+        initial_owner: Optional[UUID] = None,
+    ) -> UUID:
+        ...
+
+    def status_snapshot(
+        self,
+    ) -> tuple[
+        dict[UUID, dict[str, Any]],
+        dict[UUID, dict[UUID, MESIState]],
+    ]:
+        ...

--- a/src/ccs/coordinator/service.py
+++ b/src/ccs/coordinator/service.py
@@ -56,7 +56,7 @@ from ccs.core.types import (
     VersionedReadRejection,
 )
 
-from .registry import ArtifactRegistry
+from .registry_protocol import RegistryBase
 
 logger = logging.getLogger(__name__)
 
@@ -363,7 +363,7 @@ class CoordinatorService:
 
     def __init__(
         self,
-        registry: ArtifactRegistry,
+        registry: RegistryBase,
         *,
         session_caps: SessionCapsConfig | None = None,
     ):

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -106,9 +106,15 @@ from ccs.core.types import (
 )
 
 # Contract return types (ReclamationSlot / CasResult / CaptureResult) live in the
-# Protocol module (Phase 1 dedup); re-exported here so existing
-# `from .sqlite_registry import CasResult` importers keep working.
-from .registry_protocol import CaptureResult, CasResult, ReclamationSlot
+# Protocol module (deduplicated there); re-exported here to keep
+# `ccs.coordinator.sqlite_registry.CasResult` a stable public import path.
+from .registry_protocol import (
+    CLAIM_CAPTURE_TRIGGERS,
+    RECLAIM_TRIGGERS,
+    CaptureResult,
+    CasResult,
+    ReclamationSlot,
+)
 from .retention import RetentionPolicy, collectible_versions
 
 logger = logging.getLogger(__name__)
@@ -252,20 +258,6 @@ CREATE TABLE session_meta (
     created_at_tick INTEGER NOT NULL
 )
 """
-
-# Coordinator-side eviction triggers (the stable-grant sweep's two reclaim
-# triggers + the transient-timeout fail-safe) — an M/E -> INVALID carrying one
-# of these bumps the artifact's owner_generation (read-generation fence): the
-# claim was revoked without a version move, which version-CAS cannot see.
-# Duplicated from registry.py (the two registries share no base class); the
-# dual-registry parity test pins them equal.
-RECLAIM_TRIGGERS: frozenset[str] = frozenset(
-    {"reclaim_heartbeat", "reclaim_max_hold", "timeout"}
-)
-
-# Genuine-content-read triggers for read-generation capture (mirrors
-# registry.py; pinned equal by the parity test). Service.fetch() emits "fetch".
-CLAIM_CAPTURE_TRIGGERS: frozenset[str] = frozenset({"fetch"})
 
 # registry_meta keys persisting the retention policy on writer open (plan item
 # N v1, Unit 3). ``retention_enabled`` is the explicit marker set even in the

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -84,7 +84,7 @@ import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterable, Iterator, NoReturn, Optional, TypeAlias
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, NoReturn, Optional
 from uuid import UUID, uuid4
 
 from ccs.core.exceptions import (
@@ -105,6 +105,10 @@ from ccs.core.types import (
     VersionedReadRejection,
 )
 
+# Contract return types (ReclamationSlot / CasResult / CaptureResult) live in the
+# Protocol module (Phase 1 dedup); re-exported here so existing
+# `from .sqlite_registry import CasResult` importers keep working.
+from .registry_protocol import CaptureResult, CasResult, ReclamationSlot
 from .retention import RetentionPolicy, collectible_versions
 
 logger = logging.getLogger(__name__)
@@ -177,7 +181,6 @@ never exists at a broader umask mode; the migration re-applies it (and warns
 once) to an operator-broadened pre-existing db. Mirrors
 ``adapters/claude_code/audit_log.py:_REQUIRED_MODE``."""
 
-ReclamationSlot: TypeAlias = tuple[str, int]
 _M_OR_E_STATES: frozenset[MESIState] = frozenset({MESIState.MODIFIED, MESIState.EXCLUSIVE})
 
 # Durable version-retention table (plan item N v1, Unit 3). One row per
@@ -287,18 +290,6 @@ _META_RETENTION_MAX_AGE_SECONDS = "retention_max_age_seconds"
 _META_SCHEMA_RUNTIME = "schema_runtime"
 _SCHEMA_RUNTIME_STAMP = "python"
 
-# OCC commit-CAS result (plan Unit 2). A WIN is ``(updated_artifact,
-# invalidated_agent_ids)`` — the service layer turns the id list into
-# ``InvalidationSignal``s. A loss is a typed ``ConflictDetail`` (retry-eligible,
-# no mutation). ``CasCorruption`` is the impossible-state sentinel the service
-# maps to ``CoherenceError``. None of these is raised by the registry.
-CasResult: TypeAlias = "tuple[Artifact, list[UUID]] | ConflictDetail | CasCorruption"
-
-# Snapshot consistent-cut capture result (SB-17 / TX-1, Unit 2 / R1) — parity
-# with ArtifactRegistry.capture_version_vector. WIN = the pinned cut
-# ``{artifact_id: version}``; an unknown id = VersionedReadRejection
-# (``unknown_artifact``) with NO pins inserted. Neither is raised.
-CaptureResult: TypeAlias = "dict[UUID, int] | VersionedReadRejection"
 
 
 class SchemaVersionError(RuntimeError):
@@ -3208,3 +3199,15 @@ class SqliteArtifactRegistry:
         )
         last_writer_id = UUID(hex=row[4]) if row[4] else None
         return _ArtifactRow(artifact=artifact, last_writer_id=last_writer_id)
+
+
+if TYPE_CHECKING:
+    # Static conformance assertion (Phase 1, zero runtime change): a type checker
+    # rejects this if ``SqliteArtifactRegistry`` ever drifts from the
+    # ``SqliteExtended`` contract ``coordinator_server.py`` depends on. Structural
+    # (no runtime inheritance); no import cycle (registry_protocol imports only
+    # domain types).
+    from .registry_protocol import SqliteExtended
+
+    def _conforms(r: SqliteArtifactRegistry) -> SqliteExtended:
+        return r

--- a/tests/test_registry_protocol_parity.py
+++ b/tests/test_registry_protocol_parity.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Full-surface conformance contract for the registry Protocols (Phase 1).
+
+Before the Phase-1 extraction the two registries
+(:class:`~ccs.coordinator.registry.ArtifactRegistry` and
+:class:`~ccs.coordinator.sqlite_registry.SqliteArtifactRegistry`) shared no base
+class and their parity was asserted piecemeal (one behaviour at a time). This
+module pins the WHOLE surface:
+
+- both registries are ``isinstance`` of :class:`RegistryBase`, and the SQLite one
+  is additionally ``isinstance`` of :class:`SqliteExtended`;
+- the exact expected method names (34 base + 13 extended) are present + callable
+  on each registry;
+- each registry method's parameter STRUCTURE (names, kinds, defaults — annotation
+  strings ignored, since ``from __future__ import annotations`` stringifies them
+  and they legitimately differ, e.g. ``get_content``'s ``str`` vs ``bytes``)
+  matches the Protocol method's;
+- a deliberately-incomplete stub missing one base method is NOT
+  ``isinstance(RegistryBase)`` — proving conformance has teeth;
+- :class:`CoordinatorService` (typed against :class:`RegistryBase`) works with a
+  real registry end-to-end (register + read smoke).
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterator
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.registry_protocol import RegistryBase, SqliteExtended
+from ccs.coordinator.service import CoordinatorService
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.types import Artifact, FetchRequest
+
+# The full expected surface, frozen here as the contract (not derived from the
+# Protocol at runtime so a silent Protocol edit cannot also silently move the
+# goalposts this test guards).
+BASE_METHODS = frozenset(
+    {
+        "abort_guard",
+        "all_session_meta",
+        "artifact_ids",
+        "capture_version_vector",
+        "clear_agent_transient",
+        "commit_cas",
+        "get_agent_state",
+        "get_agent_transient",
+        "get_artifact",
+        "get_content",
+        "get_content_at_version",
+        "get_last_reclamation",
+        "get_owner_generation",
+        "get_read_generation",
+        "get_session_cut",
+        "get_session_meta",
+        "get_state_map",
+        "get_transient_map",
+        "get_transient_tick",
+        "get_version_record",
+        "granted_at_tick",
+        "has_artifact",
+        "last_heartbeat_tick",
+        "record_heartbeat",
+        "record_last_reclamation",
+        "register_artifact",
+        "release_session",
+        "remove_artifact",
+        "retention_meta",
+        "session_count",
+        "set_agent_state",
+        "set_agent_transient",
+        "set_artifact_and_content",
+        "valid_holders",
+    }
+)
+
+EXTENDED_ONLY_METHODS = frozenset(
+    {
+        "artifact_names_under_prefix",
+        "artifacts_held_by_agent",
+        "close",
+        "evict_stale_notices",
+        "get_artifact_updated_at",
+        "last_writer_for",
+        "lookup_artifact_id_by_name",
+        "peek_preemption_notice",
+        "pop_pending_notices",
+        "pop_preemption_notice",
+        "record_preemption_notice",
+        "resolve_or_register",
+        "status_snapshot",
+    }
+)
+
+
+@pytest.fixture
+def inmem_registry() -> ArtifactRegistry:
+    return ArtifactRegistry()
+
+
+@pytest.fixture
+def sqlite_registry(tmp_path: Path) -> Iterator[SqliteArtifactRegistry]:
+    reg = SqliteArtifactRegistry(tmp_path / "parity.db")
+    yield reg
+    reg.close()
+
+
+def _param_structure(func: object) -> list[tuple[str, object, object]]:
+    """Return ``(name, kind, default)`` per parameter, EXCLUDING ``self`` and
+    annotations. Annotations are excluded on purpose: ``from __future__
+    import annotations`` makes them strings that legitimately differ between a
+    registry and the Protocol (and between the two registries), so structure —
+    names + kinds + defaults — is the conformance invariant we pin."""
+    sig = inspect.signature(func)  # type: ignore[arg-type]
+    return [
+        (name, p.kind, p.default)
+        for name, p in sig.parameters.items()
+        if name != "self"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# isinstance — structural conformance via the runtime_checkable Protocols
+# ---------------------------------------------------------------------------
+
+
+def test_inmem_registry_is_registry_base(inmem_registry: ArtifactRegistry) -> None:
+    assert isinstance(inmem_registry, RegistryBase)
+
+
+def test_sqlite_registry_is_registry_base(
+    sqlite_registry: SqliteArtifactRegistry,
+) -> None:
+    assert isinstance(sqlite_registry, RegistryBase)
+
+
+def test_sqlite_registry_is_sqlite_extended(
+    sqlite_registry: SqliteArtifactRegistry,
+) -> None:
+    assert isinstance(sqlite_registry, SqliteExtended)
+
+
+# ---------------------------------------------------------------------------
+# Full expected surface — names present + callable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", sorted(BASE_METHODS))
+def test_base_method_present_on_inmem(
+    inmem_registry: ArtifactRegistry, name: str
+) -> None:
+    assert callable(getattr(inmem_registry, name))
+
+
+@pytest.mark.parametrize("name", sorted(BASE_METHODS))
+def test_base_method_present_on_sqlite(
+    sqlite_registry: SqliteArtifactRegistry, name: str
+) -> None:
+    assert callable(getattr(sqlite_registry, name))
+
+
+@pytest.mark.parametrize("name", sorted(EXTENDED_ONLY_METHODS))
+def test_extended_method_present_on_sqlite(
+    sqlite_registry: SqliteArtifactRegistry, name: str
+) -> None:
+    assert callable(getattr(sqlite_registry, name))
+
+
+def test_protocol_surface_matches_expected_names() -> None:
+    """The Protocols expose EXACTLY the frozen expected names (no drift)."""
+    base_names = {
+        n
+        for n in dir(RegistryBase)
+        if not n.startswith("_") and callable(getattr(RegistryBase, n))
+    }
+    extended_names = {
+        n
+        for n in dir(SqliteExtended)
+        if not n.startswith("_") and callable(getattr(SqliteExtended, n))
+    }
+    assert base_names == BASE_METHODS
+    assert extended_names == BASE_METHODS | EXTENDED_ONLY_METHODS
+
+
+# ---------------------------------------------------------------------------
+# Parameter STRUCTURE parity (names + kinds + defaults; annotations ignored)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", sorted(BASE_METHODS))
+def test_inmem_base_method_structure_matches_protocol(
+    inmem_registry: ArtifactRegistry, name: str
+) -> None:
+    proto = getattr(RegistryBase, name)
+    impl = getattr(type(inmem_registry), name)
+    assert _param_structure(impl) == _param_structure(proto)
+
+
+@pytest.mark.parametrize("name", sorted(BASE_METHODS))
+def test_sqlite_base_method_structure_matches_protocol(
+    sqlite_registry: SqliteArtifactRegistry, name: str
+) -> None:
+    proto = getattr(RegistryBase, name)
+    impl = getattr(type(sqlite_registry), name)
+    assert _param_structure(impl) == _param_structure(proto)
+
+
+@pytest.mark.parametrize("name", sorted(EXTENDED_ONLY_METHODS))
+def test_sqlite_extended_method_structure_matches_protocol(
+    sqlite_registry: SqliteArtifactRegistry, name: str
+) -> None:
+    proto = getattr(SqliteExtended, name)
+    impl = getattr(type(sqlite_registry), name)
+    assert _param_structure(impl) == _param_structure(proto)
+
+
+# ---------------------------------------------------------------------------
+# Teeth — an incomplete stub is rejected
+# ---------------------------------------------------------------------------
+
+
+def test_incomplete_stub_is_not_registry_base() -> None:
+    """A class implementing every base method EXCEPT one is not an instance of
+    RegistryBase — so the structural check actually discriminates."""
+
+    class _AlmostRegistry:
+        pass
+
+    # Attach every base method except a deliberately-omitted one.
+    omitted = "commit_cas"
+    for name in BASE_METHODS:
+        if name == omitted:
+            continue
+        setattr(_AlmostRegistry, name, lambda self, *a, **k: None)
+
+    instance = _AlmostRegistry()
+    assert not hasattr(instance, omitted)
+    assert not isinstance(instance, RegistryBase)
+
+
+# ---------------------------------------------------------------------------
+# Service smoke — CoordinatorService (typed RegistryBase) drives a real registry
+# ---------------------------------------------------------------------------
+
+
+def test_service_against_protocol_typed_registry_smoke() -> None:
+    """CoordinatorService is constructed against the RegistryBase parameter type
+    and a trivial register/read round-trips through it."""
+    registry: RegistryBase = ArtifactRegistry()
+    svc = CoordinatorService(registry)
+
+    artifact = svc.register_artifact(name="plan.md", content="seed-v1")
+    assert isinstance(artifact, Artifact)
+
+    resp = svc.fetch(
+        FetchRequest(
+            artifact_id=artifact.id,
+            requesting_agent_id=uuid4(),
+            requested_at_tick=1,
+        )
+    )
+    assert resp.content == "seed-v1"
+    assert resp.version == artifact.version

--- a/tests/test_registry_protocol_parity.py
+++ b/tests/test_registry_protocol_parity.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 agent-coherence contributors.
 # The Coherence Protocol for AI Agents
 
-"""Full-surface conformance contract for the registry Protocols (Phase 1).
+"""Full-surface conformance contract for the registry Protocols.
 
 Before the Phase-1 extraction the two registries
 (:class:`~ccs.coordinator.registry.ArtifactRegistry` and
@@ -242,6 +242,23 @@ def test_incomplete_stub_is_not_registry_base() -> None:
     instance = _AlmostRegistry()
     assert not hasattr(instance, omitted)
     assert not isinstance(instance, RegistryBase)
+
+
+def test_full_base_but_incomplete_extended_is_not_sqlite_extended() -> None:
+    """A class with every RegistryBase method AND every SqliteExtended method
+    EXCEPT one is RegistryBase but NOT SqliteExtended — the extended surface
+    discriminates too, not just the base."""
+
+    class _AlmostSqlite:
+        pass
+
+    omitted = "status_snapshot"
+    for name in BASE_METHODS | (EXTENDED_ONLY_METHODS - {omitted}):
+        setattr(_AlmostSqlite, name, lambda self, *a, **k: None)
+
+    instance = _AlmostSqlite()
+    assert isinstance(instance, RegistryBase)  # full base surface present
+    assert not isinstance(instance, SqliteExtended)  # missing one extended method
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registry_protocol_parity.py
+++ b/tests/test_registry_protocol_parity.py
@@ -12,7 +12,9 @@ module pins the WHOLE surface:
 - both registries are ``isinstance`` of :class:`RegistryBase`, and the SQLite one
   is additionally ``isinstance`` of :class:`SqliteExtended`;
 - the exact expected method names (34 base + 13 extended) are present + callable
-  on each registry;
+  on each registry, and the base **property** members (e.g. ``coordinator_epoch``)
+  are present as properties — the callable checks cannot see them, so they are
+  pinned separately;
 - each registry method's parameter STRUCTURE (names, kinds, defaults — annotation
   strings ignored, since ``from __future__ import annotations`` stringifies them
   and they legitimately differ, e.g. ``get_content``'s ``str`` vs ``bytes``)
@@ -97,6 +99,13 @@ EXTENDED_ONLY_METHODS = frozenset(
         "status_snapshot",
     }
 )
+
+# Property members of the base contract. The method checks below filter by
+# callable(), so a ``@property`` is structurally invisible to them; pin
+# properties explicitly so a backend typed against RegistryBase cannot omit one,
+# pass ``isinstance``, and still fail at runtime (e.g. ``coordinator_epoch`` on
+# the read-fence path).
+BASE_PROPERTIES = frozenset({"coordinator_epoch"})
 
 
 @pytest.fixture
@@ -186,6 +195,40 @@ def test_protocol_surface_matches_expected_names() -> None:
     }
     assert base_names == BASE_METHODS
     assert extended_names == BASE_METHODS | EXTENDED_ONLY_METHODS
+    base_props = {
+        n
+        for n in dir(RegistryBase)
+        if not n.startswith("_") and isinstance(getattr(RegistryBase, n, None), property)
+    }
+    assert base_props == BASE_PROPERTIES
+
+
+# ---------------------------------------------------------------------------
+# Property members — the non-callable contract surface (coordinator_epoch, …).
+# The method checks filter by callable(), so a @property is invisible to them;
+# pinned separately so a RegistryBase-typed backend cannot omit one silently.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", sorted(BASE_PROPERTIES))
+def test_base_property_declared_on_protocol(name: str) -> None:
+    assert isinstance(getattr(RegistryBase, name, None), property)
+
+
+@pytest.mark.parametrize("name", sorted(BASE_PROPERTIES))
+def test_base_property_present_on_inmem(
+    inmem_registry: ArtifactRegistry, name: str
+) -> None:
+    assert isinstance(getattr(type(inmem_registry), name, None), property)
+    assert isinstance(getattr(inmem_registry, name), str)
+
+
+@pytest.mark.parametrize("name", sorted(BASE_PROPERTIES))
+def test_base_property_present_on_sqlite(
+    sqlite_registry: SqliteArtifactRegistry, name: str
+) -> None:
+    assert isinstance(getattr(type(sqlite_registry), name, None), property)
+    assert isinstance(getattr(sqlite_registry, name), str)
 
 
 # ---------------------------------------------------------------------------
@@ -255,10 +298,31 @@ def test_full_base_but_incomplete_extended_is_not_sqlite_extended() -> None:
     omitted = "status_snapshot"
     for name in BASE_METHODS | (EXTENDED_ONLY_METHODS - {omitted}):
         setattr(_AlmostSqlite, name, lambda self, *a, **k: None)
+    for prop in BASE_PROPERTIES:  # full base surface includes the property members
+        setattr(_AlmostSqlite, prop, property(lambda self: "epoch-0"))
 
     instance = _AlmostSqlite()
     assert isinstance(instance, RegistryBase)  # full base surface present
     assert not isinstance(instance, SqliteExtended)  # missing one extended method
+
+
+def test_stub_missing_base_property_is_not_registry_base() -> None:
+    """A class with every base METHOD but missing a base @property
+    (``coordinator_epoch``) is NOT RegistryBase — the property is part of the
+    contract, so a future backend cannot omit it and still pass ``isinstance``.
+    This is the regression guard for the gap where the Protocol declared only
+    methods and a conforming-per-isinstance backend would AttributeError on the
+    first fence read."""
+
+    class _NoEpoch:
+        pass
+
+    for name in BASE_METHODS:
+        setattr(_NoEpoch, name, lambda self, *a, **k: None)
+    # deliberately omit BASE_PROPERTIES (coordinator_epoch)
+    instance = _NoEpoch()
+    assert not any(hasattr(instance, p) for p in BASE_PROPERTIES)
+    assert not isinstance(instance, RegistryBase)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Pure refactor (zero behavior change): give the two duck-typed coordinator registries (`ArtifactRegistry` in-memory, `SqliteArtifactRegistry` durable) an explicit `Protocol` interface, so a future pluggable backend can slot behind the service layer without reimplementing it.

- **New `registry_protocol.py`** — `RegistryBase` (the 34-method surface `CoordinatorService` depends on) + `SqliteExtended(RegistryBase)` (the 13 SQLite-only methods `coordinator_server.py` uses), both `@runtime_checkable`.
- The contract return types `CasResult` / `CaptureResult` / `ReclamationSlot` now live in the Protocol module and are re-exported by the registries — **deduplicating `CasResult`**, which was copied in both.
- **`service.py`** types its `registry` dependency on `RegistryBase` (no longer the concrete class).
- Both registries declare conformance via a `TYPE_CHECKING` static assertion.
- **New full-surface conformance contract** (`tests/test_registry_protocol_parity.py`) replacing the previous piecemeal parity: `isinstance` checks, the full 34/13 method surface, parameter-structure parity (annotations ignored, so the `get_content` `str`/`bytes` divergence is handled cleanly), an incomplete-stub rejection (so the check has teeth), and a `CoordinatorService`-typed-on-`RegistryBase` smoke.

## Test plan

- [x] Full suite: **2,617 passed**, 3 skipped
- [x] `ruff` clean (5 files)
- [x] No architecture cycle/boundary violation (`test_architecture.py`)
- [x] New conformance contract passes; both registries conform

Scope: exactly 5 files (2 new, 3 small edits). The single-host path is byte-unchanged.
