### PR TITLE
docs: accuracy and completeness pass

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues **privately** via GitHub Security Advisories —
+open a new report at
+[Report a vulnerability](https://github.com/Cohexa-ai/agent-coherence/security/advisories/new)
+rather than a public issue. We aim to respond within 72 hours.
+
+## Supported versions
+
+Security fixes land on the latest released version. Upgrade to the newest
+release before reporting, in case the issue is already fixed.
+
+## More detail
+
+The full trust contract, outbound-network posture, and supply-chain threat
+model live in [`docs/security.md`](../docs/security.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agent-coherence
 
-**`agent-coherence` makes "agent A silently clobbered agent B's `plan.md`" impossible — a vendor-neutral MESI + optimistic-concurrency coordinator for agent state, with the safety invariants machine-checked in TLA+.**
+**`agent-coherence` stops one agent from silently clobbering another's work on a shared `plan.md`, store key, or `memory.json` — a vendor-neutral MESI + optimistic-concurrency coordinator for agent state on a single host, with the safety invariants machine-checked in TLA+.**
 
 Two agents share an artifact — a `plan.md`, a store key, a `memory.json`. One reads it and works; meanwhile a peer commits a newer version; the first writes back anyway. Last write wins, the peer's work is silently gone, nothing errors, and every downstream decision builds on the wrong version. `agent-coherence` turns that silent clobber into a loud, typed refusal: MESI-style ownership and invalidation over shared artifacts, optimistic commit-CAS for concurrent writers, and a read-generation fence for crash-reclaimed ones — a stale write is denied or returned as a retryable conflict, never silently applied. Same library, same protocol, across LangGraph, CrewAI, AutoGen, the OpenAI Agents SDK, plain files shared across processes (`CoherentVolume`), any MCP client (the `stale-write-guard-fs` server, via the `mcp` extra), and any custom orchestrator. Same behavior regardless of which model provider (Anthropic, OpenAI, Google, Mistral, open-source) the agents talk to.
 
@@ -13,6 +13,7 @@ Two agents share an artifact — a `plan.md`, a store key, a `memory.json`. One 
 `mcp-name: io.github.cohexa-ai/stale-write-guard-fs`
 
 ```bash
+# Requires Python 3.11+
 pip install "agent-coherence[langgraph]"        # LangGraph drop-in
 pip install "agent-coherence[crewai]"           # CrewAI adapter
 pip install "agent-coherence[openai-agents]"    # OpenAI Agents SDK adapter (experimental)
@@ -31,7 +32,9 @@ from ccs.adapters import CCSStore
 store = CCSStore(strategy="lazy")
 ```
 
-`store.get()`, `store.put()`, `store.search()` keep working unchanged — reads now serve the current version, and a write from a stale view can't silently land.
+`store.get()`, `store.put()`, `store.search()` keep working unchanged. `CCSStore` adds **read-side** coherence: a peer's commit invalidates your cached view, so your next read is a fresh miss. It does **not** deny a stale write-back — `put` is not version-CAS; for write-side lost-update prevention, route writes through `CoherentVolume` or `write_cas` (below).
+
+> The one-import swap assumes your store namespaces carry the agent identity in `namespace[0]` — a `(user_id, "memories")` shape would merge users onto one shared artifact. See the [namespace convention](docs/guide.md#namespace-convention).
 
 ```python
 # Plain files shared across processes / sessions — no framework required
@@ -54,7 +57,7 @@ Each row is a safety invariant model-checked with TLA+/TLC. `make tla-check` run
 | **Concurrent lost update** — two writers hit the same key and both "succeed" | exactly one wins; the loser gets a **typed conflict + bounded retry**, never a silent drop | optimistic commit-CAS (`write_cas`) | `NoLostUpdate` |
 | **Reclaim-zombie write** — a stalled writer is reclaimed by crash recovery, wakes later, and lands its stale commit; the version never moved, so a version check passes | the commit is **rejected** with a typed `stale_read_generation` conflict | read-generation fence — reclamation bumps the artifact's ownership epoch, checked atomically at commit | `NoStaleApply` |
 | **Torn multi-artifact read (read-skew)** — an agent reads several artifacts one by one while a peer commits in between; each read was individually current, but the *combination* never coexisted | session reads serve from a **pinned consistent cut**; commits validate against the pinned base; a lapsed session **fails closed** with a typed rejection, never a silent fall-through to live state | [multi-artifact snapshot sessions](#multi-artifact-snapshot-sessions) | `NoReadSkewWithinCut`, `PinAlwaysRetained` |
-| **Dead owner blocks the fleet** — a crashed agent holds EXCLUSIVE forever | the heartbeat/TTL sweep reclaims the grant (on by default) | crash-recovery sweep | sweep invariants I3–I6 |
+| **Dead owner blocks the fleet** — a crashed agent holds EXCLUSIVE forever | the heartbeat/TTL sweep reclaims the grant (on by default; best-effort, rate-limited) | crash-recovery sweep | sweep invariants I3–I6 |
 
 **Scope, honestly:** the guarantees hold for writers that go through the coordinator, under a single coordinator (one host). Concurrent same-key writers on one host are covered; cross-host fencing is on the roadmap, demand-gated — if you need it, [open an issue](https://github.com/Cohexa-ai/agent-coherence/issues/new). Edits that *bypass* the coordinator entirely (a human in an editor, a formatter, a regenerating script) are caught at the workspace boundary by content-hash checks — the [foreign-edit guards](#foreign-edit-guards-writes-that-bypass-the-coordinator) below, enforced by tests rather than TLA+. Specs, the invariant ↔ implementation map, and the mutant recipes live in [`formal/tla/`](formal/tla/README.md).
 
@@ -72,7 +75,7 @@ Those are the **spatial** savings (more agents sharing one artifact). The **temp
 
 ## RAG & shared agent memory
 
-RAG corpora and agent memory are **shared mutable state**, so the stale-read→write lost update lands there too — and *a consistent store doesn't save you*: the staleness is in the **agent's cached view of a record**, not the store. Two agents read a record at v1; one writes v2; the other, still on its v1, writes an edit computed from v1 and clobbers v2. `agent-coherence` keeps the readers honest: `CCSStore` is a drop-in for `langgraph.store` (and composes with Mem0, Letta, LlamaIndex, a vector store, or a plain file via `CoherentVolume`) — it stores no vectors and does no ranking; it's the consistency layer underneath whatever you already use to retrieve and remember.
+RAG corpora and agent memory are **shared mutable state**, so the stale-read→write lost update lands there too — and *a consistent store doesn't save you*: the staleness is in the **agent's cached view of a record**, not the store. Two agents read a record at v1; one writes v2; the other, still on its v1, writes an edit computed from v1 and clobbers v2. `agent-coherence` keeps the **readers** current — `CCSStore` is a drop-in for `langgraph.store` (composing with Mem0, Letta, LlamaIndex, a vector store, or a plain file underneath whatever you already use; it stores no vectors and does no ranking), so a peer's commit invalidates the stale cached view (read-side coherence). Preventing the stale **write-back** itself is the write side — route those writes through `CoherentVolume` or `write_cas`.
 
 - **Runnable, deterministic demo** (offline, no keys): `python -m examples.coherent_volume.main` reproduces the documented lost update, then prevents it.
 - **Honest scope:** writes that go through the coordinator are caught. Auto-watching an *unmanaged external source* that changes with no coordinator write (a hand-edited file, an out-of-band re-index) is the source-watcher case — **on the roadmap, demand-gated, not shipped today.**
@@ -92,6 +95,7 @@ RAG corpora and agent memory are **shared mutable state**, so the stale-read→w
 - 🩺 [`ccs-diagnose` CLI](docs/ccs-diagnose.md) — find divergent reads in your existing LangGraph graph without changing any code
 - 🧩 [Claude Code plugin](https://github.com/Cohexa-ai/agent-coherence-plugin) — cross-session coherence for the prose rules (CLAUDE.md, plan.md) parallel Claude Code sessions share
 - 🔍 [Why coherence matters](docs/why-coherence-matters.md) — the gap across LangGraph, CrewAI, AutoGen, and Claude Agent SDK
+- 🧭 [The MESI-derived approach](docs/agent-coherence-approach.md) — how the protocol maps each documented gap to a shipped surface, with boundaries
 - 🔐 [Security & supply chain](docs/security.md) — kill switches, hash-pinned install, attestation verification, threat model
 - 📜 [Changelog](CHANGELOG.md) — version history
 - 📄 [Paper on arXiv (2603.15183)](https://arxiv.org/abs/2603.15183) — formal protocol, TLA+ verification, simulation results
@@ -112,7 +116,7 @@ Five synchronization strategies ship out of the box: `lazy` (default), `eager`, 
 - **Coherent workspace** (`ccs.adapters.coherent_volume`) — the **data-plane appliance**: an out-of-process coordinator client that brings the same guarantee to plain files on disk, no framework required. See [Coherent workspace](#coherent-workspace-the-data-plane-for-shared-files).
 - **MCP server** (`ccs.mcp`) — the `stale-write-guard-fs` stdio server that exposes the coherent-workspace guarantee to any [Model Context Protocol](https://modelcontextprotocol.io) client over five `swg_*` tools. See [MCP server](#mcp-server-stale-write-guard-fs).
 - **Simulation** (`ccs.simulation`) — deterministic tick-driven engine for scenario benchmarks with failure injection.
-- **Event bus** (`ccs.bus`) — pluggable transport for invalidation signals; in-memory by default, swap in Redis, Kafka, NATS, or gRPC streams for production.
+- **Event bus** (`ccs.bus`) — the transport for invalidation signals; in-memory / in-process today (`InMemoryEventBus`). Networked transports (Redis, Kafka, NATS, gRPC) for a multi-host deployment are on the roadmap, demand-gated.
 
 Protocol safety properties — single-writer, monotonic versioning, the crash-recovery sweep invariants, the OCC no-lost-update, the reclamation fence's no-stale-apply, version retention's no-collected-read, and the snapshot session's no-read-skew-within-cut — are model-checked with [TLA+/TLC](formal/tla/README.md). The `tla-check` CI job runs all six specs on every push and PR.
 

--- a/docs/agent-coherence-approach.md
+++ b/docs/agent-coherence-approach.md
@@ -22,18 +22,26 @@ problem has been solved for decades.
 
 For LangGraph specifically, `agent-coherence` ships a drop-in `BaseStore`
 replacement (`CCSStore`) that adds coherence semantics — swap the store
-import and the protocol handles the rest. Agents that hold current data skip re-reads; agents that hold
-stale data are notified. The protocol enforces single-writer exclusivity and
-monotonic versioning as invariants, not conventions.
+import and the protocol handles the rest. Agents that hold current data skip
+re-reads; an agent holding a stale version isn't pushed a notification — its
+cached view is invalidated, so its next read misses and re-fetches. The
+protocol enforces single-writer exclusivity and monotonic versioning as
+invariants, not conventions — modeled and machine-checked in
+[`formal/tla/`](../formal/tla/README.md) (TLA+/TLC, run in CI).
 
 The same primitives extend past orchestration state to **retrieval and
 memory** ([Section 6](why-coherence-matters.md#6-the-same-gap-lands-on-rag-and-agent-memory)).
 Because the lost update lives in the agent's cached view of a record — not in
-the store — `CCSStore` works as the consistency layer under a memory store,
-and [`CoherentVolume`](guide.md) brings the same guarantee to plain-file
-corpora and memory shared across processes. It stores no vectors and does no
-ranking: it sits underneath whatever you already use to retrieve and remember,
-keeping the readers honest and refusing stale writes.
+the store — `CCSStore` works as the consistency layer under a memory store.
+`CCSStore` provides read-side coherence: when a peer commits a new version,
+your cached view is invalidated so your next read is a fresh miss. It does not
+deny a stale write-back — `put` is not version-CAS. For write-side lost-update
+prevention (a stale writer overwriting a peer), route writes through
+[`CoherentVolume`](guide.md) or `write_cas`, which carry that write-side denial
+to plain-file corpora and memory shared across processes. Neither stores
+vectors nor ranks: they sit underneath whatever you already use to retrieve and
+remember, keeping the readers honest and — on the write side — denying stale
+write-backs.
 
 ## What this addresses
 
@@ -42,9 +50,14 @@ keeping the readers honest and refusing stale writes.
 | No defined isolation model (Section 1) | MESI states provide explicit read/write ownership semantics per agent per artifact |
 | Concurrent writes unresolvable (Section 2) | Single-writer exclusivity prevents concurrent writes at the protocol level |
 | Reducer pattern is append-only (Section 2) | Conflict is avoided by grant, not resolved by merge — only one agent holds write permission at a time |
-| Users requesting optimistic locking (Section 4) | Version-tracked artifacts with monotonic versioning; stale writes are rejected |
-| Full-context rebroadcasting (Section 5) | Invalidation signals notify agents of changes; only stale caches re-fetch |
+| Users requesting optimistic locking (Section 4) | Version-tracked artifacts with monotonic versioning; a stale write-back is denied on the write side via `write_cas`/`CoherentVolume` (shipped, single-host). `CCSStore`'s `put` is not version-CAS — it is read-side coherence only |
+| Full-context rebroadcasting (Section 5) | Invalidation marks a cache stale; only a stale cache re-fetches, on its next read (pull, not push) |
 | RAG corpora & agent memory are shared mutable state (Section 6) | `CCSStore` and `CoherentVolume` keep the cached *reader* current under any store; the staleness lives in the agent's view, not the store |
+| Concurrent same-key writes / true-race lost update (Section 2) | `write_cas`/`write_cas_at`: a version-checked optimistic write — a stale writer's CAS fails and the caller retries, so neither update is silently dropped (single-host, one coordinator) |
+| Escaping side effects fire on a stale input (Sections 2, 5) | `gate()` orders an escaping effect (a deploy, an opened PR, a notification) against the input version it was decided from, and raises before firing if the input changed — it *orders* effects, it never rolls one back; single-host and cooperative |
+| Non-LangGraph agents / any MCP client need coordinated file access (Section 1) | The `stale-write-guard-fs` MCP server exposes `CoherentVolume` as MCP tools; instances sharing one `SWG_ROOT` attach to a single coordinator, so a stale write is denied across sessions and peers fail closed if that coordinator exits |
+| Prose project rules that can't be expressed as policy drift across sessions | The Claude Code plugin keeps that shared-rule subset coherent across sessions (single-host) |
+| Multi-file edits must land together, never half-applied (Section 2) | Multi-artifact snapshot sessions (`atomic_publish`/`commit_all`, v0.12.0+) publish a set of files all-or-nothing, so a reader never sees a partially-applied edit (single-host) |
 
 ## What this does not address
 
@@ -59,6 +72,8 @@ evidence document apply here too:
   and RAG is addressed (above); the right *level* for long-lived memory is not.
 - The right isolation level for different workload shapes remains an open
   research question.
+- Enforcement is single-host (one coordinator). Cross-host coordination is on
+  the roadmap, demand-gated.
 
 ---
 

--- a/docs/ccs-diagnose.md
+++ b/docs/ccs-diagnose.md
@@ -1,8 +1,15 @@
 # `ccs-diagnose` — detect stale reads in your LangGraph graph
 
-`ccs-diagnose` attaches a passive callback to an existing LangGraph graph and classifies its write pattern (`single_writer` / `shared_artifact` / `parallel_branch` / `mixed`). It reports artifacts whose reads were handed divergent versions across nodes — divergence the runtime is already producing but never surfaces.
+`ccs-diagnose` attaches a passive callback to an existing LangGraph graph and classifies its write pattern (`single_writer` / `shared_artifact` / `parallel_branch` / `mixed_pattern` / `insufficient`). It reports artifacts whose reads were handed divergent versions across nodes — divergence the runtime is already producing but never surfaces.
 
 It runs as a **witness-quality** surface: it observes what the runtime *handed* a node, not what the node read. Upgrading to `CCSStore` lifts these observations into provable per-key attribution — same diagnose surface, no callback rewiring.
+
+**`ccs-diagnose` is detection only — it enforces nothing.** It surfaces divergence; it never denies a read or a write. What *closes* a divergence once you've seen it depends on which side the race is on:
+
+- **Read-side drift** (a peer committed a new version, your cached view went stale) → **CCSStore** provides read-side coherence: when a peer commits a new version, your cached view is invalidated so your next read is a fresh miss. It does not deny a stale write-back — `put` is not version-CAS.
+- **Write-side lost-update** (a stale writer overwriting a peer) → route writes through **CoherentVolume** or **`write_cas`**.
+
+**Scope:** `ccs-diagnose` observes a single in-process run — the versions the runtime hands nodes inside one process. Divergence that happens across separate OS processes (two hosts, or two processes over shared files) is invisible to it; for cross-process coordination over files, reach for CoherentVolume.
 
 The CLI makes **zero outbound network requests** in v0.
 
@@ -32,6 +39,9 @@ pip install "agent-coherence[diagnose]"
 
 ```bash
 ccs-diagnose --graph path/to/your_graph.py:build_graph
+
+# Or run it right now against the bundled example graph — no setup:
+ccs-diagnose --graph examples/langgraph_planner/main.py:build_graph_no_store
 ```
 
 The factory must accept zero arguments (or accept an initial state file via `--state-file`) and return a compiled LangGraph graph. The CLI runs the graph once with a passive observer and writes two reports:
@@ -120,7 +130,7 @@ Three independent kill switches suppress all telemetry-shaped output (no consent
 
 `--no-telemetry` and `--no-network` are the per-invocation equivalents.
 
-See [SECURITY.md](SECURITY.md) for the full trust contract, supply-chain threat model, and attestation-verification commands.
+See [security.md](security.md) for the full trust contract, supply-chain threat model, and attestation-verification commands.
 
 ## Calibration corpus
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -48,7 +48,7 @@ full command-line toolset, and the API reference.
 
 ## Installation
 
-Pick the integration extra that matches your stack. The library is the same across all of them — only the adapter surface changes.
+Requires Python 3.11+. Pick the integration extra that matches your stack. The library is the same across all of them — only the adapter surface changes.
 
 ```bash
 # LangGraph (drop-in CCSStore)
@@ -96,6 +96,31 @@ graph = builder.compile(store=store)
 
 Node code stays identical — `store.get()`, `store.put()`, and `store.search()` all
 work the same way.
+
+**What CCSStore does at the write boundary.** CCSStore provides read-side
+coherence: when a peer commits a new version, your cached view is invalidated so
+your next read is a fresh miss. It does not deny a stale write-back — `put` is not
+version-CAS. For write-side lost-update prevention (a stale writer overwriting a
+peer), route writes through [`CoherentVolume`](#coherent-workspace-coherentvolume)
+or `write_cas`.
+
+**In-process scope.** CCSStore coherence is in-process: two separate OS processes
+each constructing their own CCSStore share nothing. For cross-process coordination
+over files, use [`CoherentVolume`](#coherent-workspace-coherentvolume).
+
+**The one-import swap assumes agent-carrying namespaces.** The drop-in is one import
+change *only if* your namespaces already carry the agent identity in `namespace[0]`
+(see [Namespace convention](#namespace-convention)) — that is what lets two agents
+share one artifact while keeping private scratch private. A store keyed the
+LangGraph-memory way, `(user_id, "memories")`, would collapse every user onto one
+shared artifact, so migrate those call sites to put the agent in `namespace[0]`
+before the swap.
+
+**CCSStore and your existing store.** CCSStore's cached contents live for the
+process lifetime, not on disk — it is not a database. If you already run Mem0,
+Letta, LlamaIndex, or a LangGraph store, keep it: it stays your durability layer,
+and CCSStore adds coherence for the cached view above it (a peer write invalidates a
+stale read). It does not wrap or replace your backend's storage.
 
 ---
 
@@ -351,8 +376,8 @@ store = CCSStore(
     strategy="lazy",
     crash_recovery=CrashRecoveryConfig(
         enabled=True,
-        heartbeat_timeout_ticks=10,
-        max_hold_ticks=1000,
+        heartbeat_timeout_ticks=120,
+        max_hold_ticks=900,
     ),
 )
 ```
@@ -563,7 +588,13 @@ content)`, commits against an explicit version with no retry loop. See the race
 live: `python -m examples.concurrent_writers.main` runs two threads through the
 identical update — a plain file loses one write, `write_cas` preserves both.
 
-### Atomic multi-file publish: `atomic_publish`
+When a commit loses its race on the volume (or MCP) path, the raised
+`CommitPreempted` is **terminal for that attempt, not a transient to retry blindly**:
+the version the write assumed no longer holds. Recover by `reacquire()`-ing,
+re-reading the fresh version, and reconciling your change onto it before committing
+again — a plain retry of the same bytes just loses the same race.
+
+### Atomic multi-file publish: `atomic_publish` (v0.12.0+)
 
 `write_cas_at` lands one file. When an agent edits a *set* of files that must stay
 consistent — a plan and its manifest, a config split across files —
@@ -633,6 +664,38 @@ API is the supported contract; the shim is a convenience.
 
 Run the demo: `python -m examples.coherent_volume.main` (offline, deterministic,
 no keys) — it reproduces the silent lost update, then prevents it.
+
+### Worktrees and the workspace boundary
+
+`CoherentVolume` coordinates by *path under one `workspace_root`*. Two git
+worktrees of the same repo are separate directory trees, so `plans/plan.md` in
+worktree A and `plans/plan.md` in worktree B are **different physical artifacts** to
+the volume — a write in one does not invalidate the other unless both processes route
+through the *same* shared workspace root. To make per-worktree sessions coordinate,
+point every volume at one common root (for example the primary checkout). The Claude
+Code plugin does this for you: it resolves the parent repo via
+`git rev-parse --git-common-dir` so sessions in sibling worktrees share one
+coordinator (`src/ccs/adapters/claude_code/resolver.py`).
+
+### When you don't need this
+
+Coherence is worth adding only when agents actually share mutable state through a
+back channel your framework doesn't already serialize. You can skip it when:
+
+- **Every agent owns an isolated workspace.** If sessions never write the same
+  artifact — separate worktrees, separate branches, separate keys with no shared
+  root — there is no lost update to prevent. (The moment they *do* converge on one
+  file or one shared root, the race is back.)
+- **A single database already arbitrates the writes.** If your shared state is rows
+  behind one transactional store, its own transactions and row locks already give
+  you last-committer-wins with no torn state. `CoherentVolume` targets *plain files*
+  and in-memory agent state, where nothing is arbitrating.
+
+The liveness tradeoff runs the other way: a crashed holder does not deadlock the
+fleet. A stalled `MODIFIED`/`EXCLUSIVE` grant is bounded and auto-reclaimed by the
+best-effort crash-recovery sweep (per artifact, never a global lock), and the
+`write_cas` / `atomic_publish` CAS paths hold no lock at all — a loser just re-reads
+and retries.
 
 ### Cross-host mode (experimental, default off)
 
@@ -764,6 +827,18 @@ Denials are machine-readable: an agent parses the typed payload (for example
 blindly. The server validates every file URI — path traversal and any access to
 the coordinator's own state directory are rejected — and fails closed on IO
 errors. Strict-mode, managed-path scoped.
+
+**Multiple sessions, one workspace.** Multiple `stale-write-guard-fs` instances
+pointed at the same `SWG_ROOT` attach to one coordinator, so a stale write is denied
+across sessions; if the coordinator's session exits, peers fail closed.
+
+**Wiring a client to prefer `swg_*` over native file tools.** Registering the
+server exposes the `swg_*` tools, but an agent will still reach for its native
+Write/Edit on a managed path unless you steer it there. Deny the native file tools
+on managed paths — through the client's permission rules or a pre-tool hook — so
+writes have to go through `swg_write` / `swg_write_cas` and inherit the stale-view
+deny. The Claude Code adapter that wires this seam ships in
+`ccs.adapters.claude_code`.
 
 Run the red→green demo: `python -m examples.mcp_stale_write_guard.main`
 (offline, deterministic, no keys).
@@ -920,18 +995,22 @@ Use these to gate alerts or health checks without keeping a separate event list.
 
 All examples are runnable with `python -m examples.<name>.main` from the project root.
 
+Correctness demos lead; the token-savings / hit-rate demos follow.
+
 | Example | Command | What it shows |
 |---------|---------|---------------|
-| LangGraph planner | `python -m examples.langgraph_planner.main` | 4-agent, 1 artifact, 75% hit rate |
-| Code review pipeline | `python -m examples.code_review.main` | 3-agent, SHARED state transitions |
-| Research pipeline | `python -m examples.research_pipeline.main` | 4-agent, 3 artifacts, 60% hit rate |
-| Shared codebase | `python -m examples.shared_codebase.main` | 4-agent code review, 37.6% savings, benchmark output |
-| Conversations stale-read | `python -m examples.conversations_stale_read.main` | Two agents share one conversation; client-cache invalidation (offline, no keys) |
+| Shared knowledge base | `python -m examples.shared_knowledge_base.main` | Lost update in a shared RAG / memory corpus; `CoherentVolume` denies B's stale overwrite so both findings survive (offline, no keys) |
+| Divergent memory | `python -m examples.divergent_memory.main` | Two sessions record contradictory beliefs from a stale read; the stale write is denied fail-closed so the divergence never forms (offline, no keys) |
 | Coherent volume | `python -m examples.coherent_volume.main` | Sequential stale-write deny + recovery on plain files (offline, no keys) |
 | Concurrent writers | `python -m examples.concurrent_writers.main` | True-race lost update; `write_cas` preserves both updates (offline, no keys) |
 | Effect gate | `python -m examples.effect_gate.main` | `gate()` holds an effect on a stale input; `--baseline` shows the stale fire (offline, no keys) |
 | MCP stale-write guard | `python -m examples.mcp_stale_write_guard.main` | Red→green stale-write deny through the MCP server tools (offline, no keys) |
-| Cross-host | `python examples/cross_host/main.py` | Stale-write deny + effect ordering across a host boundary (local smoke; Docker runner in `examples/cross_host/`) |
+| Conversations stale-read | `python -m examples.conversations_stale_read.main` | Two agents share one conversation; client-cache invalidation (offline, no keys) |
+| Cross-host (experimental) | `python examples/cross_host/main.py` | Stale-write deny + effect ordering across a host boundary (local smoke; Docker runner in `examples/cross_host/`) |
+| LangGraph planner | `python -m examples.langgraph_planner.main` | 4-agent, 1 artifact, 75% hit rate |
+| Code review pipeline | `python -m examples.code_review.main` | 3-agent, SHARED state transitions |
+| Research pipeline | `python -m examples.research_pipeline.main` | 4-agent, 3 artifacts, 60% hit rate |
+| Shared codebase | `python -m examples.shared_codebase.main` | 4-agent code review, 37.6% savings, benchmark output |
 
 ### Code review pipeline
 
@@ -1312,7 +1391,7 @@ from ccs.coordinator.service import CrashRecoveryConfig
 
 adapter = LangGraphAdapter(
     strategy_name="lazy",
-    crash_recovery=CrashRecoveryConfig(enabled=True, heartbeat_timeout_ticks=10, max_hold_ticks=1000),
+    crash_recovery=CrashRecoveryConfig(enabled=True, heartbeat_timeout_ticks=120, max_hold_ticks=900),
 )
 for name in ("planner", "researcher", "executor"):
     adapter.register_agent(name, now_tick=0)

--- a/docs/reproduce.md
+++ b/docs/reproduce.md
@@ -2,6 +2,8 @@
 
 Results in [Token Coherence: Adapting MESI Cache Protocols to Minimize Synchronization Overhead in Multi-Agent LLM Systems](https://arxiv.org/abs/2603.15183) §8 are reproducible from this repository.
 
+> **Scope:** this page reproduces the **cost-proxy pipeline** — the cost/simulation axis (re-fetches avoided under coherence-gating). It does not exercise the correctness properties; for those, see [Reproducing the correctness claims](#reproducing-the-correctness-claims) below.
+
 ## Requirements
 
 - Python 3.11+
@@ -54,3 +56,16 @@ The seeded sweep reproduces the committed `benchmarks/results/cost_sweep_publish
 The simulation models token transmission accounting, MESI state transitions, write-frequency effects, and artifact volatility.
 
 It does not model LLM inference latency, real framework scheduler jitter, or event bus network RTT outside the configured simulator latency/loss parameters.
+
+## Reproducing the correctness claims
+
+The numbers above are a **cost/simulation** proxy, not a correctness proof. The coherence properties are shown by runnable examples and machine-checked models — all single-host:
+
+| What it shows | Where |
+|---------------|-------|
+| A stale write-back is denied (write-side lost-update prevention) | [`examples/coherent_volume`](../examples/coherent_volume/README.md) |
+| Concurrent writers to one artifact — the stale writer is rejected | [`examples/concurrent_writers`](../examples/concurrent_writers/README.md) |
+| `gate()` orders side effects behind a fresh read (it orders effects; it does not roll back) | [`examples/effect_gate`](../examples/effect_gate/README.md) |
+| Machine-checked TLA+ safety models (the CI-run specs and their named invariants) | [`formal/tla/`](../formal/tla/README.md) |
+
+Enforcement is single-host (one coordinator). Cross-host coordination is on the roadmap, demand-gated.

--- a/docs/security.md
+++ b/docs/security.md
@@ -19,7 +19,7 @@ security advisory](https://github.com/Cohexa-ai/agent-coherence/security/advisor
 a `CoherentVolume` at a remote coordinator (`CCS_REMOTE_HOST` / `CCS_REMOTE_PORT` /
 `CCS_REMOTE_SECRET_FILE`) makes the client open connections to that
 **user-configured, private-range coordinator endpoint** — never the internet, and
-no telemetry. This is the only network traffic the library generates, it is opt-in,
+no telemetry. This is the only host-leaving traffic the library generates, it is opt-in,
 and the coordinator only binds beyond loopback to an RFC-1918/4193 address (see the
 cross-host demo, `examples/cross_host/`). With the flag unset the zero-outbound
 posture above is unchanged.
@@ -99,6 +99,19 @@ set these **narrowly** (per-invocation / per-compose-service), never as a
 persistent global — a forgotten global assertion would blanket every future routed
 bind. Production TLS/mTLS termination is a separate hardening step; the cross-host
 mode as a whole remains experimental and default-off.
+
+### MCP server network posture
+
+The `stale-write-guard-fs` MCP server (installed via the `[mcp]` extra —
+`pip install "agent-coherence[mcp]"`) speaks the Model Context Protocol over
+**stdio only**. It opens no listening sockets and makes no outbound network
+calls: a host such as Claude Desktop or Cursor spawns it as a subprocess and
+talks to it over stdin/stdout, and the server coordinates writes through an
+in-process `CoherentVolume` on the local filesystem. There is nothing to firewall
+and no endpoint to configure on this path. See the MCP sections of the
+[README](../README.md#mcp-server-stale-write-guard-fs) and the
+[guide](guide.md#stale-write-guard-fs-mcp-server) for setup and the five `swg_*`
+tools.
 
 ## Env-var kill switches
 
@@ -219,11 +232,26 @@ prefer `requirements-diagnose.txt` for reproducible installs.
 ## Verifying release attestations (PEP 740)
 
 Each wheel published to PyPI ships with a Sigstore-backed PEP 740 attestation
-tied to the GitHub Actions workflow that built it. To verify before installing:
+tied to the GitHub Actions workflow that built it. The attesting repository is
+**version-scoped** — the project moved from `hipvlady/agent-coherence` to
+`Cohexa-ai/agent-coherence`, and each already-published wheel immutably attests
+the repository it was built under:
+
+- **Wheels v0.11.0 and earlier** attest repository `hipvlady/agent-coherence`
+  (built before the org migration; same maintainer, and the old URL redirects to
+  the new org). Verify these with `--repo hipvlady/agent-coherence`.
+- **Wheels v0.12.0 and later** attest repository `Cohexa-ai/agent-coherence`
+  (published from the Cohexa-ai Trusted Publisher). Verify these with
+  `--repo Cohexa-ai/agent-coherence`.
+
+To verify before installing, pass the repository that matches the version you
+are installing:
 
     pip install pypi-attestations
+    # v0.12.0 and later  →  --repo Cohexa-ai/agent-coherence
+    # v0.11.0 and earlier →  --repo hipvlady/agent-coherence
     pypi-attestations verify --provenance \
-        --repo Cohexa-ai/agent-coherence \
+        --repo <REPO-FOR-THIS-VERSION> \
         --workflow release.yml \
         agent_coherence-X.Y.Z-py3-none-any.whl
 
@@ -235,9 +263,13 @@ You can also inspect the raw signed attestation directly:
       | python3 -m json.tool
 
 The `publisher` block in each attestation bundle should report
-`{kind: GitHub, repository: Cohexa-ai/agent-coherence, workflow: release.yml, environment: pypi}`.
-A publisher mismatch is the signature of a Trusted Publisher misconfiguration —
-do not install if the values diverge from those above.
+`{kind: GitHub, repository: <REPO-FOR-THIS-VERSION>, workflow: release.yml, environment: pypi}`,
+where `<REPO-FOR-THIS-VERSION>` is `hipvlady/agent-coherence` for wheels v0.11.0
+and earlier and `Cohexa-ai/agent-coherence` for wheels v0.12.0 and later. A
+publisher that reports neither expected value — or reports the wrong one for the
+version being installed — is the signature of a Trusted Publisher
+misconfiguration or a tampered release: do not install if the values diverge from
+the version-scoped expectation above.
 
 > **Note on `gh attestation verify`.** That command queries GitHub's SLSA
 > build-provenance attestation store, which the current release workflow does

--- a/docs/why-coherence-matters.md
+++ b/docs/why-coherence-matters.md
@@ -141,11 +141,44 @@ strongly consistent the backing store is. Coherence here is about keeping the
 underneath whatever vector store, memory library (Mem0, Letta, LlamaIndex), or
 plain file you already use to retrieve and remember.
 
-The boundary is worth stating plainly. Writes that go through the coordinator
-are caught. Auto-watching an *unmanaged external source* that changes with no
-coordinator write — a hand-edited corpus file, an out-of-band re-index — is a
-separate problem (a source-watcher), not solved by keeping cached readers
-coherent.
+The boundary is worth stating plainly. CCSStore provides read-side coherence:
+when a peer commits a new version, your cached view is invalidated so your next
+read is a fresh miss. It does not deny a stale write-back — `put` is not
+version-CAS. For write-side lost-update prevention (a stale writer overwriting a
+peer), route writes through CoherentVolume or `write_cas`. Separately,
+auto-watching an *unmanaged external source* that changes with no coordinator
+write — a hand-edited corpus file, an out-of-band re-index — is a source-watcher
+problem, not solved by keeping cached readers coherent.
+
+### The same class lands on repos, configs, and CI
+
+The evidence above is Segment A — shared memory and orchestration state. The
+identical stale-read→write class also lands on a second surface: **shared
+repositories, configuration, and CI inputs** worked by more than one automated
+actor (parallel coding agents, bots, pipelines). The reports below are from
+unrelated third-party projects. They validate the failure *class*, not this
+library's mechanism, and none of them are users of it.
+
+- **Renovate [#18804](https://github.com/renovatebot/renovate/issues/18804)**:
+  the bot checks a branch as unmodified using a cached result, then rebases —
+  but the user force-pushed between the check and the write, so the rebase
+  clobbers their commits. The reporter names it directly: "a time-of-check vs
+  time-of-use bug." A cached read that has gone stale, driving a write-back.
+- **Terraform's `Saved plan is stale` error**: `terraform apply` refuses a
+  saved plan once current state has moved past the snapshot the plan was
+  computed against. The tool fails closed rather than apply a stale plan — an
+  explicit guard against the stale-read→write hazard on infrastructure state.
+- **Atlantis** (PR-driven Terraform automation) shows the same shape at team
+  scale: parallel PRs plan against a base a merged peer has already advanced,
+  so a later apply runs on a stale plan.
+- **Parallel Claude Code sessions** on one repository exhibit it directly — two
+  sessions read shared files, plans, or configs, and one writes back over a
+  version a peer already advanced.
+
+The pattern is invariant across surfaces: an automated actor reads shared state,
+does work, and writes back against a version that has since moved. As with
+Segment A, the shipped enforcement here is single-host (one coordinator);
+cross-host coordination is on the roadmap, demand-gated.
 
 ## 7. Open questions
 
@@ -155,7 +188,22 @@ Several questions remain unanswered by any framework or library:
 - **Is coherence worth its coordination cost for small agent counts?** At 2–3 agents with small shared state, full rebroadcasting may be cheaper than maintaining coherence metadata. The crossover point is not well-characterized.
 - **What isolation level does agent memory specifically need?** Section 6 argues the same read-your-writes coherence that applies to orchestration state applies to memory and RAG — the staleness is in the cached view, not the store. What remains open is whether *long-term* memory (e.g., `langmem`) needs a stronger level than ephemeral shared state — snapshot isolation across a multi-step recall, say — or whether read-your-writes suffices there too.
 
+## 8. One approach — and an invitation
+
+This document is written problem-first: it maps the gap, and names a shipped
+surface only where a claim needs an honest boundary. For one concrete approach
+to closing the gap — MESI-derived coherence over
+multi-agent shared state — see
+[How agent-coherence Fills the Gap](agent-coherence-approach.md).
+
+If you are hitting this shape in production — a stale read that lands on a
+write-back over a peer's update, on shared memory, a repo, or a config — we
+would like to hear how it shows up for you. Independent reproductions of the
+failure class are especially useful. The shipped enforcement is single-host
+(one coordinator); cross-host coordination is on the roadmap, demand-gated.
+
 ---
 
-*Last verified: May 7, 2026. All URLs were confirmed live and all claims
-checked against current source material on this date.*
+*Last verified: May 7, 2026 (Segment-A evidence). Segment-B anchors (§6) added
+and confirmed live July 14, 2026. All URLs were confirmed live and all claims
+checked against current source material on these dates.*


### PR DESCRIPTION
## Summary
Documentation-only accuracy + completeness pass. No code changes.

- **CCSStore read-side vs write-side** clarified everywhere: `put` is not version-CAS and does not deny a stale write-back; write-side lost-update prevention is CoherentVolume / `write_cas`.
- **Version-scoped PEP 740 provenance** (`docs/security.md`): wheels ≤ v0.11.0 attest `hipvlady/agent-coherence`; v0.12.0+ attest `Cohexa-ai/agent-coherence` (the doc previously told users to verify pre-migration wheels against the new org).
- Front-page headline scoped to single host; event-bus transports marked roadmap; `.github/SECURITY.md` added so the Security tab surfaces a policy.
- Completeness: Segment-B (repos/configs/CI) evidence, worktree/workspace boundary, in-process scope, MCP multi-session + `swg_*` wiring, "when you don't need this", `CommitPreempted` recovery, Python 3.11+ install note, de-orphaned approach doc, drift fixes (crash-recovery example kwargs → actual defaults 120/900).

`atomic_publish` is tagged **(v0.12.0+)** as shipping in the release being cut from this branch.

## Test plan
- [x] No code changed; honesty-floor sweep clean (no CCSStore-write-denial, no "impossible", no cross-host-as-shipped, no links to non-existent demos)
- [x] All cross-linked example READMEs + doc anchors resolve