### PR TITLE
feat: fail-closed plaintext-bearer transport guard (client-side)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -24,6 +24,19 @@ and the coordinator only binds beyond loopback to an RFC-1918/4193 address (see 
 cross-host demo, `examples/cross_host/`). With the flag unset the zero-outbound
 posture above is unchanged.
 
+**Plaintext-bearer guard (fail-closed, cross-host mode).** The remote transport is
+plaintext HTTP — the coordinator terminates no TLS, so encryption is the operator's
+out-of-band responsibility (a WireGuard tunnel or a TLS-terminating proxy). To stop
+a bearer from silently crossing an unencrypted routed link, the client **refuses to
+send it to a non-loopback host unless `CCS_REMOTE_INSECURE=1`** is set — an explicit
+acknowledgement that the link is secured out-of-band (a typed
+`InsecureTransportRefused` is raised otherwise). Loopback is unaffected. This
+*reduces* the silent-plaintext footgun; it does **not** guarantee encryption. Set
+the ack **narrowly** (per-invocation / per-compose-service), never in a persistent
+global shell profile — a forgotten global ack would blanket-acknowledge every
+future non-loopback host. Production TLS/mTLS termination is a separate hardening
+step.
+
 ## Env-var kill switches
 
 Set any of these to a truthy value (`1`, `true`, `yes`) to disable

--- a/examples/cross_host/README.md
+++ b/examples/cross_host/README.md
@@ -83,11 +83,18 @@ export CCS_REMOTE_COORDINATOR=1
 export CCS_REMOTE_HOST=10.0.0.1
 export CCS_REMOTE_PORT=<port from host 1>
 export CCS_REMOTE_SECRET_FILE=/path/to/mounted/hook.secret   # provisioned out-of-band; never inline
+export CCS_REMOTE_INSECURE=1   # acknowledge the plaintext-HTTP bearer over your encrypted link (see Security boundary)
 python examples/cross_host/main.py
 ```
 
 The client connects (never spawning a local coordinator), runs both clients (A
-and B), and exits `0` on a denied-then-recovered stale write.
+and B), and exits `0` on a denied-then-recovered stale write. The same two roles
+run under the "Linux netns variant" below — set `CCS_REMOTE_INSECURE=1` there too.
+
+`CCS_REMOTE_HOST` is non-loopback, so the client **fails closed** and refuses to
+send its bearer over plaintext HTTP unless you set `CCS_REMOTE_INSECURE=1` — the
+explicit acknowledgement that *you* have secured the link out-of-band (the
+encrypted tunnel above). A loopback host needs no acknowledgement.
 
 ### Docker (recommended — genuine cross-container, one command, verified)
 
@@ -122,3 +129,14 @@ validated to RFC-1918/4193 (wildcard, loopback aliases, link-local, CGNAT, and
 public addresses are all rejected); the bearer secret is provisioned via a
 confidential channel (never an inline env var — it would leak in `ps` /
 `docker inspect`); and the link is encrypted.
+
+**Plaintext-bearer guard (fail-closed).** The transport is plaintext HTTP — the
+coordinator has no TLS; encryption is *your* out-of-band responsibility (a
+WireGuard tunnel, a TLS-terminating proxy, or the isolated Docker bridge here). To
+stop a silent leak, the client **refuses to send the bearer to a non-loopback host
+unless you set `CCS_REMOTE_INSECURE=1`** — an explicit acknowledgement that the
+link is secured. It *reduces* the silent-plaintext footgun; it does not *guarantee*
+encryption. Set it **narrowly** (per-invocation or per-compose-service), not in a
+persistent global shell profile — a forgotten global ack would blanket-acknowledge
+every future non-loopback host. Production hardening (TLS/mTLS termination) is
+tracked separately.

--- a/examples/cross_host/docker/docker-compose.yml
+++ b/examples/cross_host/docker/docker-compose.yml
@@ -40,6 +40,10 @@ services:
       CCS_REMOTE_COORDINATOR: "1"
       CCS_REMOTE_HOST: 172.28.0.2
       CCS_REMOTE_SECRET_FILE: /coord/.coherence/hook.secret
+      # 172.28.0.2 is non-loopback: the client refuses to send its bearer over
+      # plaintext HTTP unless we acknowledge the link is secured out-of-band. Here
+      # that link is the isolated private-range Docker bridge — declared explicitly.
+      CCS_REMOTE_INSECURE: "1"
     command:
       - python
       - /app/examples/cross_host/docker/client_entry.py

--- a/src/ccs/cli/_coherence_client.py
+++ b/src/ccs/cli/_coherence_client.py
@@ -24,6 +24,7 @@ import os
 import sys
 import urllib.error
 import urllib.request
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -152,6 +153,14 @@ class CoordinatorEndpoint:
 
     @property
     def base_url(self) -> str:
+        # Bracket an IPv6 literal so the authority parses: http://[::1]:8080, not
+        # the ambiguous http://::1:8080 (urllib reads the last colon as the port
+        # separator). A hostname / IPv4 raises ValueError -> no brackets.
+        try:
+            if ipaddress.ip_address(self.host).version == 6:
+                return f"http://[{self.host}]:{self.port}"
+        except ValueError:
+            pass
         return f"http://{self.host}:{self.port}"
 
 
@@ -197,25 +206,36 @@ def resolve_endpoint(coordinator_root: Path) -> CoordinatorEndpoint:
     return CoordinatorEndpoint(port=port, bearer=bearer)
 
 
+#: Truthy env values that enable cross-host remote mode (mirrors the
+#: telemetry kill-switch parser). Everything else (incl. "" and "0") is OFF.
+_REMOTE_TRUTHY_ENV_VALUES: frozenset[str] = frozenset({"1", "true", "yes", "on"})
+
+
 def _is_loopback_transport_host(host: str) -> bool:
     """True for hosts that may receive a bearer over plaintext HTTP WITHOUT an ack.
 
     Broader than the Host-allowlist :func:`~ccs.adapters.claude_code.auth.is_loopback_host`:
     covers ``127.0.0.0/8`` and ``::1`` (via :mod:`ipaddress`) plus ``"localhost"``.
-    ``ipaddress.is_loopback`` also correctly resolves IPv4-mapped forms — mapped
-    loopback (``::ffff:127.0.0.1``) is loopback, while mapped-public
-    (``::ffff:8.8.8.8``) is not, so there is no bypass. A non-IP hostname (a name we
-    cannot classify) is treated as NON-loopback, so the guard fails closed on it.
+    IPv4-mapped IPv6 forms (``::ffff:127.0.0.1``) are treated as NON-loopback and
+    require the ack: ``is_loopback`` for the mapped form varies across CPython patch
+    releases, so we classify it deterministically as non-loopback rather than depend
+    on the stdlib version (fail-closed either way — genuine local dev uses
+    ``127.0.0.1`` / ``::1``). A non-IP hostname (a name we cannot classify) is
+    likewise NON-loopback, so the guard fails closed on it.
     """
     if host == "localhost":
         return True
     try:
-        return ipaddress.ip_address(host).is_loopback
+        ip = ipaddress.ip_address(host)
     except ValueError:
         return False
+    # IPv4-mapped IPv6 (::ffff:a.b.c.d): fail closed deterministically (see above).
+    if getattr(ip, "ipv4_mapped", None) is not None:
+        return False
+    return ip.is_loopback
 
 
-def _guard_plaintext_bearer(host: str, env: dict[str, str]) -> None:
+def _guard_plaintext_bearer(host: str, env: Mapping[str, str]) -> None:
     """Fail closed on a plaintext bearer to a non-loopback host (Phase-1.5 guard).
 
     The remote transport is always ``http://`` (encryption is operator-provided
@@ -239,7 +259,7 @@ def _guard_plaintext_bearer(host: str, env: dict[str, str]) -> None:
 
 
 def resolve_remote_endpoint(
-    host: str, port: int, secret: str, *, env: dict[str, str] | None = None
+    host: str, port: int, secret: str, *, env: Mapping[str, str] | None = None
 ) -> CoordinatorEndpoint:
     """Build an endpoint for a REMOTE coordinator (cross-host demo).
 
@@ -260,11 +280,6 @@ def resolve_remote_endpoint(
         raise CoordinatorUnavailable("remote coordinator bearer secret is empty")
     _guard_plaintext_bearer(host, os.environ if env is None else env)
     return CoordinatorEndpoint(port=port, bearer=secret, host=host)
-
-
-#: Truthy env values that enable cross-host remote mode (mirrors the
-#: telemetry kill-switch parser). Everything else (incl. "" and "0") is OFF.
-_REMOTE_TRUTHY_ENV_VALUES: frozenset[str] = frozenset({"1", "true", "yes", "on"})
 
 
 @dataclass(frozen=True)

--- a/src/ccs/cli/_coherence_client.py
+++ b/src/ccs/cli/_coherence_client.py
@@ -17,6 +17,7 @@ print a one-line human message + exit 1 rather than dump a stack trace.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
 import os
@@ -28,6 +29,7 @@ from pathlib import Path
 from typing import Any
 
 from ccs.adapters.claude_code.lifecycle import read_port_from_file as _read_port_from_file
+from ccs.core.exceptions import InsecureTransportRefused
 
 logger = logging.getLogger(__name__)
 
@@ -195,19 +197,68 @@ def resolve_endpoint(coordinator_root: Path) -> CoordinatorEndpoint:
     return CoordinatorEndpoint(port=port, bearer=bearer)
 
 
-def resolve_remote_endpoint(host: str, port: int, secret: str) -> CoordinatorEndpoint:
+def _is_loopback_transport_host(host: str) -> bool:
+    """True for hosts that may receive a bearer over plaintext HTTP WITHOUT an ack.
+
+    Broader than the Host-allowlist :func:`~ccs.adapters.claude_code.auth.is_loopback_host`:
+    covers ``127.0.0.0/8`` and ``::1`` (via :mod:`ipaddress`) plus ``"localhost"``.
+    ``ipaddress.is_loopback`` also correctly resolves IPv4-mapped forms — mapped
+    loopback (``::ffff:127.0.0.1``) is loopback, while mapped-public
+    (``::ffff:8.8.8.8``) is not, so there is no bypass. A non-IP hostname (a name we
+    cannot classify) is treated as NON-loopback, so the guard fails closed on it.
+    """
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _guard_plaintext_bearer(host: str, env: dict[str, str]) -> None:
+    """Fail closed on a plaintext bearer to a non-loopback host (Phase-1.5 guard).
+
+    The remote transport is always ``http://`` (encryption is operator-provided
+    out-of-band — WireGuard or a TLS-terminating proxy), so there is no in-band TLS
+    signal. For a non-loopback host the operator must set ``CCS_REMOTE_INSECURE``
+    (truthy) to acknowledge the link is secured, or the bearer is never sent
+    (:class:`InsecureTransportRefused`). Reduces-not-eliminates: it removes the
+    SILENT plaintext-bearer footgun, not the operator's duty to secure the link.
+    """
+    if _is_loopback_transport_host(host):
+        return
+    if env.get("CCS_REMOTE_INSECURE", "").strip().lower() in _REMOTE_TRUTHY_ENV_VALUES:
+        # Names host/posture only — never the bearer/secret value.
+        logger.warning(
+            "sending a bearer to non-loopback host %r over plaintext HTTP "
+            "(CCS_REMOTE_INSECURE acknowledged — ensure the link is encrypted)",
+            host,
+        )
+        return
+    raise InsecureTransportRefused(host)
+
+
+def resolve_remote_endpoint(
+    host: str, port: int, secret: str, *, env: dict[str, str] | None = None
+) -> CoordinatorEndpoint:
     """Build an endpoint for a REMOTE coordinator (cross-host demo).
 
     Unlike :func:`resolve_endpoint`, this reads nothing from the local
     ``.coherence/`` directory — host, port, and the bearer secret are supplied
     by the caller (typically via :meth:`RemoteCoordinatorConfig.from_env`).
-    Gated by :class:`RemoteCoordinatorConfig`; never used on the loopback-only
-    local path.
+    Gated by :class:`RemoteCoordinatorConfig`.
+
+    Fail-closed transport guard: for a NON-loopback host the bearer is only sent
+    when ``CCS_REMOTE_INSECURE`` (read from ``env``, default ``os.environ``) is
+    truthy — otherwise :class:`InsecureTransportRefused` is raised (the transport
+    is plaintext HTTP; the ack acknowledges an out-of-band-secured link). Loopback
+    is byte-unchanged.
     """
     if not host:
         raise CoordinatorUnavailable("remote coordinator host is empty")
     if not secret:
         raise CoordinatorUnavailable("remote coordinator bearer secret is empty")
+    _guard_plaintext_bearer(host, os.environ if env is None else env)
     return CoordinatorEndpoint(port=port, bearer=secret, host=host)
 
 

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -469,6 +469,28 @@ class RemoteAuthFailed(CoherenceError):
     client never silently degrades past a wrong secret."""
 
 
+class InsecureTransportRefused(CoherenceError):
+    """Refused to send a bearer token to a NON-loopback coordinator over plaintext
+    HTTP without an explicit operator acknowledgement (Phase-1.5 client-side guard).
+
+    The remote transport is always ``http://`` — encryption (WireGuard / a TLS
+    terminating proxy) is provided out-of-band by the operator, so there is no
+    in-band TLS signal. Rather than silently leak the bearer to a routed host, the
+    client fails LOUD and CLOSED: set ``CCS_REMOTE_INSECURE=1`` to acknowledge the
+    link is secured out-of-band, or point at a loopback host. This *reduces* the
+    silent-plaintext footgun; it does not *guarantee* the link is encrypted (the
+    ack is an operator assertion). Carries the offending ``host``."""
+
+    def __init__(self, host: str) -> None:
+        super().__init__(
+            f"refusing to send a bearer token to non-loopback host {host!r} over "
+            "plaintext HTTP; set CCS_REMOTE_INSECURE=1 to acknowledge the link is "
+            "secured out-of-band (e.g. WireGuard / a TLS-terminating proxy), or use "
+            "a loopback coordinator"
+        )
+        self.host = host
+
+
 class CommitUnconfirmed(CoherenceError):
     """OCC commit unconfirmed (MCP-C Unit 1): the coordinator transport failed
     mid-commit, a false-negative ack — NOT a confirmed loss. The write may or may

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -479,7 +479,9 @@ class InsecureTransportRefused(CoherenceError):
     client fails LOUD and CLOSED: set ``CCS_REMOTE_INSECURE=1`` to acknowledge the
     link is secured out-of-band, or point at a loopback host. This *reduces* the
     silent-plaintext footgun; it does not *guarantee* the link is encrypted (the
-    ack is an operator assertion). Carries the offending ``host``."""
+    ack is an operator assertion). The guard is evaluated once, when the endpoint is
+    minted (per process / instance) — not re-checked per request. Carries the
+    offending ``host``."""
 
     def __init__(self, host: str) -> None:
         super().__init__(

--- a/tests/adapters/test_coherent_volume_remote_failclosed.py
+++ b/tests/adapters/test_coherent_volume_remote_failclosed.py
@@ -23,6 +23,12 @@ def _http_error(code: int) -> urllib.error.HTTPError:
     return urllib.error.HTTPError("http://10.0.0.5:8080/x", code, "err", {}, None)
 
 
+# These tests exercise 401 / degraded-body fail-closed semantics for a REMOTE
+# (non-loopback) host — NOT the plaintext-transport guard — so each resolve call
+# acknowledges the test-only insecure link explicitly (deliberate per-call ack).
+_INSECURE_ACK = {"CCS_REMOTE_INSECURE": "1"}
+
+
 def _remote_volume(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, probe=None
 ) -> CoherentVolume:
@@ -31,7 +37,7 @@ def _remote_volume(
     monkeypatch.setattr(
         cv, "_coordinator_get", probe or (lambda ep, path, **k: {"ok": True})
     )
-    remote = resolve_remote_endpoint("10.0.0.5", 8080, "secret")
+    remote = resolve_remote_endpoint("10.0.0.5", 8080, "secret", env=_INSECURE_ACK)
     return CoherentVolume(tmp_path, on_error="strict", remote_endpoint=remote)
 
 
@@ -56,7 +62,7 @@ def test_attach_401_raises_remote_auth_failed(tmp_path: Path, monkeypatch: pytes
 
     monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
     monkeypatch.setattr(cv, "_coordinator_get", probe_401)
-    remote = resolve_remote_endpoint("10.0.0.5", 8080, "secret")
+    remote = resolve_remote_endpoint("10.0.0.5", 8080, "secret", env=_INSECURE_ACK)
     with pytest.raises(RemoteAuthFailed):
         CoherentVolume(tmp_path, on_error="strict", remote_endpoint=remote)
 
@@ -90,6 +96,6 @@ def test_attach_403_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
     monkeypatch.setattr(cv, "_coordinator_get", probe_403)
-    remote = resolve_remote_endpoint("10.0.0.5", 8080, "secret")
+    remote = resolve_remote_endpoint("10.0.0.5", 8080, "secret", env=_INSECURE_ACK)
     with pytest.raises(CoherenceError):
         CoherentVolume(tmp_path, on_error="strict", remote_endpoint=remote)

--- a/tests/test_coherence_client_remote_endpoint.py
+++ b/tests/test_coherence_client_remote_endpoint.py
@@ -57,7 +57,11 @@ def test_request_host_header_follows_endpoint_host(monkeypatch, method):
 # --- resolve_remote_endpoint -----------------------------------------------
 
 def test_resolve_remote_endpoint_builds_endpoint():
-    ep = resolve_remote_endpoint("10.0.0.5", 8080, "s3cr3t")
+    # This test exercises endpoint plumbing for a REMOTE host, not the transport
+    # guard — acknowledge the (test-only) plaintext link so the mint is not refused.
+    ep = resolve_remote_endpoint(
+        "10.0.0.5", 8080, "s3cr3t", env={"CCS_REMOTE_INSECURE": "1"}
+    )
     assert (ep.host, ep.port, ep.bearer) == ("10.0.0.5", 8080, "s3cr3t")
     assert ep.base_url == "http://10.0.0.5:8080"
 

--- a/tests/test_remote_transport_guard.py
+++ b/tests/test_remote_transport_guard.py
@@ -12,6 +12,8 @@ explicit operator assertion, not an in-band TLS signal.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from ccs.cli._coherence_client import (
@@ -24,12 +26,9 @@ from ccs.core.exceptions import CoherenceError, InsecureTransportRefused
 
 
 # --- loopback passes freely (no ack, byte-unchanged) -----------------------
-# Includes 127.0.0.0/8, ::1, and IPv4-mapped loopback (::ffff:127.0.0.1) — the last
-# is genuinely loopback (ipaddress.is_loopback unwraps the mapped IPv4), traffic
-# never leaves the host, so no ack is needed.
-@pytest.mark.parametrize(
-    "host", ["127.0.0.1", "localhost", "::1", "127.0.0.5", "::ffff:127.0.0.1"]
-)
+# 127.0.0.0/8 and ::1. IPv4-mapped loopback (::ffff:127.0.0.1) is deliberately NOT
+# here — it is classified non-loopback (fail-closed); see the refused matrix below.
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1", "127.0.0.5"])
 def test_loopback_passes_without_ack(host: str) -> None:
     ep = resolve_remote_endpoint(host, 8080, "secret", env={})
     assert isinstance(ep, CoordinatorEndpoint)
@@ -37,10 +36,19 @@ def test_loopback_passes_without_ack(host: str) -> None:
 
 
 # --- non-loopback without ack is refused (fail closed) ---------------------
-# A non-IP hostname and a mapped-PUBLIC address (::ffff:8.8.8.8, is_loopback False)
-# are correctly non-loopback — no bypass via the mapped form.
+# A non-IP hostname, a mapped-PUBLIC address (::ffff:8.8.8.8), AND a mapped-LOOPBACK
+# form (::ffff:127.0.0.1) all fail closed: mapped IPv6 forms are classified
+# non-loopback deterministically (stdlib is_loopback for the mapped form varies
+# across CPython patch releases), so the ack is required regardless of interpreter.
 @pytest.mark.parametrize(
-    "host", ["10.0.0.5", "172.28.0.2", "coordinator.internal", "::ffff:8.8.8.8"]
+    "host",
+    [
+        "10.0.0.5",
+        "172.28.0.2",
+        "coordinator.internal",
+        "::ffff:8.8.8.8",
+        "::ffff:127.0.0.1",
+    ],
 )
 def test_non_loopback_without_ack_refused(host: str) -> None:
     with pytest.raises(InsecureTransportRefused):
@@ -111,3 +119,30 @@ def test_from_env_nonloopback_without_ack_is_guarded_on_mint(
     assert cfg.enabled and cfg.host == "10.0.0.5"
     with pytest.raises(InsecureTransportRefused):
         resolve_remote_endpoint(cfg.host, cfg.port or 8080, "secret")
+
+
+# --- base_url brackets IPv6 literals so the authority parses ----------------
+# A loopback ::1 passes the guard, so its endpoint must yield a *usable* URL —
+# http://[::1]:8080, not the ambiguous http://::1:8080 (urllib misparses the port).
+@pytest.mark.parametrize(
+    ("host", "env", "expected"),
+    [
+        ("::1", {}, "http://[::1]:8080"),  # loopback IPv6, no ack
+        ("2001:db8::1", {"CCS_REMOTE_INSECURE": "1"}, "http://[2001:db8::1]:8080"),
+        ("127.0.0.1", {}, "http://127.0.0.1:8080"),  # IPv4 stays unbracketed
+    ],
+)
+def test_base_url_brackets_ipv6(host: str, env: dict, expected: str) -> None:
+    ep = resolve_remote_endpoint(host, 8080, "secret", env=env)
+    assert ep.base_url == expected
+
+
+# --- the acknowledgement log line names the host, never the secret (R3) -----
+def test_ack_log_names_host_never_secret(caplog: pytest.LogCaptureFixture) -> None:
+    secret = "topsecret-bearer-value"
+    with caplog.at_level(logging.WARNING):
+        resolve_remote_endpoint(
+            "10.0.0.5", 8080, secret, env={"CCS_REMOTE_INSECURE": "1"}
+        )
+    assert secret not in caplog.text
+    assert "10.0.0.5" in caplog.text

--- a/tests/test_remote_transport_guard.py
+++ b/tests/test_remote_transport_guard.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Fail-closed transport guard (Phase-1.5 client-side sliver).
+
+``resolve_remote_endpoint`` refuses to mint an endpoint for a NON-loopback host
+over plaintext HTTP unless the operator acknowledges the link is secured
+(``CCS_REMOTE_INSECURE``). Loopback is byte-unchanged. The transport is always
+``http://`` (encryption is operator-provided out-of-band), so the ack is an
+explicit operator assertion, not an in-band TLS signal.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ccs.cli._coherence_client import (
+    CoordinatorEndpoint,
+    CoordinatorUnavailable,
+    RemoteCoordinatorConfig,
+    resolve_remote_endpoint,
+)
+from ccs.core.exceptions import CoherenceError, InsecureTransportRefused
+
+
+# --- loopback passes freely (no ack, byte-unchanged) -----------------------
+# Includes 127.0.0.0/8, ::1, and IPv4-mapped loopback (::ffff:127.0.0.1) — the last
+# is genuinely loopback (ipaddress.is_loopback unwraps the mapped IPv4), traffic
+# never leaves the host, so no ack is needed.
+@pytest.mark.parametrize(
+    "host", ["127.0.0.1", "localhost", "::1", "127.0.0.5", "::ffff:127.0.0.1"]
+)
+def test_loopback_passes_without_ack(host: str) -> None:
+    ep = resolve_remote_endpoint(host, 8080, "secret", env={})
+    assert isinstance(ep, CoordinatorEndpoint)
+    assert ep.host == host
+
+
+# --- non-loopback without ack is refused (fail closed) ---------------------
+# A non-IP hostname and a mapped-PUBLIC address (::ffff:8.8.8.8, is_loopback False)
+# are correctly non-loopback — no bypass via the mapped form.
+@pytest.mark.parametrize(
+    "host", ["10.0.0.5", "172.28.0.2", "coordinator.internal", "::ffff:8.8.8.8"]
+)
+def test_non_loopback_without_ack_refused(host: str) -> None:
+    with pytest.raises(InsecureTransportRefused):
+        resolve_remote_endpoint(host, 8080, "secret", env={})
+
+
+def test_insecure_transport_refused_is_coherence_error() -> None:
+    assert issubclass(InsecureTransportRefused, CoherenceError)
+
+
+def test_refusal_message_is_actionable() -> None:
+    with pytest.raises(InsecureTransportRefused) as exc:
+        resolve_remote_endpoint("10.0.0.5", 8080, "secret", env={})
+    msg = str(exc.value)
+    assert "10.0.0.5" in msg
+    assert "CCS_REMOTE_INSECURE" in msg
+
+
+# --- non-loopback WITH ack sends (behavior unchanged) ----------------------
+@pytest.mark.parametrize("ack", ["1", "true", "yes", "on"])
+def test_non_loopback_with_ack_passes(ack: str) -> None:
+    ep = resolve_remote_endpoint(
+        "10.0.0.5", 8080, "secret", env={"CCS_REMOTE_INSECURE": ack}
+    )
+    assert ep.host == "10.0.0.5"
+
+
+@pytest.mark.parametrize("ack", ["", "0", "false", "no"])
+def test_non_loopback_falsey_ack_refused(ack: str) -> None:
+    with pytest.raises(InsecureTransportRefused):
+        resolve_remote_endpoint(
+            "10.0.0.5", 8080, "secret", env={"CCS_REMOTE_INSECURE": ack}
+        )
+
+
+# --- ordering: empty-input checks fire BEFORE the guard --------------------
+def test_empty_secret_raises_unavailable_not_refused() -> None:
+    # Non-loopback host but empty secret -> CoordinatorUnavailable (empty check),
+    # NOT the transport guard. Proves the guard sits after the empty checks so
+    # the pre-existing rejects-empty test stays green.
+    with pytest.raises(CoordinatorUnavailable):
+        resolve_remote_endpoint("10.0.0.5", 8080, "", env={})
+
+
+def test_empty_host_raises_unavailable() -> None:
+    with pytest.raises(CoordinatorUnavailable):
+        resolve_remote_endpoint("", 8080, "secret", env={})
+
+
+# --- default env is os.environ when not injected ---------------------------
+def test_default_env_reads_os_environ(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CCS_REMOTE_INSECURE", raising=False)
+    with pytest.raises(InsecureTransportRefused):
+        resolve_remote_endpoint("10.0.0.5", 8080, "secret")  # no env -> os.environ
+    monkeypatch.setenv("CCS_REMOTE_INSECURE", "1")
+    ep = resolve_remote_endpoint("10.0.0.5", 8080, "secret")
+    assert ep.host == "10.0.0.5"
+
+
+# --- integration: minting from a from_env-derived host is guarded ----------
+def test_from_env_nonloopback_without_ack_is_guarded_on_mint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    monkeypatch.setenv("CCS_REMOTE_HOST", "10.0.0.5")
+    monkeypatch.delenv("CCS_REMOTE_INSECURE", raising=False)
+    cfg = RemoteCoordinatorConfig.from_env()
+    assert cfg.enabled and cfg.host == "10.0.0.5"
+    with pytest.raises(InsecureTransportRefused):
+        resolve_remote_endpoint(cfg.host, cfg.port or 8080, "secret")


### PR DESCRIPTION
## Summary

Client-side security hardening: the coordinator client now **fails closed** — it
refuses to send the bearer token to a non-loopback host over plaintext HTTP unless
the operator sets `CCS_REMOTE_INSECURE=1` to acknowledge the link is secured
out-of-band. Turns a silent plaintext-bearer footgun into an explicit opt-in. The
loopback path is byte-unchanged and the default-off `CCS_REMOTE_COORDINATOR` gating
is unchanged. (Full TLS termination is a separate hardening step.)

## What changed

- **`InsecureTransportRefused(CoherenceError)`** — new typed error, mirroring `RemoteAuthFailed`.
- **Guard at `resolve_remote_endpoint`** (the endpoint-mint chokepoint, after the
  empty-input checks): a dedicated loopback check (`127.0.0.0/8`, `::1`, `localhost`,
  IPv4-mapped loopback via `ipaddress`; mapped-public is non-loopback -> no bypass) +
  an optional `env` param for testability. Non-loopback + no ack -> raise; the bearer
  is never assembled into a request. Reduces-not-eliminates.
- **Demo + docs:** the Docker client env + the cross-host / netns README set
  `CCS_REMOTE_INSECURE=1` (172.28.0.2 is non-loopback); the README and
  `docs/security.md` document the guard + set-it-narrowly guidance.
- Acked the pre-existing non-loopback direct callers (they exercise 401 / degrade
  semantics, not the guard) deliberately per call site.

## Test plan

- New behavior-matrix test `tests/test_remote_transport_guard.py` (loopback passes /
  non-loopback refused / acked passes / ordering vs empty-input / from_env).
- Full suite: **2645 passed, 3 skipped**; ruff clean.
- Loopback byte-unchanged (local-smoke demo passes; cross-host integration green).
