### PR TITLE
docs: end-user coverage for foreign-edit guards, MCP server, snapshot sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **`agent-coherence` makes "agent A silently clobbered agent B's `plan.md`" impossible — a vendor-neutral MESI + optimistic-concurrency coordinator for agent state, with the safety invariants machine-checked in TLA+.**
 
-Two agents share an artifact — a `plan.md`, a store key, a `memory.json`. One reads it and works; meanwhile a peer commits a newer version; the first writes back anyway. Last write wins, the peer's work is silently gone, nothing errors, and every downstream decision builds on the wrong version. `agent-coherence` turns that silent clobber into a loud, typed refusal: MESI-style ownership and invalidation over shared artifacts, optimistic commit-CAS for concurrent writers, and a read-generation fence for crash-reclaimed ones — a stale write is denied or returned as a retryable conflict, never silently applied. Same library, same protocol, across LangGraph, CrewAI, AutoGen, the OpenAI Agents SDK, plain files shared across processes (`CoherentVolume`), any MCP client (the bundled `stale-write-guard-fs` server), and any custom orchestrator. Same behavior regardless of which model provider (Anthropic, OpenAI, Google, Mistral, open-source) the agents talk to.
+Two agents share an artifact — a `plan.md`, a store key, a `memory.json`. One reads it and works; meanwhile a peer commits a newer version; the first writes back anyway. Last write wins, the peer's work is silently gone, nothing errors, and every downstream decision builds on the wrong version. `agent-coherence` turns that silent clobber into a loud, typed refusal: MESI-style ownership and invalidation over shared artifacts, optimistic commit-CAS for concurrent writers, and a read-generation fence for crash-reclaimed ones — a stale write is denied or returned as a retryable conflict, never silently applied. Same library, same protocol, across LangGraph, CrewAI, AutoGen, the OpenAI Agents SDK, plain files shared across processes (`CoherentVolume`), any MCP client (the `stale-write-guard-fs` server, via the `mcp` extra), and any custom orchestrator. Same behavior regardless of which model provider (Anthropic, OpenAI, Google, Mistral, open-source) the agents talk to.
 
 [![CI](https://github.com/hipvlady/agent-coherence/actions/workflows/ci.yml/badge.svg)](https://github.com/hipvlady/agent-coherence/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/agent-coherence)](https://pypi.org/project/agent-coherence/)
@@ -181,7 +181,7 @@ pip install "agent-coherence[mcp]"
 | `swg_write_cas` | Single-shot version-checked write for concurrent same-key contention |
 | `swg_status` | Three-state coordination health: `on` / `off` / `unknown` |
 
-The server binds one workspace per session (`SWG_ROOT`, defaulting to its working directory), rejects path traversal and any access to the coordinator's own state directory, and fails closed on IO errors. Denials come back as typed, machine-readable payloads — an agent can parse `recover: reacquire` and self-heal instead of retrying blindly. Run the red→green demo: `python -m examples.mcp_stale_write_guard.main` (offline, deterministic, no keys).
+The server binds one workspace per session (`SWG_ROOT`, defaulting to its working directory; the whole workspace is guarded unless `SWG_MANAGED` — a comma-separated glob list — narrows it), rejects path traversal and any access to the coordinator's own state directory, and fails closed on IO errors. Denials come back as typed, machine-readable payloads — an agent can parse `recover: reacquire` and self-heal instead of retrying blindly. Run the red→green demo: `python -m examples.mcp_stale_write_guard.main` (offline, deterministic, no keys).
 
 **Scope, honestly.** Same contract as the volume it wraps: single-host, managed paths, cooperative — it guards agents that route file access through the tools; it cannot see edits made around them (those are caught at the next tool call on that file by the foreign-edit guards).
 
@@ -212,10 +212,11 @@ Against a running coordinator (the same one `CoherentVolume` spawns), over HTTP:
 ```text
 POST /session/begin      {session_id, read_set: ["plans/plan.md", "config/app.json"]}
                          → {session_token, cut: {path: version}, …}
-POST /session/read       serve an artifact at its PINNED version — never a newer one
-POST /session/commit     single-artifact optimistic commit against the pinned base —
-                         wins only if no peer moved the artifact since the cut
-POST /session/heartbeat  keep the session's lease alive
+POST /session/read       {session_id, session_token, path}
+                         → the artifact at its PINNED version — never a newer one
+POST /session/commit     {session_id, session_token, path, content}
+                         → wins only if no peer moved the artifact since the cut
+POST /session/heartbeat  {session_id, session_token} — keep the session's lease alive
 ```
 
 Or in-process: `CoordinatorService.begin_session(read_set=…, owner=…)` → `session_read(…)` / `session_commit(…)`. The cut is an inspectable `{artifact: version}` map, not an opaque handle — you can read exactly which versions your session is pinned to.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **`agent-coherence` makes "agent A silently clobbered agent B's `plan.md`" impossible — a vendor-neutral MESI + optimistic-concurrency coordinator for agent state, with the safety invariants machine-checked in TLA+.**
 
-Two agents share an artifact — a `plan.md`, a store key, a `memory.json`. One reads it and works; meanwhile a peer commits a newer version; the first writes back anyway. Last write wins, the peer's work is silently gone, nothing errors, and every downstream decision builds on the wrong version. `agent-coherence` turns that silent clobber into a loud, typed refusal: MESI-style ownership and invalidation over shared artifacts, optimistic commit-CAS for concurrent writers, and a read-generation fence for crash-reclaimed ones — a stale write is denied or returned as a retryable conflict, never silently applied. Same library, same protocol, across LangGraph, CrewAI, AutoGen, the OpenAI Agents SDK, plain files shared across processes (`CoherentVolume`), and any custom orchestrator. Same behavior regardless of which model provider (Anthropic, OpenAI, Google, Mistral, open-source) the agents talk to.
+Two agents share an artifact — a `plan.md`, a store key, a `memory.json`. One reads it and works; meanwhile a peer commits a newer version; the first writes back anyway. Last write wins, the peer's work is silently gone, nothing errors, and every downstream decision builds on the wrong version. `agent-coherence` turns that silent clobber into a loud, typed refusal: MESI-style ownership and invalidation over shared artifacts, optimistic commit-CAS for concurrent writers, and a read-generation fence for crash-reclaimed ones — a stale write is denied or returned as a retryable conflict, never silently applied. Same library, same protocol, across LangGraph, CrewAI, AutoGen, the OpenAI Agents SDK, plain files shared across processes (`CoherentVolume`), any MCP client (the bundled `stale-write-guard-fs` server), and any custom orchestrator. Same behavior regardless of which model provider (Anthropic, OpenAI, Google, Mistral, open-source) the agents talk to.
 
 [![CI](https://github.com/hipvlady/agent-coherence/actions/workflows/ci.yml/badge.svg)](https://github.com/hipvlady/agent-coherence/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/agent-coherence)](https://pypi.org/project/agent-coherence/)
@@ -14,6 +14,7 @@ pip install "agent-coherence[langgraph]"        # LangGraph drop-in
 pip install "agent-coherence[crewai]"           # CrewAI adapter
 pip install "agent-coherence[openai-agents]"    # OpenAI Agents SDK adapter (experimental)
 pip install "agent-coherence[diagnose]"         # ccs-diagnose CLI
+pip install "agent-coherence[mcp]"              # stale-write-guard-fs MCP server
 pip install "agent-coherence[all]"              # everything
 ```
 
@@ -42,16 +43,17 @@ vol.write("plans/plan.md", revised_plan)   # stale view? denied fail-closed → 
 
 ## What it guarantees
 
-Each row is a safety invariant model-checked with TLA+/TLC. `make tla-check` runs all five specs in CI on every push, and every spec carries a documented mutant that must fail — the invariants are load-bearing, not decorative.
+Each row is a safety invariant model-checked with TLA+/TLC. `make tla-check` runs all six specs in CI on every push, and every spec carries a documented mutant that must fail — the invariants are load-bearing, not decorative.
 
 | The silent failure | What happens instead | Mechanism | Invariant |
 |---|---|---|---|
 | **Stale-read overwrite** — an agent acts on an old snapshot and writes over a newer version (two sessions, one `plan.md`) | the write is **denied fail-closed**; the writer must `reacquire()` and read the current version | MESI single-writer ownership + invalidation | `SingleWriter`, `MonotonicVersion` |
 | **Concurrent lost update** — two writers hit the same key and both "succeed" | exactly one wins; the loser gets a **typed conflict + bounded retry**, never a silent drop | optimistic commit-CAS (`write_cas`) | `NoLostUpdate` |
 | **Reclaim-zombie write** — a stalled writer is reclaimed by crash recovery, wakes later, and lands its stale commit; the version never moved, so a version check passes | the commit is **rejected** with a typed `stale_read_generation` conflict | read-generation fence — reclamation bumps the artifact's ownership epoch, checked atomically at commit | `NoStaleApply` |
+| **Torn multi-artifact read (read-skew)** — an agent reads several artifacts one by one while a peer commits in between; each read was individually current, but the *combination* never coexisted | session reads serve from a **pinned consistent cut**; commits validate against the pinned base; a lapsed session **fails closed** with a typed rejection, never a silent fall-through to live state | [multi-artifact snapshot sessions](#multi-artifact-snapshot-sessions) | `NoReadSkewWithinCut`, `PinAlwaysRetained` |
 | **Dead owner blocks the fleet** — a crashed agent holds EXCLUSIVE forever | the heartbeat/TTL sweep reclaims the grant (on by default) | crash-recovery sweep | sweep invariants I3–I6 |
 
-**Scope, honestly:** the guarantees hold for writers that go through the coordinator, under a single coordinator (one host). Concurrent same-key writers on one host are covered; cross-host fencing is on the roadmap, demand-gated — if you need it, [open an issue](https://github.com/hipvlady/agent-coherence/issues/new). Specs, the invariant ↔ implementation map, and the mutant recipes live in [`formal/tla/`](formal/tla/README.md).
+**Scope, honestly:** the guarantees hold for writers that go through the coordinator, under a single coordinator (one host). Concurrent same-key writers on one host are covered; cross-host fencing is on the roadmap, demand-gated — if you need it, [open an issue](https://github.com/hipvlady/agent-coherence/issues/new). Edits that *bypass* the coordinator entirely (a human in an editor, a formatter, a regenerating script) are caught at the workspace boundary by content-hash checks — the [foreign-edit guards](#foreign-edit-guards-writes-that-bypass-the-coordinator) below, enforced by tests rather than TLA+. Specs, the invariant ↔ implementation map, and the mutant recipes live in [`formal/tla/`](formal/tla/README.md).
 
 **Correctness is the wedge; the token savings come with it.** Writes publish ~12-token invalidation signals instead of rebroadcasting full artifacts, so read-heavy fleets stop re-paying for state they already hold:
 
@@ -78,8 +80,11 @@ RAG corpora and agent memory are **shared mutable state**, so the stale-read→w
 - 📖 [User guide](docs/guide.md) — installation, namespace convention, strategies, observability, telemetry, examples, full API reference
 - 🔎 [RAG & shared memory](https://agent-coherence.dev/rag/) — coherence for retrieval corpora and agent memory stores, with the runnable lost-update demo
 - 🗂️ [Coherent workspace](#coherent-workspace-the-data-plane-for-shared-files) — `CoherentVolume`, the data-plane appliance for plain files shared across processes
+- 🛡️ [Foreign-edit guards](#foreign-edit-guards-writes-that-bypass-the-coordinator) — catch out-of-band edits (a human, a formatter, a script) at the read/write boundary
+- 🔌 [MCP server](#mcp-server-stale-write-guard-fs) — `stale-write-guard-fs`, the same guarantee for any MCP client, no Python integration required
 - 🚦 [Effect-ordering gate](#effect-ordering-gate) — `gate()`, fire an agent's effect only on the input version it decided from
-- 🧮 [Formal verification](formal/tla/README.md) — the five TLA+ specs, invariant ↔ implementation map, mutant recipes
+- 📸 [Multi-artifact snapshot sessions](#multi-artifact-snapshot-sessions) — read several artifacts as one consistent cut; no torn reads
+- 🧮 [Formal verification](formal/tla/README.md) — the six TLA+ specs, invariant ↔ implementation map, mutant recipes
 - 🩺 [`ccs-diagnose` CLI](docs/ccs-diagnose.md) — find divergent reads in your existing LangGraph graph without changing any code
 - 🧩 [Claude Code plugin](https://github.com/hipvlady/agent-coherence-plugin) — cross-session coherence for the prose rules (CLAUDE.md, plan.md) parallel Claude Code sessions share
 - 🔍 [Why coherence matters](docs/why-coherence-matters.md) — the gap across LangGraph, CrewAI, AutoGen, and Claude Agent SDK
@@ -91,7 +96,7 @@ RAG corpora and agent memory are **shared mutable state**, so the stale-read→w
 
 Each shared artifact is cached locally per agent and reads serve from the local cache when that copy is fresh. Writes commit to a coordinator, which sends lightweight invalidation signals (~12 tokens) to peers so the next read fetches the new version instead of rebroadcasting the full artifact. Consistency is single-writer-multiple-reader per artifact with bounded staleness — peers re-fetch on next read.
 
-Two write disciplines share the same guarantee. **Pessimistic:** acquire EXCLUSIVE, commit; a writer whose view went stale is denied and must `reacquire()`. **Optimistic:** `write_cas` — read, compute, commit-CAS; the loser of a race gets a typed conflict and bounded retry. Crash recovery composes with both: reclaiming a stalled grant bumps the artifact's ownership epoch, so a reclaimed writer that completes later is rejected at commit even when the version is unchanged (the read-generation fence).
+Two write disciplines share the same guarantee. **Pessimistic:** acquire EXCLUSIVE, commit; a writer whose view went stale is denied and must `reacquire()`. **Optimistic:** `write_cas` — read, compute, commit-CAS; the loser of a race gets a typed conflict and bounded retry. Crash recovery composes with both: reclaiming a stalled grant bumps the artifact's ownership epoch, so a reclaimed writer that completes later is rejected at commit even when the version is unchanged (the read-generation fence). On the read side, a [snapshot session](#multi-artifact-snapshot-sessions) pins a consistent cut across several artifacts, so a multi-artifact read never sees a torn mix of versions.
 
 Five synchronization strategies ship out of the box: `lazy` (default), `eager`, `lease` (TTL-based), `access_count`, and `broadcast`. Pick the one that matches your workload's read/write ratio and how aggressively cached reads should refresh.
 
@@ -101,10 +106,11 @@ Five synchronization strategies ship out of the box: `lazy` (default), `eager`, 
 - **Coordinator** (`ccs.coordinator`) — authority service tracking directory state, publishing invalidations, arbitrating commit-CAS, and reclaiming stale grants (crash recovery + read-generation fence).
 - **Adapters** (`ccs.adapters`) — framework integrations for LangGraph, CrewAI, and AutoGen (~100 lines each), plus an experimental OpenAI Agents SDK adapter (`Session`-cache coherence + `RunHooks`).
 - **Coherent workspace** (`ccs.adapters.coherent_volume`) — the **data-plane appliance**: an out-of-process coordinator client that brings the same guarantee to plain files on disk, no framework required. See [Coherent workspace](#coherent-workspace-the-data-plane-for-shared-files).
+- **MCP server** (`ccs.mcp`) — the `stale-write-guard-fs` stdio server that exposes the coherent-workspace guarantee to any [Model Context Protocol](https://modelcontextprotocol.io) client over five `swg_*` tools. See [MCP server](#mcp-server-stale-write-guard-fs).
 - **Simulation** (`ccs.simulation`) — deterministic tick-driven engine for scenario benchmarks with failure injection.
 - **Event bus** (`ccs.bus`) — pluggable transport for invalidation signals; in-memory by default, swap in Redis, Kafka, NATS, or gRPC streams for production.
 
-Protocol safety properties — single-writer, monotonic versioning, the crash-recovery sweep invariants, the OCC no-lost-update, the reclamation fence's no-stale-apply, and version retention's no-collected-read — are model-checked with [TLA+/TLC](formal/tla/README.md). The `tla-check` CI job runs all five specs on every push and PR.
+Protocol safety properties — single-writer, monotonic versioning, the crash-recovery sweep invariants, the OCC no-lost-update, the reclamation fence's no-stale-apply, version retention's no-collected-read, and the snapshot session's no-read-skew-within-cut — are model-checked with [TLA+/TLC](formal/tla/README.md). The `tla-check` CI job runs all six specs on every push and PR.
 
 ## Coherent workspace: the data plane for shared files
 
@@ -129,7 +135,55 @@ with coherent_workspace(workspace_root, managed=("plans/**",)):
     open("plans/plan.md", "w").write(edit)    # stale view? raises out of close()
 ```
 
-**Scope, honestly.** v1 prevents the **sequential** stale-read→write lost update for a single-host fleet sharing one workspace (A reads v1, B reads v1, A commits v2, B's stale write is denied → B re-reads). It does **not** serialize concurrent racing writers, nor catch an agent that re-reads fresh bytes and then writes a buffer computed from older ones. The `open()` shim is convenience, not the contract: it covers `open()`/`pathlib` text+binary read/write, but not raw `os.open`, subprocess redirection, `mmap`, or append/update modes — those delegate to the original `open()` unchanged. Run it yourself: `python -m examples.coherent_volume.main` (offline, deterministic, no keys), or read the [positioning + FAQ](https://agent-coherence.dev/rag/).
+**Scope, honestly.** Plain `write()` prevents the **sequential** stale-read→write lost update for a single-host fleet sharing one workspace (A reads v1, B reads v1, A commits v2, B's stale write is denied → B re-reads); **concurrent** same-key racers go through `write_cas` — one winner, the loser gets a typed conflict and re-derives, never a silent drop. Edits that bypass the volume entirely are caught at the boundary by the [foreign-edit guards](#foreign-edit-guards-writes-that-bypass-the-coordinator). It does **not** catch an agent that re-reads fresh bytes and then writes a buffer computed from older ones. The `open()` shim is convenience, not the contract: it covers `open()`/`pathlib` text+binary read/write, but not raw `os.open`, subprocess redirection, `mmap`, or append/update modes — those delegate to the original `open()` unchanged. Run it yourself: `python -m examples.coherent_volume.main` (offline, deterministic, no keys), or read the [positioning + FAQ](https://agent-coherence.dev/rag/).
+
+## Foreign-edit guards: writes that bypass the coordinator
+
+Coordination covers writers that opt in — but real workspaces also get edited from *outside*: a human fixes a file in an editor, a formatter rewrites it, a CI script regenerates it. Without a guard, the next agent write silently buries that edit, and the next agent read silently builds on bytes the coordinator never saw. `CoherentVolume` guards both boundaries with a content-hash check:
+
+- **Write boundary — on by default.** Before writing, the volume checks whether the managed file's on-disk bytes changed out-of-band since it last read or wrote them. If they did, the write raises `StaleView` instead of clobbering the foreign edit — recover with `reacquire()` (fresh read → re-derive → re-write). Opt out with `CoherentVolume(on_stale_write="allow")` to restore last-writer-wins.
+
+- **Read boundary — opt-in.** With `CoherentVolume(on_stale_read="raise")`, re-reading a managed file whose bytes changed out-of-band raises `StaleView` instead of returning bytes your other state wasn't computed from; in strict mode the coordinator enforces the same check server-side. A volume never denies its own just-written bytes — the benign commit→disk-write lag window is recognized and suppressed.
+
+```python
+vol = CoherentVolume(workspace_root, managed=("plans/**",), on_stale_read="raise")
+# a formatter rewrites plans/plan.md out-of-band …
+vol.write("plans/plan.md", revised)   # StaleView — the foreign edit survives
+fresh = vol.reacquire("plans/plan.md")  # recover: fresh read, re-derive, re-write
+```
+
+**Scope, honestly.** These are content-hash checks at the volume's read/write boundary — best-effort point-in-time detection, not filesystem interception. A write that never goes through the volume is *caught at the next volume read/write of that file*, not blocked as it happens; watching unmanaged external sources is on the roadmap, demand-gated. These guards are enforced by tests, not TLA+ — the model-checked invariants cover the protocol state machine, not disk bytes.
+
+## MCP server: `stale-write-guard-fs`
+
+The same guarantee for agents that speak [Model Context Protocol](https://modelcontextprotocol.io) — Claude Code, Cursor, or a custom runtime — with **no Python integration at all**. `stale-write-guard-fs` is a stdio MCP server that wraps `CoherentVolume` and exposes coordinated file access as five tools:
+
+```bash
+pip install "agent-coherence[mcp]"
+```
+
+```json
+{
+  "mcpServers": {
+    "stale-write-guard-fs": {
+      "command": "stale-write-guard-fs",
+      "env": { "SWG_ROOT": "/path/to/shared/workspace" }
+    }
+  }
+}
+```
+
+| Tool | What it does |
+|---|---|
+| `swg_read` | Tracked read — registers the agent's view of the file |
+| `swg_write` | Guarded write — a stale view or a foreign edit gets a typed `stale_view` deny with `recover: reacquire`, never a silent overwrite |
+| `swg_reacquire` | Recovery — fresh identity + mandatory fresh read after a deny |
+| `swg_write_cas` | Single-shot version-checked write for concurrent same-key contention |
+| `swg_status` | Three-state coordination health: `on` / `off` / `unknown` |
+
+The server binds one workspace per session (`SWG_ROOT`, defaulting to its working directory), rejects path traversal and any access to the coordinator's own state directory, and fails closed on IO errors. Denials come back as typed, machine-readable payloads — an agent can parse `recover: reacquire` and self-heal instead of retrying blindly. Run the red→green demo: `python -m examples.mcp_stale_write_guard.main` (offline, deterministic, no keys).
+
+**Scope, honestly.** Same contract as the volume it wraps: single-host, managed paths, cooperative — it guards agents that route file access through the tools; it cannot see edits made around them (those are caught at the next tool call on that file by the foreign-edit guards).
 
 ## Effect-ordering gate
 
@@ -147,7 +201,28 @@ gate(vol, "deploy/config.txt", decide=plan_deploy, effect=run_deploy)
 
 It's plain Python, so the same call drops into a LangGraph node, a CrewAI task, or a raw script unchanged.
 
-**Scope, honestly.** The gate *orders* effects, it does not roll them back: it fires pre-effect and never undoes one, so for an escaping effect there's a residual re-read→fire window it narrows but can't close. It's single-host and cooperative — the agent opts in. For a pure *write* effect, use `vol.write_cas_at(path, expected_version, content)` directly, which is the atomic, no-window path. Gating several mutually-consistent inputs at once is a coherent-cut operation on the coordinator, not this single-input wrapper. Run it: `python -m examples.effect_gate.main` (offline, deterministic, no keys), or add `--baseline` to see the stale fire it catches.
+**Scope, honestly.** The gate *orders* effects, it does not roll them back: it fires pre-effect and never undoes one, so for an escaping effect there's a residual re-read→fire window it narrows but can't close. It's single-host and cooperative — the agent opts in. For a pure *write* effect, use `vol.write_cas_at(path, expected_version, content)` directly, which is the atomic, no-window path. Gating several mutually-consistent inputs at once is a [snapshot-session](#multi-artifact-snapshot-sessions) operation on the coordinator, not this single-input wrapper. Run it: `python -m examples.effect_gate.main` (offline, deterministic, no keys), or add `--baseline` to see the stale fire it catches.
+
+## Multi-artifact snapshot sessions
+
+`gate()` protects one input. But an agent that reads *several* artifacts one by one — a plan, a config, a memory file — can see a torn combination: `plan.md` from before a peer's commit and `config.json` from after it. Every individual read was current; the *set* never coexisted (read-skew). A snapshot session closes that window: it pins a consistent cut of the artifacts you name, captured at a single point, and serves every session read from that cut while peers keep writing.
+
+Against a running coordinator (the same one `CoherentVolume` spawns), over HTTP:
+
+```text
+POST /session/begin      {session_id, read_set: ["plans/plan.md", "config/app.json"]}
+                         → {session_token, cut: {path: version}, …}
+POST /session/read       serve an artifact at its PINNED version — never a newer one
+POST /session/commit     single-artifact optimistic commit against the pinned base —
+                         wins only if no peer moved the artifact since the cut
+POST /session/heartbeat  keep the session's lease alive
+```
+
+Or in-process: `CoordinatorService.begin_session(read_set=…, owner=…)` → `session_read(…)` / `session_commit(…)`. The cut is an inspectable `{artifact: version}` map, not an opaque handle — you can read exactly which versions your session is pinned to.
+
+Fail-closed by construction: reading an artifact that was **not** in the pinned read-set is refused with a typed rejection — never silently served from live state. Sessions have a bounded lifetime backed by a heartbeat lease: a session whose heartbeat lapses, or that is lost to a coordinator restart, is invalidated — later reads get a typed "session invalidated" rejection telling the agent to re-establish, never a quiet fall-through to whatever is current. Model-checked: `NoReadSkewWithinCut` and `PinAlwaysRetained` ([`formal/tla/Snapshot.tla`](formal/tla/Snapshot.tla)).
+
+**Scope, honestly.** This prevents **read-skew** — torn reads across artifacts. It does not add write-skew prevention: commits validate per-artifact against the pinned base through the same optimistic CAS as `write_cas`, so two sessions that read one cut and write *different* artifacts can still interleave. Single coordinator, single host. When the coordinator retains version bodies it serves the pinned bytes directly; otherwise it returns the pinned version and content hash as a typed signal and the caller fetches the bytes from its own data plane.
 
 ## Status
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -27,19 +27,22 @@ full command-line toolset, and the API reference.
 7. [Content audit log](#content-audit-log)
 8. [Crash recovery](#crash-recovery)
 9. [Version retention and read-at-version](#version-retention-and-read-at-version)
-10. [Inline benchmark mode](#inline-benchmark-mode)
-11. [Telemetry](#telemetry)
-12. [Graceful degradation](#graceful-degradation)
-13. [Examples](#examples)
-14. [Real-workload benchmarks](#real-workload-benchmarks)
-15. [Benchmarking your own workload](#benchmarking-your-own-workload)
-16. [`ccs-diagnose` — detect stale reads](#ccs-diagnose--detect-stale-reads)
-17. [Replay (v0.8.2+)](#replay-v082)
-18. [Command-line tools](#command-line-tools)
-19. [API reference](#api-reference)
-20. [Low-level adapter API](#low-level-adapter-api)
-21. [CrewAI and AutoGen adapters](#crewai-and-autogen-adapters)
-22. [OpenAI Agents SDK adapter (experimental)](#openai-agents-sdk-adapter-experimental)
+10. [Coherent workspace (`CoherentVolume`)](#coherent-workspace-coherentvolume)
+11. [Multi-artifact snapshot sessions](#multi-artifact-snapshot-sessions)
+12. [`stale-write-guard-fs` MCP server](#stale-write-guard-fs-mcp-server)
+13. [Inline benchmark mode](#inline-benchmark-mode)
+14. [Telemetry](#telemetry)
+15. [Graceful degradation](#graceful-degradation)
+16. [Examples](#examples)
+17. [Real-workload benchmarks](#real-workload-benchmarks)
+18. [Benchmarking your own workload](#benchmarking-your-own-workload)
+19. [`ccs-diagnose` — detect stale reads](#ccs-diagnose--detect-stale-reads)
+20. [Replay (v0.8.2+)](#replay-v082)
+21. [Command-line tools](#command-line-tools)
+22. [API reference](#api-reference)
+23. [Low-level adapter API](#low-level-adapter-api)
+24. [CrewAI and AutoGen adapters](#crewai-and-autogen-adapters)
+25. [OpenAI Agents SDK adapter (experimental)](#openai-agents-sdk-adapter-experimental)
 
 ---
 
@@ -66,11 +69,14 @@ pip install "agent-coherence[langgraph,langsmith]"
 # OpenAI Agents SDK adapter (experimental, 0.x)
 pip install "agent-coherence[openai-agents]"
 
-# Everything (langgraph + crewai + otel + langsmith + benchmark + diagnose + openai-agents + mistral)
+# stale-write-guard-fs MCP server (coordinated file access for any MCP client)
+pip install "agent-coherence[mcp]"
+
+# Everything (langgraph + crewai + otel + langsmith + benchmark + diagnose + openai-agents + mistral + mcp)
 pip install "agent-coherence[all]"
 ```
 
-For security-sensitive installs with full transitive hash pinning, see [SECURITY.md](SECURITY.md#hash-pinned-install-for-security-sensitive-users) and the bundled `requirements-diagnose.txt`.
+For security-sensitive installs with full transitive hash pinning, see [the security guide](security.md#hash-pinned-install-for-security-sensitive-users) and the bundled `requirements-diagnose.txt`.
 
 ---
 
@@ -517,6 +523,175 @@ older retained version still commits a fence-legal write of stale meaning — th
 coherence guarantee is "write from the bytes your latest read returned," and
 read-at-version makes an older version easy to fetch, so keep writes anchored to
 the current read.
+
+## Coherent workspace (`CoherentVolume`)
+
+`CoherentVolume` brings the coherence guarantee to **plain files on disk** — no
+framework required. It is an out-of-process coordinator *client*: it spawns (or
+attaches to) a local coordinator over SQLite-WAL and routes reads and writes
+through it. Your content stays on the real filesystem; the coordinator holds only
+per-file MESI state, a content hash, and a version. Point a second volume in
+another process at the same workspace and it attaches to the same coordinator, so
+every process on the host shares one coherent view.
+
+```python
+from ccs.adapters.coherent_volume import CoherentVolume
+
+vol = CoherentVolume(workspace_root, managed=("plans/**", "memory/**"))
+data = vol.read("plans/plan.md")            # bytes — registers a SHARED view
+vol.write("plans/plan.md", revise(data))    # stale view? denied fail-closed
+data = vol.reacquire("plans/plan.md")       # recover: fresh identity + fresh read
+```
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `workspace_root` | — | Directory the volume manages; the coordinator's state lives in `<root>/.coherence/` |
+| `managed` | — | Glob patterns for the files under coordination; unmanaged paths bypass the volume |
+| `on_error` | `"degrade"` | `"strict"` raises on any coordination failure instead of degrading to plain IO |
+| `on_stale_read` | `"allow"` | `"raise"` — deny a re-read of a managed file whose on-disk bytes changed out-of-band |
+| `on_stale_write` | `"raise"` | `"allow"` — restore last-writer-wins over a foreign edit (not recommended) |
+
+### Concurrent writers: `write_cas`
+
+Plain `write()` denies the *sequential* stale view. For **concurrent** same-key
+contention, `write_cas(path, make_content)` is the optimistic path: it reads the
+file, runs your `make_content` closure on the current bytes, and commits only if
+the version is unchanged. The loser of a race gets the winner's value re-fed to
+its closure through a bounded retry — one writer wins each round and no update is
+silently dropped. A single-shot variant, `write_cas_at(path, expected_version,
+content)`, commits against an explicit version with no retry loop.
+
+### Foreign-edit guards
+
+Files also change *outside* the fleet — a human edit, a formatter, a regenerating
+script. The volume checks a content hash at both boundaries:
+
+- **Write boundary (on by default).** If a managed file's on-disk bytes changed
+  out-of-band since this volume last read or wrote them, `write()` raises
+  `StaleView` instead of clobbering the foreign edit. Recover with `reacquire()`:
+  fresh read → re-derive → re-write.
+- **Read boundary (opt-in).** With `on_stale_read="raise"`, re-reading a managed
+  file whose bytes changed out-of-band raises `StaleView` instead of returning
+  bytes the rest of your state wasn't computed from. In strict mode the
+  coordinator enforces the same check server-side.
+
+A volume never denies its own just-written bytes: the benign window between a
+commit and its disk write is recognized and suppressed.
+
+These guards are **content-hash checks at the volume boundary** — best-effort
+point-in-time detection, not filesystem interception. An edit that bypasses the
+volume is caught at the *next* volume read or write of that file, not blocked as
+it happens.
+
+### The `open()` shim (demo-grade)
+
+For code you'd rather not rewrite, `coherent_workspace()` / `install()` patch
+`open()` and `pathlib` so managed-path opens route through the volume unchanged.
+It covers text and binary read/write via `open()`/`pathlib` — not raw `os.open`,
+subprocess redirection, `mmap`, or append/update modes, which delegate to the
+original `open()` unchanged. The explicit `read`/`write`/`reacquire`/`write_cas`
+API is the supported contract; the shim is a convenience.
+
+Run the demo: `python -m examples.coherent_volume.main` (offline, deterministic,
+no keys) — it reproduces the silent lost update, then prevents it.
+
+## Multi-artifact snapshot sessions
+
+An agent that reads *several* artifacts one at a time can see a torn combination:
+`plan.md` from before a peer's commit and `config.json` from after it. Each
+individual read was current; the set never coexisted — read-skew. A **snapshot
+session** pins a consistent cut of the artifacts you name, captured at a single
+point, and serves every session read from that cut while peers keep writing.
+
+Over HTTP, against a running coordinator (the same one `CoherentVolume` spawns):
+
+| Endpoint | Request | Result |
+|---|---|---|
+| `POST /session/begin` | `{session_id, read_set: ["plans/plan.md", …]}` | `{session_token, cut: {path: version}, coordinator_epoch, retain_versions}` |
+| `POST /session/read` | `{session_token, path}` | the artifact at its **pinned** version — never a newer one |
+| `POST /session/commit` | `{session_token, path, content}` | wins only if no peer moved the artifact since the cut was pinned |
+| `POST /session/heartbeat` | `{session_token}` | keeps the session's lease alive |
+
+The `session_token` is server-minted and unguessable; the cut is an inspectable
+`{path: version}` map, so you can see exactly which versions your session is
+pinned to. In-process, the same surface is
+`CoordinatorService.begin_session(read_set=…, owner=…)` →
+`session_read(session_token, artifact_id, caller=…)` →
+`session_commit(session_token, artifact_id, content, caller=…)`.
+
+Semantics, precisely:
+
+- **Reads serve only from the cut.** An artifact that was *not* in the pinned
+  read-set is refused with a typed rejection (`artifact_not_in_cut`) — never
+  silently served from live state.
+- **Reads are non-mutating.** A session read grants no ownership and blocks no
+  writer; peers keep committing while you read.
+- **Commits validate against the pinned base.** `session_commit` is a
+  single-artifact optimistic commit: it wins only if the artifact's version still
+  equals the cut's pinned version, and returns a typed, retryable conflict
+  otherwise.
+- **Sessions fail closed.** Pins have a bounded lifetime backed by a heartbeat
+  lease. A session whose heartbeat lapses — or that is lost to a coordinator
+  restart — is invalidated: later reads return a typed `session_invalidated`
+  rejection telling the agent to re-establish, never a quiet fall-through to
+  whatever is current.
+- **Bytes vs versions.** When the coordinator retains version bodies
+  ([version retention](#version-retention-and-read-at-version)), a session read
+  serves the pinned bytes directly. Otherwise it returns the pinned version and
+  content hash as a typed signal, and the caller fetches the exact pinned bytes
+  from its own data plane.
+
+The no-torn-read property is model-checked: `NoReadSkewWithinCut` and
+`PinAlwaysRetained` in `formal/tla/Snapshot.tla`, run by `make tla-check` in CI.
+
+**Honesty boundary.** Snapshot sessions prevent **read-skew** — torn reads across
+artifacts. They do not add write-skew prevention: commits validate per-artifact
+against the pinned base, so two sessions that read one cut and write *different*
+artifacts can still interleave. Single coordinator, single host.
+
+## `stale-write-guard-fs` MCP server
+
+The coherent-workspace guarantee for agents that speak
+[Model Context Protocol](https://modelcontextprotocol.io) — Claude Code, Cursor,
+or a custom runtime — with no Python integration. The server wraps
+`CoherentVolume` and exposes coordinated file access over stdio:
+
+```bash
+pip install "agent-coherence[mcp]"
+```
+
+Register it with your MCP client (the exact file depends on the client):
+
+```json
+{
+  "mcpServers": {
+    "stale-write-guard-fs": {
+      "command": "stale-write-guard-fs",
+      "env": { "SWG_ROOT": "/path/to/shared/workspace" }
+    }
+  }
+}
+```
+
+`SWG_ROOT` selects the workspace (defaulting to the server's working directory);
+the whole workspace is guarded unless the managed set is narrowed.
+
+| Tool | What it does |
+|---|---|
+| `swg_read` | Tracked read — registers the agent's view of the file |
+| `swg_write` | Guarded write — a stale view or foreign edit returns a typed `stale_view` deny with `recover: reacquire`, never a silent overwrite |
+| `swg_reacquire` | Recovery after a deny — fresh identity + mandatory fresh read |
+| `swg_write_cas` | Single-shot version-checked write for concurrent same-key contention |
+| `swg_status` | Three-state coordination health: `on` / `off` / `unknown` |
+
+Denials are machine-readable: an agent parses the typed payload (for example
+`reason: stale_view`, `recover: reacquire`) and self-heals instead of retrying
+blindly. The server validates every file URI — path traversal and any access to
+the coordinator's own state directory are rejected — and fails closed on IO
+errors. Strict-mode, managed-path scoped.
+
+Run the red→green demo: `python -m examples.mcp_stale_write_guard.main`
+(offline, deterministic, no keys).
 
 ## Inline benchmark mode
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -546,8 +546,8 @@ data = vol.reacquire("plans/plan.md")       # recover: fresh identity + fresh re
 | Parameter | Default | Meaning |
 |---|---|---|
 | `workspace_root` | — | Directory the volume manages; the coordinator's state lives in `<root>/.coherence/` |
-| `managed` | — | Glob patterns for the files under coordination; unmanaged paths bypass the volume |
-| `on_error` | `"degrade"` | `"strict"` raises on any coordination failure instead of degrading to plain IO |
+| `managed` | `()` | Glob patterns for the files under coordination; unmanaged paths bypass the volume |
+| `on_error` | `"strict"` | `"degrade"` warns once and falls back to plain IO instead of raising on a coordination failure |
 | `on_stale_read` | `"allow"` | `"raise"` — deny a re-read of a managed file whose on-disk bytes changed out-of-band |
 | `on_stale_write` | `"raise"` | `"allow"` — restore last-writer-wins over a foreign edit (not recommended) |
 
@@ -559,7 +559,9 @@ file, runs your `make_content` closure on the current bytes, and commits only if
 the version is unchanged. The loser of a race gets the winner's value re-fed to
 its closure through a bounded retry — one writer wins each round and no update is
 silently dropped. A single-shot variant, `write_cas_at(path, expected_version,
-content)`, commits against an explicit version with no retry loop.
+content)`, commits against an explicit version with no retry loop. See the race
+live: `python -m examples.concurrent_writers.main` runs two threads through the
+identical update — a plain file loses one write, `write_cas` preserves both.
 
 ### Foreign-edit guards
 
@@ -595,6 +597,21 @@ API is the supported contract; the shim is a convenience.
 Run the demo: `python -m examples.coherent_volume.main` (offline, deterministic,
 no keys) — it reproduces the silent lost update, then prevents it.
 
+### Cross-host mode (experimental, default off)
+
+Everything above is single-host. An experimental, demo-grade remote mode — gated
+entirely by `CCS_REMOTE_COORDINATOR=1` (default off, loopback path byte-unchanged)
+— lets a volume connect to a coordinator on another host: `CCS_REMOTE_HOST` /
+`CCS_REMOTE_PORT` name the endpoint, and the bearer secret arrives via
+`CCS_REMOTE_SECRET_FILE` (a mounted file — never an inline env var). The transport
+is plaintext HTTP, so encryption is your out-of-band responsibility (a WireGuard
+tunnel or a TLS-terminating proxy); to stop a silent leak, the client **refuses to
+send the bearer to a non-loopback host unless `CCS_REMOTE_INSECURE=1`**
+acknowledges the link is secured, raising a typed `InsecureTransportRefused`
+otherwise. Setup, the Docker two-container runner, and the full security boundary
+live in [`examples/cross_host/README.md`](../examples/cross_host/README.md) and
+[the security guide](security.md).
+
 ## Multi-artifact snapshot sessions
 
 An agent that reads *several* artifacts one at a time can see a torn combination:
@@ -608,9 +625,13 @@ Over HTTP, against a running coordinator (the same one `CoherentVolume` spawns):
 | Endpoint | Request | Result |
 |---|---|---|
 | `POST /session/begin` | `{session_id, read_set: ["plans/plan.md", …]}` | `{session_token, cut: {path: version}, coordinator_epoch, retain_versions}` |
-| `POST /session/read` | `{session_token, path}` | the artifact at its **pinned** version — never a newer one |
-| `POST /session/commit` | `{session_token, path, content}` | wins only if no peer moved the artifact since the cut was pinned |
-| `POST /session/heartbeat` | `{session_token}` | keeps the session's lease alive |
+| `POST /session/read` | `{session_id, session_token, path}` | the artifact at its **pinned** version — never a newer one |
+| `POST /session/commit` | `{session_id, session_token, path, content}` | wins only if no peer moved the artifact since the cut was pinned |
+| `POST /session/heartbeat` | `{session_id, session_token}` | keeps the session's lease alive |
+
+Every session call carries both identifiers: `session_id` (your client identity,
+from which the server derives the caller) and the server-minted `session_token`
+(the handle to the pinned cut).
 
 The `session_token` is server-minted and unguessable; the cut is an inspectable
 `{path: version}` map, so you can see exactly which versions your session is
@@ -634,7 +655,8 @@ Semantics, precisely:
   lease. A session whose heartbeat lapses — or that is lost to a coordinator
   restart — is invalidated: later reads return a typed `session_invalidated`
   rejection telling the agent to re-establish, never a quiet fall-through to
-  whatever is current.
+  whatever is current. A token that was never a session at all (malformed, or
+  never opened) is distinguished as `session_not_found`.
 - **Bytes vs versions.** When the coordinator retains version bodies
   ([version retention](#version-retention-and-read-at-version)), a session read
   serves the pinned bytes directly. Otherwise it returns the pinned version and
@@ -673,8 +695,9 @@ Register it with your MCP client (the exact file depends on the client):
 }
 ```
 
-`SWG_ROOT` selects the workspace (defaulting to the server's working directory);
-the whole workspace is guarded unless the managed set is narrowed.
+`SWG_ROOT` selects the workspace (defaulting to the server's working directory).
+By default the whole workspace is guarded; narrow it with `SWG_MANAGED`, a
+comma-separated glob list (for example `SWG_MANAGED=plans/**,memory/**`).
 
 | Tool | What it does |
 |---|---|
@@ -852,6 +875,11 @@ All examples are runnable with `python -m examples.<name>.main` from the project
 | Research pipeline | `python -m examples.research_pipeline.main` | 4-agent, 3 artifacts, 60% hit rate |
 | Shared codebase | `python -m examples.shared_codebase.main` | 4-agent code review, 37.6% savings, benchmark output |
 | Conversations stale-read | `python -m examples.conversations_stale_read.main` | Two agents share one conversation; client-cache invalidation (offline, no keys) |
+| Coherent volume | `python -m examples.coherent_volume.main` | Sequential stale-write deny + recovery on plain files (offline, no keys) |
+| Concurrent writers | `python -m examples.concurrent_writers.main` | True-race lost update; `write_cas` preserves both updates (offline, no keys) |
+| Effect gate | `python -m examples.effect_gate.main` | `gate()` holds an effect on a stale input; `--baseline` shows the stale fire (offline, no keys) |
+| MCP stale-write guard | `python -m examples.mcp_stale_write_guard.main` | Red→green stale-write deny through the MCP server tools (offline, no keys) |
+| Cross-host | `python examples/cross_host/main.py` | Stale-write deny + effect ordering across a host boundary (local smoke; Docker runner in `examples/cross_host/`) |
 
 ### Code review pipeline
 
@@ -911,7 +939,7 @@ invalidations, more misses. The planning workload has 1 write and 12 reads (75% 
 rate). The high-churn workload has 4 writes and 8 reads (50% hit rate).
 
 For the simulation-based results from the paper (84–95% savings), see
-[REPRODUCE.md](REPRODUCE.md).
+[reproduce.md](reproduce.md).
 
 ### Temporal cost: source drift between turns (TC-1)
 
@@ -1145,7 +1173,7 @@ YAML scenarios in `benchmarks/scenarios/` define a deterministic workload
 (agent count, artifacts, write probability, network latency/loss, strategy
 config). Output is a `StrategyComparisonReport` printed to stdout — useful
 when you want protocol-only numbers without spinning up a real LangGraph
-graph. See [REPRODUCE.md](REPRODUCE.md) for the simulation methodology behind
+graph. See [reproduce.md](reproduce.md) for the simulation methodology behind
 the paper's headline numbers.
 
 ### `ccs-check-architecture`


### PR DESCRIPTION
Documentation audit of v0.9.0 → v0.11.0 found end-user features that shipped without README/guide coverage. This PR closes the gaps; no code changes.

## README
- Install block gains `pip install "agent-coherence[mcp]"` (was missing since v0.10.0)
- **New sections:** Foreign-edit guards (`on_stale_read`/`on_stale_write`), MCP server (`stale-write-guard-fs` — config, `SWG_ROOT`/`SWG_MANAGED`, five-tool table), Multi-artifact snapshot sessions (HTTP + Python surface, fail-closed semantics)
- "What it guarantees" gains the read-skew row (`NoReadSkewWithinCut`, `PinAlwaysRetained`); spec count corrected to **six** (Snapshot.tla, two places)
- Architecture gains the `ccs.mcp` bullet; nav gains four entries; Coherent-workspace scope paragraph updated (write_cas covers concurrent same-key; foreign-edit pointer)

## docs/guide.md
- **New sections:** Coherent workspace (`CoherentVolume` — parameters, `write_cas`/`write_cas_at`, foreign-edit guards, `open()` shim, cross-host mode subsection incl. the fail-closed `CCS_REMOTE_INSECURE` acknowledgement), Multi-artifact snapshot sessions (endpoint table with exact request fields, semantics, honesty boundary), `stale-write-guard-fs` MCP server
- Install block gains the `mcp` extra; Contents renumbered; Examples table gains the five missing runnable demos
- Link fixes: security-guide link pointed at the tracked `docs/security.md`; `REPRODUCE.md` → `reproduce.md` casing

## Verification
Four-checker adversarial pass (accuracy-vs-source, end-user language gate, completeness-vs-CHANGELOG, links/anchors) ran against the branch; all findings fixed in the second commit — notably the `on_error` default (`"strict"`, not `"degrade"`) and the required `session_id` field on every `/session/*` request.

After merge: fast-forward `dev` to `main` (they are currently equal).