### PR TITLE
chore(mcp): add MCP Registry server.json + PyPI ownership tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Two agents share an artifact — a `plan.md`, a store key, a `memory.json`. One 
 [![arXiv](https://img.shields.io/badge/arXiv-2603.15183-b31b1b)](https://arxiv.org/abs/2603.15183)
 [![Discussions](https://img.shields.io/github/discussions/hipvlady/agent-coherence)](https://github.com/hipvlady/agent-coherence/discussions)
 
+<!-- MCP Registry — PyPI ownership tag for the stale-write-guard-fs server -->
+`mcp-name: io.github.hipvlady/stale-write-guard-fs`
+
 ```bash
 pip install "agent-coherence[langgraph]"        # LangGraph drop-in
 pip install "agent-coherence[crewai]"           # CrewAI adapter

--- a/server.json
+++ b/server.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.hipvlady/stale-write-guard-fs",
+  "title": "Agent Coherence — Stale Write Guard (FS)",
+  "description": "Coherence guard for shared files: denies stale writes so agents don't silently overwrite each other.",
+  "repository": {
+    "url": "https://github.com/hipvlady/agent-coherence",
+    "source": "github"
+  },
+  "version": "0.10.1",
+  "websiteUrl": "https://agent-coherence.dev",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "agent-coherence",
+      "version": "0.10.1",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `server.json` — the manifest to publish the `stale-write-guard-fs` MCP server to the [Official MCP Registry](https://registry.modelcontextprotocol.io/) (namespace `io.github.hipvlady`, PyPI package `agent-coherence`, stdio transport).
- Adds an `mcp-name: io.github.hipvlady/stale-write-guard-fs` line to `README.md` so the registry can verify PyPI **package** ownership.

## Why
Unblocks `mcp-publisher publish`. The namespace verifies via GitHub OAuth automatically; the PyPI-ownership check reads the `mcp-name` line from the **published** PyPI description, so this must ship in the next PyPI release before publishing to the registry.

## Test plan
- [x] `server.json` validates against the 2025-12-11 schema (stdio + pypi package block)
- [x] Docs-only + manifest; no code paths touched