### PR TITLE
feat: TLS transport guards + backend atomic-boundary contract (buildable track)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -603,14 +603,29 @@ Everything above is single-host. An experimental, demo-grade remote mode — gat
 entirely by `CCS_REMOTE_COORDINATOR=1` (default off, loopback path byte-unchanged)
 — lets a volume connect to a coordinator on another host: `CCS_REMOTE_HOST` /
 `CCS_REMOTE_PORT` name the endpoint, and the bearer secret arrives via
-`CCS_REMOTE_SECRET_FILE` (a mounted file — never an inline env var). The transport
-is plaintext HTTP, so encryption is your out-of-band responsibility (a WireGuard
-tunnel or a TLS-terminating proxy); to stop a silent leak, the client **refuses to
-send the bearer to a non-loopback host unless `CCS_REMOTE_INSECURE=1`**
-acknowledges the link is secured, raising a typed `InsecureTransportRefused`
-otherwise. Setup, the Docker two-container runner, and the full security boundary
-live in [`examples/cross_host/README.md`](../examples/cross_host/README.md) and
+`CCS_REMOTE_SECRET_FILE` (a mounted file — never an inline env var).
+
+The client can speak **verified https** to a TLS-terminating front: set
+`CCS_REMOTE_TLS=1` to use https with enforced certificate verification (and
+`CCS_REMOTE_CA_FILE` to trust a private certificate authority). Verification is
+fail-closed — an unverifiable certificate means the bearer is never sent — and a
+verified-https connection needs no `CCS_REMOTE_INSECURE=1` acknowledgement. Without
+https the transport is plaintext HTTP, so encryption is your out-of-band
+responsibility (a WireGuard tunnel or a TLS-terminating proxy); to stop a silent
+leak, the client **refuses to send the bearer to a non-loopback host** over
+plaintext unless `CCS_REMOTE_INSECURE=1` acknowledges you secured the link
+yourself, raising a typed `InsecureTransportRefused` otherwise. Symmetrically, a
+coordinator that binds **beyond loopback** refuses to start unless the operator
+asserts `CCS_TLS_TERMINATED=1` (a TLS front is present) or `CCS_SERVE_INSECURE=1`
+(an acknowledged insecure link) — these are operator assertions, not enforcement.
+Setup, the Docker two-container runner, and the full security boundary and
+certificate requirements live in
+[`examples/cross_host/README.md`](../examples/cross_host/README.md) and
 [the security guide](security.md).
+
+> An internal, experimental seam formalizes what a networked registry backend
+> would have to provide; it is not a public extension point, and there is nothing
+> for end users to configure today.
 
 ## Multi-artifact snapshot sessions
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -17,25 +17,88 @@ security advisory](https://github.com/hipvlady/agent-coherence/security/advisori
 
 **Cross-host mode (default OFF).** Setting `CCS_REMOTE_COORDINATOR=1` and pointing
 a `CoherentVolume` at a remote coordinator (`CCS_REMOTE_HOST` / `CCS_REMOTE_PORT` /
-`CCS_REMOTE_SECRET_FILE`) makes the client open HTTP connections to that
+`CCS_REMOTE_SECRET_FILE`) makes the client open connections to that
 **user-configured, private-range coordinator endpoint** — never the internet, and
 no telemetry. This is the only network traffic the library generates, it is opt-in,
 and the coordinator only binds beyond loopback to an RFC-1918/4193 address (see the
 cross-host demo, `examples/cross_host/`). With the flag unset the zero-outbound
 posture above is unchanged.
 
-**Plaintext-bearer guard (fail-closed, cross-host mode).** The remote transport is
-plaintext HTTP — the coordinator terminates no TLS, so encryption is the operator's
-out-of-band responsibility (a WireGuard tunnel or a TLS-terminating proxy). To stop
-a bearer from silently crossing an unencrypted routed link, the client **refuses to
-send it to a non-loopback host unless `CCS_REMOTE_INSECURE=1`** is set — an explicit
-acknowledgement that the link is secured out-of-band (a typed
-`InsecureTransportRefused` is raised otherwise). Loopback is unaffected. This
-*reduces* the silent-plaintext footgun; it does **not** guarantee encryption. Set
-the ack **narrowly** (per-invocation / per-compose-service), never in a persistent
-global shell profile — a forgotten global ack would blanket-acknowledge every
-future non-loopback host. Production TLS/mTLS termination is a separate hardening
-step.
+**Client TLS (verified https).** The client can speak `https://` to a
+TLS-terminating front with **enforced certificate verification**. Set
+`CCS_REMOTE_TLS=1` to select https; the client verifies the server certificate
+and, if verification fails, **fails closed — the bearer token is never sent** over
+an unverifiable connection. There is no way to turn certificate verification off:
+an insecure-https mode simply does not exist in the client's configuration. To
+trust a private certificate authority instead of the system trust store, point
+`CCS_REMOTE_CA_FILE` at a CA-bundle file; it is loaded fail-closed — a symlinked
+bundle is refused, and a group- or world-writable bundle is refused (a trust
+anchor an attacker can rewrite is not a trust anchor). The client also **refuses
+to follow redirects**: it talks to the one coordinator endpoint you configured, so
+any redirect response is rejected rather than followed with the bearer attached.
+The loopback path is unchanged — a plain `http://` loopback endpoint behaves
+exactly as before.
+
+**CA-profile requirements for the terminating proxy (read this before you
+provision a certificate).** Coordinator endpoints are almost always IP literals
+(private-range addresses like `10.0.0.5`), and that shapes what certificate the
+TLS-terminating proxy must present:
+
+- **The certificate must carry an IP subject alternative name** matching the
+  endpoint address — for example `subjectAltName = IP:10.0.0.5`. A DNS-only
+  certificate has no name that matches an IP-literal endpoint, so verification
+  **fails closed** against it. This is the single most common cause of a
+  connection that refuses to establish.
+- **On Python 3.13 and newer the certificate must be RFC 5280-strict**, or
+  verification rejects it: it needs a subject key identifier and an authority key
+  identifier, `basicConstraints` marked critical, and an extended key usage of
+  `serverAuth`. Older certificates that older Python tolerated will be refused
+  here.
+- **Self-signed certificates are not a supported posture.** Use a private
+  certificate authority and supply its bundle via `CCS_REMOTE_CA_FILE`. A private
+  CA is what lets you mint an IP-SAN, RFC 5280-strict server certificate the
+  client will actually verify.
+
+**Plaintext-bearer guard (fail-closed, cross-host mode).** When the client is
+*not* using verified https, the remote transport is plaintext HTTP — the
+coordinator terminates no TLS itself, so encryption is the operator's out-of-band
+responsibility (a WireGuard tunnel or a TLS-terminating proxy). To stop a bearer
+from silently crossing an unencrypted routed link, the client **refuses to send it
+to a non-loopback host** over plaintext (a typed `InsecureTransportRefused` is
+raised). There are now two clean ways to satisfy the guard:
+
+- **Verified https (the clean path).** A verified-https connection satisfies the
+  guard automatically — the link is encrypted and the certificate is checked, so
+  no acknowledgement is needed. `CCS_REMOTE_INSECURE=1` is **not** required for a
+  properly TLS-fronted deployment.
+- **`CCS_REMOTE_INSECURE=1` (the narrow out-of-band case).** This remains only for
+  a *plaintext* link you have secured yourself out-of-band — a WireGuard tunnel or
+  equivalent — where you knowingly accept the bearer riding plaintext HTTP inside
+  that secured channel.
+
+Loopback is unaffected. The plaintext ack *reduces* the silent-plaintext footgun;
+it does **not** itself encrypt anything. Set the ack **narrowly** (per-invocation /
+per-compose-service), never in a persistent global shell profile — a forgotten
+global ack would blanket-acknowledge every future non-loopback host.
+
+**Coordinator-side bind guard (fail-closed).** Symmetrically, a coordinator that
+binds **beyond loopback** now refuses to serve unless the operator makes one of two
+explicit assertions:
+
+- `CCS_TLS_TERMINATED=1` — you assert a TLS-terminating front sits ahead of the
+  coordinator.
+- `CCS_SERVE_INSECURE=1` — you explicitly acknowledge an insecure (plaintext) link.
+
+With neither set, a routed bind fails at startup rather than silently serving
+bearer-authenticated requests in the clear. **These are operator assertions, not
+enforcement:** the coordinator cannot verify that a proxy is actually present or
+that the link is actually encrypted — it takes your word for it and records the
+posture in its log. They acknowledge; they do not themselves encrypt or verify.
+Loopback binds read neither variable and are unchanged. As with the client ack,
+set these **narrowly** (per-invocation / per-compose-service), never as a
+persistent global — a forgotten global assertion would blanket every future routed
+bind. Production TLS/mTLS termination is a separate hardening step; the cross-host
+mode as a whole remains experimental and default-off.
 
 ## Env-var kill switches
 

--- a/examples/cross_host/README.md
+++ b/examples/cross_host/README.md
@@ -96,6 +96,22 @@ send its bearer over plaintext HTTP unless you set `CCS_REMOTE_INSECURE=1` — t
 explicit acknowledgement that *you* have secured the link out-of-band (the
 encrypted tunnel above). A loopback host needs no acknowledgement.
 
+**Or terminate TLS in front and skip the ack.** If a TLS-terminating proxy sits in
+front of the coordinator, point the client at it with verified https instead:
+
+```
+export CCS_REMOTE_TLS=1                                       # https with enforced certificate verification
+export CCS_REMOTE_CA_FILE=/path/to/private-ca.pem            # trust your private CA (fail-closed: no symlink, not group/world-writable)
+# CCS_REMOTE_INSECURE is NOT needed — a verified-https link satisfies the guard
+```
+
+Verification is fail-closed: an unverifiable certificate means the bearer is never
+sent. Because the endpoint here is an IP literal, the proxy's certificate must
+carry an IP subject alternative name (`subjectAltName = IP:10.0.0.1`) — a DNS-only
+certificate fails closed against an IP endpoint — and on Python 3.13+ it must be
+RFC 5280-strict. Use a private CA (not a self-signed certificate) and supply it via
+`CCS_REMOTE_CA_FILE`. See the Security boundary below.
+
 ### Docker (recommended — genuine cross-container, one command, verified)
 
 Two containers on a private-range bridge — **separate network namespaces, real
@@ -130,13 +146,32 @@ public addresses are all rejected); the bearer secret is provisioned via a
 confidential channel (never an inline env var — it would leak in `ps` /
 `docker inspect`); and the link is encrypted.
 
-**Plaintext-bearer guard (fail-closed).** The transport is plaintext HTTP — the
-coordinator has no TLS; encryption is *your* out-of-band responsibility (a
-WireGuard tunnel, a TLS-terminating proxy, or the isolated Docker bridge here). To
-stop a silent leak, the client **refuses to send the bearer to a non-loopback host
-unless you set `CCS_REMOTE_INSECURE=1`** — an explicit acknowledgement that the
-link is secured. It *reduces* the silent-plaintext footgun; it does not *guarantee*
-encryption. Set it **narrowly** (per-invocation or per-compose-service), not in a
-persistent global shell profile — a forgotten global ack would blanket-acknowledge
-every future non-loopback host. Production hardening (TLS/mTLS termination) is
-tracked separately.
+**Plaintext-bearer guard (fail-closed).** Without TLS the transport is plaintext
+HTTP — the coordinator terminates no TLS itself; encryption is *your* out-of-band
+responsibility (a WireGuard tunnel, a TLS-terminating proxy, or the isolated Docker
+bridge here). To stop a silent leak, the client **refuses to send the bearer to a
+non-loopback host** over plaintext. Two clean ways to satisfy it:
+
+- **Verified https** — set `CCS_REMOTE_TLS=1` (see the Host-2 instructions above).
+  A verified-https connection satisfies the guard automatically; no
+  acknowledgement is needed. Certificate verification is enforced and fails
+  closed — the bearer is never sent over an unverifiable link — with no way to
+  turn verification off.
+- **`CCS_REMOTE_INSECURE=1`** — the narrow case: a *plaintext* link you have
+  secured yourself out-of-band. It *reduces* the silent-plaintext footgun; it does
+  not *guarantee* encryption.
+
+Set the plaintext ack **narrowly** (per-invocation or per-compose-service), not in
+a persistent global shell profile — a forgotten global ack would
+blanket-acknowledge every future non-loopback host.
+
+**Coordinator-side bind guard (fail-closed).** A coordinator that binds beyond
+loopback now refuses to start unless the operator asserts either
+`CCS_TLS_TERMINATED=1` (a TLS-terminating front is present) or
+`CCS_SERVE_INSECURE=1` (an acknowledged insecure link). These are **operator
+assertions, not enforcement** — the coordinator cannot verify a proxy is really
+there or that the link is really encrypted; it records the posture and serves. This
+demo binds beyond loopback, so it sets `CCS_SERVE_INSECURE=1` (already wired into
+the Docker compose service). Set it **narrowly** (per-compose-service), never as a
+persistent global. Production hardening (TLS/mTLS termination) is tracked
+separately; this cross-host mode remains experimental and default-off.

--- a/examples/cross_host/docker/docker-compose.yml
+++ b/examples/cross_host/docker/docker-compose.yml
@@ -14,6 +14,15 @@ services:
         ipv4_address: 172.28.0.2
     volumes:
       - coordstate:/coord/.coherence
+    environment:
+      # 172.28.0.2 is a routed (non-loopback) bind: the coordinator refuses to
+      # serve its bearer over plaintext HTTP unless the operator asserts a
+      # TLS-terminating front (CCS_TLS_TERMINATED) or acknowledges the insecure
+      # link (CCS_SERVE_INSECURE). Here the link is the isolated private-range
+      # Docker bridge — acknowledged explicitly, mirroring the client's
+      # CCS_REMOTE_INSECURE below. Symmetry with the fail-closed client guard.
+      CCS_REMOTE_COORDINATOR: "1"
+      CCS_SERVE_INSECURE: "1"
     command:
       - python
       - -m

--- a/examples/cross_host/main.py
+++ b/examples/cross_host/main.py
@@ -302,7 +302,18 @@ def main(argv: list[str] | None = None) -> int:
         _log(f"Cross-host demo against coordinator at {remote.host}:{remote.port}")
 
         def make_ep():
-            return resolve_remote_endpoint(remote.host, remote.port, remote.secret)
+            # Thread the verified-TLS surface (CCS_REMOTE_TLS / CCS_REMOTE_CA_FILE,
+            # parsed by from_env) through to the endpoint. Without this, an https
+            # deployment would fall back to scheme="http" and the guard would
+            # refuse the non-loopback bearer — i.e. the documented TLS workflow
+            # (README "Or terminate TLS in front and skip the ack") could not run.
+            return resolve_remote_endpoint(
+                remote.host,
+                remote.port,
+                remote.secret,
+                scheme=remote.scheme,
+                ca_file=remote.ca_file,
+            )
 
         try:
             _track(make_ep())

--- a/src/ccs/adapters/claude_code/auth.py
+++ b/src/ccs/adapters/claude_code/auth.py
@@ -125,12 +125,82 @@ def validate_bind_host(host: str) -> None:
         )
 
 
+#: Server-side transport-posture env vars (Unit 3 / R5). ``CCS_TLS_TERMINATED``
+#: asserts a TLS-terminating front sits ahead of the coordinator (posture INFO);
+#: ``CCS_SERVE_INSECURE`` is the explicit plaintext-link acknowledgement (WARNING),
+#: the mirror of the client's ``CCS_REMOTE_INSECURE``. Both parse against the same
+#: truthy set as ``CCS_REMOTE_COORDINATOR`` (:data:`_REMOTE_TRUTHY_ENV_VALUES`).
+_TLS_TERMINATED_ENV = "CCS_TLS_TERMINATED"
+_SERVE_INSECURE_ENV = "CCS_SERVE_INSECURE"
+
+
+def _serve_env_enabled(name: str) -> bool:
+    """True when the named transport-posture env var is set to a truthy value."""
+    return os.environ.get(name, "").strip().lower() in _REMOTE_TRUTHY_ENV_VALUES
+
+
+def assert_serve_transport_acknowledged(bind_host: str) -> None:
+    """Fail-closed guard: refuse to serve on a routed bind without a transport ack.
+
+    Symmetry with the client's ``CCS_REMOTE_INSECURE`` plaintext-bearer guard
+    (#135): the coordinator authenticates hook requests with a bearer secret, so
+    serving them on a routed (non-loopback) bind over plaintext exposes the
+    bearer on the wire. This guard refuses to construct such a server unless the
+    operator either asserts a TLS-terminating front is present
+    (``CCS_TLS_TERMINATED``) or explicitly acknowledges the insecure link
+    (``CCS_SERVE_INSECURE``).
+
+    Loopback binds read NEITHER env and return immediately (byte-unchanged; no
+    log). The bind host must already have passed :func:`validate_bind_host`
+    (non-loopback ⇒ CCS_REMOTE_COORDINATOR-gated private-range IP); this guard
+    reuses that loopback classification rather than re-deriving one, so the
+    client and server never drift.
+
+    Precedence: if BOTH envs are set the TLS assertion wins the log line (a
+    single INFO posture line, no double-warn). Raises :class:`ValueError` (the
+    established construction-time bind-rejection idiom of
+    :func:`build_host_allowlist`) naming both envs when neither is set.
+    """
+    if is_loopback_host(bind_host):
+        return
+    if _serve_env_enabled(_TLS_TERMINATED_ENV):
+        # Assertion wins even when CCS_SERVE_INSECURE is also set (no double-warn).
+        # Names the bind host + posture only — there is no secret in scope here.
+        logger.info(
+            "serving the coordinator on routed bind %r; %s asserted "
+            "(a TLS-terminating front is expected ahead of the coordinator)",
+            bind_host,
+            _TLS_TERMINATED_ENV,
+        )
+        return
+    if _serve_env_enabled(_SERVE_INSECURE_ENV):
+        logger.warning(
+            "serving the coordinator bearer on routed bind %r over plaintext HTTP "
+            "(%s acknowledged — ensure the link is encrypted out-of-band)",
+            bind_host,
+            _SERVE_INSECURE_ENV,
+        )
+        return
+    raise ValueError(
+        f"refusing to serve the coordinator bearer on routed bind {bind_host!r} "
+        f"over plaintext HTTP; set {_TLS_TERMINATED_ENV} to assert a "
+        f"TLS-terminating front, or {_SERVE_INSECURE_ENV} to acknowledge an "
+        "out-of-band-secured link"
+    )
+
+
 def build_host_allowlist(bind_host: str) -> frozenset[str]:
     """The Host-header allowlist for a coordinator bound to ``bind_host``.
 
     Always includes loopback; for a validated non-loopback bind it also admits
     that exact host. Validates ``bind_host`` (raises on a disallowed bind), so a
     coordinator constructed with a bad bind fails loud at construction.
+
+    This function stays a pure address→allowlist derivation (no env-driven
+    transport-posture side effects). The routed-bind transport acknowledgement is
+    a distinct concern enforced by :func:`assert_serve_transport_acknowledged` at
+    the coordinator construction path — keeping the two separable lets callers
+    that only need the allowlist derive it without a live transport-posture env.
     """
     validate_bind_host(bind_host)
     if is_loopback_host(bind_host):

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -54,6 +54,7 @@ from ccs.adapters.claude_code import audit_log as _audit_log
 from ccs.adapters.claude_code import hook_payloads as _payloads
 from ccs.adapters.claude_code import session_audit_log as _session_audit
 from ccs.adapters.claude_code.auth import (
+    assert_serve_transport_acknowledged,
     build_host_allowlist,
     ensure_secret,
     verify_bearer,
@@ -347,6 +348,14 @@ class CoordinatorHTTPServer:
         # disallowed bind (wildcard, loopback alias, link-local, CGNAT, public, or
         # non-loopback without the CCS_REMOTE_COORDINATOR opt-in) raises.
         self.host_allowlist = build_host_allowlist(bind_host)
+        # Unit 3 / R5: fail-closed transport symmetry with the client's #135
+        # plaintext-bearer guard. A routed (non-loopback) bind serves the bearer
+        # secret on the wire, so it must either assert a TLS-terminating front
+        # (CCS_TLS_TERMINATED) or explicitly acknowledge the insecure link
+        # (CCS_SERVE_INSECURE), else construction raises ValueError. Loopback binds
+        # read neither env and are byte-unchanged. Runs before the socket bind so a
+        # routed coordinator without an ack never opens a listening socket.
+        assert_serve_transport_acknowledged(bind_host)
         # Monotonic reference points (NOT wall-clock): idle/uptime deltas must
         # survive NTP steps and suspend/resume (finding L5). time.time() stays
         # reserved for operator-facing absolute timestamps elsewhere.

--- a/src/ccs/cli/_coherence_client.py
+++ b/src/ccs/cli/_coherence_client.py
@@ -583,6 +583,13 @@ class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
     ):  # noqa: ANN001, ANN201 - matches the stdlib handler signature
         raise RedirectRefused(newurl, status=code)
 
+    # urllib's HTTPRedirectHandler routes 301/302/303/307 through
+    # ``redirect_request`` but has NO ``http_error_308`` method, so a 308 would
+    # otherwise surface as a bare ``HTTPError`` (still not followed — the bearer
+    # never rides it — but untyped). Alias it to the 302 path so a 308 is a
+    # typed ``RedirectRefused`` too, making "refuse ANY 3xx" literally true.
+    http_error_308 = urllib.request.HTTPRedirectHandler.http_error_302
+
 
 def _build_opener(context: ssl.SSLContext | None) -> urllib.request.OpenerDirector:
     """A private opener whose redirect handler refuses every 3xx.

--- a/src/ccs/cli/_coherence_client.py
+++ b/src/ccs/cli/_coherence_client.py
@@ -21,6 +21,7 @@ import ipaddress
 import json
 import logging
 import os
+import ssl
 import sys
 import urllib.error
 import urllib.request
@@ -30,7 +31,12 @@ from pathlib import Path
 from typing import Any
 
 from ccs.adapters.claude_code.lifecycle import read_port_from_file as _read_port_from_file
-from ccs.core.exceptions import InsecureTransportRefused
+from ccs.core.exceptions import (
+    InsecureTransportRefused,
+    RedirectRefused,
+    TlsConfigError,
+    TlsVerificationFailed,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -145,23 +151,34 @@ class CoordinatorEndpoint:
     ``host`` defaults to loopback so the local path is byte-unchanged; the
     cross-host demo (gated by :class:`RemoteCoordinatorConfig`) supplies a
     routable host via :func:`resolve_remote_endpoint`.
+
+    ``scheme`` defaults to ``"http"`` (the loopback path is byte-unchanged);
+    ``"https"`` selects verified TLS — :func:`_execute` builds a hardened
+    context via :func:`build_tls_context` (there is no insecure ``https`` mode).
+    ``ca_file`` optionally names an exclusive private-CA bundle for that
+    context; it is validated and read once at request time (see
+    :func:`build_tls_context`).
     """
 
     port: int
     bearer: str
     host: str = "127.0.0.1"
+    scheme: str = "http"
+    ca_file: str | None = None
 
     @property
     def base_url(self) -> str:
         # Bracket an IPv6 literal so the authority parses: http://[::1]:8080, not
         # the ambiguous http://::1:8080 (urllib reads the last colon as the port
-        # separator). A hostname / IPv4 raises ValueError -> no brackets.
+        # separator). A hostname / IPv4 raises ValueError -> no brackets. The
+        # bracketing branch fires for BOTH schemes (https://[::1]:8443 too).
+        authority = self.host
         try:
             if ipaddress.ip_address(self.host).version == 6:
-                return f"http://[{self.host}]:{self.port}"
+                authority = f"[{self.host}]"
         except ValueError:
             pass
-        return f"http://{self.host}:{self.port}"
+        return f"{self.scheme}://{authority}:{self.port}"
 
 
 class CoordinatorUnavailable(Exception):
@@ -169,6 +186,101 @@ class CoordinatorUnavailable(Exception):
 
     Carries a human-readable message the console script prints verbatim.
     """
+
+
+def _read_ca_bundle(ca_file: str) -> str:
+    """Read a private-CA PEM bundle with the same discipline as ``_read_secret``.
+
+    A CA bundle is a *trust anchor* — a symlink swap or a writable file between
+    check and use is the same attack class as a swapped bearer file, so we open
+    with ``O_NOFOLLOW`` (refuse symlinks), reject a group/world-*writable* file
+    (the ``0o022`` bits — readable is fine, certs are public), and read ONCE via
+    the fd (no path re-open → no TOCTOU). The bytes are handed to the SSL context
+    as ``cadata`` so the path is never re-opened.
+
+    Any failure (missing / unreadable / symlink / loose perms) is normalized to
+    a :class:`~ccs.core.exceptions.TlsConfigError` naming the path — never a raw
+    ``OSError`` / ``ssl.SSLError`` leaking out.
+    """
+    try:
+        fd = os.open(ca_file, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    except OSError as exc:
+        # Missing, or a symlink (ELOOP), or otherwise unopenable — fail closed.
+        raise TlsConfigError(
+            f"CCS_REMOTE_CA_FILE {ca_file!r} could not be opened "
+            f"({exc.strerror or exc}); it must be a regular, readable PEM file "
+            "(symlinks are refused)",
+            path=ca_file,
+        ) from exc
+    try:
+        with os.fdopen(fd, encoding="utf-8") as handle:
+            mode = os.fstat(handle.fileno()).st_mode
+            # Only the WRITABLE bits are the attack (a swapped trust anchor);
+            # a public cert may be group/world-readable.
+            if mode & 0o022:
+                raise TlsConfigError(
+                    f"CCS_REMOTE_CA_FILE {ca_file!r} is group/world-writable "
+                    f"(mode {mode & 0o777:o}); tighten it so the trust anchor "
+                    "cannot be swapped (e.g. 0644)",
+                    path=ca_file,
+                )
+            return handle.read()
+    except UnicodeDecodeError as exc:
+        raise TlsConfigError(
+            f"CCS_REMOTE_CA_FILE {ca_file!r} is not a text PEM file ({exc})",
+            path=ca_file,
+        ) from exc
+    except OSError as exc:
+        raise TlsConfigError(
+            f"CCS_REMOTE_CA_FILE {ca_file!r} could not be read ({exc.strerror or exc})",
+            path=ca_file,
+        ) from exc
+
+
+def build_tls_context(ca_file: str | None = None) -> ssl.SSLContext:
+    """Build the ONE verified-TLS context for the coordinator client.
+
+    This is the single mTLS-forward-compat choke point: a later mTLS phase adds
+    ``load_cert_chain`` config keys here and nowhere else. There is deliberately
+    NO cert-verification off-switch — ``CERT_NONE`` / ``check_hostname=False`` is
+    unrepresentable through any parameter (the footgun rule).
+
+    - ``create_default_context`` (secure defaults on 3.11+: ``CERT_REQUIRED`` +
+      ``check_hostname`` + ``VERIFY_X509_STRICT``); with ``cadata`` from an
+      exclusive private-CA bundle when ``ca_file`` is given, else the system
+      trust store.
+    - The TLS floor is pinned to 1.2 explicitly (do not rely on the default).
+    - ``OP_NO_RENEGOTIATION`` is intentionally NOT set (mTLS forward-compat).
+    - Hardening invariant asserted: if ``check_hostname`` or ``CERT_REQUIRED``
+      were ever weakened by a future edit, this raises :class:`TlsConfigError`
+      rather than silently shipping an insecure client.
+    """
+    cadata = _read_ca_bundle(ca_file) if ca_file else None
+    try:
+        ctx = ssl.create_default_context(cadata=cadata)
+    except ssl.SSLError as exc:
+        # e.g. cadata present but not valid PEM — normalize to a typed config error.
+        raise TlsConfigError(
+            f"CCS_REMOTE_CA_FILE {ca_file!r} does not contain a valid PEM certificate "
+            f"({exc})",
+            path=ca_file,
+        ) from exc
+
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+    # IP-literal endpoints: OpenSSL matches IP SANs natively; disabling the
+    # legacy CN fallback keeps verification to SAN-only (no effect on the SAN
+    # match, tightens the no-SAN case). Harmless where the attribute is absent.
+    if hasattr(ctx, "hostname_checks_common_name"):
+        ctx.hostname_checks_common_name = False
+
+    # Invariant: verification MUST be enforced. This is the assertion the guard's
+    # positive signal (Unit 2) relies on — https means enforced verification.
+    if not (ctx.check_hostname and ctx.verify_mode == ssl.CERT_REQUIRED):
+        raise TlsConfigError(
+            "internal error: the TLS context is not enforcing certificate "
+            "verification (check_hostname/CERT_REQUIRED invariant violated)"
+        )
+    return ctx
 
 
 def resolve_endpoint(coordinator_root: Path) -> CoordinatorEndpoint:
@@ -259,7 +371,13 @@ def _guard_plaintext_bearer(host: str, env: Mapping[str, str]) -> None:
 
 
 def resolve_remote_endpoint(
-    host: str, port: int, secret: str, *, env: Mapping[str, str] | None = None
+    host: str,
+    port: int,
+    secret: str,
+    *,
+    scheme: str = "http",
+    ca_file: str | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> CoordinatorEndpoint:
     """Build an endpoint for a REMOTE coordinator (cross-host demo).
 
@@ -268,18 +386,27 @@ def resolve_remote_endpoint(
     by the caller (typically via :meth:`RemoteCoordinatorConfig.from_env`).
     Gated by :class:`RemoteCoordinatorConfig`.
 
+    ``scheme`` (default ``"http"``) and ``ca_file`` (default ``None``) are
+    additive: they thread the verified-TLS surface onto the endpoint without
+    changing any existing caller. ``scheme="https"`` selects the verified-TLS
+    request path in :func:`_execute`.
+
     Fail-closed transport guard: for a NON-loopback host the bearer is only sent
     when ``CCS_REMOTE_INSECURE`` (read from ``env``, default ``os.environ``) is
     truthy — otherwise :class:`InsecureTransportRefused` is raised (the transport
     is plaintext HTTP; the ack acknowledges an out-of-band-secured link). Loopback
-    is byte-unchanged.
+    is byte-unchanged. (Unit 2 will consult ``scheme`` inside the guard so a
+    verified-TLS endpoint passes without the ack; this unit only threads it
+    through — the guard decision is unchanged here.)
     """
     if not host:
         raise CoordinatorUnavailable("remote coordinator host is empty")
     if not secret:
         raise CoordinatorUnavailable("remote coordinator bearer secret is empty")
     _guard_plaintext_bearer(host, os.environ if env is None else env)
-    return CoordinatorEndpoint(port=port, bearer=secret, host=host)
+    return CoordinatorEndpoint(
+        port=port, bearer=secret, host=host, scheme=scheme, ca_file=ca_file
+    )
 
 
 @dataclass(frozen=True)
@@ -301,6 +428,12 @@ class RemoteCoordinatorConfig:
     host: str | None = None
     port: int | None = None
     secret: str | None = None
+    #: ``"https"`` when ``CCS_REMOTE_TLS`` is truthy, else ``"http"`` (default).
+    #: Selects verified TLS on the resolved endpoint (Unit 1).
+    scheme: str = "http"
+    #: Optional private-CA bundle PATH from ``CCS_REMOTE_CA_FILE`` (file-not-inline,
+    #: mirroring ``CCS_REMOTE_SECRET_FILE``). Validated/read at request time.
+    ca_file: str | None = None
 
     @classmethod
     def from_env(cls, env: dict[str, str] | None = None) -> RemoteCoordinatorConfig:
@@ -314,7 +447,16 @@ class RemoteCoordinatorConfig:
         port = int(port_raw) if port_raw.isdigit() else None
         if port is not None and not (1 <= port <= 65535):
             port = None  # out of TCP range -> treat as unset (fail closed downstream)
-        return cls(enabled=True, host=host, port=port, secret=cls._read_secret(env))
+        tls = env.get("CCS_REMOTE_TLS", "").strip().lower() in _REMOTE_TRUTHY_ENV_VALUES
+        ca_file = (env.get("CCS_REMOTE_CA_FILE") or "").strip() or None
+        return cls(
+            enabled=True,
+            host=host,
+            port=port,
+            secret=cls._read_secret(env),
+            scheme="https" if tls else "http",
+            ca_file=ca_file,
+        )
 
     @staticmethod
     def _read_secret(env: dict[str, str]) -> str | None:
@@ -374,6 +516,8 @@ def get(
         method="GET",
         headers=headers,
     )
+    # Carry the CA bundle to _execute (only consulted for https requests).
+    req._ccs_ca_file = endpoint.ca_file  # type: ignore[attr-defined]
     return _execute(req)
 
 
@@ -404,17 +548,69 @@ def post(
         method="POST",
         headers=headers,
     )
+    # Carry the CA bundle to _execute (only consulted for https requests).
+    req._ccs_ca_file = endpoint.ca_file  # type: ignore[attr-defined]
     return _execute(req)
 
 
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse ANY 3xx instead of following it.
+
+    The coordinator is one fixed, operator-configured endpoint — no redirect is
+    ever legitimate. Critically, urllib's default ``HTTPRedirectHandler`` COPIES
+    the ``Authorization`` header onto the redirected hop *before* returning, so a
+    post-hoc check on the final response cannot protect the bearer. Refusing here,
+    inside ``redirect_request`` (called before the second request is issued),
+    ensures the bearer never leaves the configured endpoint.
+    """
+
+    def redirect_request(  # type: ignore[override]
+        self, req, fp, code, msg, headers, newurl
+    ):  # noqa: ANN001, ANN201 - matches the stdlib handler signature
+        raise RedirectRefused(newurl, status=code)
+
+
+def _build_opener(context: ssl.SSLContext | None) -> urllib.request.OpenerDirector:
+    """A private opener whose redirect handler refuses every 3xx.
+
+    ``build_opener`` with our ``_NoRedirectHandler`` REPLACES the default
+    ``HTTPRedirectHandler`` (``build_opener`` de-dupes by handler class). For
+    https, the ``HTTPSHandler(context=...)`` carries the verified-TLS context.
+    """
+    handlers: list[urllib.request.BaseHandler] = [_NoRedirectHandler()]
+    if context is not None:
+        handlers.append(urllib.request.HTTPSHandler(context=context))
+    return urllib.request.build_opener(*handlers)
+
+
 def _execute(req: urllib.request.Request) -> dict[str, Any]:
+    context: ssl.SSLContext | None = None
+    if req.type == "https":
+        # build_tls_context may raise TlsConfigError (typed, fail-closed) — that
+        # is a config bug, not a transient network failure, so it propagates.
+        ca_file = getattr(req, "_ccs_ca_file", None)
+        context = build_tls_context(ca_file)
+
+    opener = _build_opener(context)
     try:
-        with urllib.request.urlopen(req, timeout=CLI_HTTP_TIMEOUT_SEC) as resp:
+        with opener.open(req, timeout=CLI_HTTP_TIMEOUT_SEC) as resp:
             raw = resp.read()
     except urllib.error.HTTPError:
         # Caller handles status-code-specific paths.
         raise
+    except RedirectRefused:
+        # Typed refusal from _NoRedirectHandler — fail closed, do not degrade.
+        raise
     except urllib.error.URLError as exc:
+        # A TLS certificate-verification failure surfaces here (SSLError wrapped
+        # in URLError). It is a TRUST decision, not a transient hiccup: map it to
+        # the typed refusal so the bearer is never retried over plaintext, and
+        # keep it distinct from CoordinatorUnavailable (which callers may treat
+        # as retryable). Every other URLError stays CoordinatorUnavailable.
+        if isinstance(exc.reason, ssl.SSLCertVerificationError):
+            raise TlsVerificationFailed(
+                _host_of(req), str(exc.reason)
+            ) from exc
         raise CoordinatorUnavailable(
             f"could not reach coordinator at {req.full_url}: {exc.reason}"
         ) from exc
@@ -431,6 +627,16 @@ def _execute(req: urllib.request.Request) -> dict[str, Any]:
         raise CoordinatorUnavailable(
             f"coordinator returned non-JSON response: {exc}"
         ) from exc
+
+
+def _host_of(req: urllib.request.Request) -> str:
+    """Best-effort host for a TLS-verification error message (never the bearer).
+
+    Prefer the explicit ``Host`` header (a bare host, set by ``get``/``post`` from
+    ``endpoint.host``) over ``req.host`` (which carries ``host:port``) so the
+    typed refusal names the clean host the operator configured.
+    """
+    return req.get_header("Host") or getattr(req, "host", "") or req.full_url
 
 
 def http_status_from_error(exc: urllib.error.HTTPError) -> dict[str, Any] | None:

--- a/src/ccs/cli/_coherence_client.py
+++ b/src/ccs/cli/_coherence_client.py
@@ -347,16 +347,30 @@ def _is_loopback_transport_host(host: str) -> bool:
     return ip.is_loopback
 
 
-def _guard_plaintext_bearer(host: str, env: Mapping[str, str]) -> None:
+def _guard_plaintext_bearer(host: str, env: Mapping[str, str], scheme: str = "http") -> None:
     """Fail closed on a plaintext bearer to a non-loopback host (Phase-1.5 guard).
 
-    The remote transport is always ``http://`` (encryption is operator-provided
-    out-of-band — WireGuard or a TLS-terminating proxy), so there is no in-band TLS
-    signal. For a non-loopback host the operator must set ``CCS_REMOTE_INSECURE``
-    (truthy) to acknowledge the link is secured, or the bearer is never sent
-    (:class:`InsecureTransportRefused`). Reduces-not-eliminates: it removes the
-    SILENT plaintext-bearer footgun, not the operator's duty to secure the link.
+    ``scheme == "https"`` is the verified-TLS positive signal (Unit 2): in THIS
+    client ``https`` ALWAYS means enforced certificate verification
+    (:func:`build_tls_context` has no insecure-https mode — the footgun rule), so
+    the bearer rides an in-band-trusted link. The guard passes at mint with NO ack
+    and NO warning, short-circuiting BEFORE the ack branch — the ack is irrelevant
+    when verification is enforced (an ``https`` endpoint with ``CCS_REMOTE_INSECURE``
+    also set emits no plaintext warning). This retires the permanent-
+    ``CCS_REMOTE_INSECURE=1`` wart for TLS-fronted deployments. If that "https ⇒
+    verified" invariant ever weakened, this positive signal would regress — it is
+    asserted in :func:`build_tls_context`.
+
+    The ``http`` path is byte-unchanged. The remote transport there is plaintext
+    (encryption is operator-provided out-of-band — WireGuard or a TLS-terminating
+    proxy), so there is no in-band TLS signal. For a non-loopback host the operator
+    must set ``CCS_REMOTE_INSECURE`` (truthy) to acknowledge the link is secured, or
+    the bearer is never sent (:class:`InsecureTransportRefused`). Reduces-not-
+    eliminates: it removes the SILENT plaintext-bearer footgun, not the operator's
+    duty to secure the link.
     """
+    if scheme == "https":
+        return
     if _is_loopback_transport_host(host):
         return
     if env.get("CCS_REMOTE_INSECURE", "").strip().lower() in _REMOTE_TRUTHY_ENV_VALUES:
@@ -391,19 +405,19 @@ def resolve_remote_endpoint(
     changing any existing caller. ``scheme="https"`` selects the verified-TLS
     request path in :func:`_execute`.
 
-    Fail-closed transport guard: for a NON-loopback host the bearer is only sent
-    when ``CCS_REMOTE_INSECURE`` (read from ``env``, default ``os.environ``) is
-    truthy — otherwise :class:`InsecureTransportRefused` is raised (the transport
-    is plaintext HTTP; the ack acknowledges an out-of-band-secured link). Loopback
-    is byte-unchanged. (Unit 2 will consult ``scheme`` inside the guard so a
-    verified-TLS endpoint passes without the ack; this unit only threads it
-    through — the guard decision is unchanged here.)
+    Fail-closed transport guard: an ``https`` endpoint (verified TLS — there is no
+    insecure ``https`` mode) passes at mint with NO ack; for a plaintext ``http``
+    NON-loopback host the bearer is only sent when ``CCS_REMOTE_INSECURE`` (read
+    from ``env``, default ``os.environ``) is truthy — otherwise
+    :class:`InsecureTransportRefused` is raised (the ack acknowledges an
+    out-of-band-secured link). Loopback ``http`` is byte-unchanged. See
+    :func:`_guard_plaintext_bearer` for the verified-TLS positive signal (Unit 2).
     """
     if not host:
         raise CoordinatorUnavailable("remote coordinator host is empty")
     if not secret:
         raise CoordinatorUnavailable("remote coordinator bearer secret is empty")
-    _guard_plaintext_bearer(host, os.environ if env is None else env)
+    _guard_plaintext_bearer(host, os.environ if env is None else env, scheme)
     return CoordinatorEndpoint(
         port=port, bearer=secret, host=host, scheme=scheme, ca_file=ca_file
     )

--- a/src/ccs/coordinator/backend_contract.py
+++ b/src/ccs/coordinator/backend_contract.py
@@ -191,12 +191,16 @@ _MEMBER_CONTRACTS: tuple[MemberContract, ...] = (
     ),
     MemberContract(
         "record_last_reclamation",
-        MemberClass.ATOMIC_CLASS,
+        MemberClass.INDEPENDENT,
         "base",
-        "Records the (trigger, tick) reclamation slot ATOMICALLY with the "
-        "M/E->INVALID grant reclaim in the same-lock enforce_stable_grant_timeouts "
-        "sweep. Read back by commit to explain a reclaimed-grant failure. Part of "
-        "the sweep leg of the boundary's single-process serialization.",
+        "Records the (trigger, tick) reclamation slot during the same-lock "
+        "enforce_stable_grant_timeouts sweep, in its OWN transaction — a serialized "
+        "follow-on AFTER the M/E->INVALID reclaim, NOT one atomic RMW with it "
+        "(verified: set_agent_state and record_last_reclamation each open their own "
+        "BEGIN IMMEDIATE, called consecutively by the sweep). Read back by commit "
+        "only to explain a reclaimed-grant failure — a diagnostic write a backend "
+        "makes individually durable, not part of the single-writer boundary "
+        "(cf. the heartbeat record, likewise INDEPENDENT).",
     ),
     # ---- ATOMIC_CLASS reads consumed INSIDE the boundary -------------------
     MemberContract(

--- a/src/ccs/coordinator/backend_contract.py
+++ b/src/ccs/coordinator/backend_contract.py
@@ -1,0 +1,974 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""The generalized backend atomic-boundary contract — importable vocabulary.
+
+This module formalizes what a networked registry backend must provide to
+re-home the coordinator's atomic write-arbitration boundary out of a single
+process, so N stateless coordinators can front one managed HA backend. It is
+**pure vocabulary**: enums, frozen dataclasses, and string constants with rich
+docstrings — **zero networked code, zero I/O, zero behavior change** to anything
+shipped. Nothing here connects to, reads from, or writes to any store.
+
+It follows the :mod:`ccs.coordinator.registry_protocol` precedent (a module that
+owns Protocols + shared types the two registries re-export). Where that module
+names the registry SURFACE (the 48-member ``RegistryBase`` + ``SqliteExtended``
+Protocols), this module names the CONTRACT that surface must satisfy for a
+backend to host the atomic boundary: which members participate in the
+single-writer atomic step (:data:`MEMBER_CLASSIFICATION`), what that atomic step
+IS (:data:`R9_ATOMIC_BOUNDARY`), the conformance tiers (:class:`Tier`), the
+statelessness re-home inventory (:data:`STATELESSNESS_INVENTORY`), and the
+liveness / epoch / content / credential / identity obligations (R18, R12, R13,
+R14, R15).
+
+**Non-goal (R2 trip-wire — never own the durable store).** The competitive
+niche survives only if we never own the durable store or log. A conforming
+backend is **operated infrastructure we depend on, NEVER a store we ship**. This
+contract names the atomic primitive a backend must expose; it does not, and must
+not, grow into a store the project builds and operates. That trip-wire binds the
+contract itself, not just its consumers.
+
+**Build gating.** This module is the BUILDABLE, gate-independent contract layer.
+Writing it does NOT move Gate B. Any networked backend *implementation*, any
+routed production deployment, and the HA topology itself remain Gate-B-gated.
+R14/R15 appear here as documented OBLIGATION records with typed placeholders,
+never implementations — their code is backend-connect logic (Gate-B).
+
+Layer discipline: this lives in ``ccs.coordinator`` (the application layer). It
+imports ONLY from ``ccs.core`` and the sibling ``registry_protocol`` /
+``retention`` modules — never from ``bus`` / ``transport`` / ``simulation``
+(infrastructure) or any interface namespace (``output`` / ``cli`` / ``adapters``
+/ ``validation`` / ``diagnose`` / ``replay`` / ``mcp``). ``tools/check_architecture.py``
+enforces this.
+
+Requirement trace (see
+``docs/brainstorms/2026-07-06-tls-posture-and-networked-backend-contract-requirements.md``):
+R2 (non-goal, above), R8 (member mapping), R9 (atomic boundary), R10 (tiers),
+R11 (statelessness inventory), R12 (epoch monotonicity), R13 (content posture),
+R14/R15 (documented obligations), R18 (liveness source).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+# ---------------------------------------------------------------------------
+# R8 — member classification enum + map
+# ---------------------------------------------------------------------------
+
+
+class MemberClass(Enum):
+    """How a ``RegistryBase`` / ``SqliteExtended`` member relates to the R9
+    single-writer atomic boundary, when the boundary is re-homed into a networked
+    backend (R8). Exactly three classes — a value outside this enum is
+    unrepresentable (:data:`MEMBER_CLASSIFICATION` is typed by it), which is the
+    drift guard against an ad-hoc string slipping into the map.
+    """
+
+    ATOMIC_CLASS = "atomic_class"
+    """The member participates in the single-writer atomic boundary (R9): the
+    version-CAS **+** grant arbitration (``other_holder`` over ``state_by_agent``)
+    **+** read-generation fence, arbitrated in ONE backend atomic step, OR the
+    same-lock liveness sweep that shares that serialization. A Tier-1 backend must
+    host every ATOMIC_CLASS member such that they compose into one atomic RMW (the
+    sweep may keep separate-sweep semantics under an equivalent serialization
+    guarantee — see :data:`R9_ATOMIC_BOUNDARY`). Authored from the ``service.py``
+    call sites, NOT assumed."""
+
+    INDEPENDENT = "independent"
+    """The member is a mutation, but NOT part of the R9 boundary: it may be
+    individually atomic in the backend without composing into the single-writer
+    RMW. Examples: the grant-holder heartbeat record (liveness input, read by the
+    sweep but written on its own), a session's durable-cut release, artifact
+    registration/removal, the preemption-notice surface. A backend must make each
+    individually durable but need not fold them into the boundary."""
+
+    READ_ONLY = "read_only"
+    """The member only READS registry state (never mutates). It serves the atomic
+    boundary's inputs and the coordinator's read paths but is not itself part of
+    the atomic mutation. A backend serves these as consistent reads; they carry no
+    single-writer obligation of their own."""
+
+
+@dataclass(frozen=True)
+class MemberContract:
+    """One ``RegistryBase`` / ``SqliteExtended`` member's classification (R8).
+
+    Frozen so the map is immutable vocabulary. ``rationale`` records WHY the
+    member lands in ``member_class`` — authored from the ``service.py`` call site,
+    so a reviewer can check the classification against the code rather than trust
+    it. ``surface`` records whether the member is on the base contract (every
+    backend) or the SQLite-extended contract (the durable-store-only surface the
+    HTTP server depends on).
+    """
+
+    name: str
+    member_class: MemberClass
+    surface: str  # "base" | "sqlite_extended"
+    rationale: str
+
+
+# The 48 members of RegistryBase (34 methods + 1 property) and SqliteExtended
+# (+13 methods), classified against the CoordinatorService call sites. The
+# ATOMIC_CLASS members are the ones the service touches INSIDE its atomic
+# mutation paths (``write`` / ``commit`` / ``commit_cas`` under ``abort_guard``;
+# ``invalidate``; the same-lock ``enforce_stable_grant_timeouts`` sweep; the
+# session capture). INDEPENDENT members are individually-durable mutations that
+# do not compose into the R9 RMW. READ_ONLY members never mutate.
+#
+# The ``coordinator_epoch`` PROPERTY is included explicitly (property-omission
+# teeth — ``@runtime_checkable`` cannot see properties, per the #133 lesson; a
+# map that classified only methods would silently drop it, the exact gap that
+# lesson exists to prevent).
+_MEMBER_CONTRACTS: tuple[MemberContract, ...] = (
+    # ---- ATOMIC_CLASS (base) ----------------------------------------------
+    MemberContract(
+        "commit_cas",
+        MemberClass.ATOMIC_CLASS,
+        "base",
+        "THE atomic boundary. The version-CAS + grant arbitration (other_holder "
+        "over state_by_agent) + read-generation fence all live INSIDE "
+        "registry.commit_cas and return a CasResult in one serialized step "
+        "(sqlite: BEGIN IMMEDIATE). service.commit_cas wraps it in abort_guard "
+        "and maps the three outcomes; the arbitration itself is atomic here.",
+    ),
+    MemberContract(
+        "set_artifact_and_content",
+        MemberClass.ATOMIC_CLASS,
+        "base",
+        "The pessimistic-commit version bump + content persist, carrying "
+        "fence_agent_id so the read-generation fence check fires ATOMICALLY with "
+        "the version move (service._commit_impl). A StaleReadGeneration raise "
+        "here is the fence rejecting a reclaimed committer in the write's race "
+        "window — part of the boundary, not a plain write.",
+    ),
+    MemberContract(
+        "set_agent_state",
+        MemberClass.ATOMIC_CLASS,
+        "base",
+        "The MESI grant transition — the grant-arbitration leg of the boundary. "
+        "Called inside every atomic mutation path (write/commit peer-invalidation "
+        "+ grant, invalidate, and the same-lock sweep's M/E->INVALID reclaim, "
+        "which bumps owner_generation for the fence). Single-writer is checked "
+        "after each such transition.",
+    ),
+    MemberContract(
+        "set_agent_transient",
+        MemberClass.ATOMIC_CLASS,
+        "base",
+        "Sets the ISG/IED/EIA/SIA/MWB/MSA transient marking an in-flight grant "
+        "arbitration. Written under abort_guard inside write/commit (the "
+        "acquire/downgrade legs) and gates the sweep (a pair mid-transient is "
+        "skipped). Part of the grant-arbitration state the boundary serializes.",
+    ),
+    MemberContract(
+        "clear_agent_transient",
+        MemberClass.ATOMIC_CLASS,
+        "base",
+        "Clears the arbitration transient at the end of a grant transition, "
+        "under abort_guard inside write/commit/invalidate. The completing half of "
+        "the transient leg of the boundary.",
+    ),
+    MemberContract(
+        "capture_version_vector",
+        MemberClass.ATOMIC_CLASS,
+        "base",
+        "Atomically pins a consistent multi-artifact cut AND persists the durable "
+        "session_meta owner-binding at ONE linearization point (begin_session). "
+        "The snapshot-session surface is part of the boundary at Tier-1 (R9): the "
+        "cut + durable owner are captured together or not at all.",
+    ),
+    MemberContract(
+        "abort_guard",
+        MemberClass.ATOMIC_CLASS,
+        "base",
+        "The context manager that wraps EVERY atomic mutation (write / commit / "
+        "commit_cas / invalidate). It is the boundary's serialization + fail-shut "
+        "seam: a watchdog-aborted mutation fails closed at the write lock instead "
+        "of landing as a phantom write. A backend re-homing the boundary must "
+        "provide the equivalent atomic-or-abort envelope.",
+    ),
+    MemberContract(
+        "record_last_reclamation",
+        MemberClass.ATOMIC_CLASS,
+        "base",
+        "Records the (trigger, tick) reclamation slot ATOMICALLY with the "
+        "M/E->INVALID grant reclaim in the same-lock enforce_stable_grant_timeouts "
+        "sweep. Read back by commit to explain a reclaimed-grant failure. Part of "
+        "the sweep leg of the boundary's single-process serialization.",
+    ),
+    # ---- ATOMIC_CLASS reads consumed INSIDE the boundary -------------------
+    MemberContract(
+        "get_state_map",
+        MemberClass.ATOMIC_CLASS,
+        "base",
+        "Reads state_by_agent — the grant-arbitration operand. Read INSIDE the "
+        "atomic mutation loop of write/commit (to invalidate peers) and by the "
+        "same-lock sweep to enumerate M/E holders and re-check single-writer. Its "
+        "consistency with the concurrent grant transitions is what the boundary "
+        "serializes; a backend must serve it inside the same atomic step.",
+    ),
+    # ---- INDEPENDENT (base) -----------------------------------------------
+    MemberContract(
+        "register_artifact",
+        MemberClass.INDEPENDENT,
+        "base",
+        "Seeds a new artifact + initial content (register_artifact). A durable "
+        "insert, individually atomic, but not part of a single-writer RMW — an "
+        "artifact has no competing writer at first observation.",
+    ),
+    MemberContract(
+        "remove_artifact",
+        MemberClass.INDEPENDENT,
+        "base",
+        "Deletes an artifact (delete). Individually durable; not part of the "
+        "version-CAS/grant boundary (delete does not arbitrate a writer).",
+    ),
+    MemberContract(
+        "record_heartbeat",
+        MemberClass.INDEPENDENT,
+        "base",
+        "Records a grant-holder's liveness tick (max(prev, incoming)). A liveness "
+        "INPUT the same-lock sweep reads, but written on its own outside any "
+        "atomic mutation — individually durable, not part of the boundary. Its "
+        "authoritative-source obligation is R18, not atomicity.",
+    ),
+    MemberContract(
+        "release_session",
+        MemberClass.INDEPENDENT,
+        "base",
+        "Drops a session's durable pins + session_meta owner-binding (reap / "
+        "release / effect-gate teardown). Individually durable and idempotent; "
+        "not part of the write-arbitration RMW.",
+    ),
+    # ---- READ_ONLY (base) --------------------------------------------------
+    MemberContract(
+        "coordinator_epoch",
+        MemberClass.READ_ONLY,
+        "base",
+        "PROPERTY (not a method) — included explicitly per the #133 "
+        "property-omission lesson. Read (never written by the service) on the "
+        "read-fence and session paths to stamp results with the coordinator "
+        "incarnation. READ_ONLY as a registry SURFACE; its re-home disposition is "
+        "the strongest MUST_REHOME (R12) — the classification and the "
+        "statelessness disposition are orthogonal axes.",
+    ),
+    MemberContract(
+        "get_artifact",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads artifact metadata + current version. The version operand every CAS "
+        "reason is decided against, but the READ itself is non-mutating "
+        "(_require_artifact, read_at_version, session paths, effect-gate "
+        "re-validate).",
+    ),
+    MemberContract(
+        "get_content",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads current canonical body (fetch). Non-mutating serve.",
+    ),
+    MemberContract(
+        "get_content_at_version",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads a retained historical body by version. Non-mutating serve (only "
+        "present under declared retention, R13).",
+    ),
+    MemberContract(
+        "get_version_record",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads a (body, captured_at) history row (read_at_version / session_read). "
+        "Non-mutating; immutable once captured.",
+    ),
+    MemberContract(
+        "get_agent_state",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads one agent's MESI state as a PRECONDITION check before an atomic "
+        "mutation (commit's M/E holder check; commit_cas's shared-or-invalid "
+        "gate). The read is non-mutating; the atomicity lives in the subsequent "
+        "commit_cas / set_artifact_and_content step, not here.",
+    ),
+    MemberContract(
+        "get_agent_transient",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads one agent's transient (commit_cas precondition; the sweep's "
+        "skip-if-transient guard). Non-mutating read of arbitration state.",
+    ),
+    MemberContract(
+        "get_transient_map",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads all transients for an artifact (enforce_transient_timeouts scan). "
+        "Non-mutating.",
+    ),
+    MemberContract(
+        "get_transient_tick",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads when a transient was entered (transient-timeout age check). "
+        "Non-mutating.",
+    ),
+    MemberContract(
+        "get_last_reclamation",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads the (trigger, tick) reclamation slot to EXPLAIN a reclaimed-grant "
+        "commit failure (commit). Non-mutating; the WRITE side "
+        "(record_last_reclamation) is ATOMIC_CLASS.",
+    ),
+    MemberContract(
+        "get_owner_generation",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads the per-artifact fence counter. Non-mutating; the BUMP happens "
+        "inside the atomic reclaim (set_agent_state with a RECLAIM_TRIGGER).",
+    ),
+    MemberContract(
+        "get_read_generation",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads an agent's captured read-generation (the fence operand). "
+        "Non-mutating; the fence CHECK against owner_generation is atomic inside "
+        "commit_cas / set_artifact_and_content.",
+    ),
+    MemberContract(
+        "granted_at_tick",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads when a grant was granted (the sweep's max-hold age check). "
+        "Non-mutating liveness input.",
+    ),
+    MemberContract(
+        "last_heartbeat_tick",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads a grant-holder's last heartbeat (the sweep's staleness check). "
+        "Non-mutating liveness input; its authoritative source is R18.",
+    ),
+    MemberContract(
+        "has_artifact",
+        MemberClass.READ_ONLY,
+        "base",
+        "Existence check (invalidate / delete short-circuit). Non-mutating.",
+    ),
+    MemberContract(
+        "artifact_ids",
+        MemberClass.READ_ONLY,
+        "base",
+        "Enumerates artifact ids (the sweep + transient-timeout scans). "
+        "Non-mutating.",
+    ),
+    MemberContract(
+        "valid_holders",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads the non-INVALID holders of an artifact. Non-mutating serve.",
+    ),
+    MemberContract(
+        "retention_meta",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads (retain_versions, policy) — the deployment branch indicator (R13). "
+        "Non-mutating.",
+    ),
+    MemberContract(
+        "get_session_cut",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads a session's pinned cut (session_read / session_commit / owner "
+        "validation). Non-mutating; the cut was written atomically by "
+        "capture_version_vector.",
+    ),
+    MemberContract(
+        "get_session_meta",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads one session's durable (owner, created_at_tick) — the durable "
+        "fallback the service-level owner/lease maps fall back to across a "
+        "restart. Non-mutating.",
+    ),
+    MemberContract(
+        "all_session_meta",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads ALL durable session metas (the liveness sweep enumerates the union "
+        "of in-memory + durable sessions). Non-mutating.",
+    ),
+    MemberContract(
+        "session_count",
+        MemberClass.READ_ONLY,
+        "base",
+        "Counts live durable sessions for the begin_session max-sessions cap. "
+        "Non-mutating; the cap decision is made under the SERVICE-level "
+        "_session_lock, but this registry read is a plain count.",
+    ),
+    # ---- INDEPENDENT / READ_ONLY (sqlite_extended) ------------------------
+    MemberContract(
+        "resolve_or_register",
+        MemberClass.INDEPENDENT,
+        "sqlite_extended",
+        "First-observation seeding of a durable artifact by path+hash. An "
+        "individually-atomic upsert; not a single-writer RMW.",
+    ),
+    MemberContract(
+        "record_preemption_notice",
+        MemberClass.INDEPENDENT,
+        "sqlite_extended",
+        "Records an adapter-side preemption notice for a sweep-reclaimed victim. "
+        "A durable side-record threaded through the sweep's on_reclaim callback; "
+        "best-effort and adapter-only, NOT part of the boundary (a notice failure "
+        "must not stop the sweep).",
+    ),
+    MemberContract(
+        "pop_preemption_notice",
+        MemberClass.INDEPENDENT,
+        "sqlite_extended",
+        "Consumes one preemption notice (adapter enrichment path). A durable "
+        "read-and-delete; individually atomic, not part of the boundary.",
+    ),
+    MemberContract(
+        "pop_pending_notices",
+        MemberClass.INDEPENDENT,
+        "sqlite_extended",
+        "Consumes all pending notices for an agent. Durable read-and-delete; not "
+        "part of the boundary.",
+    ),
+    MemberContract(
+        "evict_stale_notices",
+        MemberClass.INDEPENDENT,
+        "sqlite_extended",
+        "Prunes aged preemption notices. Durable maintenance delete; not part of "
+        "the boundary.",
+    ),
+    MemberContract(
+        "close",
+        MemberClass.INDEPENDENT,
+        "sqlite_extended",
+        "Closes the durable connection. Lifecycle, not a registry mutation; a "
+        "networked backend's equivalent is disconnect, outside the boundary.",
+    ),
+    MemberContract(
+        "peek_preemption_notice",
+        MemberClass.READ_ONLY,
+        "sqlite_extended",
+        "Reads (without consuming) a victim's preemption notice. Non-mutating.",
+    ),
+    MemberContract(
+        "artifact_names_under_prefix",
+        MemberClass.READ_ONLY,
+        "sqlite_extended",
+        "Durable prefix listing of artifact names. Non-mutating serve.",
+    ),
+    MemberContract(
+        "artifacts_held_by_agent",
+        MemberClass.READ_ONLY,
+        "sqlite_extended",
+        "Lists artifacts an agent holds in given MESI states. Non-mutating serve.",
+    ),
+    MemberContract(
+        "get_artifact_updated_at",
+        MemberClass.READ_ONLY,
+        "sqlite_extended",
+        "Reads an artifact's last-updated wall time. Non-mutating.",
+    ),
+    MemberContract(
+        "last_writer_for",
+        MemberClass.READ_ONLY,
+        "sqlite_extended",
+        "Reads the recorded last writer of an artifact. Non-mutating.",
+    ),
+    MemberContract(
+        "lookup_artifact_id_by_name",
+        MemberClass.READ_ONLY,
+        "sqlite_extended",
+        "Resolves a durable name to an artifact id. Non-mutating.",
+    ),
+    MemberContract(
+        "status_snapshot",
+        MemberClass.READ_ONLY,
+        "sqlite_extended",
+        "Batch read of the artifact + state maps for the /status surface. "
+        "Non-mutating.",
+    ),
+)
+
+MEMBER_CLASSIFICATION: dict[str, MemberContract] = {
+    contract.name: contract for contract in _MEMBER_CONTRACTS
+}
+"""Every ``RegistryBase`` + ``SqliteExtended`` member → its :class:`MemberContract`
+(R8). Keyed by member name. The key set must equal the 48-member Protocol surface
+exactly — :mod:`tests.test_backend_contract` fails if ``registry_protocol.py``
+gains or loses a member without a matching update here (bidirectional drift
+guard). Includes the ``coordinator_epoch`` property (property-omission teeth)."""
+
+
+# ---------------------------------------------------------------------------
+# R9 — the atomic boundary definition
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AtomicBoundary:
+    """The R9 single-writer atomic boundary — the extended P0 tuple.
+
+    A frozen documentation record, not runtime behavior. It names, in prose a
+    backend implementer targets, the ONE atomic operation class a Tier-1 backend
+    must host and the reference semantics it must reproduce.
+    """
+
+    tuple_elements: tuple[str, ...]
+    """The three legs that MUST be arbitrated together in one atomic step:
+    version-CAS, grant arbitration, and the read-generation fence. Single-writer
+    enforcement is NOT the version compare alone — it is all three composing."""
+
+    fence_admit_on_absent: str
+    """The fence's load-bearing admit-on-absent asymmetry, stated EXACTLY (it has
+    drifted once before — the fence-parity lesson)."""
+
+    reference_semantics: str
+    """What "atomic" references: the registry's single-process serialization AS A
+    WHOLE — atomic mutations PLUS the same-lock liveness sweep."""
+
+    liveness_eviction_note: str
+    """Precision on where liveness eviction sits relative to the atomic RMW."""
+
+
+R9_ATOMIC_BOUNDARY = AtomicBoundary(
+    tuple_elements=(
+        "version-CAS (the artifact version compare-and-swap: a write wins only if "
+        "the expected version still matches current)",
+        "grant arbitration (other_holder over state_by_agent: no pessimistic peer "
+        "may hold MODIFIED/EXCLUSIVE when an OCC writer commits; the MESI grant "
+        "transition is part of the same step)",
+        "read-generation fence (owner_generation vs the committer's captured "
+        "read_generation: reject a writer whose M/E grant was reclaimed by the "
+        "sweep — version never moved, so version-CAS alone cannot see it)",
+    ),
+    # Reproduced verbatim from the shipped guard semantics + the fence-parity
+    # lesson (docs/solutions/.../fence-admit-on-absent-...). Do NOT paraphrase:
+    # an ABSENT read_generation is ADMITTED, and version-CAS arbitrates; only a
+    # PRESENT-and-superseded read_generation is rejected.
+    fence_admit_on_absent=(
+        "An ABSENT read_generation is ADMITTED — version-CAS arbitrates it (a "
+        "plain OCC writer that never established a fence claim; NoLostUpdate, the "
+        "sibling invariant, is its protection). A PRESENT read_generation equal to "
+        "owner_generation WINS (the version bumps). ONLY a PRESENT read_generation "
+        "that is superseded (< owner_generation) is REJECTED as "
+        "stale_read_generation. A reclaim-zombie is NEVER absent — it captured its "
+        "read_generation atomically at the I/S->M/E acquire and the sweep "
+        "preserved that value while bumping owner_generation — so admit-on-absent "
+        "removes no fence coverage. The `is not None` predicate is load-bearing, "
+        "not defensive: it separates the plain OCC writer (admit) from the "
+        "reclaim-zombie (reject)."
+    ),
+    reference_semantics=(
+        "The registry's single-process serialization AS A WHOLE: the atomic "
+        "mutations (version-CAS + grant arbitration + fence, under one sqlite "
+        "BEGIN IMMEDIATE transaction / one process lock) TOGETHER WITH the "
+        "same-lock enforce_stable_grant_timeouts sweep. A backend re-homing the "
+        "boundary reproduces this whole serialization, not merely the version "
+        "compare."
+    ),
+    liveness_eviction_note=(
+        "Liveness EVICTION is a SEPARATE same-lock sweep "
+        "(enforce_stable_grant_timeouts), NOT read inside commit_cas's "
+        "transaction. It reclaims stale M/E grants (heartbeat / max-hold) and "
+        "bumps owner_generation atomically with the M/E->INVALID transition, "
+        "serialized under the SAME registry lock as the atomic mutations. Per "
+        "tier, a backend states whether liveness folds into the atomic RMW "
+        "(Tier-1 may) or preserves the separate-sweep semantics WITH an equivalent "
+        "serialization guarantee."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# R10 — conformance tiers
+# ---------------------------------------------------------------------------
+
+
+class Tier(Enum):
+    """A backend's declared conformance tier (R10). Exactly two tiers.
+
+    A backend declares a tier and the conformance kit verifies it. The kit builds
+    Tier-1 verification NOW; Tier-2 is DEFINED here but its conformance machinery
+    is a stated scope boundary — NOT built until a real Tier-2 candidate backend
+    exists (speculative test infrastructure for an implementation class with zero
+    candidates is not built).
+    """
+
+    TIER_1 = "tier_1_full_tuple"
+    """FULL-TUPLE. The backend expresses the R9 boundary as ONE atomic RMW (a
+    multi-key transaction or atomic script). Guarantee parity: full SingleWriter
+    + NoStaleApply (+ session fail-closed lifecycle) with the shipped registry.
+    The snapshot-session surface (pins + session_meta ownership + session leases)
+    is REQUIRED at Tier-1 — it is shipped core; a backend without it cannot claim
+    a stateless coordinator. QUALIFIES for the stateless-N-replica HA claim."""
+
+    TIER_2 = "tier_2_lease_decomposed"
+    """LEASE-DECOMPOSED. The backend provides per-artifact atomic version-CAS PLUS
+    a lease/fencing-token primitive; the grant arbitration is re-derived rather
+    than hosted as one RMW. Residual windows are documented per residual and
+    test-demonstrated. NO NoStaleApply parity claim. Session support is an OPEN
+    research question (the admit-on-absent fence + session-scoped uuid5 committer
+    identity may impose ordering a lease primitive cannot express). Does NOT
+    qualify for the HA claim. DEFINED here; its conformance-kit machinery is NOT
+    built (scope boundary)."""
+
+
+@dataclass(frozen=True)
+class TierDeclaration:
+    """A tier's obligations, parity, and HA qualification (R10). Frozen
+    documentation vocabulary — the human-readable expansion of :class:`Tier`."""
+
+    tier: Tier
+    backend_must_provide: str
+    guarantee_parity: str
+    ha_qualifies: bool
+    session_support: str
+
+
+TIER_DECLARATIONS: dict[Tier, TierDeclaration] = {
+    Tier.TIER_1: TierDeclaration(
+        tier=Tier.TIER_1,
+        backend_must_provide=(
+            "The R9 boundary as ONE atomic RMW (multi-key transaction / atomic "
+            "script): version-CAS + grant arbitration + read-generation fence "
+            "arbitrated together, plus the same-lock liveness sweep semantics and "
+            "the durable snapshot-session surface."
+        ),
+        guarantee_parity=(
+            "Full SingleWriter + NoStaleApply parity with the shipped registry, "
+            "plus the session fail-closed lifecycle."
+        ),
+        ha_qualifies=True,
+        session_support=(
+            "REQUIRED. Pins + session_meta ownership + session leases must re-home; "
+            "a backend without them cannot claim a stateless coordinator."
+        ),
+    ),
+    Tier.TIER_2: TierDeclaration(
+        tier=Tier.TIER_2,
+        backend_must_provide=(
+            "Per-artifact atomic version-CAS + a lease/fencing-token primitive; "
+            "grant arbitration re-derived from the lease rather than hosted as one "
+            "RMW."
+        ),
+        guarantee_parity=(
+            "Documented residual windows (named per residual, test-demonstrated). "
+            "NO NoStaleApply parity claim."
+        ),
+        ha_qualifies=False,
+        session_support=(
+            "OPEN research question — the admit-on-absent fence and the "
+            "session-scoped uuid5 committer identity may impose ordering a lease "
+            "primitive cannot express; Tier-2 may exclude sessions or grow its "
+            "residual list. Its conformance-kit machinery is NOT built here."
+        ),
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# R11 — statelessness inventory
+# ---------------------------------------------------------------------------
+
+
+class Disposition(Enum):
+    """A coordinator state item's re-home disposition on failover (R11)."""
+
+    MUST_REHOME = "must_rehome"
+    """The item MUST live in the shared backend for the coordinator to be
+    stateless. If it does not re-home, a failover loses correctness or liveness."""
+
+    DERIVABLE = "derivable"
+    """The item can be left in-process because it is re-derivable from re-homed
+    backend state after a failover (rebuilt on demand, no durable copy needed)."""
+
+    SAFELY_LOST = "safely_lost"
+    """The item can be left in-process and simply dropped on failover with no
+    correctness consequence (at worst a benign efficiency/attribution loss).
+    ``coordinator_epoch`` is NEVER eligible for this disposition (R12)."""
+
+
+@dataclass(frozen=True)
+class StateItem:
+    """One coordinator state item + its R11 re-home disposition. Frozen."""
+
+    name: str
+    disposition: Disposition
+    location: str  # "durable_registry" | "service_level" | "service_with_durable_fallback"
+    consequence: str
+
+
+STATELESSNESS_INVENTORY: tuple[StateItem, ...] = (
+    StateItem(
+        "artifacts / versions / content_hashes",
+        Disposition.MUST_REHOME,
+        "durable_registry",
+        "The version operand of every CAS. If not re-homed, a failover cannot "
+        "arbitrate writes — every version-CAS is decided against wrong state.",
+    ),
+    StateItem(
+        "MESI grants (state_by_agent)",
+        Disposition.MUST_REHOME,
+        "durable_registry",
+        "The grant-arbitration operand (other_holder). If not re-homed, "
+        "single-writer cannot be enforced across coordinators — two could both "
+        "grant EXCLUSIVE.",
+    ),
+    StateItem(
+        "fence generations (owner_generation / read_generation)",
+        Disposition.MUST_REHOME,
+        "durable_registry",
+        "The read-generation fence operands. If not re-homed, a reclaim-zombie "
+        "write cannot be rejected — NoStaleApply is lost.",
+    ),
+    StateItem(
+        "grant heartbeats",
+        Disposition.MUST_REHOME,
+        "durable_registry",
+        "The liveness input the sweep reads. If not re-homed, one coordinator's "
+        "heartbeats are invisible to another's sweep — grants mis-reclaimed or "
+        "never reclaimed. Its VALUES re-home, but an authoritative time SOURCE is "
+        "a separate obligation (R18).",
+    ),
+    StateItem(
+        "session pins (consistent cuts)",
+        Disposition.MUST_REHOME,
+        "durable_registry",
+        "The pinned cut a session reads/commits against. If not re-homed, a "
+        "failover silently invalidates every live session (fail-closed, but an "
+        "availability cliff the HA claim must own).",
+    ),
+    StateItem(
+        "session_meta (durable owner + created_at_tick)",
+        Disposition.MUST_REHOME,
+        "service_with_durable_fallback",
+        "The durable session owner-binding (sqlite schema v4, the #132 "
+        "make-identity-survive-restart precedent). The SERVICE-level owner/lease "
+        "maps are the fast tier; this durable table is the fallback. If not "
+        "re-homed, a survived session cannot be owner-validated across a failover "
+        "without opening an owner-isolation hole (R13).",
+    ),
+    StateItem(
+        "session leases (heartbeat lease + creation tick + reaped tombstone)",
+        Disposition.MUST_REHOME,
+        "service_with_durable_fallback",
+        "The session-liveness lease and absolute-age ceiling inputs. Today these "
+        "live in SERVICE-level maps (_session_heartbeats / _session_created / "
+        "_reaped_tombstone) under service._session_lock, with the durable "
+        "session_meta as the restart fallback (a post-restart heartbeat rehydrates "
+        "the in-memory lease from the durable owner+created tick). For a stateless "
+        "coordinator the lease + ceiling must re-home too, else a failover drops "
+        "them and the session's GC-starvation bounds go unenforced across replicas.",
+    ),
+    StateItem(
+        "retention rows (version bodies, when retention declared)",
+        Disposition.MUST_REHOME,
+        "durable_registry",
+        "Present ONLY under a declared retain-versions capability (R13). When "
+        "declared they must re-home for a failover to serve pinned/historical "
+        "bytes; with retention OFF there are no bodies to re-home (hash-only "
+        "baseline).",
+    ),
+    StateItem(
+        "coordinator_epoch",
+        Disposition.MUST_REHOME,
+        "durable_registry",
+        "The fence token identifying the coordinator incarnation. NEVER eligible "
+        "for SAFELY_LOST (R12): losing it invalidates ALL client-carried tokens "
+        "(session tokens, versioned reads) at once. Always MUST_REHOME. NOTE: the "
+        "shipped LOCAL epoch is an opaque uuid4 string; the backend epoch must be "
+        "a monotonic-increasing integer (R12) — that str->int migration is "
+        "deferred to a re-home, out of this contract's scope.",
+    ),
+    StateItem(
+        "reaped-session tombstone (attribution only)",
+        Disposition.SAFELY_LOST,
+        "service_level",
+        "Precise 'definitely reaped' attribution for a dead token. Its LOSS is "
+        "benign: an in-shape token still classifies session_invalidated via the "
+        "shape predicate, so the fail-closed guarantee never depends on it — only "
+        "the sharper attribution is lost. (The lease + creation-tick portions of "
+        "the session-lease item above are MUST_REHOME; this attribution-only "
+        "residue is the safely-lost part.)",
+    ),
+)
+"""Every coordinator state item + its R11 re-home disposition. ``coordinator_epoch``
+is MUST_REHOME and asserted never SAFELY_LOST by
+:mod:`tests.test_backend_contract`. Session owner/lease maps are SERVICE-level
+(``service._session_lock``) with a durable ``session_meta`` fallback — noted in
+each item's ``location`` / ``consequence``."""
+
+
+# ---------------------------------------------------------------------------
+# R18 — liveness / clock source declaration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LivenessSourceObligation:
+    """R18 — a conforming backend (or the coordinator above it) MUST supply an
+    authoritative time/lease source. Frozen documentation record."""
+
+    requirement: str
+    conforming_sources: tuple[str, ...]
+    non_conforming: str
+    shipped_source: str
+
+
+R18_LIVENESS_SOURCE = LivenessSourceObligation(
+    requirement=(
+        "Heartbeat and lease timing must ride an AUTHORITATIVE time/lease source. "
+        "N stateless coordinators have no shared tick base, so this is a "
+        "backend-selection criterion alongside the atomic CAS."
+    ),
+    conforming_sources=(
+        "a backend-authoritative monotonic clock or sequence",
+        "a backend-native lease/TTL primitive (exactly what a Tier-2 lease "
+        "primitive provides; Tier-1 must state its source explicitly)",
+    ),
+    non_conforming=(
+        "Storing tick VALUES without an authoritative source does NOT conform — "
+        "that is the silent mis-evict / never-reclaim failure this requirement "
+        "names (the plan's second P0)."
+    ),
+    shipped_source=(
+        "The shipped registries' source is CALLER-SUPPLIED LOGICAL TICKS under a "
+        "SINGLE coordinator. Fine single-host (one process is the authority); it "
+        "does NOT survive N coordinators — there is no shared tick base, so it "
+        "does not conform for the HA claim until a re-home supplies an "
+        "authoritative source."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# R12 — epoch monotonicity
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EpochObligation:
+    """R12 — the backend coordinator_epoch contract. Frozen documentation."""
+
+    backend_contract: str
+    shipped_local: str
+    migration_scope: str
+
+
+R12_EPOCH = EpochObligation(
+    backend_contract=(
+        "When promoted to the shared backend, coordinator_epoch is a "
+        "MONOTONICALLY-INCREASING INTEGER across restarts and failovers — NEVER a "
+        "fresh random id (that would invalidate all client-carried session tokens "
+        "and versioned reads at once). A deposed coordinator is provably stale by "
+        "comparison."
+    ),
+    shipped_local=(
+        "The shipped LOCAL epoch is an opaque uuid4().hex string, seeded in "
+        "registry_meta. It stays as-is (an incarnation label, not a monotonic "
+        "counter) until a re-home."
+    ),
+    migration_scope=(
+        "The str->monotonic-int migration (and its client-carried-token "
+        "compatibility across the cutover) is a Gate-B re-home concern, OUT of "
+        "this contract's scope / deferred."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# R13 — content posture
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ContentPosture:
+    """R13 — what a backend holds. Frozen documentation record."""
+
+    baseline: str
+    retention_capability: str
+    disclosure_note: str
+
+
+R13_CONTENT_POSTURE = ContentPosture(
+    baseline=(
+        "HASH-ONLY. The backend holds coherence metadata only: content_hash + "
+        "version + the R9/R11 state. It NEVER holds artifact bodies at baseline."
+    ),
+    retention_capability=(
+        "RETENTION is an explicit, DECLARED opt-in capability. A backend that "
+        "declares it stores version bodies with the SAME gating as "
+        "SqliteArtifactRegistry(retain_versions=True) — mirroring shipped "
+        "semantics (KTD-13 held), parity with the reference backend."
+    ),
+    disclosure_note=(
+        "With retention ON, artifact BODIES cross the network and rest in the "
+        "backend — the disclosure / tenancy surface WIDENS and the deployment's "
+        "security posture MUST say so."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# R14 / R15 — documented obligations only (NO implementation — Gate-B)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BackendConnectObligation:
+    """A backend-connect security obligation stated as documentation ONLY (R14 /
+    R15). Its CODE is Gate-B backend-connect logic (credential read, fingerprint
+    verification, rotation) — NOT implemented here. This is a typed placeholder
+    that names the obligation so a conformance discussion has vocabulary, without
+    any networked code."""
+
+    requirement_id: str  # "R14" | "R15"
+    obligation: str
+    discipline: str
+    open_at_planning: str
+
+
+R14_CREDENTIAL = BackendConnectObligation(
+    requirement_id="R14",
+    obligation=(
+        "The backend credential (DSN / password) arrives via a 0600 credential "
+        "FILE — never inline env or config literal."
+    ),
+    discipline=(
+        "Mirror the CCS_REMOTE_SECRET_FILE reader's O_NOFOLLOW open + mode-check + "
+        "single-read discipline (a trust anchor is the same attack class as the "
+        "bearer file: a symlink swap between check and read must not be possible)."
+    ),
+    open_at_planning=(
+        "The rotation path (file-replace + re-read-on-reconnect vs "
+        "restart-required, and the dual-credential overlap window if live) MUST be "
+        "specified AT PLANNING — TBD, not decided here."
+    ),
+)
+
+
+R15_BACKEND_IDENTITY = BackendConnectObligation(
+    requirement_id="R15",
+    obligation=(
+        "The coordinator validates the backend target (allowlist) and verifies a "
+        "schema/contract FINGERPRINT on FIRST connect AND re-verifies on ANY "
+        "reconnect or failover. Mismatch is a FAIL-CLOSED refusal."
+    ),
+    discipline=(
+        "A promoted replica or a re-pointed DSN with a foreign fingerprint is the "
+        "SAME attacker-controlled-backend surface (SSRF) as a bad first connect — "
+        "so re-verify every reconnect/failover, never just the first."
+    ),
+    open_at_planning=(
+        "The fingerprint content (schema version + epoch + contract revision?) and "
+        "where the allowlist lives are open at planning."
+    ),
+)

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -501,6 +501,76 @@ class InsecureTransportRefused(CoherenceError):
         self.host = host
 
 
+class TlsVerificationFailed(CoherenceError):
+    """The coordinator's TLS certificate did not verify against the trusted CA
+    (Unit-1 client-side ``https://`` guard).
+
+    Raised when a verified-TLS request fails certificate validation — a wrong /
+    untrusted signing CA, a hostname/IP-SAN mismatch (e.g. a DNS-only cert on an
+    IP-literal endpoint), an expired cert, or any other
+    :class:`ssl.SSLCertVerificationError`. The client *always* verifies (there is
+    no insecure ``https`` mode), so this fails LOUD and CLOSED: the bearer is NOT
+    retried over plaintext and no request body reaches the peer — the handshake
+    dies before the HTTP exchange. Distinct from :class:`CoordinatorUnavailable`
+    (a network hiccup that a caller might treat as transient); a verification
+    failure is a trust decision, never a degrade. Carries the offending
+    ``host``."""
+
+    def __init__(self, host: str, detail: str = "") -> None:
+        suffix = f": {detail}" if detail else ""
+        super().__init__(
+            f"TLS certificate verification failed for coordinator host {host!r}"
+            f"{suffix}; the bearer was NOT sent — check the server certificate and "
+            "the trusted CA (CCS_REMOTE_CA_FILE), then retry"
+        )
+        self.host = host
+        self.detail = detail
+
+
+class TlsConfigError(CoherenceError):
+    """The TLS client configuration is unusable (Unit-1 factory guard).
+
+    Raised at SSL-context build time for an operator misconfiguration of the
+    CA-trust anchor: ``CCS_REMOTE_CA_FILE`` names a path that is missing,
+    unreadable, a symlink (refused via ``O_NOFOLLOW`` — a swapped trust anchor is
+    the same attack class as a swapped bearer file), group/world-*writable*, or
+    not valid PEM. Fails CLOSED with an actionable message naming the path rather
+    than surfacing a raw :class:`ssl.SSLError` / :class:`OSError`. Also raised if
+    the built context ever fails its own hardening invariant
+    (``check_hostname`` + ``CERT_REQUIRED``) — that guards against a future edit
+    silently weakening verification. Carries the CA ``path`` (when applicable)
+    and a human ``reason``."""
+
+    def __init__(self, reason: str, *, path: str | None = None) -> None:
+        super().__init__(reason)
+        self.path = path
+        self.reason = reason
+
+
+class RedirectRefused(CoherenceError):
+    """The coordinator responded with a 3xx redirect; the client refuses to
+    follow it (Unit-1 no-redirects-ever policy).
+
+    The client talks to ONE fixed, operator-configured coordinator endpoint — no
+    redirect is ever legitimate. A bare ``urlopen`` would auto-follow and
+    urllib's default redirect handler *copies the Authorization header onto the
+    new hop* before application code can intervene, so the bearer would ride an
+    attacker-chosen URL. The client therefore refuses ANY 3xx (both ``http`` and
+    ``https`` endpoints) before a second request is made — the bearer never
+    leaves the configured endpoint. Carries the attempted ``location`` and
+    ``status``."""
+
+    def __init__(self, location: str, status: int | None = None) -> None:
+        status_part = f" ({status})" if status is not None else ""
+        super().__init__(
+            f"coordinator returned a redirect{status_part} to {location!r}; refusing "
+            "to follow — the coordinator is one fixed endpoint and following a "
+            "redirect would leak the bearer onto another host"
+        )
+        self.location = location
+        self.status = status
+
+
 class CommitUnconfirmed(CoherenceError):
     """OCC commit unconfirmed (MCP-C Unit 1): the coordinator transport failed
     mid-commit, a false-negative ack — NOT a confirmed loss. The write may or may

--- a/tests/backend_conformance/__init__.py
+++ b/tests/backend_conformance/__init__.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Executable Tier-1 backend conformance kit (plan Unit 5, R16 + R18 check).
+
+This package verifies a :class:`~ccs.coordinator.registry_protocol.RegistryBase`
+implementation against the atomic-boundary contract formalized in
+:mod:`ccs.coordinator.backend_contract` (Unit 4). It exists so that a future
+networked backend has an *executable* target — not just a prose contract — for
+the R9 single-writer atomic boundary, and so the two SHIPPED registries are
+each proven conformant at their honest declared tier.
+
+Two verification arms today:
+
+- :class:`~ccs.coordinator.sqlite_registry.SqliteArtifactRegistry` — declares
+  **Tier-1** (:data:`ccs.coordinator.backend_contract.Tier.TIER_1`): the full
+  R9 tuple under one ``BEGIN IMMEDIATE`` transaction, PLUS durable
+  restart-survival of ``session_meta`` / pins.
+- :class:`~ccs.coordinator.registry.ArtifactRegistry` (in-memory) — declares
+  its OWN honest tier: it hosts the full atomic boundary under a single process
+  (GIL-atomic), so it passes every MUST-MATCH scenario, but it declares
+  restart **LOSS** (process-scoped state). That is NOT a Tier-1 / HA-stateless
+  claim — a fresh in-memory instance is a fresh, empty store. The kit asserts
+  the in-memory arm's declared restart-loss *as declared*, never as a bug.
+
+**The must-match vs backend-defined split is STRUCTURAL in the kit API, not a
+convention** (see :mod:`tests.backend_conformance.kit`): MUST-MATCH scenarios
+are functions over a bare :class:`~tests.backend_conformance.kit.RegistryFactory`
+that hard-assert the same correctness property on every arm; BACKEND-DEFINED
+scenarios take a per-arm :class:`~tests.backend_conformance.kit.RestartDeclaration`
+and assert the arm behaves *as its own declaration says*. A backend-defined
+function's signature DEMANDS a declaration — it cannot assert cross-arm
+identity, so the split cannot silently erode into "assert everything matches"
+(the flake / watering-down failure mode the plan's Risks table names).
+
+**Honesty limit of the concurrency arm (declared, stated once, here).** The
+concurrency scenarios use two independent SQLite handles on ONE WAL database
+file inside ONE process. That is a genuine two-connection race against a shared
+durable store — the real-concurrency arm the plan calls for — but it is NOT a
+full cross-PROCESS exercise: both handles share the process, the GIL, and the
+OS page cache. A true multi-process arm (separate interpreters over the same
+store, or over a network socket) is a DECLARED kit limitation, deferred to the
+first networked backend. No subprocess arm is built in v1 (subprocess pools
+flake on constrained CI — the mp-pool learning). The cross-PROCESS coordinator
+path IS separately exercised over HTTP by the existing e2e / ``protocol_corpus``
+suites, but that is the SERVER seam, not the registry seam this kit targets.
+
+Reason matching is ALWAYS ``reason == CONSTANT`` against the wire-stable
+constants imported from :mod:`ccs.core.exceptions` / the ``ConflictDetail``
+literal set — NEVER a substring of a human message (the
+typed-signal-not-substring house rule).
+
+Concurrency-realism discipline (from ``tests/test_occ_commit_cas.py``): the
+ONLY hard assertion in a concurrency scenario is the correctness property; a
+``threading.Barrier`` forces the race window, and "did the threads actually
+overlap" is a :class:`RuntimeWarning`, never an assertion (a constrained runner
+may serialize threads).
+"""

--- a/tests/backend_conformance/kit.py
+++ b/tests/backend_conformance/kit.py
@@ -1,0 +1,600 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""The conformance scenarios — parametrizable over a registry factory.
+
+Every scenario is a plain function taking a :class:`RegistryFactory` (a callable
+that mints a fresh registry of one arm, tracking handles to close at teardown).
+The scenarios split into two structurally-distinct families — the split the plan
+demands be MECHANICAL, not a naming convention:
+
+**MUST-MATCH** (``assert_*`` functions taking only a :class:`RegistryFactory`):
+contract behaviors that MUST be identical on every conforming arm — CAS
+arbitration, the read-generation fence (including admit-on-absent), single-writer
+under barrier-forced contention, and session fail-closed refusals. Each
+hard-asserts the SAME correctness property regardless of arm. There is no arm
+parameter and no expected-outcome parameter — the property is universal, so a
+must-match function CANNOT express "arm X may differ".
+
+**BACKEND-DEFINED** (``assert_declared_*`` functions taking a
+:class:`RegistryFactory` AND a :class:`RestartDeclaration`): behaviors the
+contract explicitly lets backends DIVERGE on — restart survival, sweep timing.
+The function asserts the arm behaves *as ITS OWN declaration says* — the caller
+passes ``RestartDeclaration.SURVIVES`` for sqlite and ``RestartDeclaration.LOST``
+for in-memory, and the SAME function verifies each against its own declared
+disposition. Because the signature REQUIRES a per-arm declaration, a
+backend-defined scenario is structurally incapable of asserting cross-arm
+identity — that is the mechanism that keeps the split honest (a reviewer cannot
+accidentally turn restart-survival into a must-match assertion; the type won't
+let them).
+
+The :class:`RegistryFactory` protocol is deliberately narrow (mint one arm, close
+handles) so a degraded-stub factory (``tests/test_kit_teeth.py``) plugs in
+identically — the teeth test runs the SAME single-writer scenario against a
+wrapper whose ``commit_cas`` skips the grant arbitration, and the scenario FAILS
+it (proving the kit discriminates).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+import warnings
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Protocol
+from uuid import UUID, uuid4
+
+from ccs.coordinator.backend_contract import R18_LIVENESS_SOURCE, LivenessSourceObligation
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.service import CoordinatorService
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from ccs.core.exceptions import (
+    SESSION_INVALIDATED_REASON,
+    STALE_READ_GENERATION_REASON,
+    VERSION_MISMATCH_REASON,
+    SessionInvalidated,
+)
+from ccs.core.states import MESIState
+from ccs.core.types import (
+    Artifact,
+    ConflictDetail,
+    SessionReadRejection,
+    SnapshotSession,
+    VersionedContent,
+)
+
+# The reclaim trigger the fence keys on (a RECLAIM_TRIGGER bumps owner_generation
+# WITHOUT a version move — exactly what version-CAS cannot see). Named here as the
+# wire-stable constant, matched by identity, never by substring.
+_RECLAIM_TRIGGER = "reclaim_heartbeat"
+
+# The single-writer conflict reason the arbitration leg emits when a version-
+# matching OCC writer meets a pessimistic M/E peer. The registries return it as a
+# bare ``ConflictDetail`` literal (there is no exported OTHER_HOLDER_REASON
+# constant — the Literal in ``core.types`` IS the wire contract), so the kit pins
+# the literal here as its single source of truth.
+OTHER_HOLDER_REASON = "other_holder"
+
+
+# ---------------------------------------------------------------------------
+# The factory protocol — the one seam every arm (and the degraded stub) plugs in.
+# ---------------------------------------------------------------------------
+
+
+class RegistryFactory(Protocol):
+    """Mint a fresh registry of one arm. Every scenario takes one of these.
+
+    ``__call__`` returns a registry satisfying (at least) ``RegistryBase``. The
+    factory OWNS handle lifecycle: it tracks what it mints and closes durable
+    handles when :meth:`close_all` runs (the pytest fixture calls it at teardown).
+    A ``db_path`` is exposed so the restart scenario can re-open the SAME durable
+    store on a fresh handle (the sqlite "restart"); an in-memory factory leaves it
+    ``None`` (a fresh in-memory instance is a fresh, empty store — the declared
+    restart-loss).
+    """
+
+    def __call__(self) -> object:
+        ...
+
+    def close_all(self) -> None:
+        ...
+
+    @property
+    def db_path(self) -> Path | None:
+        ...
+
+
+@dataclass
+class InMemoryFactory:
+    """Mints :class:`ArtifactRegistry`. Restart is LOSS: a fresh instance is a
+    fresh empty store, so :attr:`db_path` is ``None`` — there is no shared store a
+    "restart" could re-open."""
+
+    retain_versions: bool = True
+
+    def __call__(self) -> ArtifactRegistry:
+        return ArtifactRegistry(retain_versions=self.retain_versions)
+
+    def close_all(self) -> None:
+        # In-memory registries hold no OS resource to release.
+        return None
+
+    @property
+    def db_path(self) -> Path | None:
+        return None
+
+
+@dataclass
+class SqliteFactory:
+    """Mints :class:`SqliteArtifactRegistry` handles over ONE db file under
+    ``tmp_path`` (isolated per test; never the shared ``state.db``, never a
+    ``user_version`` bump, never a foreign-lineage marker). Tracks every handle so
+    :meth:`close_all` closes them at teardown. Two calls return two INDEPENDENT
+    handles on the SAME file — the real two-connection concurrency arm."""
+
+    tmp_path: Path
+    retain_versions: bool = True
+    _handles: list[SqliteArtifactRegistry] = field(default_factory=list)
+
+    def __call__(self) -> SqliteArtifactRegistry:
+        reg = SqliteArtifactRegistry(
+            self.tmp_path / "conformance.db", retain_versions=self.retain_versions
+        )
+        self._handles.append(reg)
+        return reg
+
+    def close_all(self) -> None:
+        for reg in self._handles:
+            reg.close()
+        self._handles.clear()
+
+    @property
+    def db_path(self) -> Path | None:
+        return self.tmp_path / "conformance.db"
+
+
+# ---------------------------------------------------------------------------
+# Small helpers shared across scenarios.
+# ---------------------------------------------------------------------------
+
+
+def _register(reg: object, artifact_id: UUID, *, version: int = 1) -> Artifact:
+    art = Artifact(id=artifact_id, name="plan.md", version=version, content_hash="h-init")
+    reg.register_artifact(art, content="")  # type: ignore[attr-defined]
+    return art
+
+
+def _hash(label: str) -> str:
+    return hashlib.sha256(label.encode()).hexdigest()
+
+
+def _seed_shared_writer(reg: object, artifact_id: UUID, writer: UUID, *, tick: int = 1) -> None:
+    """Put ``writer`` in SHARED on ``artifact_id`` (OCC-eligible; the grant is
+    elected by the version check, not ``other_holder``)."""
+    reg.set_agent_state(artifact_id, writer, MESIState.SHARED, tick=tick)  # type: ignore[attr-defined]
+
+
+# ===========================================================================
+# MUST-MATCH scenarios — identical correctness property on every arm.
+# Signature: (factory) -> None. No arm param, no expected-outcome param.
+# ===========================================================================
+
+
+def assert_cas_arbitration_one_winner(factory: RegistryFactory) -> None:
+    """CAS arbitration (MUST-MATCH). Two writers hold the SAME stale version N and
+    each computes DISTINCT content from that one N; both call ``commit_cas`` under
+    a barrier. EXACTLY one wins (returns ``(Artifact, list)``); the loser gets a
+    typed ``ConflictDetail(version_mismatch)``; NEVER two winners, and the final
+    version is N+1 (the loser's stale buffer did not clobber).
+
+    Uses TWO independent handles on the durable arm (the real two-connection
+    race); the in-memory arm degrades to two writers over the single store object.
+    Only the correctness property is a hard assert; "did the threads overlap" is a
+    ``RuntimeWarning`` (a constrained runner may serialize)."""
+    writer_reg = factory()
+    peer_reg = factory() if factory.db_path is not None else writer_reg
+    artifact_id = uuid4()
+    _register(writer_reg, artifact_id, version=1)
+
+    writers = [uuid4(), uuid4()]
+    # Each writer is SHARED on the store it commits through (sqlite: seed on both
+    # handles' shared file; in-memory: one object).
+    _seed_shared_writer(writer_reg, artifact_id, writers[0])
+    _seed_shared_writer(peer_reg, artifact_id, writers[1])
+    regs = {writers[0]: writer_reg, writers[1]: peer_reg}
+
+    results: dict[UUID, object] = {}
+    barrier = threading.Barrier(len(writers))
+    overlap = threading.Event()
+    in_flight = {"n": 0}
+    lock = threading.Lock()
+
+    def attempt(writer_id: UUID) -> None:
+        content_hash = _hash(str(writer_id))  # FIXED stale buffer, keyed on identity
+        barrier.wait()
+        with lock:
+            in_flight["n"] += 1
+            if in_flight["n"] > 1:
+                overlap.set()
+        try:
+            results[writer_id] = regs[writer_id].commit_cas(  # type: ignore[attr-defined]
+                artifact_id, writer_id, expected_version=1, content_hash=content_hash, tick=5
+            )
+        finally:
+            with lock:
+                in_flight["n"] -= 1
+
+    threads = [threading.Thread(target=attempt, args=(w,)) for w in writers]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    wins = [r for r in results.values() if isinstance(r, tuple)]
+    conflicts = [r for r in results.values() if isinstance(r, ConflictDetail)]
+    assert len(wins) == 1, f"single-writer CAS must elect exactly one winner, got {results}"
+    assert len(conflicts) == 1, f"the loser must get a typed ConflictDetail, got {results}"
+    # Two OCC (SHARED) writers → the loss is version-elected, so the reason is
+    # ALWAYS version_mismatch (matched against the wire-stable constant).
+    assert conflicts[0].reason == VERSION_MISMATCH_REASON, conflicts[0].reason
+    assert conflicts[0].current_version == 2
+
+    # The final version advanced by EXACTLY one — no double bump from the loser.
+    final = writer_reg.get_artifact(artifact_id)  # type: ignore[attr-defined]
+    assert final.version == 2
+    winner_id = next(w for w, r in results.items() if isinstance(r, tuple))
+    assert final.content_hash == _hash(str(winner_id)), "the loser silently clobbered the winner"
+
+    if not overlap.is_set():
+        warnings.warn(
+            "CAS arbitration round did not observe overlapping in-flight writers; "
+            "the runner may have serialized threads. The correctness property is "
+            "still asserted; the race window was not stressed this run.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+def assert_single_writer_under_contention(factory: RegistryFactory) -> None:
+    """Single-writer under contention (MUST-MATCH — the TEETH scenario). A
+    pessimistic peer holds MODIFIED; an OCC writer at the CORRECT current version
+    calls ``commit_cas``. The grant-arbitration leg of the R9 boundary MUST reject
+    it with ``ConflictDetail(other_holder)`` — the version compare ALONE would let
+    it through (the version matches), so this scenario isolates the grant leg.
+
+    A barrier forces the OCC writer to fire while the M/E grant is held. The
+    degraded stub (``test_kit_teeth.py``) skips exactly this grant check, so its
+    OCC writer WINS while the M/E holder still holds — two writers — and this
+    assertion fails on it. The failure message NAMES the missing tuple element
+    (grant arbitration / other_holder)."""
+    reg = factory()
+    peer_reg = factory() if factory.db_path is not None else reg
+    artifact_id = uuid4()
+    _register(reg, artifact_id, version=1)
+
+    holder = uuid4()
+    occ_writer = uuid4()
+    # The pessimistic peer takes MODIFIED (a genuine single-writer grant).
+    reg.set_agent_state(artifact_id, holder, MESIState.MODIFIED, tick=1)  # type: ignore[attr-defined]
+    # The OCC writer is SHARED and commits at the CORRECT current version (1) — so
+    # only the grant leg, not the version leg, can reject it.
+    _seed_shared_writer(peer_reg, artifact_id, occ_writer)
+
+    barrier = threading.Barrier(2)
+    result: dict[str, object] = {}
+
+    def hold() -> None:
+        barrier.wait()
+        # The holder does nothing but keep MODIFIED live across the window.
+
+    def commit() -> None:
+        barrier.wait()
+        result["occ"] = peer_reg.commit_cas(  # type: ignore[attr-defined]
+            artifact_id, occ_writer, expected_version=1, content_hash=_hash("occ"), tick=5
+        )
+
+    th = threading.Thread(target=hold)
+    tc = threading.Thread(target=commit)
+    th.start()
+    tc.start()
+    th.join()
+    tc.join()
+
+    outcome = result["occ"]
+    assert isinstance(outcome, ConflictDetail), (
+        "single-writer VIOLATED: an OCC writer at the correct version WON while a "
+        "peer held MODIFIED — the R9 grant-arbitration leg (other_holder over "
+        "state_by_agent) was NOT enforced in the atomic step. The missing tuple "
+        f"element is grant arbitration ({OTHER_HOLDER_REASON}); commit_cas returned "
+        f"{outcome!r}"
+    )
+    assert outcome.reason == OTHER_HOLDER_REASON, (
+        f"single-writer rejection carried the wrong reason: expected "
+        f"{OTHER_HOLDER_REASON!r} (grant-arbitration leg), got {outcome.reason!r}"
+    )
+    # The version did NOT move — the arbitration rejected before any mutation.
+    assert reg.get_artifact(artifact_id).version == 1  # type: ignore[attr-defined]
+
+
+def assert_fence_rejects_superseded_read_generation(factory: RegistryFactory) -> None:
+    """Read-generation fence — REJECT leg (MUST-MATCH). An agent acquires
+    EXCLUSIVE (capturing its ``read_generation`` at the current ``owner_generation``);
+    a sweep-class reclaim (``reclaim_heartbeat``) drives it to INVALID, which bumps
+    ``owner_generation`` while the agent keeps its now-STALE ``read_generation``;
+    the agent re-grants SHARED and commits at the correct version. The fence MUST
+    reject it with ``ConflictDetail(stale_read_generation)`` — the version never
+    moved, so version-CAS alone cannot catch this reclaim-zombie."""
+    reg = factory()
+    artifact_id = uuid4()
+    _register(reg, artifact_id, version=1)
+    agent = uuid4()
+
+    # Acquire EXCLUSIVE → captures read_generation = owner_generation (0).
+    reg.set_agent_state(artifact_id, agent, MESIState.EXCLUSIVE, tick=1)  # type: ignore[attr-defined]
+    captured = reg.get_read_generation(artifact_id, agent)  # type: ignore[attr-defined]
+    assert captured is not None, "an M/E acquire must capture a read_generation"
+
+    # Sweep-class reclaim → INVALID with a RECLAIM_TRIGGER bumps owner_generation.
+    reg.set_agent_state(  # type: ignore[attr-defined]
+        artifact_id, agent, MESIState.INVALID, trigger=_RECLAIM_TRIGGER, tick=2
+    )
+    assert reg.get_owner_generation(artifact_id) > captured, (  # type: ignore[attr-defined]
+        "a sweep-class reclaim must bump owner_generation past the captured "
+        "read_generation, else the fence has nothing to reject"
+    )
+
+    # Re-grant SHARED (a re-read would land it back in S) WITHOUT a fresh capture,
+    # so the stale read_generation survives (SHARED does not re-capture).
+    reg.set_agent_state(artifact_id, agent, MESIState.SHARED, trigger="peer_regrant", tick=3)  # type: ignore[attr-defined]
+
+    result = reg.commit_cas(  # type: ignore[attr-defined]
+        artifact_id, agent, expected_version=1, content_hash=_hash("zombie"), tick=4
+    )
+    assert isinstance(result, ConflictDetail), (
+        "the fence FAILED to reject a reclaim-zombie: a superseded read_generation "
+        f"committed while the version was unchanged, got {result!r}"
+    )
+    assert result.reason == STALE_READ_GENERATION_REASON, result.reason
+    # No mutation — the version stayed put.
+    assert reg.get_artifact(artifact_id).version == 1  # type: ignore[attr-defined]
+
+
+def assert_fence_admits_absent_read_generation(factory: RegistryFactory) -> None:
+    """Read-generation fence — ADMIT-ON-ABSENT leg (MUST-MATCH). Reproduced EXACTLY
+    per the fence-parity lesson (it has drifted once before). A plain OCC writer
+    that NEVER established a fence claim (SHARED, no captured ``read_generation``)
+    is ADMITTED even after ``owner_generation`` has been bumped by an UNRELATED
+    agent's reclaim — the ``is not None`` predicate is load-bearing, and version-
+    CAS (not the fence) is this writer's lost-update protection.
+
+    Contrast with :func:`assert_fence_rejects_superseded_read_generation`: a
+    PRESENT-and-superseded read_generation is rejected; an ABSENT one is admitted.
+    Both legs run so the asymmetry is pinned, not just one side."""
+    reg = factory()
+    artifact_id = uuid4()
+    _register(reg, artifact_id, version=1)
+
+    # An UNRELATED agent acquires + is reclaimed, bumping owner_generation to > 0.
+    other = uuid4()
+    reg.set_agent_state(artifact_id, other, MESIState.EXCLUSIVE, tick=1)  # type: ignore[attr-defined]
+    reg.set_agent_state(  # type: ignore[attr-defined]
+        artifact_id, other, MESIState.INVALID, trigger=_RECLAIM_TRIGGER, tick=2
+    )
+    assert reg.get_owner_generation(artifact_id) > 0  # type: ignore[attr-defined]
+
+    # A FRESH plain OCC writer: SHARED, never captured a read_generation (absent).
+    plain = uuid4()
+    _seed_shared_writer(reg, artifact_id, plain, tick=3)
+    assert reg.get_read_generation(artifact_id, plain) is None, (  # type: ignore[attr-defined]
+        "the admit-on-absent scenario requires the writer to have NO captured "
+        "read_generation — a SHARED grant must not capture one"
+    )
+
+    result = reg.commit_cas(  # type: ignore[attr-defined]
+        artifact_id, plain, expected_version=1, content_hash=_hash("plain-occ"), tick=4
+    )
+    assert isinstance(result, tuple), (
+        "admit-on-absent VIOLATED: a plain OCC writer with NO fence claim was "
+        f"rejected — version-CAS, not the fence, is its protection. Got {result!r}"
+    )
+    updated, _invalidated = result
+    assert updated.version == 2, "the admitted OCC writer must WIN and bump the version"
+
+
+def assert_session_fail_closed_on_foreign_and_reaped(factory: RegistryFactory) -> None:
+    """Session fail-closed refusals (MUST-MATCH). Two typed refusals a conforming
+    backend must reproduce identically, NEVER serving live HEAD:
+
+    1. A FOREIGN caller (not the session owner) reading a live session RAISES
+       :class:`SessionInvalidated` (owner-isolation, R13) — matched by its typed
+       ``reason``, not a message substring.
+    2. A REAPED / released token classifies as ``session_invalidated`` on read —
+       a typed :class:`SessionReadRejection`, never a live-HEAD fall-through.
+    """
+    reg = factory()
+    svc = CoordinatorService(reg)
+    artifact_id = uuid4()
+    art = Artifact(id=artifact_id, name="plan.md", version=1, content_hash="h")
+    reg.register_artifact(art, content="PINNED-V1")  # type: ignore[attr-defined]
+
+    owner = uuid4()
+    session = svc.begin_session(read_set=[artifact_id], owner=owner)
+    assert isinstance(session, SnapshotSession)
+    token = session.session_token
+
+    # (1) A foreign caller is rejected fail-closed (owner-isolation).
+    try:
+        svc.session_read(token, artifact_id, caller=uuid4())
+    except SessionInvalidated as exc:
+        assert exc.reason == SESSION_INVALIDATED_REASON, exc.reason
+    else:
+        raise AssertionError(
+            "a FOREIGN caller was NOT rejected — session owner-isolation (R13) "
+            "must fail closed, never serve another owner's cut"
+        )
+
+    # (2) A reaped/released token classifies session_invalidated on read.
+    reg.release_session(token)  # type: ignore[attr-defined]
+    result = svc.session_read(token, artifact_id, caller=owner)
+    assert isinstance(result, SessionReadRejection), (
+        "a released session token served (or crashed) instead of failing closed"
+    )
+    assert result.reason == SESSION_INVALIDATED_REASON, result.reason
+
+
+# ===========================================================================
+# BACKEND-DEFINED scenarios — assert the arm behaves as ITS OWN declaration.
+# Signature: (factory, declaration) -> None. The declaration param is what makes
+# the split STRUCTURAL: a backend-defined function cannot assert cross-arm
+# identity — it verifies each arm against the disposition it declared.
+# ===========================================================================
+
+
+class RestartDeclaration(Enum):
+    """A backend's DECLARED restart-survival disposition (R11 / R6). The kit does
+    NOT assert the two arms agree — it asserts EACH arm matches the disposition IT
+    declared. Passing this per-arm is the mechanism that keeps restart-survival a
+    backend-defined property and NOT a must-match one."""
+
+    SURVIVES = "survives"
+    """The backend re-homes ``session_meta`` / pins durably: a re-open of the SAME
+    store on a fresh handle still finds the session cut and serves the owner's
+    pinned bytes. The Tier-1 durability disposition (sqlite)."""
+
+    LOST = "lost"
+    """The backend is process-scoped: a fresh instance is a fresh, empty store —
+    the session cut is GONE and a read fails closed. This is the HONEST in-memory
+    declaration; it is NOT a Tier-1 / HA-statelessness claim, and the kit records
+    it as such (asserted-as-declared, never flagged as a bug)."""
+
+
+def assert_declared_restart_survival(
+    factory: RegistryFactory, declaration: RestartDeclaration
+) -> None:
+    """Restart survival (BACKEND-DEFINED). Begin a session, then simulate a
+    "restart" and assert the arm behaves as ``declaration`` says:
+
+    - ``SURVIVES`` (durable arm): re-open the SAME db file on a FRESH handle; the
+      session cut is still readable AND the owner can still serve the pinned bytes
+      (identity survived). Requires ``factory.db_path`` (a shared store to re-open).
+    - ``LOST`` (process-scoped arm): a FRESH instance has NO pins — the cut is
+      ``None`` and a read FAILS CLOSED (``session_invalidated``), never live HEAD.
+      The declared loss is asserted AS DECLARED — not treated as a regression.
+
+    This function NEVER compares the two arms to each other. Each arm is checked
+    only against the disposition it declared — that is the structural split."""
+    if declaration is RestartDeclaration.SURVIVES:
+        _assert_restart_survives(factory)
+    else:
+        _assert_restart_lost(factory)
+
+
+def _assert_restart_survives(factory: RegistryFactory) -> None:
+    db_path = factory.db_path
+    assert db_path is not None, (
+        "a SURVIVES declaration requires a durable store to re-open; this arm "
+        "exposes no db_path (it is process-scoped and cannot declare SURVIVES)"
+    )
+    reg1 = factory()
+    artifact_id = UUID(int=0xF00D5E55)
+    owner = UUID(int=0x0114E5)
+    art = Artifact(id=artifact_id, name="plan.md", version=1, content_hash="h")
+    reg1.register_artifact(art, content="SURVIVOR-V1")  # type: ignore[attr-defined]
+    session = CoordinatorService(reg1).begin_session(read_set=[artifact_id], owner=owner)
+    assert isinstance(session, SnapshotSession)
+    token = session.session_token
+
+    # The "restart": a SECOND handle on the SAME store (the durable pin persisted).
+    reg2 = factory()
+    svc2 = CoordinatorService(reg2)
+    assert svc2.registry.get_session_cut(token) == {artifact_id: 1}, (
+        "declared SURVIVES but the session cut did NOT survive a re-open — the "
+        "durable session_meta / pins did not re-home"
+    )
+    served = svc2.session_read(token, artifact_id, caller=owner)
+    assert isinstance(served, VersionedContent), (
+        "declared SURVIVES but the owner could not serve the pinned bytes after "
+        "restart — the durable pin was not intact"
+    )
+    assert served.content == "SURVIVOR-V1"
+
+
+def _assert_restart_lost(factory: RegistryFactory) -> None:
+    assert factory.db_path is None, (
+        "a LOST declaration is for process-scoped arms; this arm exposes a "
+        "db_path, so a 'fresh instance' would re-open the SAME store and survive"
+    )
+    reg1 = factory()
+    artifact_id = UUID(int=0xF00D5E55)
+    owner = UUID(int=0x0114E5)
+    art = Artifact(id=artifact_id, name="plan.md", version=1, content_hash="h")
+    reg1.register_artifact(art, content="EPHEMERAL-V1")  # type: ignore[attr-defined]
+    session = CoordinatorService(reg1).begin_session(read_set=[artifact_id], owner=owner)
+    assert isinstance(session, SnapshotSession)
+    token = session.session_token
+
+    # The "restart": a BRAND-NEW instance — no shared store, no pins. This is the
+    # DECLARED loss, asserted as declared (never as a bug).
+    reg2 = factory()
+    svc2 = CoordinatorService(reg2)
+    assert svc2.registry.get_session_cut(token) is None, (
+        "declared LOST but the session cut survived a fresh instance — the "
+        "process-scoped contract was violated (this would be the surprising case)"
+    )
+    result = svc2.session_read(token, artifact_id, caller=owner)
+    assert isinstance(result, SessionReadRejection), (
+        "declared LOST but session_read did not fail closed on a fresh instance — "
+        "it must reject, NEVER serve live HEAD"
+    )
+    assert result.reason == SESSION_INVALIDATED_REASON, result.reason
+
+
+# ===========================================================================
+# R18 — liveness-source declaration check (a DECLARED-source assertion).
+# ===========================================================================
+
+
+def assert_declared_liveness_source_matches_contract(
+    factory: RegistryFactory,
+    *,
+    contract_record: LivenessSourceObligation = R18_LIVENESS_SOURCE,
+) -> None:
+    """R18 liveness-source check. Assert the backend's OBSERVED liveness behavior
+    matches the source DECLARED in the Unit-4 contract record. For BOTH shipped
+    registries the declared source is CALLER-SUPPLIED LOGICAL TICKS under a SINGLE
+    coordinator (the single-host declaration, NOT a cross-host / HA claim).
+
+    Observed behavior: ``record_heartbeat`` accepts a caller-supplied tick and
+    ``last_heartbeat_tick`` reflects it verbatim — i.e. the registry stores the
+    tick VALUE the caller supplies and does NOT synthesize an authoritative clock
+    of its own (which is precisely why the contract record says this does NOT
+    conform for the HA claim until a re-home supplies an authoritative source).
+    The assertion pins that the OBSERVED store-the-caller's-tick behavior matches
+    the DECLARED caller-supplied-tick source."""
+    # The contract's shipped-source declaration must name the caller-supplied,
+    # single-coordinator source (matched as declared text, the Unit-4 record).
+    declared = contract_record.shipped_source
+    assert "CALLER-SUPPLIED" in declared and "SINGLE coordinator" in declared, (
+        "the R18 contract record's shipped_source no longer declares the "
+        "caller-supplied single-coordinator source the kit checks against; the "
+        "contract and the kit have drifted"
+    )
+
+    reg = factory()
+    artifact_id = uuid4()
+    _register(reg, artifact_id, version=1)
+    agent = uuid4()
+    reg.set_agent_state(artifact_id, agent, MESIState.EXCLUSIVE, tick=1)  # type: ignore[attr-defined]
+
+    # Observed: the registry stores the CALLER's tick verbatim (no authoritative
+    # clock of its own) — the single-host declaration made concrete.
+    reg.record_heartbeat(agent, 100)  # type: ignore[attr-defined]
+    assert reg.last_heartbeat_tick(agent) == 100, (  # type: ignore[attr-defined]
+        "observed liveness source diverged from the declared caller-supplied tick: "
+        "the registry did not store the caller's tick verbatim"
+    )
+    # A later caller tick is honored verbatim (monotonic max, still caller-driven).
+    reg.record_heartbeat(agent, 250)  # type: ignore[attr-defined]
+    assert reg.last_heartbeat_tick(agent) == 250  # type: ignore[attr-defined]

--- a/tests/backend_conformance/test_kit_teeth.py
+++ b/tests/backend_conformance/test_kit_teeth.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Teeth: a deliberately-degraded backend MUST FAIL the kit (plan Unit 5).
+
+A conformance kit that every plausible implementation passes proves nothing. This
+test builds a backend that is correct on the version-CAS leg but DROPS one leg of
+the R9 atomic boundary — the grant arbitration — and asserts the kit's
+single-writer-under-contention scenario CATCHES it. If the degraded stub ever
+passed that scenario, the kit would be decorative; the assertion here is that it
+does NOT (``pytest.raises(AssertionError)``), and that the failure message NAMES
+the missing tuple element so a real backend author knows what they skipped.
+
+The degraded stub (:class:`_GrantBlindRegistry`) wraps a real in-memory registry
+and delegates EVERYTHING to it EXCEPT ``commit_cas``, which it reimplements as a
+VERSION-ONLY compare-and-swap: it checks the artifact version but SKIPS the
+``other_holder`` grant check that the real ``commit_cas`` performs in the same
+atomic step. That is exactly the bug a naive "just do a version CAS in the
+backend" implementation would ship — the version matches, so a version-only CAS
+lets an OCC writer win while a pessimistic peer still holds MODIFIED, producing
+TWO writers. The kit's single-writer scenario is written to isolate precisely
+this leg (the OCC writer commits at the CORRECT version, so only the grant check
+can stop it).
+
+The MUST-MATCH scenarios that do NOT depend on the grant leg (pure version-CAS
+arbitration, admit-on-absent) still PASS the stub — proving the teeth test fails
+the stub for the RIGHT reason (the dropped grant leg), not because the stub is
+broken everywhere.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.registry_protocol import CasResult
+from ccs.core.states import MESIState
+from ccs.core.types import CasCorruption, ConflictDetail
+from tests.backend_conformance import kit
+from tests.backend_conformance.kit import RegistryFactory
+
+_M_OR_E = frozenset({MESIState.MODIFIED, MESIState.EXCLUSIVE})
+
+
+class _GrantBlindRegistry:
+    """A degraded backend: correct version-CAS, but the grant-arbitration leg of
+    the R9 boundary is DROPPED. Delegates everything to a wrapped real in-memory
+    registry via ``__getattr__`` EXCEPT ``commit_cas``, which it reimplements to
+    skip the ``other_holder`` check — so a version-matching OCC writer wins even
+    while a pessimistic peer holds MODIFIED (single-writer violated)."""
+
+    def __init__(self) -> None:
+        self._inner = ArtifactRegistry(retain_versions=True)
+
+    def __getattr__(self, name: str) -> object:
+        # Every member except commit_cas comes straight from the real registry.
+        return getattr(self._inner, name)
+
+    def commit_cas(  # noqa: D401 - degraded on purpose
+        self,
+        artifact_id: UUID,
+        agent_id: UUID,
+        *,
+        expected_version: int,
+        content_hash: str,
+        size_tokens: int | None = None,
+        content: bytes | str | None = None,
+        tick: int = 0,
+        trigger: str = "commit_cas",
+    ) -> CasResult:
+        """Version-only CAS — the grant-arbitration leg is intentionally MISSING.
+
+        It performs the version compare correctly (so the pure-CAS and
+        admit-on-absent scenarios still pass), then WINS without checking whether a
+        peer holds M/E. To win it delegates to the inner registry's real
+        ``commit_cas`` AFTER neutralizing any peer M/E grant — mechanically the
+        same effect as a backend that simply never consulted ``state_by_agent``:
+        the peer grant does not block the write."""
+        record = self._inner._records.get(artifact_id)  # noqa: SLF001 - test stub reaches in
+        if record is None:
+            raise KeyError(f"artifact {artifact_id} not in registry")
+        current = record.artifact.version
+        if expected_version > current:
+            return CasCorruption(current_version=current)
+        if expected_version < current:
+            return ConflictDetail("version_mismatch", current)
+        # THE DROPPED LEG: a correct commit_cas rejects here when a peer holds
+        # M/E (ConflictDetail("other_holder")). This degraded stub does NOT —
+        # it demotes every peer M/E grant so the inner real commit_cas cannot
+        # see a competing holder, then wins on the version leg alone.
+        for peer_id, state in list(record.state_by_agent.items()):
+            if peer_id != agent_id and state in _M_OR_E:
+                record.state_by_agent[peer_id] = MESIState.SHARED
+        return self._inner.commit_cas(
+            artifact_id,
+            agent_id,
+            expected_version=expected_version,
+            content_hash=content_hash,
+            size_tokens=size_tokens,
+            content=content,
+            tick=tick,
+            trigger=trigger,
+        )
+
+
+class _DegradedFactory:
+    """A :class:`RegistryFactory` minting :class:`_GrantBlindRegistry`. Single
+    object per factory (the degraded stub is process-scoped, like in-memory), so
+    ``db_path`` is ``None`` — the concurrency scenarios run against the one store
+    object, which is all the single-writer teeth scenario needs."""
+
+    def __init__(self) -> None:
+        self._reg: _GrantBlindRegistry | None = None
+
+    def __call__(self) -> _GrantBlindRegistry:
+        if self._reg is None:
+            self._reg = _GrantBlindRegistry()
+        return self._reg
+
+    def close_all(self) -> None:
+        return None
+
+    @property
+    def db_path(self) -> Path | None:
+        return None
+
+
+def test_degraded_stub_fails_single_writer_scenario() -> None:
+    """THE TEETH. The kit's single-writer-under-contention scenario MUST FAIL the
+    grant-blind stub — proving the kit actually discriminates a backend that drops
+    the grant-arbitration leg. The failure is a raised ``AssertionError`` whose
+    message NAMES the missing tuple element (grant arbitration / other_holder)."""
+    factory: RegistryFactory = _DegradedFactory()
+    with pytest.raises(AssertionError) as excinfo:
+        kit.assert_single_writer_under_contention(factory)
+    message = str(excinfo.value)
+    assert "single-writer VIOLATED" in message
+    assert kit.OTHER_HOLDER_REASON in message, (
+        "the teeth failure must name the missing tuple element (the grant-"
+        "arbitration / other_holder leg) so a backend author knows what they "
+        f"skipped; got: {message}"
+    )
+
+
+def test_degraded_stub_still_passes_grant_independent_scenarios() -> None:
+    """The stub only drops the GRANT leg — so the scenarios that do not depend on
+    it (pure version-CAS arbitration, fence admit-on-absent) still PASS. This
+    proves the teeth test fails the stub for the RIGHT reason (the dropped grant
+    leg), not because the stub is broken across the board (which would make the
+    single-writer failure uninformative)."""
+    factory: RegistryFactory = _DegradedFactory()
+    # Pure version-CAS: two SHARED writers, one winner, loser version_mismatch —
+    # no grant leg involved, so the degraded stub is still correct here.
+    kit.assert_cas_arbitration_one_winner(_DegradedFactory())
+    # Admit-on-absent: a plain OCC writer with no fence claim wins — again grant-
+    # independent (a fresh factory so no cross-scenario state bleed).
+    kit.assert_fence_admits_absent_read_generation(factory)
+
+
+def test_degraded_stub_fence_reject_leg_still_holds() -> None:
+    """The stub delegates the fence to the real inner registry, so the fence
+    REJECT leg still works — the degradation is scoped to grant arbitration ONLY.
+    Documents the exact blast radius of the injected bug (one leg, not the fence).
+    """
+    kit.assert_fence_rejects_superseded_read_generation(_DegradedFactory())

--- a/tests/backend_conformance/test_shipped_backends.py
+++ b/tests/backend_conformance/test_shipped_backends.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Run the Tier-1 conformance kit over the two SHIPPED registries (plan Unit 5).
+
+SQLite is verified at **Tier-1** (the full R9 tuple under one ``BEGIN IMMEDIATE``
+transaction, plus durable restart-survival). The in-memory registry is verified
+at its OWN honest declared tier: it passes every MUST-MATCH scenario (it hosts
+the whole atomic boundary GIL-atomically under one process) but declares restart
+**LOSS** — a fresh instance is a fresh, empty store, which is NOT a Tier-1 / HA
+claim. The kit asserts the in-memory arm's declared restart-loss *as declared*,
+never as a bug.
+
+The MUST-MATCH vs BACKEND-DEFINED split is expressed in the test parametrization,
+mirroring the kit API: the must-match tests take only the ``factory`` fixture and
+run the SAME assertion on both arms; the backend-defined test takes the arm's
+declared :class:`~tests.backend_conformance.kit.RestartDeclaration` too, and the
+SAME kit function verifies each arm against ITS OWN declaration (sqlite SURVIVES,
+in-memory LOST) — never against each other.
+
+Fixtures use isolated ``tmp_path`` databases and close every handle at teardown;
+they never bump ``PRAGMA user_version`` (Node-shared, currently v4) and never
+write foreign lineage markers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from tests.backend_conformance import kit
+from tests.backend_conformance.kit import (
+    InMemoryFactory,
+    RegistryFactory,
+    RestartDeclaration,
+    SqliteFactory,
+)
+
+# Arm id → (factory builder, declared restart disposition). The declaration is
+# the arm's HONEST tier statement: sqlite re-homes session_meta/pins durably
+# (SURVIVES); in-memory is process-scoped (LOST — NOT a Tier-1/HA claim).
+_ARMS = {
+    "in_memory": RestartDeclaration.LOST,
+    "sqlite": RestartDeclaration.SURVIVES,
+}
+
+
+@pytest.fixture(params=sorted(_ARMS))
+def factory(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[RegistryFactory]:
+    """A registry factory for one arm. The sqlite arm mints handles over an
+    isolated ``tmp_path`` db and closes them all at teardown; the in-memory arm
+    holds no OS resource. Every scenario runs against BOTH arms via this fixture's
+    parametrization — that is where the MUST-MATCH universality lives."""
+    arm: str = request.param
+    fac: RegistryFactory = InMemoryFactory() if arm == "in_memory" else SqliteFactory(tmp_path)
+    try:
+        yield fac
+    finally:
+        fac.close_all()
+
+
+@pytest.fixture
+def declared_restart(request: pytest.FixtureRequest) -> RestartDeclaration:
+    """The DECLARED restart disposition for the current ``factory`` arm — resolved
+    from the same parametrization so the backend-defined test verifies each arm
+    against its own declaration."""
+    # The active ``factory`` param is the arm id carried on the request node.
+    arm = request.node.callspec.params["factory"]
+    return _ARMS[arm]
+
+
+# ---------------------------------------------------------------------------
+# MUST-MATCH scenarios — the SAME assertion, both arms (identical property).
+# ---------------------------------------------------------------------------
+
+
+def test_cas_arbitration_one_winner(factory: RegistryFactory) -> None:
+    kit.assert_cas_arbitration_one_winner(factory)
+
+
+def test_single_writer_under_contention(factory: RegistryFactory) -> None:
+    kit.assert_single_writer_under_contention(factory)
+
+
+def test_fence_rejects_superseded_read_generation(factory: RegistryFactory) -> None:
+    kit.assert_fence_rejects_superseded_read_generation(factory)
+
+
+def test_fence_admits_absent_read_generation(factory: RegistryFactory) -> None:
+    kit.assert_fence_admits_absent_read_generation(factory)
+
+
+def test_session_fail_closed_on_foreign_and_reaped(factory: RegistryFactory) -> None:
+    kit.assert_session_fail_closed_on_foreign_and_reaped(factory)
+
+
+# ---------------------------------------------------------------------------
+# R18 — declared liveness source matches the Unit-4 contract + observed behavior.
+# ---------------------------------------------------------------------------
+
+
+def test_declared_liveness_source_matches_contract(factory: RegistryFactory) -> None:
+    kit.assert_declared_liveness_source_matches_contract(factory)
+
+
+# ---------------------------------------------------------------------------
+# BACKEND-DEFINED — each arm verified against ITS OWN declared disposition.
+# (No cross-arm identity assertion: sqlite SURVIVES, in-memory LOST.)
+# ---------------------------------------------------------------------------
+
+
+def test_declared_restart_survival(
+    factory: RegistryFactory, declared_restart: RestartDeclaration
+) -> None:
+    kit.assert_declared_restart_survival(factory, declared_restart)

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Drift guards for the generalized backend atomic-boundary contract.
+
+:mod:`ccs.coordinator.backend_contract` is pure documented vocabulary (enums,
+frozen dataclasses, string constants) formalizing what a networked registry
+backend must provide to re-home the coordinator's atomic boundary. These tests
+are the DRIFT GUARDS the plan calls for:
+
+- the member-classification map covers EXACTLY the 48 ``RegistryBase`` +
+  ``SqliteExtended`` members — no more, no fewer — so a Protocol member added or
+  removed in ``registry_protocol.py`` without a matching contract update FAILS
+  CI (bidirectional guard);
+- the ``coordinator_epoch`` PROPERTY is present in the map (property-omission
+  teeth — ``@runtime_checkable`` cannot see properties, per the #133 lesson);
+- every statelessness item names a disposition and ``coordinator_epoch``'s is
+  never ``SAFELY_LOST`` (R12);
+- a classification value outside the enum is unrepresentable (typed);
+- the tier enum has exactly ``TIER_1`` and ``TIER_2``.
+
+The expected 48-member set is FROZEN here (imported from the parity test's own
+frozen name-sets), NOT derived from the Protocol at runtime — so a silent
+Protocol edit cannot move the goalposts this test guards (the same discipline
+``tests/test_registry_protocol_parity.py`` uses).
+"""
+
+from __future__ import annotations
+
+from ccs.coordinator.backend_contract import (
+    MEMBER_CLASSIFICATION,
+    R9_ATOMIC_BOUNDARY,
+    R12_EPOCH,
+    R13_CONTENT_POSTURE,
+    R14_CREDENTIAL,
+    R15_BACKEND_IDENTITY,
+    R18_LIVENESS_SOURCE,
+    STATELESSNESS_INVENTORY,
+    TIER_DECLARATIONS,
+    Disposition,
+    MemberClass,
+    Tier,
+)
+
+# The 48-member expected surface, imported from the parity test's FROZEN
+# name-sets (34 base methods + 13 extended methods + 1 base property). Reusing
+# those frozensets means this contract and the Protocol parity share ONE
+# source of truth for the surface: if either the parity test or the Protocol
+# changes the surface, the two drift guards fire together.
+from tests.test_registry_protocol_parity import (  # noqa: E402
+    BASE_METHODS,
+    BASE_PROPERTIES,
+    EXTENDED_ONLY_METHODS,
+)
+
+EXPECTED_MEMBERS = BASE_METHODS | EXTENDED_ONLY_METHODS | BASE_PROPERTIES
+
+
+# ---------------------------------------------------------------------------
+# Member classification — exactly the 48 Protocol members, no drift
+# ---------------------------------------------------------------------------
+
+
+def test_member_map_covers_exactly_the_protocol_surface() -> None:
+    """The classification map keys equal the 48-member Protocol surface EXACTLY
+    — no more, no fewer. A member added to (or removed from) ``registry_protocol.py``
+    without a matching contract update fails HERE (bidirectional drift guard)."""
+    assert set(MEMBER_CLASSIFICATION) == EXPECTED_MEMBERS
+
+
+def test_member_map_has_exactly_48_members() -> None:
+    """Pin the count explicitly: 34 base methods + 13 extended methods + 1 base
+    property = 48. Guards against a same-size add+remove that would slip past the
+    set-equality check on cardinality alone."""
+    assert len(MEMBER_CLASSIFICATION) == 48
+    assert len(EXPECTED_MEMBERS) == 48
+
+
+def test_coordinator_epoch_property_is_in_the_map() -> None:
+    """The ``coordinator_epoch`` PROPERTY is classified (property-omission teeth,
+    the #133 lesson: ``@runtime_checkable`` cannot see properties, so a
+    method-only map would silently drop it — the exact gap that lesson exists to
+    prevent)."""
+    assert "coordinator_epoch" in MEMBER_CLASSIFICATION
+    assert "coordinator_epoch" in BASE_PROPERTIES
+
+
+def test_every_member_has_a_typed_classification() -> None:
+    """Every mapped member carries a :class:`MemberClass` enum value — a
+    classification outside the enum is unrepresentable (typed, not a bare
+    string)."""
+    for name, contract in MEMBER_CLASSIFICATION.items():
+        assert isinstance(contract.member_class, MemberClass), name
+        assert contract.name == name
+        assert contract.surface in {"base", "sqlite_extended"}
+        assert contract.rationale  # non-empty rationale authored from service.py
+
+
+def test_member_surface_matches_the_protocol_split() -> None:
+    """Each member's declared ``surface`` matches which Protocol frozenset it
+    belongs to (base methods + the base property are "base"; extended-only
+    methods are "sqlite_extended")."""
+    base_surface = BASE_METHODS | BASE_PROPERTIES
+    for name, contract in MEMBER_CLASSIFICATION.items():
+        if name in base_surface:
+            assert contract.surface == "base", name
+        else:
+            assert contract.surface == "sqlite_extended", name
+
+
+def test_the_atomic_class_boundary_members_are_classified_atomic() -> None:
+    """The members the service touches INSIDE its atomic mutation paths (authored
+    from the ``service.py`` call sites) are ATOMIC_CLASS. This pins the core
+    classification decision so a later edit that silently downgrades one to
+    READ_ONLY/INDEPENDENT fails."""
+    expected_atomic = {
+        "commit_cas",
+        "set_artifact_and_content",
+        "set_agent_state",
+        "set_agent_transient",
+        "clear_agent_transient",
+        "capture_version_vector",
+        "abort_guard",
+        "record_last_reclamation",
+        "get_state_map",
+    }
+    actual_atomic = {
+        name
+        for name, contract in MEMBER_CLASSIFICATION.items()
+        if contract.member_class is MemberClass.ATOMIC_CLASS
+    }
+    assert actual_atomic == expected_atomic
+
+
+def test_classification_enum_has_exactly_three_classes() -> None:
+    """The member-class taxonomy is exactly {ATOMIC_CLASS, INDEPENDENT,
+    READ_ONLY} — a value outside it cannot be represented."""
+    assert {m.name for m in MemberClass} == {
+        "ATOMIC_CLASS",
+        "INDEPENDENT",
+        "READ_ONLY",
+    }
+
+
+# ---------------------------------------------------------------------------
+# R11 statelessness inventory + R12 epoch never-safely-lost
+# ---------------------------------------------------------------------------
+
+
+def test_every_state_item_names_a_typed_disposition() -> None:
+    """Every statelessness item names a :class:`Disposition` — nothing implicit
+    (R11: every listed state has a stated re-home or safe-loss disposition)."""
+    assert STATELESSNESS_INVENTORY  # non-empty
+    for item in STATELESSNESS_INVENTORY:
+        assert isinstance(item.disposition, Disposition), item.name
+        assert item.consequence  # the stated consequence if it does not re-home
+
+
+def test_coordinator_epoch_is_must_rehome_and_never_safely_lost() -> None:
+    """``coordinator_epoch``'s disposition is MUST_REHOME and — the R12 assertion
+    — is NEVER ``SAFELY_LOST`` (losing it invalidates every client-carried token
+    at once)."""
+    epoch_items = [
+        item for item in STATELESSNESS_INVENTORY if item.name == "coordinator_epoch"
+    ]
+    assert len(epoch_items) == 1, "coordinator_epoch must appear exactly once"
+    (epoch_item,) = epoch_items
+    assert epoch_item.disposition is Disposition.MUST_REHOME
+    assert epoch_item.disposition is not Disposition.SAFELY_LOST
+
+
+def test_disposition_enum_has_exactly_three_values() -> None:
+    assert {d.name for d in Disposition} == {
+        "MUST_REHOME",
+        "DERIVABLE",
+        "SAFELY_LOST",
+    }
+
+
+# ---------------------------------------------------------------------------
+# R10 tiers
+# ---------------------------------------------------------------------------
+
+
+def test_tier_enum_has_exactly_tier_1_and_tier_2() -> None:
+    """Exactly two tiers (R10) — TIER_1 full-tuple and TIER_2 lease-decomposed."""
+    assert {t.name for t in Tier} == {"TIER_1", "TIER_2"}
+
+
+def test_tier_declarations_cover_both_tiers() -> None:
+    assert set(TIER_DECLARATIONS) == {Tier.TIER_1, Tier.TIER_2}
+    assert TIER_DECLARATIONS[Tier.TIER_1].ha_qualifies is True
+    assert TIER_DECLARATIONS[Tier.TIER_2].ha_qualifies is False
+
+
+# ---------------------------------------------------------------------------
+# R9 atomic boundary — fence admit-on-absent reproduced exactly
+# ---------------------------------------------------------------------------
+
+
+def test_r9_boundary_names_the_three_tuple_legs() -> None:
+    """The boundary names all three legs — version-CAS + grant arbitration +
+    fence — not the version compare alone."""
+    assert len(R9_ATOMIC_BOUNDARY.tuple_elements) == 3
+    joined = " ".join(R9_ATOMIC_BOUNDARY.tuple_elements).lower()
+    assert "version-cas" in joined
+    assert "grant arbitration" in joined
+    assert "read-generation fence" in joined
+
+
+def test_r9_fence_admit_on_absent_is_stated_exactly() -> None:
+    """The admit-on-absent asymmetry is reproduced EXACTLY (the fence-parity
+    lesson — it has drifted once before): an ABSENT read_generation is ADMITTED
+    (version-CAS arbitrates); only a PRESENT-and-superseded one is REJECTED."""
+    text = R9_ATOMIC_BOUNDARY.fence_admit_on_absent
+    assert "ABSENT read_generation is ADMITTED" in text
+    assert "version-CAS arbitrates" in text
+    assert "superseded" in text and "REJECTED" in text
+    # The load-bearing `is not None` predicate is named (not treated as defensive).
+    assert "is not None" in text
+
+
+def test_r9_reference_semantics_include_the_same_lock_sweep() -> None:
+    """Reference semantics = the single-process serialization AS A WHOLE — atomic
+    mutations PLUS the same-lock sweep — and liveness eviction is stated to be a
+    separate same-lock sweep, NOT inside commit_cas's transaction."""
+    assert "as a whole" in R9_ATOMIC_BOUNDARY.reference_semantics.lower()
+    assert "sweep" in R9_ATOMIC_BOUNDARY.reference_semantics.lower()
+    note = R9_ATOMIC_BOUNDARY.liveness_eviction_note.lower()
+    assert "separate" in note and "sweep" in note
+    assert "not read inside commit_cas" in note
+
+
+# ---------------------------------------------------------------------------
+# R18 / R12 / R13 / R14 / R15 obligation records exist and are honest
+# ---------------------------------------------------------------------------
+
+
+def test_r18_liveness_source_names_shipped_source_as_non_ha() -> None:
+    """R18: the shipped source is caller-supplied logical ticks under a single
+    coordinator; it does NOT survive N coordinators."""
+    assert R18_LIVENESS_SOURCE.conforming_sources
+    assert "caller-supplied" in R18_LIVENESS_SOURCE.shipped_source.lower()
+    assert "single coordinator" in R18_LIVENESS_SOURCE.shipped_source.lower()
+
+
+def test_r12_epoch_backend_is_monotonic_int_local_stays_uuid() -> None:
+    """R12: backend epoch is a monotonic-increasing integer; the shipped local
+    epoch stays an opaque uuid4 string; the migration is deferred."""
+    assert "monotonic" in R12_EPOCH.backend_contract.lower()
+    assert "uuid4" in R12_EPOCH.shipped_local.lower()
+    assert "deferred" in R12_EPOCH.migration_scope.lower()
+
+
+def test_r13_content_posture_is_hash_only_with_declared_retention() -> None:
+    """R13: hash-only baseline; retention is a declared opt-in that widens the
+    disclosure surface."""
+    assert "hash-only" in R13_CONTENT_POSTURE.baseline.lower()
+    assert "retain_versions=true" in R13_CONTENT_POSTURE.retention_capability.lower()
+    assert "widen" in R13_CONTENT_POSTURE.disclosure_note.lower()
+
+
+def test_r14_r15_are_documented_obligations_only() -> None:
+    """R14/R15 are documented obligations with typed placeholders — the module
+    carries their vocabulary without any networked/connect code."""
+    assert R14_CREDENTIAL.requirement_id == "R14"
+    assert "0600" in R14_CREDENTIAL.obligation
+    assert "O_NOFOLLOW" in R14_CREDENTIAL.discipline
+    assert R15_BACKEND_IDENTITY.requirement_id == "R15"
+    assert "fingerprint" in R15_BACKEND_IDENTITY.obligation.lower()
+    assert "fail-closed" in R15_BACKEND_IDENTITY.obligation.lower()
+
+
+# ---------------------------------------------------------------------------
+# Non-goal (R2 trip-wire) + no networked code — module hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_module_states_the_never_own_the_store_non_goal() -> None:
+    """R2 trip-wire: the module docstring states the never-own-the-durable-store
+    non-goal ("operated infrastructure we depend on, never a store we ship")."""
+    import ccs.coordinator.backend_contract as mod
+
+    assert mod.__doc__ is not None
+    doc = mod.__doc__.lower()
+    assert "never" in doc and "store we ship" in doc
+
+
+def test_module_imports_no_networked_code() -> None:
+    """The module is pure vocabulary — it imports no I/O, networking, or higher
+    layers. Guards against a networked dependency creeping in."""
+    import ccs.coordinator.backend_contract as mod
+
+    source = mod.__file__
+    assert source is not None
+    with open(source, encoding="utf-8") as fh:
+        text = fh.read()
+    for forbidden in ("import socket", "import ssl", "import urllib", "import http", "requests"):
+        assert forbidden not in text, forbidden

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -121,7 +121,6 @@ def test_the_atomic_class_boundary_members_are_classified_atomic() -> None:
         "clear_agent_transient",
         "capture_version_vector",
         "abort_guard",
-        "record_last_reclamation",
         "get_state_map",
     }
     actual_atomic = {

--- a/tests/test_claude_code_bind_validation.py
+++ b/tests/test_claude_code_bind_validation.py
@@ -146,3 +146,128 @@ def test_coordinator_cli_has_bind_host_flag():
 
     assert build_parser().parse_args([]).bind_host == "127.0.0.1"
     assert build_parser().parse_args(["--bind-host", "10.0.0.5"]).bind_host == "10.0.0.5"
+
+
+# ---------------------------------------------------------------------------
+# Unit 3 (R5): coordinator-side routed-bind TLS/insecure-ack guard.
+#
+# Fail-closed symmetry with the client's #135 plaintext-bearer guard: a
+# non-loopback (private-range, already CCS_REMOTE_COORDINATOR-gated) bind must
+# either assert a TLS-terminating front (CCS_TLS_TERMINATED) or explicitly
+# acknowledge the insecure link (CCS_SERVE_INSECURE); otherwise construction
+# raises. Loopback binds read NEITHER env and are byte-unchanged.
+# ---------------------------------------------------------------------------
+
+from ccs.adapters.claude_code.auth import assert_serve_transport_acknowledged
+
+
+def _clear_serve_envs(monkeypatch):
+    monkeypatch.delenv("CCS_TLS_TERMINATED", raising=False)
+    monkeypatch.delenv("CCS_SERVE_INSECURE", raising=False)
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost"])
+def test_serve_guard_loopback_reads_no_env(host, monkeypatch, caplog):
+    """Loopback: the guard returns without reading either env and logs nothing."""
+    # Set BOTH to truthy — a loopback bind must ignore them entirely (byte-unchanged).
+    monkeypatch.setenv("CCS_TLS_TERMINATED", "1")
+    monkeypatch.setenv("CCS_SERVE_INSECURE", "1")
+    with caplog.at_level("INFO", logger="ccs.adapters.claude_code.auth"):
+        assert_serve_transport_acknowledged(host)  # no raise
+    assert caplog.records == []
+
+
+def test_serve_guard_tls_terminated_logs_posture(monkeypatch, caplog):
+    """Private-range bind + CCS_TLS_TERMINATED=1 → passes with an INFO posture log."""
+    _clear_serve_envs(monkeypatch)
+    monkeypatch.setenv("CCS_TLS_TERMINATED", "1")
+    with caplog.at_level("INFO", logger="ccs.adapters.claude_code.auth"):
+        assert_serve_transport_acknowledged("10.0.0.5")  # no raise
+    assert any(r.levelname == "INFO" for r in caplog.records)
+    assert "CCS_TLS_TERMINATED" in caplog.text
+    assert "10.0.0.5" in caplog.text
+    # The bind host is named; the guard never logs a secret (there is none here).
+    assert not any(r.levelname == "WARNING" for r in caplog.records)
+
+
+def test_serve_guard_serve_insecure_logs_warning(monkeypatch, caplog):
+    """Private-range bind + CCS_SERVE_INSECURE=1 → passes with a WARNING."""
+    _clear_serve_envs(monkeypatch)
+    monkeypatch.setenv("CCS_SERVE_INSECURE", "1")
+    with caplog.at_level("WARNING", logger="ccs.adapters.claude_code.auth"):
+        assert_serve_transport_acknowledged("10.0.0.5")  # no raise
+    assert any(r.levelname == "WARNING" for r in caplog.records)
+    assert "CCS_SERVE_INSECURE" in caplog.text
+    assert "10.0.0.5" in caplog.text
+
+
+def test_serve_guard_neither_env_raises_and_names_both(monkeypatch):
+    """Private-range bind + neither env → raises; message names BOTH envs actionably."""
+    _clear_serve_envs(monkeypatch)
+    with pytest.raises(ValueError) as excinfo:
+        assert_serve_transport_acknowledged("10.0.0.5")
+    message = str(excinfo.value)
+    assert "CCS_TLS_TERMINATED" in message
+    assert "CCS_SERVE_INSECURE" in message
+    assert "10.0.0.5" in message
+
+
+def test_serve_guard_both_envs_assertion_wins_single_log(monkeypatch, caplog):
+    """Both envs set → passes; the TLS assertion wins the log (INFO, no WARNING)."""
+    _clear_serve_envs(monkeypatch)
+    monkeypatch.setenv("CCS_TLS_TERMINATED", "1")
+    monkeypatch.setenv("CCS_SERVE_INSECURE", "1")
+    with caplog.at_level("INFO", logger="ccs.adapters.claude_code.auth"):
+        assert_serve_transport_acknowledged("10.0.0.5")  # no raise
+    info_records = [r for r in caplog.records if r.levelname == "INFO"]
+    warn_records = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(info_records) == 1  # single posture line, no double-warn
+    assert warn_records == []
+    assert "CCS_TLS_TERMINATED" in caplog.text
+
+
+@pytest.mark.parametrize("falsey", ["0", "false", "no", "off", "", "  ", "nope"])
+def test_serve_guard_falsey_values_behave_as_unset(falsey, monkeypatch):
+    """Falsey/empty values are treated as unset → private-range bind still raises."""
+    _clear_serve_envs(monkeypatch)
+    monkeypatch.setenv("CCS_TLS_TERMINATED", falsey)
+    monkeypatch.setenv("CCS_SERVE_INSECURE", falsey)
+    with pytest.raises(ValueError):
+        assert_serve_transport_acknowledged("10.0.0.5")
+
+
+def test_coordinator_routed_bind_requires_serve_ack(tmp_path, monkeypatch):
+    """A routed bind with the cross-host flag on but NO transport ack raises at
+    construction — fail-closed symmetry with the client guard."""
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    _clear_serve_envs(monkeypatch)
+    from ccs.adapters.claude_code.coordinator_server import CoordinatorHTTPServer
+
+    with pytest.raises(ValueError, match="CCS_TLS_TERMINATED"):
+        CoordinatorHTTPServer(tmp_path, bind_host="10.0.0.5")
+
+
+def test_coordinator_routed_bind_constructs_with_insecure_ack(tmp_path, monkeypatch):
+    """A routed bind constructs once CCS_SERVE_INSECURE acknowledges the link.
+
+    Uses 127.0.0.1 for the actual socket bind (port 0) so the test is
+    platform-agnostic, but drives the guard by pre-validating the routed host:
+    the guard path is exercised in the function-level tests above; here we assert
+    the routed construction path does not raise once the ack is present.
+    """
+    monkeypatch.setenv("CCS_REMOTE_COORDINATOR", "1")
+    _clear_serve_envs(monkeypatch)
+    monkeypatch.setenv("CCS_SERVE_INSECURE", "1")
+    from ccs.adapters.claude_code.coordinator_server import CoordinatorHTTPServer
+
+    # A private-range bind cannot open a real socket on most CI hosts, so we
+    # assert the guard admits it by construction up to the socket bind. The
+    # OSError from the unbindable address (if any) is distinct from the guard's
+    # ValueError; a ValueError here would mean the ack was not honored.
+    try:
+        server = CoordinatorHTTPServer(tmp_path, bind_host="10.0.0.5")
+    except ValueError:  # pragma: no cover - would signal the ack was ignored
+        raise
+    except OSError:
+        return  # address not assignable on this host — guard already passed
+    server.shutdown()

--- a/tests/test_coherence_client_remote_endpoint.py
+++ b/tests/test_coherence_client_remote_endpoint.py
@@ -37,6 +37,21 @@ def test_endpoint_remote_host_in_base_url():
     assert ep.base_url == "http://10.0.0.5:8080"
 
 
+def test_endpoint_scheme_defaults_to_http():
+    # Unit 1 additive field: the default scheme keeps the loopback/plaintext
+    # path byte-unchanged.
+    ep = CoordinatorEndpoint(port=8080, bearer="deadbeef", host="10.0.0.5")
+    assert ep.scheme == "http"
+    assert ep.ca_file is None
+
+
+def test_endpoint_https_scheme_renders_https_base_url():
+    ep = CoordinatorEndpoint(
+        port=8443, bearer="deadbeef", host="10.0.0.5", scheme="https"
+    )
+    assert ep.base_url == "https://10.0.0.5:8443"
+
+
 @pytest.mark.parametrize("method", ["get", "post"])
 def test_request_host_header_follows_endpoint_host(monkeypatch, method):
     captured: dict[str, str | None] = {}

--- a/tests/test_coherence_client_tls.py
+++ b/tests/test_coherence_client_tls.py
@@ -46,6 +46,7 @@ from ccs.cli._coherence_client import (
     resolve_remote_endpoint,
 )
 from ccs.core.exceptions import (
+    InsecureTransportRefused,
     RedirectRefused,
     TlsConfigError,
     TlsVerificationFailed,
@@ -92,6 +93,13 @@ class TestTlsContextFactory:
         assert ctx.check_hostname is True
         assert ctx.verify_mode == ssl.CERT_REQUIRED
 
+    def test_default_context_disables_legacy_cn_fallback(self) -> None:
+        # SAN-only tightening: the legacy Common Name fallback is off, so a cert
+        # with no matching SAN is rejected even if its CN matches (this is what
+        # makes the DNS-only-SAN-on-IP-endpoint case fail closed).
+        ctx = build_tls_context()
+        assert getattr(ctx, "hostname_checks_common_name", False) is False
+
     def test_default_context_pins_tls12_floor(self) -> None:
         ctx = build_tls_context()
         assert ctx.minimum_version == ssl.TLSVersion.TLSv1_2
@@ -119,6 +127,18 @@ class TestTlsContextFactory:
         with pytest.raises(TlsConfigError) as exc:
             build_tls_context(ca_file=str(garbage))
         assert str(garbage) in str(exc.value)
+
+    def test_non_utf8_ca_file_raises_tls_config_error_naming_path(
+        self, tmp_path: Path
+    ) -> None:
+        # Non-UTF-8 bytes exercise the UnicodeDecodeError branch in the CA reader
+        # (distinct from the valid-UTF-8-but-not-PEM SSLError branch above); it
+        # must fail closed as a typed TlsConfigError, never a raw UnicodeDecodeError.
+        binary = tmp_path / "binary-ca.pem"
+        binary.write_bytes(b"\xff\xfe\x00\x01not a cert")
+        with pytest.raises(TlsConfigError) as exc:
+            build_tls_context(ca_file=str(binary))
+        assert str(binary) in str(exc.value)
 
     def test_symlinked_ca_file_is_refused(self, tmp_path: Path) -> None:
         real = tmp_path / "real-ca.pem"
@@ -508,22 +528,26 @@ class TestRedirectRefusal:
             redirecting.shutdown()
             target.shutdown()
 
-    def test_http_endpoint_3xx_is_also_refused(self, tmp_path: Path) -> None:
-        # Redirect refusal is scheme-agnostic: a plaintext http endpoint that
-        # 3xxes is refused too (the coordinator is one fixed endpoint).
+    @pytest.mark.parametrize("code", [301, 302, 303, 307, 308])
+    def test_http_endpoint_3xx_is_also_refused(self, code: int) -> None:
+        # Redirect refusal is scheme-agnostic AND uniform across 3xx codes: any
+        # 3xx from a plaintext http endpoint is refused (the coordinator is one
+        # fixed endpoint). 308 in particular has no stdlib redirect method — the
+        # _NoRedirectHandler.http_error_308 alias makes it a typed refusal too.
         class _PlainHandler(http.server.BaseHTTPRequestHandler):
             seen: list[str | None] = []
+            status = 302
 
             def do_GET(self) -> None:  # noqa: N802
                 type(self).seen.append(self.headers.get("Authorization"))
-                self.send_response(302)
+                self.send_response(type(self).status)
                 self.send_header("Location", "http://127.0.0.1:1/elsewhere")
                 self.end_headers()
 
             def log_message(self, *a: object) -> None:
                 pass
 
-        scoped = type("_ScopedPlain", (_PlainHandler,), {"seen": []})
+        scoped = type("_ScopedPlain", (_PlainHandler,), {"seen": [], "status": code})
         srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), scoped)
         port = srv.socket.getsockname()[1]
         threading.Thread(target=srv.serve_forever, daemon=True).start()
@@ -568,6 +592,42 @@ class TestFromEnvIntegration:
             assert srv.handler_cls.seen_authorizations == ["Bearer s3cr3t"]
         finally:
             srv.shutdown()
+
+
+# ===========================================================================
+# Regression: the cross-host demo's TLS resolution pattern (examples/cross_host/
+# main.py) must thread scheme/ca_file from from_env into resolve_remote_endpoint.
+# Pure-function (no socket) — pins the exact contract a review caught main.py
+# violating: an https routed host needs NO CCS_REMOTE_INSECURE ack.
+# ===========================================================================
+
+
+class TestTlsSatisfiesGuardForRoutedHost:
+    def test_from_env_tls_routed_host_resolves_without_insecure_ack(self) -> None:
+        cfg = RemoteCoordinatorConfig.from_env(
+            env={
+                "CCS_REMOTE_COORDINATOR": "1",
+                "CCS_REMOTE_TLS": "1",
+                "CCS_REMOTE_HOST": "10.0.0.5",
+                "CCS_REMOTE_PORT": "8443",
+            }
+        )
+        assert cfg.scheme == "https"
+        # Threaded (what main.py now does): the verified-TLS scheme satisfies the
+        # guard for a routed host with NO ack — resolves cleanly.
+        ep = resolve_remote_endpoint(
+            cfg.host, cfg.port, "s3cr3t", scheme=cfg.scheme, ca_file=cfg.ca_file, env={}
+        )
+        assert ep.base_url == "https://10.0.0.5:8443"
+        assert ep.scheme == "https"
+
+    def test_dropping_the_scheme_thread_through_reproduces_the_bug(self) -> None:
+        # The signature of the main.py bug: without scheme= the endpoint defaults
+        # to http, so a routed host without the ack is refused. This is exactly
+        # what a caller following the TLS docs would hit if the thread-through
+        # were dropped — kept as a guard against regressing it.
+        with pytest.raises(InsecureTransportRefused):
+            resolve_remote_endpoint("10.0.0.5", 8443, "s3cr3t", env={})
 
 
 # ===========================================================================

--- a/tests/test_coherence_client_tls.py
+++ b/tests/test_coherence_client_tls.py
@@ -1,0 +1,600 @@
+"""Unit 1 (R3/R6): client ``https://`` endpoint support with fail-closed
+certificate verification.
+
+The coordinator client can speak *verified* TLS to a terminating front. The
+loopback ``http`` path stays byte-identical to today (regression matrix lives in
+``tests/test_coherence_client_remote_endpoint.py`` and is untouched here).
+
+Test-first ordering: these scenarios were written before the implementation and
+watched to fail (missing scheme/context/redirect wiring), then the code was
+added to make them pass.
+
+Two families:
+
+- **Pure-function tests** — ``base_url`` scheme rendering, the SSL-context
+  factory invariants, CA-file discipline, ``from_env`` plumbing. No sockets;
+  always run.
+- **Socket tests** — an in-process ``ThreadingHTTPServer`` wrapped in a
+  server-side ``SSLContext``, fronted by a throwaway CA + IP-SAN server cert
+  minted with the ``openssl`` CLI. These ``pytest.skip`` when ``openssl`` is
+  not on PATH so the pure-function coverage still runs everywhere.
+
+The cert profile deliberately satisfies Python 3.13's ``VERIFY_X509_STRICT``
+(the default under ``create_default_context``): subjectKeyIdentifier,
+authorityKeyIdentifier, critical basicConstraints, keyUsage,
+extendedKeyUsage=serverAuth, and ``subjectAltName=IP:127.0.0.1`` (an IP SAN,
+because our endpoints are IP literals and OpenSSL matches IP SANs natively).
+"""
+
+from __future__ import annotations
+
+import http.server
+import shutil
+import ssl
+import subprocess
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from ccs.cli import _coherence_client as cc
+from ccs.cli._coherence_client import (
+    CoordinatorEndpoint,
+    RemoteCoordinatorConfig,
+    build_tls_context,
+    resolve_remote_endpoint,
+)
+from ccs.core.exceptions import (
+    RedirectRefused,
+    TlsConfigError,
+    TlsVerificationFailed,
+)
+
+_OPENSSL = shutil.which("openssl")
+requires_openssl = pytest.mark.skipif(
+    _OPENSSL is None, reason="openssl CLI not on PATH (socket TLS tests skipped)"
+)
+
+
+# ===========================================================================
+# Pure-function tests (no sockets) — always run.
+# ===========================================================================
+
+
+class TestBaseUrlScheme:
+    def test_http_scheme_is_the_default(self) -> None:
+        ep = CoordinatorEndpoint(port=8080, bearer="deadbeef", host="10.0.0.5")
+        assert ep.scheme == "http"
+        assert ep.base_url == "http://10.0.0.5:8080"
+
+    def test_https_scheme_renders_https(self) -> None:
+        ep = CoordinatorEndpoint(
+            port=8443, bearer="deadbeef", host="10.0.0.5", scheme="https"
+        )
+        assert ep.base_url == "https://10.0.0.5:8443"
+
+    def test_https_scheme_brackets_ipv6(self) -> None:
+        ep = CoordinatorEndpoint(
+            port=8443, bearer="deadbeef", host="fd00::1", scheme="https"
+        )
+        assert ep.base_url == "https://[fd00::1]:8443"
+
+    def test_http_scheme_still_brackets_ipv6(self) -> None:
+        # Regression: the IPv6-bracketing branch must fire for BOTH schemes.
+        ep = CoordinatorEndpoint(port=8080, bearer="deadbeef", host="::1")
+        assert ep.base_url == "http://[::1]:8080"
+
+
+class TestTlsContextFactory:
+    def test_default_context_enforces_verification(self) -> None:
+        ctx = build_tls_context()
+        assert ctx.check_hostname is True
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+    def test_default_context_pins_tls12_floor(self) -> None:
+        ctx = build_tls_context()
+        assert ctx.minimum_version == ssl.TLSVersion.TLSv1_2
+
+    def test_no_off_switch_is_representable(self) -> None:
+        # There is intentionally no parameter that could yield CERT_NONE or
+        # check_hostname=False — the factory takes only an optional CA path.
+        ctx = build_tls_context(ca_file=None)
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+        assert ctx.check_hostname is True
+
+    def test_missing_ca_file_raises_tls_config_error_naming_path(
+        self, tmp_path: Path
+    ) -> None:
+        missing = tmp_path / "nope-ca.pem"
+        with pytest.raises(TlsConfigError) as exc:
+            build_tls_context(ca_file=str(missing))
+        assert str(missing) in str(exc.value)
+
+    def test_non_pem_ca_file_raises_tls_config_error_naming_path(
+        self, tmp_path: Path
+    ) -> None:
+        garbage = tmp_path / "garbage-ca.pem"
+        garbage.write_text("this is not a certificate", encoding="utf-8")
+        with pytest.raises(TlsConfigError) as exc:
+            build_tls_context(ca_file=str(garbage))
+        assert str(garbage) in str(exc.value)
+
+    def test_symlinked_ca_file_is_refused(self, tmp_path: Path) -> None:
+        real = tmp_path / "real-ca.pem"
+        real.write_text("dummy", encoding="utf-8")
+        link = tmp_path / "link-ca.pem"
+        link.symlink_to(real)
+        with pytest.raises(TlsConfigError) as exc:
+            build_tls_context(ca_file=str(link))
+        assert str(link) in str(exc.value)
+
+    def test_group_writable_ca_file_is_refused(self, tmp_path: Path) -> None:
+        import os
+
+        ca = tmp_path / "loose-ca.pem"
+        ca.write_text("dummy", encoding="utf-8")
+        os.chmod(ca, 0o664)  # group-writable — the attack surface for a trust anchor
+        with pytest.raises(TlsConfigError) as exc:
+            build_tls_context(ca_file=str(ca))
+        assert str(ca) in str(exc.value)
+
+    def test_world_writable_ca_file_is_refused(self, tmp_path: Path) -> None:
+        import os
+
+        ca = tmp_path / "world-ca.pem"
+        ca.write_text("dummy", encoding="utf-8")
+        os.chmod(ca, 0o666)
+        with pytest.raises(TlsConfigError):
+            build_tls_context(ca_file=str(ca))
+
+    def test_readable_but_not_writable_ca_file_is_accepted(
+        self, tmp_path: Path
+    ) -> None:
+        # Certs are public: group/world-READABLE is fine (0o644). Only the
+        # WRITABLE bits are the attack (a swapped trust anchor).
+        import os
+
+        real_ca = _make_ca_pem(tmp_path)
+        if real_ca is None:
+            pytest.skip("openssl not available to mint a valid PEM")
+        os.chmod(real_ca, 0o644)
+        ctx = build_tls_context(ca_file=str(real_ca))
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+class TestFromEnvTlsPlumbing:
+    def test_ccs_remote_tls_selects_https_scheme(self) -> None:
+        cfg = RemoteCoordinatorConfig.from_env(
+            env={"CCS_REMOTE_COORDINATOR": "1", "CCS_REMOTE_TLS": "1"}
+        )
+        assert cfg.scheme == "https"
+
+    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+    def test_ccs_remote_tls_truthy_values(self, val: str) -> None:
+        cfg = RemoteCoordinatorConfig.from_env(
+            env={"CCS_REMOTE_COORDINATOR": "1", "CCS_REMOTE_TLS": val}
+        )
+        assert cfg.scheme == "https"
+
+    @pytest.mark.parametrize("val", ["", "0", "false", "no", "off", "  "])
+    def test_ccs_remote_tls_falsey_stays_http(self, val: str) -> None:
+        cfg = RemoteCoordinatorConfig.from_env(
+            env={"CCS_REMOTE_COORDINATOR": "1", "CCS_REMOTE_TLS": val}
+        )
+        assert cfg.scheme == "http"
+
+    def test_default_scheme_is_http(self) -> None:
+        cfg = RemoteCoordinatorConfig.from_env(env={"CCS_REMOTE_COORDINATOR": "1"})
+        assert cfg.scheme == "http"
+        assert cfg.ca_file is None
+
+    def test_ca_file_path_is_carried(self, tmp_path: Path) -> None:
+        # File-path not inline (mirrors CCS_REMOTE_SECRET_FILE): the path is
+        # carried verbatim; existence/permission validation happens at factory
+        # time, not parse time.
+        ca_path = tmp_path / "ca.pem"
+        cfg = RemoteCoordinatorConfig.from_env(
+            env={
+                "CCS_REMOTE_COORDINATOR": "1",
+                "CCS_REMOTE_TLS": "1",
+                "CCS_REMOTE_CA_FILE": str(ca_path),
+            }
+        )
+        assert cfg.ca_file == str(ca_path)
+
+    def test_resolve_remote_endpoint_threads_scheme_and_ca(self) -> None:
+        ep = resolve_remote_endpoint(
+            "10.0.0.5",
+            8443,
+            "s3cr3t",
+            scheme="https",
+            env={"CCS_REMOTE_INSECURE": "1"},
+        )
+        assert ep.scheme == "https"
+        assert ep.base_url == "https://10.0.0.5:8443"
+
+    def test_resolve_remote_endpoint_defaults_preserve_http(self) -> None:
+        ep = resolve_remote_endpoint(
+            "10.0.0.5", 8080, "s3cr3t", env={"CCS_REMOTE_INSECURE": "1"}
+        )
+        assert ep.scheme == "http"
+        assert ep.base_url == "http://10.0.0.5:8080"
+
+
+# ===========================================================================
+# Socket tests — real TLS handshake against an in-process server.
+# ===========================================================================
+
+
+def _run_openssl(args: list[str], cwd: Path) -> None:
+    subprocess.run(
+        [_OPENSSL, *args],
+        cwd=cwd,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _make_ca_pem(tmp_path: Path) -> Path | None:
+    """Mint just a CA cert PEM (for the readable-CA-file acceptance test)."""
+    if _OPENSSL is None:
+        return None
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    ca_cnf = tmp_path / "ca.cnf"
+    ca_cnf.write_text(
+        "[req]\ndistinguished_name=dn\nx509_extensions=v3_ca\nprompt=no\n"
+        "[dn]\nCN=coherence-test-ca\n"
+        "[v3_ca]\nsubjectKeyIdentifier=hash\nauthorityKeyIdentifier=keyid:always\n"
+        "basicConstraints=critical,CA:TRUE\nkeyUsage=critical,keyCertSign,cRLSign\n",
+        encoding="utf-8",
+    )
+    ca_key = tmp_path / "ca.key"
+    ca_pem = tmp_path / "ca.pem"
+    _run_openssl(
+        [
+            "req", "-x509", "-newkey", "rsa:2048",
+            "-keyout", str(ca_key), "-out", str(ca_pem),
+            "-days", "1", "-nodes", "-config", str(ca_cnf),
+        ],
+        tmp_path,
+    )
+    return ca_pem
+
+
+@dataclass(frozen=True)
+class _CertBundle:
+    ca_pem: Path
+    server_cert: Path
+    server_key: Path
+
+
+def _sign_leaf(
+    tmp_path: Path, ca_pem: Path, ca_key: Path, san_line: str, name: str
+) -> tuple[Path, Path]:
+    """Sign an RFC5280-strict leaf cert with the given subjectAltName line."""
+    leaf_cnf = tmp_path / f"{name}.cnf"
+    leaf_cnf.write_text(
+        "[req]\ndistinguished_name=dn\nprompt=no\n[dn]\nCN=coherence-test-server\n",
+        encoding="utf-8",
+    )
+    ext_cnf = tmp_path / f"{name}_ext.cnf"
+    ext_cnf.write_text(
+        "subjectKeyIdentifier=hash\n"
+        "authorityKeyIdentifier=keyid:always\n"
+        "basicConstraints=critical,CA:FALSE\n"
+        "keyUsage=critical,digitalSignature,keyEncipherment\n"
+        "extendedKeyUsage=serverAuth\n"
+        f"subjectAltName={san_line}\n",
+        encoding="utf-8",
+    )
+    key = tmp_path / f"{name}.key"
+    csr = tmp_path / f"{name}.csr"
+    cert = tmp_path / f"{name}.pem"
+    _run_openssl(
+        ["req", "-newkey", "rsa:2048", "-keyout", str(key), "-out", str(csr),
+         "-nodes", "-config", str(leaf_cnf)],
+        tmp_path,
+    )
+    _run_openssl(
+        ["x509", "-req", "-in", str(csr), "-CA", str(ca_pem), "-CAkey", str(ca_key),
+         "-CAcreateserial", "-out", str(cert), "-days", "1", "-extfile", str(ext_cnf)],
+        tmp_path,
+    )
+    return cert, key
+
+
+def _mint_bundle(tmp_path: Path, san_line: str = "IP:127.0.0.1") -> _CertBundle:
+    ca_pem = _make_ca_pem(tmp_path)
+    assert ca_pem is not None
+    ca_key = tmp_path / "ca.key"
+    cert, key = _sign_leaf(tmp_path, ca_pem, ca_key, san_line, "server")
+    return _CertBundle(ca_pem=ca_pem, server_cert=cert, server_key=key)
+
+
+class _RecordingHandler(http.server.BaseHTTPRequestHandler):
+    #: Populated per-server-instance; each item is the Authorization header a
+    #: request presented (or None). Non-empty => the bearer reached this server.
+    seen_authorizations: list[str | None] = []
+    #: Set on the *first* server to force a 302 to this location (redirect test).
+    redirect_to: str | None = None
+
+    def _record_and_respond(self) -> None:
+        type(self).seen_authorizations.append(self.headers.get("Authorization"))
+        if type(self).redirect_to is not None:
+            self.send_response(302)
+            self.send_header("Location", type(self).redirect_to)
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"ok": true}')
+
+    def do_GET(self) -> None:  # noqa: N802 (stdlib handler contract)
+        self._record_and_respond()
+
+    def log_message(self, *args: object) -> None:  # silence test noise
+        pass
+
+
+def _make_handler_class(
+    redirect_to: str | None = None,
+) -> type[_RecordingHandler]:
+    # A fresh subclass per server so seen_authorizations/redirect_to don't leak
+    # across the two servers in the redirect test.
+    return type(
+        "_ScopedHandler",
+        (_RecordingHandler,),
+        {"seen_authorizations": [], "redirect_to": redirect_to},
+    )
+
+
+@dataclass
+class _RunningServer:
+    port: int
+    handler_cls: type[_RecordingHandler]
+    _server: http.server.ThreadingHTTPServer
+
+    def shutdown(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+
+
+def _start_tls_server(
+    bundle: _CertBundle, handler_cls: type[_RecordingHandler]
+) -> _RunningServer:
+    sctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    sctx.load_cert_chain(str(bundle.server_cert), str(bundle.server_key))
+    srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    srv.socket = sctx.wrap_socket(srv.socket, server_side=True)
+    port = srv.socket.getsockname()[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return _RunningServer(port=port, handler_cls=handler_cls, _server=srv)
+
+
+@pytest.fixture
+def tls_bundle(tmp_path: Path) -> _CertBundle:
+    if _OPENSSL is None:
+        pytest.skip("openssl CLI not on PATH")
+    return _mint_bundle(tmp_path)
+
+
+@requires_openssl
+class TestHttpsRequestPath:
+    def test_https_request_with_matching_ip_san_cert_succeeds(
+        self, tls_bundle: _CertBundle
+    ) -> None:
+        handler = _make_handler_class()
+        srv = _start_tls_server(tls_bundle, handler)
+        try:
+            ep = CoordinatorEndpoint(
+                port=srv.port,
+                bearer="s3cr3t",
+                host="127.0.0.1",
+                scheme="https",
+                ca_file=str(tls_bundle.ca_pem),
+            )
+            body = cc.get(ep, "/status")
+            assert body == {"ok": True}
+            # The bearer DID ride the verified hop (positive control).
+            assert srv.handler_cls.seen_authorizations == ["Bearer s3cr3t"]
+        finally:
+            srv.shutdown()
+
+    def test_private_ca_bundle_validates_server(
+        self, tls_bundle: _CertBundle
+    ) -> None:
+        # Same happy path, framed as the CCS_REMOTE_CA_FILE story: an exclusive
+        # private-CA bundle validates a private-CA-signed server.
+        handler = _make_handler_class()
+        srv = _start_tls_server(tls_bundle, handler)
+        try:
+            ep = CoordinatorEndpoint(
+                port=srv.port,
+                bearer="s3cr3t",
+                host="127.0.0.1",
+                scheme="https",
+                ca_file=str(tls_bundle.ca_pem),
+            )
+            assert cc.get(ep, "/status") == {"ok": True}
+        finally:
+            srv.shutdown()
+
+    def test_cert_not_signed_by_trusted_ca_refuses_and_bearer_never_sent(
+        self, tmp_path: Path
+    ) -> None:
+        # Server presents a cert from CA #1; the client trusts a DIFFERENT CA #2.
+        server_bundle = _mint_bundle(tmp_path / "srv")
+        client_only = tmp_path / "cli"
+        client_only.mkdir()
+        other_ca = _make_ca_pem(client_only)
+        assert other_ca is not None
+
+        handler = _make_handler_class()
+        srv = _start_tls_server(server_bundle, handler)
+        try:
+            ep = CoordinatorEndpoint(
+                port=srv.port,
+                bearer="s3cr3t",
+                host="127.0.0.1",
+                scheme="https",
+                ca_file=str(other_ca),
+            )
+            with pytest.raises(TlsVerificationFailed) as exc:
+                cc.get(ep, "/status")
+            assert exc.value.host == "127.0.0.1"
+            # The handshake failed BEFORE any HTTP request — the bearer never
+            # reached the server.
+            assert srv.handler_cls.seen_authorizations == []
+        finally:
+            srv.shutdown()
+
+    def test_dns_only_san_cert_on_ip_endpoint_fails_closed(
+        self, tmp_path: Path
+    ) -> None:
+        # Pins the OpenSSL behavior we rely on: an IP-literal endpoint against a
+        # DNS-only-SAN cert must NOT validate (no CN fallback, no name match).
+        bundle = _mint_bundle(tmp_path, san_line="DNS:coherence.example")
+        handler = _make_handler_class()
+        srv = _start_tls_server(bundle, handler)
+        try:
+            ep = CoordinatorEndpoint(
+                port=srv.port,
+                bearer="s3cr3t",
+                host="127.0.0.1",
+                scheme="https",
+                ca_file=str(bundle.ca_pem),
+            )
+            with pytest.raises(TlsVerificationFailed):
+                cc.get(ep, "/status")
+            assert srv.handler_cls.seen_authorizations == []
+        finally:
+            srv.shutdown()
+
+
+@requires_openssl
+class TestRedirectRefusal:
+    def test_any_3xx_refused_and_target_receives_no_request(
+        self, tmp_path: Path
+    ) -> None:
+        # Two TLS servers sharing one CA: the first 302s to the second. A bare
+        # urlopen would follow AND copy Authorization onto the second hop before
+        # returning — so we assert the target saw NO request at all.
+        bundle = _mint_bundle(tmp_path)
+        target_handler = _make_handler_class()
+        target = _start_tls_server(bundle, target_handler)
+        redirecting_handler = _make_handler_class(
+            redirect_to=f"https://127.0.0.1:{target.port}/elsewhere"
+        )
+        redirecting = _start_tls_server(bundle, redirecting_handler)
+        try:
+            ep = CoordinatorEndpoint(
+                port=redirecting.port,
+                bearer="s3cr3t",
+                host="127.0.0.1",
+                scheme="https",
+                ca_file=str(bundle.ca_pem),
+            )
+            with pytest.raises(RedirectRefused) as exc:
+                cc.get(ep, "/status")
+            # The refusal carries the attempted location.
+            assert "elsewhere" in str(exc.value.location)
+            # The redirect TARGET must have received nothing — the bearer never
+            # rode the hop.
+            assert target.handler_cls.seen_authorizations == []
+        finally:
+            redirecting.shutdown()
+            target.shutdown()
+
+    def test_http_endpoint_3xx_is_also_refused(self, tmp_path: Path) -> None:
+        # Redirect refusal is scheme-agnostic: a plaintext http endpoint that
+        # 3xxes is refused too (the coordinator is one fixed endpoint).
+        class _PlainHandler(http.server.BaseHTTPRequestHandler):
+            seen: list[str | None] = []
+
+            def do_GET(self) -> None:  # noqa: N802
+                type(self).seen.append(self.headers.get("Authorization"))
+                self.send_response(302)
+                self.send_header("Location", "http://127.0.0.1:1/elsewhere")
+                self.end_headers()
+
+            def log_message(self, *a: object) -> None:
+                pass
+
+        scoped = type("_ScopedPlain", (_PlainHandler,), {"seen": []})
+        srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), scoped)
+        port = srv.socket.getsockname()[1]
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        try:
+            ep = CoordinatorEndpoint(port=port, bearer="s3cr3t", host="127.0.0.1")
+            with pytest.raises(RedirectRefused):
+                cc.get(ep, "/status")
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+
+@requires_openssl
+class TestFromEnvIntegration:
+    def test_from_env_https_with_ca_mints_working_endpoint(
+        self, tls_bundle: _CertBundle
+    ) -> None:
+        handler = _make_handler_class()
+        srv = _start_tls_server(tls_bundle, handler)
+        try:
+            cfg = RemoteCoordinatorConfig.from_env(
+                env={
+                    "CCS_REMOTE_COORDINATOR": "1",
+                    "CCS_REMOTE_TLS": "1",
+                    "CCS_REMOTE_HOST": "127.0.0.1",
+                    "CCS_REMOTE_PORT": str(srv.port),
+                    "CCS_REMOTE_CA_FILE": str(tls_bundle.ca_pem),
+                }
+            )
+            assert cfg.scheme == "https"
+            assert cfg.ca_file == str(tls_bundle.ca_pem)
+            ep = resolve_remote_endpoint(
+                "127.0.0.1",
+                srv.port,
+                "s3cr3t",
+                scheme=cfg.scheme,
+                ca_file=cfg.ca_file,
+                env={"CCS_REMOTE_INSECURE": "1"},
+            )
+            assert ep.base_url == f"https://127.0.0.1:{srv.port}"
+            assert cc.get(ep, "/status") == {"ok": True}
+            assert srv.handler_cls.seen_authorizations == ["Bearer s3cr3t"]
+        finally:
+            srv.shutdown()
+
+
+# ===========================================================================
+# Edge: loopback http endpoint — byte-identical behavior to today.
+# ===========================================================================
+
+
+class TestLoopbackHttpUnchanged:
+    def test_loopback_http_endpoint_uses_no_tls_context(self, tmp_path: Path) -> None:
+        # A plain http loopback server: the request must succeed WITHOUT any TLS
+        # machinery (the context param is None on http paths).
+        class _Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self) -> None:  # noqa: N802
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b'{"loopback": true}')
+
+            def log_message(self, *a: object) -> None:
+                pass
+
+        srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        port = srv.socket.getsockname()[1]
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        try:
+            ep = CoordinatorEndpoint(port=port, bearer="deadbeef", host="127.0.0.1")
+            assert ep.scheme == "http"
+            assert cc.get(ep, "/status") == {"loopback": True}
+        finally:
+            srv.shutdown()
+            srv.server_close()

--- a/tests/test_remote_transport_guard.py
+++ b/tests/test_remote_transport_guard.py
@@ -146,3 +146,91 @@ def test_ack_log_names_host_never_secret(caplog: pytest.LogCaptureFixture) -> No
         )
     assert secret not in caplog.text
     assert "10.0.0.5" in caplog.text
+
+
+# ===========================================================================
+# Unit 2: verified-TLS positive signal (scheme=https passes the guard)
+# ===========================================================================
+#
+# In THIS client ``https`` ALWAYS means enforced certificate verification —
+# :func:`build_tls_context` has no insecure-https mode (the footgun rule). So a
+# verified-TLS endpoint carries an in-band trust signal the plaintext guard
+# lacked: it passes at mint with NO ack and NO warning, retiring the
+# permanent-``CCS_REMOTE_INSECURE=1`` wart. The ``http`` rows above are
+# byte-unchanged — the guard's plaintext refusal is not weakened.
+#
+# The matrix is scheme × host-class × ack:
+#   scheme     ∈ {https, http}
+#   host-class ∈ {loopback, routed}
+#   ack        ∈ {no-ack, ack, falsey-ack}
+# The http quadrant is already pinned by the tests above; these rows add the
+# https quadrant (always-pass) plus the one https×ack log-cleanliness edge.
+
+
+# --- https passes for every host class / ack value, with NO warning ---------
+@pytest.mark.parametrize("host", ["10.0.0.5", "coordinator.internal", "127.0.0.1", "::1"])
+@pytest.mark.parametrize("env", [{}, {"CCS_REMOTE_INSECURE": "1"}, {"CCS_REMOTE_INSECURE": "0"}])
+def test_https_passes_regardless_of_host_or_ack(
+    host: str, env: dict, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        ep = resolve_remote_endpoint(host, 8443, "secret", scheme="https", env=env)
+    assert isinstance(ep, CoordinatorEndpoint)
+    assert ep.host == host
+    assert ep.scheme == "https"
+    # No plaintext-ack warning is ever emitted on an https path — the ack is
+    # irrelevant when verification is enforced (https short-circuits the guard
+    # before the ack branch that would otherwise WARNING).
+    assert caplog.text == ""
+
+
+# --- the new positive signal: https + routed + no ack passes, no warning ----
+def test_https_routed_no_ack_passes(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        ep = resolve_remote_endpoint(
+            "10.0.0.5", 8443, "secret", scheme="https", env={}
+        )
+    assert ep.host == "10.0.0.5"
+    assert ep.scheme == "https"
+    assert ep.base_url == "https://10.0.0.5:8443"
+    assert caplog.text == ""
+
+
+# --- https + routed + CCS_REMOTE_INSECURE=1: passes, NO ack warning, no secret
+def test_https_with_insecure_ack_emits_no_plaintext_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # https short-circuits BEFORE the ack branch, so even with the ack set the
+    # plaintext-bearer WARNING must not fire (and the secret must never appear).
+    secret = "topsecret-bearer-value"
+    with caplog.at_level(logging.WARNING):
+        ep = resolve_remote_endpoint(
+            "10.0.0.5", 8443, secret, scheme="https", env={"CCS_REMOTE_INSECURE": "1"}
+        )
+    assert ep.host == "10.0.0.5"
+    assert secret not in caplog.text
+    assert "plaintext" not in caplog.text.lower()
+    assert caplog.text == ""
+
+
+# --- ordering: empty checks fire BEFORE any guard/scheme logic, https or not -
+def test_empty_secret_raises_unavailable_even_on_https() -> None:
+    # Non-loopback host + scheme=https but empty secret -> CoordinatorUnavailable
+    # (the empty-secret check), NOT a pass via the https positive signal. Pins the
+    # #135 ordering contract: empty-input checks precede the transport guard, and
+    # the bearer is never assembled on this path.
+    with pytest.raises(CoordinatorUnavailable):
+        resolve_remote_endpoint("10.0.0.5", 8443, "", scheme="https", env={})
+
+
+def test_empty_host_raises_unavailable_even_on_https() -> None:
+    with pytest.raises(CoordinatorUnavailable):
+        resolve_remote_endpoint("", 8443, "secret", scheme="https", env={})
+
+
+# --- http rows still refuse: the plaintext guard is NOT weakened by https ----
+# Explicitly re-pin the routed-http refusal alongside the new https passes so a
+# future edit that made scheme="http" fall through would fail here too.
+def test_http_routed_no_ack_still_refused_with_explicit_scheme() -> None:
+    with pytest.raises(InsecureTransportRefused):
+        resolve_remote_endpoint("10.0.0.5", 8080, "secret", scheme="http", env={})


### PR DESCRIPTION
The gate-independent slice of the cross-host TLS + networked-backend work: client-side TLS support with fail-closed verification, a coordinator-side routed-bind guard, and a backend-agnostic atomic-boundary contract + conformance kit. **No networked backend is built** — a routed production deployment and any networked store stay demand-gated.

Origin requirements + plan authored via ce:brainstorm → ce:plan → ce:work (both docs multi-persona-reviewed).

## What ships

| Unit | Change |
|---|---|
| **1** `89701b8` | Client `https://` support. One SSL-context factory (verification always on, no off-switch, TLS 1.2 floor); `CCS_REMOTE_CA_FILE` loaded fail-closed (`O_NOFOLLOW`, rejects group/world-writable, single read); a private opener that **refuses any redirect** so the bearer never rides a downgrade hop; typed `TlsVerificationFailed` / `TlsConfigError` / `RedirectRefused`. |
| **2** `efabecd` | A verified-https endpoint now **satisfies the plaintext-bearer guard automatically** — retiring the permanent `CCS_REMOTE_INSECURE=1` for TLS-fronted deployments. The http branch is byte-identical (guard test diff is append-only). |
| **3** `1cfd6cc` | Coordinator-side routed-bind guard: a bind beyond loopback refuses to serve unless the operator sets `CCS_TLS_TERMINATED=1` or `CCS_SERVE_INSECURE=1` (raises at construction, before the socket opens). Reuses the existing loopback classifier — no client/server drift. Loopback unchanged. |
| **4** `aff746a` | `backend_contract.py`: the atomic-boundary tuple, all 48 Protocol members classified, Tier-1/Tier-2 declarations, statelessness inventory, liveness/epoch/content-posture obligations. Zero networked code; internal seam, not a public extension point. |
| **5** `335ccdc` | Tier-1 conformance kit: SQLite passes at Tier-1, in-memory at its declared tier; a grant-blind stub is caught. must-match vs backend-defined split is structural. |
| **6** `891da44` | Docs: client TLS + CA-profile operator requirements (IP SANs, RFC 5280-strict for 3.13, private-CA-not-self-signed), the bind guard framed as operator assertions that acknowledge but don't encrypt. |

## Honest scope
- Client TLS verification is **real enforcement** (fail-closed, no off-switch). The server acks (`CCS_TLS_TERMINATED` / `CCS_SERVE_INSECURE`) are **operator assertions** — they acknowledge, they don't themselves encrypt or verify a proxy is present.
- Cross-host mode stays **experimental, default-off, demo-grade**. The backend contract + kit are an internal formalization; no networked backend exists.
- The loopback path (client and server) is byte-unchanged; `CCS_REMOTE_COORDINATOR` default-off gating unchanged.

## Verification
- Full suite **2780 passed** · `protocol_corpus` **32 passed** (no `/status` wire change) · architecture + ruff clean.
- New tests: TLS client matrix (openssl-minted IP-SAN certs satisfying 3.13 strict flags), guard scheme×host×ack matrix, bind-guard matrix + a 254-test construction sweep, contract drift guards, conformance kit + teeth.

Test plan: unit + integration green as above; TLS socket tests skip gracefully where `openssl` is absent.