### PR TITLE
chore(mcp): migrate registry namespace to io.github.cohexa-ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Two agents share an artifact — a `plan.md`, a store key, a `memory.json`. One 
 [![Discussions](https://img.shields.io/github/discussions/Cohexa-ai/agent-coherence)](https://github.com/Cohexa-ai/agent-coherence/discussions)
 
 <!-- MCP Registry — PyPI ownership tag for the stale-write-guard-fs server -->
-`mcp-name: io.github.hipvlady/stale-write-guard-fs`
+`mcp-name: io.github.cohexa-ai/stale-write-guard-fs`
 
 ```bash
 pip install "agent-coherence[langgraph]"        # LangGraph drop-in

--- a/server.json
+++ b/server.json
@@ -1,20 +1,20 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.hipvlady/stale-write-guard-fs",
+  "name": "io.github.cohexa-ai/stale-write-guard-fs",
   "title": "Agent Coherence — Stale Write Guard (FS)",
   "description": "Coherence guard for shared files: denies stale writes so agents don't silently overwrite each other.",
   "repository": {
-    "url": "https://github.com/hipvlady/agent-coherence",
+    "url": "https://github.com/Cohexa-ai/agent-coherence",
     "source": "github"
   },
-  "version": "0.10.1",
+  "version": "0.11.0",
   "websiteUrl": "https://agent-coherence.dev",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "agent-coherence",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
Completes the org migration's deferred MCP-registry item. The repo moved to **Cohexa-ai**, and the MCP registry namespace is coupled to the GitHub account, so:
- `server.json` `name`: `io.github.hipvlady/stale-write-guard-fs` → `io.github.cohexa-ai/stale-write-guard-fs`
- `server.json` `repository.url` → `Cohexa-ai`; `version` + `packages[].version` synced `0.10.1` → `0.11.0` (matches `__version__`)
- `README.md` `mcp-name` → `io.github.cohexa-ai/stale-write-guard-fs`

After this, the repo has **no live `hipvlady` references** (only dated `benchmarks/results/v0.9.0/*` artifacts remain, intentionally).

## Notes
- **New registry identity**: `io.github.cohexa-ai/...` is a distinct identity from the published `io.github.hipvlady/...`, which stays live/orphaned. **Republishing to the MCP registry is a separate manual step** (`mcp-publisher`, OIDC from the Cohexa-ai repo) and is not triggered by this PR.
- Namespace casing (lowercase `cohexa-ai`) follows reverse-DNS convention + the existing lowercase `io.github.hipvlady`; the registry is authoritative and confirms it at republish.

`server.json` validates as JSON; no test coupling (only a docstring mention in `tests/mcp/conftest.py`).