### PR TITLE
feat(examples): CCSStore read-side demo — the read/write split, runnable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to `agent-coherence` are documented here. The format follows
 
 Alpha — APIs may change before `v1.0`.
 
+## [Unreleased]
+
+### Added
+
+- **CCSStore read-side demo — `examples/ccsstore_read_side/`.** A three-act,
+  offline, deterministic demo that makes the read/write split legible: Act 1
+  shows the shipped read-side guarantee (a peer's commit invalidates the
+  cached view, so the next `get()` is a fresh miss serving the new version —
+  never a stale hit); Act 2 shows the documented boundary (`put()` is not
+  version-CAS — a stale write-back lands, silently erasing the peer's update);
+  Act 3 routes the same intent through `store.core.write_cas`, re-applying it
+  against the freshly read version so nothing is lost. Runs via
+  `python -m examples.ccsstore_read_side.demo` (or `uv run demo.py`
+  standalone); exit 0 iff every invariant held, so it doubles as a CI gate.
+  Tests: `tests/test_ccsstore_read_side_demo.py`.
+
+### Fixed
+
+- **Guide examples table: two broken commands.** `examples.divergent_memory`
+  and `examples.shared_knowledge_base` ship `demo.py`, not `main.py`; the
+  documented `python -m examples.<name>.main` commands failed. Corrected to
+  `.demo`.
+
 ## [0.12.0] - 2026-07-14
 
 Atomic multi-artifact publish (commit a *set* of files all-or-nothing), the

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -993,14 +993,15 @@ Use these to gate alerts or health checks without keeping a separate event list.
 
 ## Examples
 
-All examples are runnable with `python -m examples.<name>.main` from the project root.
+All examples are runnable with `python -m examples.<name>.main` (or `.demo` where noted) from the project root.
 
 Correctness demos lead; the token-savings / hit-rate demos follow.
 
 | Example | Command | What it shows |
 |---------|---------|---------------|
-| Shared knowledge base | `python -m examples.shared_knowledge_base.main` | Lost update in a shared RAG / memory corpus; `CoherentVolume` denies B's stale overwrite so both findings survive (offline, no keys) |
-| Divergent memory | `python -m examples.divergent_memory.main` | Two sessions record contradictory beliefs from a stale read; the stale write is denied fail-closed so the divergence never forms (offline, no keys) |
+| Shared knowledge base | `python -m examples.shared_knowledge_base.demo` | Lost update in a shared RAG / memory corpus; `CoherentVolume` denies B's stale overwrite so both findings survive (offline, no keys) |
+| Divergent memory | `python -m examples.divergent_memory.demo` | Two sessions record contradictory beliefs from a stale read; the stale write is denied fail-closed so the divergence never forms (offline, no keys) |
+| CCSStore read side | `python -m examples.ccsstore_read_side.demo` | Read-side invalidation on a LangGraph `BaseStore` (peer commit → next `get()` serves the new version), the `put()`-is-not-version-CAS boundary, and the `write_cas` fix (offline, no keys) |
 | Coherent volume | `python -m examples.coherent_volume.main` | Sequential stale-write deny + recovery on plain files (offline, no keys) |
 | Concurrent writers | `python -m examples.concurrent_writers.main` | True-race lost update; `write_cas` preserves both updates (offline, no keys) |
 | Effect gate | `python -m examples.effect_gate.main` | `gate()` holds an effect on a stale input; `--baseline` shows the stale fire (offline, no keys) |

--- a/examples/ccsstore_read_side/README.md
+++ b/examples/ccsstore_read_side/README.md
@@ -1,0 +1,50 @@
+# CCSStore read-side coherence — and the write-side boundary, honestly
+
+Your LangGraph agent read a `BaseStore` key a peer already updated and acted on
+the stale value. This demo shows exactly what `CCSStore` does about that — and,
+just as precisely, what it does **not** do.
+
+Two agents (`planner`, `reviewer`) share one artifact through the store. The
+namespace convention carries agent identity in position 0, so
+`("planner", "notes")` and `("reviewer", "notes")` address the **same**
+artifact.
+
+**Act 1 — read-side invalidation (the CCSStore guarantee).** The reviewer's
+repeat read is a local cache hit — no re-fetch, no re-broadcast. The moment the
+planner commits a new version, the reviewer's cached copy is invalidated: its
+next `get()` is a fresh miss that serves the new version. The stale hit an
+agent-local cache would have served never happens.
+
+**Act 2 — the boundary (broken by design).** `put()` is **not** version-CAS. A
+writer holding a snapshot from before a peer's commit can still write back, and
+the write lands — the peer's update is silently erased, no error raised.
+CCSStore keeps *readers* honest; it does not deny a stale *write-back*.
+
+**Act 3 — the write-side fix, one call away.** The same edit routed through
+`store.core.write_cas` (the OCC commit-CAS, shipped v0.9.1) re-applies the
+writer's intent against the freshly read version on every attempt. Both the
+peer's update and the writer's edit survive.
+
+## Run it
+
+```bash
+uv run demo.py
+# or
+pip install "agent-coherence[langgraph]>=0.12.0" && python demo.py
+# or, from a repo checkout
+python -m examples.ccsstore_read_side.demo
+```
+
+Offline, deterministic, no API keys, no model calls. Exit 0 iff every
+invariant held — it doubles as a CI gate.
+
+## Honest scope
+
+- One `CCSStore` instance, one Python process, one host. Two processes each
+  constructing a `CCSStore` share nothing — for cross-process state on one
+  host, put the shared state behind `CoherentVolume` or the
+  `stale-write-guard-fs` MCP server.
+- Read-side is the CCSStore guarantee. The write-side lost-update deny lives
+  in `write_cas` / `CoherentVolume` — that split is the point of this demo,
+  not a caveat hidden under it.
+- Cross-host coordination is roadmap (design-partner co-build), not shipped.

--- a/examples/ccsstore_read_side/demo.py
+++ b/examples/ccsstore_read_side/demo.py
@@ -1,0 +1,176 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["agent-coherence[langgraph]>=0.12.0"]
+# ///
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+#
+# Run it (no repo checkout, no API keys, offline):
+#
+#     uv run demo.py
+# or
+#     pip install "agent-coherence[langgraph]>=0.12.0" && python demo.py
+#
+"""CCSStore read-side coherence — and the write-side boundary, honestly.
+
+Two agents share one artifact through a LangGraph-style ``BaseStore``. The
+planner writes the decision; the reviewer reads it, caches it, and acts on it.
+
+**Act 1 — what CCSStore ships: read-side invalidation.** The reviewer's second
+read is a local cache hit (no re-fetch, no re-broadcast). The moment the
+planner commits a new version, the reviewer's cached copy is invalidated — its
+next ``get()`` is a fresh miss that returns the new version. The stale hit a
+plain agent-local cache would have served never happens.
+
+**Act 2 — what CCSStore does NOT do: ``put`` is not version-CAS.** A writer
+holding a snapshot from before a peer's commit can still write back, and the
+write lands — silently erasing the peer's update. No error is raised. This is
+the documented boundary, not a bug in the demo: CCSStore keeps *readers*
+honest; it does not deny a stale *write-back*.
+
+**Act 3 — the write-side fix, one call away in the same library.** The same
+edit routed through ``store.core.write_cas`` (the OCC commit-CAS shipped in
+v0.9.1) re-applies the writer's intent against the freshly read version on
+every attempt. Both the peer's update and the writer's edit survive — the
+lost update never forms.
+
+Honest scope: one CCSStore instance, one Python process, one host. Two
+processes each constructing a CCSStore share nothing — for cross-process
+state on one host use ``CoherentVolume`` or the ``stale-write-guard-fs`` MCP
+server. Deterministic, offline, no model calls. Exit 0 iff every invariant
+held.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from ccs.adapters import CCSStore
+from ccs.adapters.events import StoreMetricEvent
+from ccs.core.identity import artifact_uuid
+
+# namespace[0] is the agent identity; namespace[1:] is the shared artifact
+# scope, so ("planner", "notes") and ("reviewer", "notes") address ONE artifact.
+PLANNER = ("planner", "notes")
+REVIEWER = ("reviewer", "notes")
+KEY = "decision"
+
+
+def _reviewer_gets(events: list[StoreMetricEvent]) -> list[StoreMetricEvent]:
+    return [e for e in events if e.agent_name == "reviewer" and e.operation == "get"]
+
+
+def run_readside() -> dict[str, Any]:
+    """Act 1: peer commit invalidates the reviewer's cached view (FIXED-by-design)."""
+    events: list[StoreMetricEvent] = []
+    store = CCSStore(strategy="lazy", on_metric=events.append)
+
+    store.put(PLANNER, KEY, {"db": "postgres", "reason": "relational joins"})  # v1
+    first = store.get(REVIEWER, KEY)  # miss → coordinator fetch of v1
+    second = store.get(REVIEWER, KEY)  # local cache hit — no re-fetch
+
+    # The peer commits v2; the reviewer's cached copy goes INVALID.
+    store.put(PLANNER, KEY, {"db": "postgres", "reason": "relational joins", "status": "approved-in-review"})
+    third = store.get(REVIEWER, KEY)  # fresh miss → serves v2, never the stale hit
+
+    gets = _reviewer_gets(events)
+    return {
+        "first_was_miss": gets[0].cache_hit is False,
+        "second_was_local_hit": gets[1].cache_hit is True,
+        "post_commit_was_fresh_miss": gets[2].cache_hit is False,
+        "value_after_peer_commit": third.value if third else None,
+        "saw_new_version": bool(third and third.value.get("status") == "approved-in-review"),
+        "first_value": first.value if first else None,
+        "second_value": second.value if second else None,
+    }
+
+
+def run_broken_writeback() -> dict[str, Any]:
+    """Act 2: put() is not version-CAS — the stale write-back lands (BROKEN)."""
+    store = CCSStore(strategy="lazy")
+
+    store.put(PLANNER, KEY, {"db": "postgres"})
+    snapshot = store.get(REVIEWER, KEY).value  # reviewer's basis: v1
+
+    # The planner commits an update the reviewer never sees…
+    store.put(PLANNER, KEY, {"db": "postgres", "budget": "approved"})
+
+    # …and the reviewer writes back a value derived from its stale snapshot.
+    edited = dict(snapshot)
+    edited["owner"] = "reviewer"
+    store.put(REVIEWER, KEY, edited)  # lands — no version check on put()
+
+    final = store.get(PLANNER, KEY).value
+    return {
+        "planner_update_lost": "budget" not in final,
+        "reviewer_edit_present": final.get("owner") == "reviewer",
+        "final_value": final,
+    }
+
+
+def run_fixed_writeback() -> dict[str, Any]:
+    """Act 3: the same intent through store.core.write_cas — nothing is lost (FIXED)."""
+    store = CCSStore(strategy="lazy")
+
+    store.put(PLANNER, KEY, {"db": "postgres"})
+    store.get(REVIEWER, KEY)  # reviewer reads v1 (its stale basis)
+    store.put(PLANNER, KEY, {"db": "postgres", "budget": "approved"})
+
+    aid = artifact_uuid("notes", KEY)
+
+    def apply_reviewer_edit(entry: Any) -> tuple[str, None]:
+        # Invoked per attempt AFTER a fresh read — current is never stale here.
+        current = json.loads(store.core.content(agent_name="reviewer", artifact_id=aid) or "{}")
+        current["owner"] = "reviewer"
+        return json.dumps(current, sort_keys=True, separators=(",", ":")), None
+
+    store.core.write_cas(agent_name="reviewer", artifact_id=aid, make_content=apply_reviewer_edit, now_tick=0)
+
+    final = store.get(PLANNER, KEY).value
+    return {
+        "planner_update_survived": final.get("budget") == "approved",
+        "reviewer_edit_present": final.get("owner") == "reviewer",
+        "final_value": final,
+    }
+
+
+def main() -> int:
+    print("CCSStore read-side coherence — and the write-side boundary, honestly")
+    print("=" * 72)
+
+    print("\nAct 1 — read-side invalidation (what CCSStore ships)")
+    act1 = run_readside()
+    print(f"  reviewer's 1st get : coordinator fetch (miss)      → {act1['first_value']}")
+    print(f"  reviewer's 2nd get : local cache hit, no re-fetch  → {act1['second_value']}")
+    print("  planner commits v2 : reviewer's cached copy → INVALID")
+    print(f"  reviewer's 3rd get : fresh miss, never a stale hit → {act1['value_after_peer_commit']}")
+    ok1 = all(
+        act1[k] for k in ("first_was_miss", "second_was_local_hit", "post_commit_was_fresh_miss", "saw_new_version")
+    )
+    print(f"  invariant: the read after the peer commit served the NEW version — {'HELD' if ok1 else 'VIOLATED'}")
+
+    print("\nAct 2 — the boundary: put() is not version-CAS (BROKEN by design)")
+    act2 = run_broken_writeback()
+    print("  reviewer snapshots v1, planner commits budget=approved,")
+    print(f"  reviewer puts a v1-derived edit → it LANDS: {act2['final_value']}")
+    print(f"  the planner's update is silently gone: {act2['planner_update_lost']} — no error was raised")
+
+    print("\nAct 3 — the fix, one call away: store.core.write_cas (OCC)")
+    act3 = run_fixed_writeback()
+    print(f"  same stale-based intent, re-applied against the fresh version → {act3['final_value']}")
+    ok3 = act3["planner_update_survived"] and act3["reviewer_edit_present"]
+    print(f"  invariant: BOTH the peer's update and the edit survived — {'HELD' if ok3 else 'VIOLATED'}")
+
+    print("\nScope: one CCSStore, one process, one host. Cross-process on one host →")
+    print("CoherentVolume / stale-write-guard-fs. Docs: read-side is the CCSStore")
+    print("guarantee; the write-side deny lives in write_cas / CoherentVolume.")
+
+    all_held = ok1 and act2["planner_update_lost"] and act2["reviewer_edit_present"] and ok3
+    print(f"\n{'ALL INVARIANTS HELD — exit 0' if all_held else 'INVARIANT VIOLATED — exit 1'}")
+    return 0 if all_held else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ccsstore_read_side_demo.py
+++ b/tests/test_ccsstore_read_side_demo.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Offline tests for the CCSStore read-side demo.
+
+The demo's job is to make the read/write split legible: Act 1 proves the
+read-side invalidation guarantee (a peer commit turns the next get into a
+fresh miss serving the new version), Act 2 proves the documented boundary
+(put() is not version-CAS — a stale write-back lands), and Act 3 proves the
+write-side fix one call away (store.core.write_cas re-applies intent against
+the fresh version, nothing lost). In-process, deterministic, no network.
+"""
+
+from __future__ import annotations
+
+from examples.ccsstore_read_side.demo import (
+    main,
+    run_broken_writeback,
+    run_fixed_writeback,
+    run_readside,
+)
+
+# --- Act 1: read-side invalidation (the guarantee) --------------------------
+
+
+def test_repeat_read_is_a_local_cache_hit() -> None:
+    trace = run_readside()
+    assert trace["first_was_miss"] is True
+    assert trace["second_was_local_hit"] is True
+
+
+def test_peer_commit_invalidates_and_next_get_serves_new_version() -> None:
+    trace = run_readside()
+    assert trace["post_commit_was_fresh_miss"] is True
+    assert trace["saw_new_version"] is True
+    assert trace["value_after_peer_commit"]["status"] == "approved-in-review"
+
+
+# --- Act 2: the boundary (put is not version-CAS) ----------------------------
+
+
+def test_stale_writeback_lands_and_erases_the_peer_update() -> None:
+    trace = run_broken_writeback()
+    assert trace["planner_update_lost"] is True
+    assert trace["reviewer_edit_present"] is True
+    assert "budget" not in trace["final_value"]
+
+
+# --- Act 3: the fix (core.write_cas) -----------------------------------------
+
+
+def test_write_cas_preserves_both_updates() -> None:
+    trace = run_fixed_writeback()
+    assert trace["planner_update_survived"] is True
+    assert trace["reviewer_edit_present"] is True
+    assert trace["final_value"]["budget"] == "approved"
+    assert trace["final_value"]["owner"] == "reviewer"
+
+
+# --- The demo doubles as a CI gate -------------------------------------------
+
+
+def test_demo_main_exits_zero(capsys) -> None:
+    assert main() == 0
+    out = capsys.readouterr().out
+    assert "ALL INVARIANTS HELD" in out

--- a/tests/test_ccsstore_read_side_demo.py
+++ b/tests/test_ccsstore_read_side_demo.py
@@ -13,6 +13,10 @@ the fresh version, nothing lost). In-process, deterministic, no network.
 
 from __future__ import annotations
 
+import pytest
+
+pytest.importorskip("langgraph.store.base")
+
 from examples.ccsstore_read_side.demo import (
     main,
     run_broken_writeback,


### PR DESCRIPTION
## Summary
- Adds `examples/ccsstore_read_side/` — a three-act, offline, deterministic demo that makes the CCSStore read/write split legible:
  1. **Read-side invalidation** (the shipped guarantee): a peer's commit invalidates the cached view, so the next `get()` is a fresh miss serving the new version — never a stale hit.
  2. **The documented boundary**: `put()` is not version-CAS — a stale write-back lands and silently erases the peer's update, no error raised.
  3. **The fix, one call away**: the same intent through `store.core.write_cas` is re-applied against the freshly read version; both updates survive.
- Fixes two broken commands in the guide examples table (`divergent_memory` and `shared_knowledge_base` ship `demo.py`, not `main.py`).
- Adds an `[Unreleased]` CHANGELOG section.

Runs standalone (`uv run demo.py`, PEP-723 header) or from a checkout (`python -m examples.ccsstore_read_side.demo`). Exit 0 iff every invariant held, so it doubles as a CI gate.

## Test Plan
- [x] `tests/test_ccsstore_read_side_demo.py` — 5 tests, all passing (repeat-read cache hit; peer-commit invalidation serves new version; stale write-back lands (boundary); `write_cas` preserves both updates; `main()` exits 0)
- [x] Adjacent suite `tests/adapters/test_ccsstore.py` green (100 passed total)
- [x] `tools/check_architecture.py` passes
- [x] ruff check + format clean