### PR TITLE
chore(glama): add glama.json + Dockerfile for MCP directory scoring

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Keep the Glama build context to the package + build metadata. The installed
+# distribution is src/ccs only (setuptools package-dir = src), and the build
+# reads pyproject.toml + README.md; nothing below is needed to build or run.
+.git
+.github
+tests
+benchmarks
+formal
+docs
+examples
+scripts
+*.pyc
+__pycache__
+.pytest_cache
+.ruff_cache
+uv.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Dockerfile for the stale-write-guard-fs MCP server.
+#
+# Consumed by the Glama MCP directory, which builds and runs the image to
+# introspect the server (its coherence / tool-definition score requires a
+# runnable release, not just a repo scan). Not part of the pip install path —
+# end users run `uvx --from "agent-coherence[mcp]" stale-write-guard-fs`.
+#
+# Builds the `mcp` extra from source and launches the stdio server via the
+# console script from pyproject.toml:
+#   [project.scripts] stale-write-guard-fs = "ccs.mcp.server:main"
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY . /app
+
+# The `mcp` extra is the only new runtime dep (official MCP SDK, pinned <2).
+# Version is a static attr (ccs.__version__), so no .git is needed to build.
+RUN pip install --no-cache-dir ".[mcp]"
+
+# stdio transport: Glama starts the process and reads tools/list to score it.
+ENTRYPOINT ["stale-write-guard-fs"]

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["hipvlady"]
+}


### PR DESCRIPTION
## Summary
- Add `glama.json` (maintainer handle) so the Glama MCP directory can verify org-owned authorship via GitHub auth.
- Add a `Dockerfile` that builds the `[mcp]` extra from source and runs the `stale-write-guard-fs` stdio server, so Glama can build a release and compute its coherence / tool-definition score (a repo scan alone leaves it "not tested / cannot be installed").
- Add `.dockerignore` to keep the build context to the `src` package + build metadata.

Directory-integration only. No change to library behavior or the end-user install path (`uvx --from "agent-coherence[mcp]" stale-write-guard-fs`).

## Notes
- `Dockerfile` ENTRYPOINT is the console script `stale-write-guard-fs = ccs.mcp.server:main` (pyproject `[project.scripts]`); the `[mcp]` extra provides the MCP SDK it imports.
- No README/guide change — nothing user-facing here.

## Test plan
- [ ] CI green (no `src/` or test changes; architecture check unaffected)
- [ ] Glama release build succeeds + server introspects (validated on Glama after merge + claim)