### PR TITLE
feat(examples): add three lead-use-case demos

### DIFF
--- a/examples/ci_merge_gate/README.md
+++ b/examples/ci_merge_gate/README.md
@@ -1,0 +1,86 @@
+# CI merge-gate demo
+
+> "Three agents, three clean PRs, three green CI runs, one broken product."
+
+An agentic-SDLC / CI symptom: an agent validates its PR against base@SHA-A, a
+peer's PR merges first and moves the base to SHA-B, and the first agent's merge
+fires against a base that no longer exists. Its green CI run never saw the
+peer's changes, so the integration break lands **silently** — every individual
+check was green. `gate()` re-reads the base pointer at the effect boundary and
+**holds** the merge instead of firing on a validation that already went stale.
+
+```
+# requires Python 3.11+ — activate the project venv first:
+cd /path/to/agent-coherence && source .venv/bin/activate
+python -m examples.ci_merge_gate.main             # the with-gate demo
+python -m examples.ci_merge_gate.main --baseline  # negative control first, then the gate
+```
+
+Offline, no API keys, no network, no git — the repo state is a mock (one JSON
+file holds the base-branch SHA plus a commit log) and the "merge" is an
+in-process ledger append. It spawns a local coordinator subprocess. Exit code
+`0` iff the contract holds:
+
+- **negative control (no gate, `--baseline`):** agent A merges on a validation
+  that ran against `SHA-A` after peer B already moved the base to `SHA-B` — the
+  failure the gate prevents, and
+- **gated path:** that same merge is **held** (`StaleView`, carrying the
+  expected/current versions), then fires against the fresh base (`SHA-B`) after
+  `reacquire()`, and never merges on the stale validation.
+
+## What it shows
+
+Two actors share one versioned input, `ci/base.json` (base SHA + commit log).
+Agent A reads `base@SHA-A`, runs its mock CI validation against it, and gates
+the merge on that version. Peer B merges its own PR in between (`base -> SHA-B`).
+The gate re-reads at the effect boundary, sees the version moved, and **holds**:
+the merge never fires against the base that no longer exists. A reacquires the
+fresh base, re-validates against `SHA-B`, and merges cleanly.
+
+```python
+from ccs.adapters import CoherentVolume, gate
+
+vol = CoherentVolume(root, managed=("ci/**",))
+
+def validate_pr(base_bytes):
+    base = json.loads(base_bytes)
+    return run_ci_and_decide_merge(base["sha"])
+
+# fires the merge only if ci/base.json is unchanged since validate_pr read it;
+# else raises StaleView BEFORE the merge runs.
+gate(vol, "ci/base.json", decide=validate_pr, effect=do_merge)
+```
+
+`gate()` is plain Python, so it drops into any agent loop identically — a
+LangGraph merge node, a CrewAI task, or a raw CI script:
+
+```python
+def merge_node(state):
+    gate(vol, "ci/base.json", decide=lambda b: validate(state, b), effect=do_merge)
+    return state
+```
+
+## Honest boundary
+
+- **Ordering, not rollback.** The gate fires *pre-effect* and never undoes a
+  fired merge. For an escaping effect (a real merge API call) there is a
+  residual re-check -> fire window this layer **narrows but cannot close**.
+- **Cooperative opt-in.** The agent calls the gate; it is not magic interception.
+- **Single-host.** Both actors share one local coordinator with the same
+  `managed` globs. Coordinating agents on separate machines is out of scope here.
+- **Pure writes** use `CoherentVolume.write_cas_at(...)` directly — the atomic,
+  no-window path.
+
+## The same idea, one layer down
+
+This is the check-then-act (TOCTOU) race serious CI tooling already fights:
+Renovate hit it branch-side ([renovate#18804](https://github.com/renovatebot/renovate/issues/18804)),
+Terraform refuses to apply a plan built on moved state (`Error: Saved plan is
+stale`), and Atlantis has the same stale-plan problem for PR-driven applies.
+This demo brings that freshness check to an agent's merge decision. Builder
+example, not an enterprise CI product. Sibling demos: `examples/effect_gate`
+(the bare primitive) and `examples/gate_effect_ordering` (deploy-framed).
+
+---
+Comparing notes on multi-agent coherence?
+https://github.com/Cohexa-ai/agent-coherence/discussions

--- a/examples/ci_merge_gate/__init__.py
+++ b/examples/ci_merge_gate/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+"""CI merge-gate demo — hold an agent's merge when the base branch moved."""

--- a/examples/ci_merge_gate/main.py
+++ b/examples/ci_merge_gate/main.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+"""CI merge-gate demo — merge a PR only against the base SHA its CI validated.
+
+Buyer symptom (agentic SDLC / CI): "three agents, three clean PRs, three green
+CI runs, one broken product." An agent validates its PR against base@SHA-A, a
+peer's PR merges first and moves the base to SHA-B, and the first agent's merge
+fires against a base that no longer exists — its green CI run never saw the
+peer's changes, so the integration break lands silently. `gate()` re-reads the
+base pointer at the effect boundary, sees the version moved, and HOLDs (raises
+the shipped `StaleView`) instead of merging on stale validation; the agent
+reacquires the fresh base, re-validates against it, and merges cleanly.
+
+    python -m examples.ci_merge_gate.main             # the with-gate demo
+    python -m examples.ci_merge_gate.main --baseline  # negative control first (no gate -> stale merge fires)
+
+Exit 0 iff the honest contract holds: with the gate the stale merge is HELD then
+fires against the fresh base after reacquire; with --baseline, the no-gate path
+merges on the stale validation (the failure the gate prevents) — the hold is
+measured against its absence, not asserted.
+
+Single-host, offline, no network, no git — the repo state is a mock: one JSON
+file holds the base-branch SHA plus a commit log, and the "merge" is an
+in-process ledger append.
+
+Honest boundary: `gate()` ORDERS effects (check-before-fire); it never rolls
+back a fired merge. For an escaping effect (a real merge API call) there is a
+residual re-check->fire window this layer narrows but cannot close. Cooperative
+opt-in, single-host. The same TOCTOU that Renovate hit branch-side (#18804) and
+the same freshness check Terraform ships ("Error: Saved plan is stale") and
+Atlantis needs for stale plans — brought to an agent's merge decision.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from ccs.adapters.claude_code.lifecycle import (  # noqa: E402  (after sys.path setup)
+    LifecycleConfig,
+    stop_coordinator,
+)
+from ccs.adapters.coherent_volume import CoherentVolume  # noqa: E402
+from ccs.adapters.effect_gate import gate  # noqa: E402
+from ccs.core.exceptions import StaleView  # noqa: E402
+
+BASE = "ci/base.json"
+SHA_A = "a1f9c04"
+SHA_B = "b7e2d55"
+BASE_AT_A = {
+    "sha": SHA_A,
+    "log": [{"sha": SHA_A, "subject": "chore(trunk): baseline"}],
+}
+
+
+def _fast_cfg() -> LifecycleConfig:
+    return LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0.1,
+        notice_evict_max_age_sec=1.0,
+        port_file_retry_attempts=40,
+        port_file_retry_interval_sec=0.05,
+        connect_retry_attempts=20,
+        connect_retry_interval_sec=0.05,
+    )
+
+
+def _validate_pr(base_bytes: bytes) -> str:
+    """Mock CI: validate PR #1 against the base SHA it sees, decide the merge."""
+    base = json.loads(base_bytes)
+    return f"merge PR#1 onto {base['sha']} (CI green vs {base['sha']})"
+
+
+def _peer_merge(base_bytes: bytes) -> bytes:
+    """Peer B's PR #2 lands first: append its commit, move the base pointer."""
+    base = json.loads(base_bytes)
+    base["log"].append({"sha": SHA_B, "subject": "feat(api): PR#2 merged by peer"})
+    base["sha"] = SHA_B
+    return json.dumps(base).encode()
+
+
+def run_baseline(root: Path) -> dict:
+    """Negative control: no gate. Agent A validates PR#1 against base@SHA-A, peer
+    B merges PR#2 first (base -> SHA-B), and A's merge fires anyway — against a
+    base that no longer exists. Returns a trace with the merge ledger."""
+    (root / "ci").mkdir(parents=True, exist_ok=True)
+    agent = CoherentVolume(root, managed=("ci/**",), config=_fast_cfg())
+    ledger: list[str] = []
+    trace: dict = {"fired_stale": False, "merged": None, "base_now": None, "ledger": ledger}
+    try:
+        agent.write(BASE, json.dumps(BASE_AT_A).encode())
+        peer = CoherentVolume(root, managed=("ci/**",), config=_fast_cfg())
+
+        base_bytes, _ = agent.read_with_version(BASE)
+        decision = _validate_pr(base_bytes)  # CI green — against base@SHA-A
+
+        peer.write(BASE, _peer_merge(base_bytes))  # PR#2 lands; base moves to SHA-B
+
+        ledger.append(decision)  # A's merge FIRES against the moved base
+        trace["fired_stale"] = True
+        trace["merged"] = decision
+        base_now = json.loads(agent.reacquire(BASE))["sha"]
+        trace["base_now"] = base_now
+        print(
+            f"  x (no gate) merge fired: {decision!r} while the base had already "
+            f"moved to {base_now} — PR#1's green CI never saw PR#2's changes"
+        )
+        return trace
+    finally:
+        stop_coordinator(root)
+
+
+def run_gated(root: Path) -> dict:
+    """With the gate: peer B merges mid-validation, so A's merge is HELD; A
+    reacquires the fresh base, re-validates against SHA-B, and merges cleanly."""
+    (root / "ci").mkdir(parents=True, exist_ok=True)
+    agent = CoherentVolume(root, managed=("ci/**",), config=_fast_cfg())
+    ledger: list[str] = []
+    trace: dict = {"held": False, "merged": None, "ledger": ledger}
+    try:
+        agent.write(BASE, json.dumps(BASE_AT_A).encode())
+        peer = CoherentVolume(root, managed=("ci/**",), config=_fast_cfg())
+
+        def validate(base_bytes: bytes) -> str:
+            # Peer B's PR#2 merges AFTER agent A read the base (fixed-stale buffer).
+            peer.write(BASE, _peer_merge(base_bytes))
+            return _validate_pr(base_bytes)
+
+        def merge(decision: str) -> str:
+            ledger.append(decision)  # the mock merge: ledger append, no network
+            return decision
+
+        print("  Agent A validates PR#1 against the base, gates the merge on that version...")
+        try:
+            gate(agent, BASE, decide=validate, effect=merge)
+            print("  x merge FIRED on stale base (gate did not hold)")
+        except StaleView as held:
+            trace["held"] = True
+            print(
+                f"  ok HELD: base moved v{held.expected_version} -> "
+                f"v{held.current_version}; merge NOT fired on the stale validation"
+            )
+
+        agent.reacquire(BASE)  # recover: fresh base, then re-validate + merge
+        merged = gate(agent, BASE, decide=_validate_pr, effect=merge)
+        trace["merged"] = merged
+        print(f"  ok after reacquire, merge fired against the fresh base: {merged!r}")
+        return trace
+    finally:
+        stop_coordinator(root)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="CI merge-gate demo (single-host)."
+    )
+    parser.add_argument(
+        "--baseline",
+        action="store_true",
+        help="run the no-gate negative control first (stale merge fires)",
+    )
+    args = parser.parse_args(argv)
+
+    print(
+        "CI merge-gate — merge a PR only against the base SHA its CI actually "
+        "validated.\n"
+    )
+
+    baseline_ok = True
+    if args.baseline:
+        print("Negative control (no gate):")
+        with tempfile.TemporaryDirectory() as d:
+            baseline = run_baseline(Path(d))
+        baseline_ok = (
+            bool(baseline["fired_stale"])  # the failure the gate prevents
+            and baseline["merged"] == f"merge PR#1 onto {SHA_A} (CI green vs {SHA_A})"
+            and baseline["base_now"] == SHA_B
+        )
+        print("")
+
+    print("With the gate:")
+    with tempfile.TemporaryDirectory() as d:
+        gated = run_gated(Path(d))
+
+    gated_held = bool(gated["held"])
+    gated_fired_fresh = gated["merged"] == f"merge PR#1 onto {SHA_B} (CI green vs {SHA_B})"
+    gated_never_merged_stale = (
+        f"merge PR#1 onto {SHA_A} (CI green vs {SHA_A})" not in gated["ledger"]
+    )
+
+    print("\nContract:")
+    if args.baseline:
+        print(f"  baseline merged against the STALE base       : {baseline_ok}")
+    print(f"  gate HELD the stale merge                    : {gated_held}")
+    print(f"  gate merged against the FRESH base           : {gated_fired_fresh}")
+    print(f"  gate never merged on the stale validation    : {gated_never_merged_stale}")
+
+    print("\nTakeaway: without ordering, the agent merges a PR whose green CI ran")
+    print("against a base that no longer exists — the integration break lands")
+    print("silently. The gate holds that merge at the effect boundary, then fires")
+    print("it against the fresh base after reacquire. Ordering, not rollback;")
+    print("single-host, cooperative — the freshness check Terraform does for a")
+    print("saved plan, brought to an agent's merge decision.")
+
+    ok = baseline_ok and gated_held and gated_fired_fresh and gated_never_merged_stale
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+# Comparing notes on multi-agent coherence?
+# https://github.com/Cohexa-ai/agent-coherence/discussions

--- a/examples/gate_effect_ordering/README.md
+++ b/examples/gate_effect_ordering/README.md
@@ -1,0 +1,78 @@
+# Deploy-on-moved-base gate demo
+
+> "The deploy ran on a config/base that had already moved."
+
+An agentic-SDLC / CI symptom: a build agent reads the release base, plans a
+deploy from it, and fires — but by the time it fires, a peer promoted a new base.
+The deploy ships the artifact planned from the **old** base, and the promotion is
+silently skipped. `gate()` re-reads the base at the effect boundary and **holds**
+the deploy instead of firing on state that already moved.
+
+```
+# requires Python 3.11+ — activate the project venv first:
+cd /path/to/agent-coherence && source .venv/bin/activate
+python -m examples.gate_effect_ordering.main
+```
+
+Offline, no API keys, no real deploy — it spawns a local coordinator subprocess
+and the "deploy" is an in-process ledger append. Exit code `0` iff the contract
+holds on **both** paths:
+
+- **negative control (no gate):** the agent fires the deploy on the stale base
+  (`app@sha-A`) after a peer promoted `app@sha-B` — the failure the gate prevents, and
+- **gated path:** that same deploy is **held** (`StaleView`), then fires on the
+  fresh base (`app@sha-B`) after `reacquire()`, and never ships the stale artifact.
+
+## What it shows
+
+Two actors share one versioned input, `build/base.json` (`{image, replicas}`).
+Actor A reads `base@v1`, plans a deploy from it, and gates the deploy on that
+version. Actor B promotes `base -> v2` in between. The gate re-reads at the effect
+boundary, sees the version moved, and **holds**: the deploy never fires on the
+base that no longer exists. A reacquires the fresh base, re-plans, and fires.
+
+```python
+from ccs.adapters import CoherentVolume, gate
+
+vol = CoherentVolume(root, managed=("build/**",))
+
+def plan_deploy(base_bytes):
+    base = json.loads(base_bytes)
+    return f"{base['image']} x{base['replicas']}"
+
+# fires the deploy only if build/base.json is unchanged since plan_deploy read it;
+# else raises StaleView BEFORE the deploy runs.
+gate(vol, "build/base.json", decide=plan_deploy, effect=run_deploy)
+```
+
+`gate()` is plain Python, so it drops into any agent loop identically — a
+LangGraph deploy node, a CrewAI task, or a raw CI script:
+
+```python
+def deploy_node(state):
+    gate(vol, "build/base.json", decide=lambda b: plan(state, b), effect=run_deploy)
+    return state
+```
+
+## Honest boundary
+
+- **Ordering, not rollback.** The gate fires *pre-effect* and never undoes a
+  fired deploy. For an escaping effect (a deploy, a PR, a charge) there is a
+  residual re-validate -> fire window this layer **narrows but cannot eliminate**.
+- **Cooperative opt-in.** The agent calls the gate; it is not magic interception.
+- **Single-host.** Both actors share one local coordinator with the same
+  `managed` globs. Coordinating agents on separate machines is out of scope here.
+- **Pure writes** use `CoherentVolume.write_cas_at(...)` directly — the atomic,
+  no-window path.
+
+## The same idea, one layer down
+
+Serious infra already does this freshness check. Terraform refuses to apply a
+saved plan built on a state that has moved: `Error: Saved plan is stale`. This
+demo brings that check to an agent's deploy. Builder example, not an enterprise
+CI product. Sibling demo `examples/effect_gate` shows the same primitive on a
+bare `replicas=` config.
+
+---
+Comparing notes on multi-agent coherence?
+https://github.com/Cohexa-ai/agent-coherence/discussions

--- a/examples/gate_effect_ordering/__init__.py
+++ b/examples/gate_effect_ordering/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+"""Deploy-on-moved-base demo — hold a build/deploy when its base config moved."""

--- a/examples/gate_effect_ordering/main.py
+++ b/examples/gate_effect_ordering/main.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+"""Deploy-on-moved-base demo — order a deploy against the base it was planned from.
+
+Buyer symptom (agentic SDLC / CI): "the deploy ran on a config/base that had
+already moved." A build agent reads the release base (image sha + replicas),
+plans a deploy from it, and then FIRES the deploy. In between, a peer promotes a
+new base. Without ordering, the agent fires the deploy it planned from the OLD
+base — it ships a superseded artifact and the peer's promotion is silently
+skipped. `gate()` re-reads the base at the effect boundary, sees the version
+moved, and HOLDs (raises the shipped `StaleView`) instead of firing on stale
+state; the agent reacquires the fresh base, re-plans, and fires on it.
+
+    python -m examples.gate_effect_ordering.main
+
+Runs BOTH paths and exits 0 iff the honest contract holds:
+  * negative control (no gate) FIRES the deploy on the stale base (the failure), and
+  * the gated path HOLDs that same deploy, then fires on the fresh base after reacquire.
+
+Single-host, offline, no API keys, no real deploy — it spawns a local coordinator
+subprocess and the "deploy" is an in-process ledger append.
+
+Honest boundary: `gate()` ORDERS effects (check-before-fire); it does NOT roll
+back a fired deploy. For an escaping effect there is a residual re-validate->fire
+window this layer narrows but cannot eliminate. Single-host, cooperative opt-in.
+A pure *write* effect uses `CoherentVolume.write_cas_at` directly (the atomic,
+no-window path). Sibling demo `examples/effect_gate` shows the same primitive on
+a bare `replicas=` config; this one dresses it in the CI/release-base workload.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from ccs.adapters.claude_code.lifecycle import (  # noqa: E402  (after sys.path setup)
+    LifecycleConfig,
+    stop_coordinator,
+)
+from ccs.adapters.coherent_volume import CoherentVolume  # noqa: E402
+from ccs.adapters.effect_gate import gate  # noqa: E402
+from ccs.core.exceptions import StaleView  # noqa: E402
+
+BASE = "build/base.json"
+BASE_A = b'{"image": "app@sha-A", "replicas": 2}'
+BASE_B = b'{"image": "app@sha-B", "replicas": 5}'
+
+
+def _fast_cfg() -> LifecycleConfig:
+    return LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0.1,
+        notice_evict_max_age_sec=1.0,
+        port_file_retry_attempts=20,
+        port_file_retry_interval_sec=0.05,
+        connect_retry_attempts=10,
+        connect_retry_interval_sec=0.05,
+    )
+
+
+def _plan_deploy(base_bytes: bytes) -> str:
+    """Turn a release base into the artifact a deploy would ship."""
+    base = json.loads(base_bytes)
+    return f"{base['image']} x{base['replicas']}"
+
+
+def run_baseline(root: Path) -> dict:
+    """Negative control: no gate. The agent plans from base@A, a peer promotes
+    base@B, and the agent fires the deploy it planned anyway — shipping the
+    superseded artifact. Returns a trace with the deploy ledger."""
+    (root / "build").mkdir(parents=True, exist_ok=True)
+    agent = CoherentVolume(root, managed=("build/**",), config=_fast_cfg())
+    ledger: list[str] = []
+    trace: dict = {"fired_stale": False, "shipped": None, "ledger": ledger}
+    try:
+        agent.write(BASE, BASE_A)
+        peer = CoherentVolume(root, managed=("build/**",), config=_fast_cfg())
+
+        base, _ = agent.read_with_version(BASE)
+        plan = _plan_deploy(base)  # planned from base@A
+
+        peer.write(BASE, BASE_B)  # base promoted to @B; no gate to catch it
+
+        ledger.append(plan)  # deploy FIRES on the plan from the moved base
+        trace["fired_stale"] = True
+        trace["shipped"] = plan
+        current = _plan_deploy(agent.reacquire(BASE))  # what SHOULD have shipped
+        print(
+            f"  x (no gate) deploy fired shipping {plan!r} while the base had "
+            f"already moved to {current!r} — peer's promotion silently skipped"
+        )
+        return trace
+    finally:
+        stop_coordinator(root)
+
+
+def run_gated(root: Path) -> dict:
+    """With the gate: a peer promotes the base mid-plan, so the deploy is HELD;
+    the agent reacquires, re-plans on base@B, and fires on fresh state."""
+    (root / "build").mkdir(parents=True, exist_ok=True)
+    agent = CoherentVolume(root, managed=("build/**",), config=_fast_cfg())
+    ledger: list[str] = []
+    trace: dict = {"held": False, "shipped": None, "ledger": ledger}
+    try:
+        agent.write(BASE, BASE_A)
+        peer = CoherentVolume(root, managed=("build/**",), config=_fast_cfg())
+
+        def decide(base_bytes: bytes) -> str:
+            # A peer promotes the base AFTER the agent read it (fixed-stale buffer).
+            peer.write(BASE, BASE_B)
+            return _plan_deploy(base_bytes)
+
+        def fire(plan: str) -> str:
+            ledger.append(plan)  # the mock deploy: append to the ledger, no network
+            return plan
+
+        print("  Agent reads base, plans a deploy, gates the deploy on that version...")
+        try:
+            gate(agent, BASE, decide=decide, effect=fire)
+            print("  x deploy FIRED on stale base (gate did not hold)")
+        except StaleView as held:
+            trace["held"] = True
+            print(
+                f"  ok HELD: base moved v{held.expected_version} -> "
+                f"v{held.current_version}; deploy NOT fired on stale base"
+            )
+
+        agent.reacquire(BASE)  # recover: fresh base, then re-plan + fire
+        shipped = gate(agent, BASE, decide=_plan_deploy, effect=fire)
+        trace["shipped"] = shipped
+        print(f"  ok after reacquire, deploy fired on fresh base: {shipped!r}")
+        return trace
+    finally:
+        stop_coordinator(root)
+
+
+def main(argv: list[str] | None = None) -> int:
+    print(
+        "Deploy-on-moved-base — fire the deploy only on the release base you "
+        "planned from.\n"
+    )
+
+    print("Negative control (no gate):")
+    with tempfile.TemporaryDirectory() as d:
+        baseline = run_baseline(Path(d))
+    print("")
+
+    print("With the gate:")
+    with tempfile.TemporaryDirectory() as d:
+        gated = run_gated(Path(d))
+
+    # The failure the gate prevents: baseline shipped the stale plan (from base@A).
+    baseline_fired_stale = bool(baseline["fired_stale"]) and baseline["shipped"] == (
+        "app@sha-A x2"
+    )
+    # The fix: the gate HELD the stale deploy, then shipped the fresh plan (base@B).
+    gated_held = bool(gated["held"])
+    gated_fired_fresh = gated["shipped"] == "app@sha-B x5"
+    gated_never_shipped_stale = "app@sha-A x2" not in gated["ledger"]
+
+    print("\nContract:")
+    print(f"  baseline fired the deploy on the STALE base : {baseline_fired_stale}")
+    print(f"  gate HELD the stale deploy                  : {gated_held}")
+    print(f"  gate fired on the FRESH base after reacquire: {gated_fired_fresh}")
+    print(f"  gate never shipped the stale artifact       : {gated_never_shipped_stale}")
+
+    print("\nTakeaway: without ordering, the agent ships an artifact planned from a")
+    print("base that already moved and the peer's promotion is silently skipped. The")
+    print("gate holds that deploy at the effect boundary, then fires it on fresh state")
+    print("after reacquire. Ordering, not rollback; single-host, cooperative — the")
+    print("freshness check Terraform does for a saved plan, brought to a deploy.")
+
+    ok = (
+        baseline_fired_stale
+        and gated_held
+        and gated_fired_fresh
+        and gated_never_shipped_stale
+    )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+# Comparing notes on multi-agent coherence?
+# https://github.com/Cohexa-ai/agent-coherence/discussions

--- a/examples/rag_stale_memory/README.md
+++ b/examples/rag_stale_memory/README.md
@@ -1,0 +1,78 @@
+# RAG stale-memory write-back — an agent clobbers a moved memory record
+
+> "A better vector DB won't help. My agent cached a memory record, the source
+> moved, and it wrote back a stale edit that erased the update."
+
+Two agents share one memory record — a RAG/memory entry for a customer:
+`{"summary": ..., "facts": [...]}`. Agent A reads it. Agent B learns a new fact
+and appends it (the record moves). Then agent A writes back an edit it computed
+from the snapshot it read *before* B's write — a refreshed summary carried on top
+of the old fact list. Without coordination, A's write-back silently overwrites
+B's appended fact: a lost update, and the incoherence is now baked into shared
+memory that every future retrieval will read.
+
+With `CoherentVolume`, B's write invalidates A's view, so A's stale write-back is
+**denied** (`StaleView`, fail-closed). A reacquires the current record, re-applies
+its edit intent (the summary refinement) on top of it, and writes — so B's fact
+and A's summary both survive.
+
+## What it proves
+
+- **Broken path** (`broken.py`, plain files): A's edit lands, B's fact is erased →
+  `lost_update = True`. This is the negative control.
+- **Fixed path** (`fixed.py`, CoherentVolume): A's stale write-back is denied, A
+  reacquires → re-reads the moved record → re-applies → converges. Both updates
+  survive → `lost_update = False`.
+
+The runner exits `0` **only if both hold** (broken must lose, fixed must prevent),
+so the red→green is machine-checked, not eyeballed.
+
+## Run it
+
+```bash
+cd /path/to/agent-coherence && source .venv/bin/activate
+python -m examples.rag_stale_memory.main
+```
+
+Sequenced, not raced — deterministic and offline (no API keys, no cost, no
+network). The fixed case spawns a local coordinator subprocess on `127.0.0.1`
+and tears it down.
+
+## Files
+
+| File | Role |
+|---|---|
+| `broken.py` | No coherence — A's write-back from an older snapshot erases B's appended fact (the lost update) |
+| `fixed.py` | CoherentVolume denies A's stale write; A reacquires and re-applies — no loss |
+| `main.py` | Runs both side by side, prints the divergence, exits non-zero if the invariant fails |
+
+## The supported API (explicit)
+
+```python
+from ccs.adapters.coherent_volume import CoherentVolume
+from ccs.core.exceptions import CoherenceError
+
+vol = CoherentVolume("/path/to/workspace", managed=("memory/**",))
+record = json.loads(vol.read("memory/customer.json").decode())   # registers a SHARED view
+# ... a peer appends a fact and writes it back, superseding this view ...
+try:
+    vol.write("memory/customer.json", edited(record))            # denied: your view is stale
+except CoherenceError:
+    fresh = json.loads(vol.reacquire("memory/customer.json").decode())  # re-mint + fresh read
+    vol.write("memory/customer.json", reapply(edit_intent, fresh))      # rewritten from current bytes — lands
+```
+
+The deny is **sticky**: a bare re-read does not clear it (so a naive retry stays
+denied rather than silently overwriting); recovery is `reacquire()`.
+
+## Honest boundary
+
+Prevents the **sequential** stale-read→write-back lost update on a single-host
+coordinator: a write derived from a superseded read is **denied** (`StaleView`)
+until the agent `reacquire()`s and re-applies. It does **not** merge two
+conclusions an agent has already recorded, does **not** serialize concurrent
+writers (use `write_cas` for the true race), and does **not** coordinate across
+hosts. Single OS user, one host, cooperative opt-in — every instance coordinating
+a workspace must declare the **same** `managed` globs. The recovery re-applies the
+edit *intent* on the fresh record; it does not auto-rebase an arbitrary in-flight
+buffer computed before the read.

--- a/examples/rag_stale_memory/__init__.py
+++ b/examples/rag_stale_memory/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""RAG stale-memory write-back demo — an agent clobbers a moved memory record.
+
+``broken.py`` reproduces the lost update over a plain memory file: an agent
+edits a record from a snapshot a peer already superseded, erasing the peer's
+update. ``fixed.py`` shows the same sequence denied (then recovered) through the
+CoherentVolume explicit API. Run both side by side with
+``python -m examples.rag_stale_memory.main``.
+"""

--- a/examples/rag_stale_memory/broken.py
+++ b/examples/rag_stale_memory/broken.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Broken case: a stale memory write-back erases a peer's update (lost update).
+
+A shared memory record holds an agent's working knowledge about a customer:
+``{"summary": ..., "facts": [...]}``. Two agents touch it. Agent A reads the
+record; agent B appends a freshly-learned fact and writes it back; then agent A
+writes an *edit it computed from the snapshot it read before B's write* — a
+refreshed summary carried on top of the OLD fact list. A's write-back silently
+overwrites B's appended fact: the classic RAG failure where "a better vector DB
+won't help — the agent cached a memory record, the source moved, and it wrote
+back a stale edit that erased the update."
+
+No coordinator is involved; that is the point. ``fixed.py`` shows the same
+sequence denied and recovered through CoherentVolume.
+
+Deterministic and offline — sequenced, not raced.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+# The record the two agents share (a RAG/memory entry for one customer).
+_V1 = {"summary": "Customer prefers email contact.", "facts": ["channel: email"]}
+# Fact B learns and appends while A is mid-edit.
+_B_FACT = "timezone: PST"
+# The summary refinement A wants to apply (A's edit intent).
+_A_SUMMARY = "Customer prefers email contact; flagged VIP."
+_SCENARIO = "two agents edit one shared memory record (A refines the summary, B appends a fact)"
+
+
+def _dumps(record: dict) -> str:
+    """Stable serialization so the demo is byte-deterministic."""
+    return json.dumps(record, sort_keys=True)
+
+
+def run_broken() -> dict[str, object]:
+    """Sequenced read→write with no coherence; A's stale edit clobbers B's fact.
+
+    Returns a structured trace so the runner and tests can assert the lost
+    update without parsing prose.
+    """
+    workspace = Path(tempfile.mkdtemp(prefix="rag_stale_memory_broken_"))
+    target = workspace / "memory.json"
+    try:
+        target.write_text(_dumps(_V1))
+
+        a_view = json.loads(target.read_text())  # agent A reads the record (v1)
+
+        # Agent B learns a new fact and writes the record back (this is v2).
+        b_view = json.loads(target.read_text())
+        b_view["facts"].append(_B_FACT)
+        target.write_text(_dumps(b_view))  # v2 on disk: facts include B's new fact
+
+        # Agent A now writes an edit computed from its PRE-B snapshot: it refreshes
+        # the summary but carries A's OLD fact list. B's appended fact is erased.
+        a_view["summary"] = _A_SUMMARY
+        target.write_text(_dumps(a_view))  # clobbers v2
+
+        final = json.loads(target.read_text())
+        b_fact_survived = _B_FACT in final["facts"]
+        a_edit_survived = final["summary"] == _A_SUMMARY
+        return {
+            "scenario": _SCENARIO,
+            "b_fact": _B_FACT,
+            "a_summary": _A_SUMMARY,
+            "final_facts": final["facts"],
+            "final_summary": final["summary"],
+            "b_fact_survived": b_fact_survived,  # False — B's update was erased
+            "a_edit_survived": a_edit_survived,
+            # A converged copy where BOTH survive is the goal; the lost update is
+            # exactly "A's edit landed but B's fact did not".
+            "lost_update": a_edit_survived and not b_fact_survived,
+        }
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def main() -> int:
+    trace = run_broken()
+    print("BROKEN (no coherence) — stale memory write-back over a plain file")
+    print(f"  scenario: {trace['scenario']}")
+    print(f"  B appended fact {trace['b_fact']!r}; A then wrote back its refreshed summary")
+    print(f"  final summary: {trace['final_summary']!r}")
+    print(f"  final facts:   {trace['final_facts']}")
+    print(
+        f"  LOST UPDATE: {trace['lost_update']}  "
+        f"(A's edit survived={trace['a_edit_survived']}, "
+        f"B's fact survived={trace['b_fact_survived']})"
+    )
+    # Exit code reflects the invariant so an agent can use this as a gate.
+    return 0 if trace["lost_update"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/rag_stale_memory/fixed.py
+++ b/examples/rag_stale_memory/fixed.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Fixed case: the same stale write-back, denied and recovered via CoherentVolume.
+
+Same sequence as ``broken.py`` — A reads the memory record, B appends a fact and
+writes it back, A writes an edit computed from its older snapshot — but routed
+through the CoherentVolume *explicit* API. B's write-back invalidates A's view;
+A's stale write is then **denied** (`StaleView`, fail-closed), so the lost update
+is prevented. A recovers with ``reacquire()`` (re-mint identity + a mandatory
+fresh read), re-applies its edit *intent* (the summary refinement) on top of the
+current record, and writes — so both B's fact and A's summary survive.
+
+The record is derived from ``read()``/``reacquire()`` bytes, then written back —
+this is exactly the supported "write from the bytes the API returned" shape.
+
+Sequenced, not raced: deterministic by construction. This spawns a local
+coordinator subprocess (no network, no API keys) and tears it down in ``finally``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+# A spawned coordinator subprocess must import ``ccs`` too; propagate the src
+# path so the demo also runs from a bare checkout (harmless when installed).
+_pp = os.environ.get("PYTHONPATH", "")
+if str(SRC_ROOT) not in _pp.split(os.pathsep):
+    os.environ["PYTHONPATH"] = f"{SRC_ROOT}{os.pathsep}{_pp}" if _pp else str(SRC_ROOT)
+
+from ccs.adapters.claude_code.lifecycle import LifecycleConfig, stop_coordinator  # noqa: E402  (after sys.path setup)
+from ccs.adapters.coherent_volume import CoherentVolume  # noqa: E402
+from ccs.core.exceptions import CoherenceError  # noqa: E402
+
+_V1 = {"summary": "Customer prefers email contact.", "facts": ["channel: email"]}
+_B_FACT = "timezone: PST"
+_A_SUMMARY = "Customer prefers email contact; flagged VIP."
+_REL = "memory/customer.json"
+_SCENARIO = "two agents edit one shared memory record (A refines the summary, B appends a fact)"
+
+# Snappy local spawn for a one-command demo; no idle shutdown mid-run.
+_DEMO_CFG = LifecycleConfig(
+    idle_shutdown_sec=0,
+    sweep_interval_sec=0.1,
+    port_file_retry_attempts=40,
+    port_file_retry_interval_sec=0.05,
+    connect_retry_attempts=20,
+    connect_retry_interval_sec=0.05,
+)
+
+
+def _dumps(record: dict) -> bytes:
+    """Stable serialization so the demo is byte-deterministic."""
+    return json.dumps(record, sort_keys=True).encode()
+
+
+def run_fixed() -> dict[str, object]:
+    """Sequenced read→write through CoherentVolume; A's stale write is denied,
+    then A recovers via reacquire() and no update is lost.
+
+    Returns a structured trace mirroring ``run_broken`` for side-by-side asserts.
+    """
+    workspace = Path(tempfile.mkdtemp(prefix="rag_stale_memory_fixed_"))
+    target = workspace / _REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(_V1, sort_keys=True))
+
+    # Agent A spawns the coordinator (strict on the managed glob); agent B is a
+    # sibling instance that attaches to the same coordinator.
+    vol_a = CoherentVolume(workspace, managed=("memory/**",), config=_DEMO_CFG)
+    try:
+        vol_b = CoherentVolume(workspace, managed=("memory/**",), config=_DEMO_CFG)
+
+        a_view = json.loads(vol_a.read(_REL).decode())  # A reads v1 (SHARED)
+
+        # Agent B appends a freshly-learned fact and writes it back -> A INVALID.
+        b_view = json.loads(vol_b.read(_REL).decode())
+        b_view["facts"].append(_B_FACT)
+        vol_b.write(_REL, _dumps(b_view))  # v2 committed
+
+        denied = False
+        denial_reason = ""
+        recovered = False
+        try:
+            # A attempts its stale write-back: refreshed summary on the OLD facts.
+            a_view["summary"] = _A_SUMMARY
+            vol_a.write(_REL, _dumps(a_view))
+        except CoherenceError as exc:
+            # PREVENTION: the lost update is denied, fail-closed.
+            denied = True
+            denial_reason = str(exc)
+            # RECOVERY: reacquire (re-mint + mandatory fresh read), re-apply A's
+            # edit INTENT (the summary refinement) on top of the current record —
+            # so B's appended fact and A's summary both survive.
+            fresh = json.loads(vol_a.reacquire(_REL).decode())  # reads v2
+            fresh["summary"] = _A_SUMMARY
+            vol_a.write(_REL, _dumps(fresh))
+            recovered = True
+
+        final = json.loads(target.read_text())
+        b_fact_survived = _B_FACT in final["facts"]
+        a_edit_survived = final["summary"] == _A_SUMMARY
+        return {
+            "scenario": _SCENARIO,
+            "b_fact": _B_FACT,
+            "a_summary": _A_SUMMARY,
+            "a_write_denied": denied,
+            "denial_reason": denial_reason,
+            "a_recovered_via_reacquire": recovered,
+            "final_facts": final["facts"],
+            "final_summary": final["summary"],
+            "b_fact_survived": b_fact_survived,  # True — nothing erased
+            "a_edit_survived": a_edit_survived,  # True — A's summary landed
+            "lost_update": a_edit_survived and not b_fact_survived,
+        }
+    finally:
+        stop_coordinator(workspace)
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def main() -> int:
+    trace = run_fixed()
+    print("FIXED (CoherentVolume) — the stale write-back is denied, then recovered")
+    print(f"  scenario: {trace['scenario']}")
+    print(f"  A's stale write denied: {trace['a_write_denied']}  (fail-closed)")
+    print(f"  A recovered via reacquire(): {trace['a_recovered_via_reacquire']}")
+    print(f"  final summary: {trace['final_summary']!r}")
+    print(f"  final facts:   {trace['final_facts']}")
+    print(
+        f"  LOST UPDATE: {trace['lost_update']}  "
+        f"(A's edit survived={trace['a_edit_survived']}, "
+        f"B's fact survived={trace['b_fact_survived']})"
+    )
+    # Exit code reflects the invariant so an agent can use this as a gate.
+    return 0 if not trace["lost_update"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/rag_stale_memory/main.py
+++ b/examples/rag_stale_memory/main.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Side-by-side runner for the RAG stale-memory write-back demo.
+
+Runs the broken case (no coherence → agent A's stale write-back clobbers the
+fact agent B appended) and the fixed case (CoherentVolume denies A's stale write,
+A reacquires and recovers → no update lost), and prints the divergence. Sequenced
+and offline — no API keys, no cost; the fixed case spawns a local coordinator
+subprocess.
+
+    python -m examples.rag_stale_memory.main
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from examples.rag_stale_memory import broken, fixed  # noqa: E402  (after sys.path setup)
+
+
+def main() -> int:
+    print("RAG stale-memory write-back — a moved memory record clobbered by a stale edit.")
+    print("Same read→edit→write-back sequence both times; only the coordination differs.\n")
+    broken_trace = broken.run_broken()
+    broken.main()
+    print("")
+    fixed_trace = fixed.run_fixed()
+    fixed.main()
+
+    print("\nTakeaway: without coherence, A's edit from an older snapshot silently")
+    print("erases the fact B appended (lost update). CoherentVolume denies that")
+    print("write-back fail-closed; A reacquires the current record and re-applies its")
+    print("edit — both B's fact and A's summary survive.")
+
+    # Exit non-zero unless the invariant held both ways (broken must lose, fixed
+    # must prevent) so CI / a reader can trust the run rather than eyeball it.
+    ok = bool(broken_trace["lost_update"]) and not bool(fixed_trace["lost_update"])
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+# Comparing notes on multi-agent coherence?
+# https://github.com/Cohexa-ai/agent-coherence/discussions

--- a/tests/test_ci_merge_gate_demo.py
+++ b/tests/test_ci_merge_gate_demo.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Smoke test for the CI merge-gate demo (examples/ci_merge_gate).
+
+Runs the demo in --baseline mode (which exercises BOTH the no-gate negative
+control and the with-gate hold-then-fire path) and asserts the honest contract
+holds (exit 0), plus exact final values, determinism, and the broken-vs-fixed
+divergence, so the demo cannot silently rot.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+STALE_MERGE = "merge PR#1 onto a1f9c04 (CI green vs a1f9c04)"
+FRESH_MERGE = "merge PR#1 onto b7e2d55 (CI green vs b7e2d55)"
+
+
+def test_ci_merge_gate_demo_exits_zero() -> None:
+    from examples.ci_merge_gate.main import main
+
+    assert main(["--baseline"]) == 0
+
+
+def test_baseline_fires_merge_on_stale_base() -> None:
+    from examples.ci_merge_gate.main import run_baseline
+
+    with tempfile.TemporaryDirectory() as d:
+        trace = run_baseline(Path(d))
+
+    assert trace["fired_stale"] is True
+    assert trace["merged"] == STALE_MERGE  # validated vs SHA-A...
+    assert trace["base_now"] == "b7e2d55"  # ...while the base already moved
+    assert trace["ledger"] == [STALE_MERGE]
+
+
+def test_gated_holds_then_merges_on_fresh_base() -> None:
+    from examples.ci_merge_gate.main import run_gated
+
+    with tempfile.TemporaryDirectory() as d:
+        trace = run_gated(Path(d))
+
+    assert trace["held"] is True
+    assert trace["merged"] == FRESH_MERGE
+    # The stale merge never lands: the only ledger entry is the fresh one.
+    assert trace["ledger"] == [FRESH_MERGE]
+
+
+def test_broken_vs_fixed_divergence_and_determinism() -> None:
+    from examples.ci_merge_gate.main import run_baseline, run_gated
+
+    with tempfile.TemporaryDirectory() as d:
+        baseline = run_baseline(Path(d))
+    with tempfile.TemporaryDirectory() as d:
+        gated_1 = run_gated(Path(d))
+    with tempfile.TemporaryDirectory() as d:
+        gated_2 = run_gated(Path(d))
+
+    # Divergence: no gate merges on the stale validation, the gate on the fresh one.
+    assert baseline["merged"] != gated_1["merged"]
+    assert baseline["merged"] == STALE_MERGE
+    assert gated_1["merged"] == FRESH_MERGE
+
+    # Determinism: the gated path lands the same trace on every run.
+    assert gated_1 == gated_2

--- a/tests/test_gate_effect_ordering_demo.py
+++ b/tests/test_gate_effect_ordering_demo.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Smoke test for the deploy-on-moved-base demo (examples/gate_effect_ordering).
+
+Runs the demo, which exercises BOTH the no-gate negative control (fires the
+deploy on the stale base) and the with-gate hold-then-fire-on-fresh path, and
+asserts the honest contract holds (exit 0), so the demo cannot silently rot.
+"""
+
+from __future__ import annotations
+
+
+def test_gate_effect_ordering_demo_exits_zero() -> None:
+    from examples.gate_effect_ordering.main import main
+
+    assert main([]) == 0

--- a/tests/test_rag_stale_memory_demo.py
+++ b/tests/test_rag_stale_memory_demo.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Offline tests for the RAG stale-memory write-back demo.
+
+Sequenced, deterministic: the broken case proves an edit written back from an
+older snapshot erases a peer's appended fact; the fixed case proves CoherentVolume
+denies that stale write-back (fail-closed) and recovers via reacquire() with no
+loss. The fixed case spawns a local coordinator subprocess (no network), so these
+double as the end-to-end check for the demo.
+"""
+
+from __future__ import annotations
+
+from examples.rag_stale_memory.broken import run_broken
+from examples.rag_stale_memory.fixed import run_fixed
+from examples.rag_stale_memory.main import main as run_main
+
+_B_FACT = "timezone: PST"
+_A_SUMMARY = "Customer prefers email contact; flagged VIP."
+
+# --- broken case (no coherence) --------------------------------------------
+
+
+def test_broken_loses_the_update() -> None:
+    trace = run_broken()
+    assert trace["lost_update"] is True
+    assert trace["a_edit_survived"] is True  # A's summary landed
+    assert trace["b_fact_survived"] is False  # B's appended fact was erased
+    assert _B_FACT not in trace["final_facts"]
+
+
+def test_broken_is_deterministic_across_runs() -> None:
+    # Sequenced, not raced — the lost update must reproduce every time.
+    assert all(run_broken()["lost_update"] is True for _ in range(10))
+
+
+# --- fixed case (CoherentVolume explicit API) ------------------------------
+
+
+def test_fixed_denies_stale_write_then_recovers() -> None:
+    trace = run_fixed()
+    assert trace["a_write_denied"] is True  # the stale write was denied fail-closed
+    assert trace["a_recovered_via_reacquire"] is True  # recovery via reacquire()
+    assert trace["lost_update"] is False
+    assert trace["b_fact_survived"] is True  # B's fact preserved
+    assert trace["a_edit_survived"] is True  # A's summary re-applied
+    assert _B_FACT in trace["final_facts"]
+    assert trace["final_summary"] == _A_SUMMARY
+    assert trace["denial_reason"]  # the coordinator's deny reason, surfaced verbatim
+
+
+def test_fixed_is_deterministic_across_runs() -> None:
+    # Sequenced by construction → always prevents (assert the correctness
+    # property, never pids or timing).
+    assert all(run_fixed()["lost_update"] is False for _ in range(2))
+
+
+# --- the divergence the demo exists to show --------------------------------
+
+
+def test_broken_and_fixed_diverge_on_the_same_scenario() -> None:
+    # Same read→edit→write-back sequence; only coherence differs.
+    broken_trace = run_broken()
+    fixed_trace = run_fixed()
+    assert broken_trace["b_fact_survived"] is False  # lost update
+    assert fixed_trace["b_fact_survived"] is True  # prevented + recovered
+    assert broken_trace["scenario"] == fixed_trace["scenario"]
+
+
+def test_runner_exits_zero_when_both_invariants_hold() -> None:
+    # Exit 0 only if broken loses AND fixed prevents.
+    assert run_main() == 0


### PR DESCRIPTION
## Summary
Three runnable, offline, exit-0-gated demos — built earlier but never committed to the repo (they existed only as untracked files on a stale branch). Each covers a lead ICP shape with a red→green negative control:

- **`examples/rag_stale_memory`** (Segment A) — stale memory write-back erases a peer's fact; `CoherentVolume` denies the stale write, reacquire + re-apply, both survive. Write-side via CoherentVolume/`reacquire`, **not** CCSStore.
- **`examples/ci_merge_gate`** (Segment B) — "three clean PRs, one broken product": merge on a base SHA a peer moved; `gate()` holds and re-fires on the fresh base.
- **`examples/gate_effect_ordering`** (Segment B) — deploy planned from a moved base; `gate()` holds and re-plans.

All single-host, cooperative; `gate()` orders effects (never rolls back). Stale `hipvlady` URLs updated to `Cohexa-ai`; Python-version notes aligned to 3.11+.

## Test plan
- [x] `tests/test_{rag_stale_memory,ci_merge_gate,gate_effect_ordering}_demo.py` — **11 pass** (via `uv`, v0.12.0 code)
- [x] All 3 `python -m examples.X.main` exit `0` with correct red→green output
- [x] `ruff check` clean (added `# noqa: E402` on post-`sys.path` imports, matching existing examples)