### PR TITLE
chore(mcp-registry): sync server.json version to 0.12.0

### DIFF
--- a/server.json
+++ b/server.json
@@ -7,14 +7,14 @@
     "url": "https://github.com/Cohexa-ai/agent-coherence",
     "source": "github"
   },
-  "version": "0.11.0",
+  "version": "0.12.0",
   "websiteUrl": "https://agent-coherence.dev",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "agent-coherence",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- Bump `server.json` (top-level + pypi package) `0.11.0` → `0.12.0` to match the released package.

The registry manifest had drifted behind the published PyPI version (0.12.0). Syncing it so the `mcp-publisher` entry in the Official MCP Registry references the current release. Metadata-only; no code or behavior change.

## Test plan
- [ ] CI green (single metadata file; no src/test impact)
- [ ] `mcp-publisher publish` references 0.12.0 after this lands