### PR TITLE
feat(byo-substrate): coherence over the store you already run — Postgres row + S3 object bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,13 @@ docs/*
 !docs/reproduce.md
 !docs/security.md
 !docs/ccs-diagnose.md
+# docs/usage/byo-substrate.md is end-user-facing, but a bare "!" negation can't
+# re-include it while "docs/*" excludes its parent directory. Re-include the
+# directory, re-exclude its contents, then whitelist just this file — so the
+# rest of docs/usage/ stays local-only like everything else under docs/.
+!docs/usage/
+docs/usage/*
+!docs/usage/byo-substrate.md
 
 states/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ RAG corpora and agent memory are **shared mutable state**, so the stale-read→w
 - 📖 [User guide](docs/guide.md) — installation, namespace convention, strategies, observability, telemetry, examples, full API reference
 - 🔎 [RAG & shared memory](https://agent-coherence.dev/rag/) — coherence for retrieval corpora and agent memory stores, with the runnable lost-update demo
 - 🗂️ [Coherent workspace](#coherent-workspace-the-data-plane-for-shared-files) — `CoherentVolume`, the data-plane appliance for plain files shared across processes
+- 🧱 [BYO substrate](#byo-substrate-coherence-over-the-store-you-already-run) — `CoherentRow` / `CoherentObject`, the same coherence over a Postgres row or an S3 object you already run
 - 🛡️ [Foreign-edit guards](#foreign-edit-guards-writes-that-bypass-the-coordinator) — catch out-of-band edits (a human, a formatter, a script) at the read/write boundary
 - 🔌 [MCP server](#mcp-server-stale-write-guard-fs) — `stale-write-guard-fs`, the same guarantee for any MCP client, no Python integration required
 - 🚦 [Effect-ordering gate](#effect-ordering-gate) — `gate()`, fire an agent's effect only on the input version it decided from
@@ -253,6 +254,26 @@ versions = vol.atomic_publish([
 Either every member's version advances or none does, and a moved member holds the whole batch — a torn *commit* is never a reachable state, formally specified as the `NoPartialPublish` invariant in [`formal/tla/AtomicPublish.tla`](formal/tla/AtomicPublish.tla). A single-file publish takes the direct CAS path; a multi-file publish opens a [snapshot session](#multi-artifact-snapshot-sessions) so the versions it checks are captured at one point (no member read across a peer commit). Run it: `python -m examples.atomic_publish.main` (offline, deterministic, no keys), or add `--baseline` to see the file-by-file torn pair it prevents.
 
 **Scope, honestly.** The all-or-nothing guarantee is at the **coordinator commit** — that is what `NoPartialPublish` covers. Disk materialization happens *after* the commit and is best-effort: every file is staged to a temp then renamed into place, so a disk fault fails before any rename (disk stays uniformly old) and a rename failing partway raises a typed `PublishMaterializationError` naming exactly which files landed — never a bare error implying nothing published. This shrinks, but a crash between renames can't fully eliminate, the multi-file disk window (there is no POSIX multi-file atomic rename); on that error the coordinator is ahead of disk and you re-read + re-materialize. It is single-host and cooperative. The multi-file path also adds a small capture→commit window (the session open); a peer winning it **holds** the publish rather than tearing it. This is all-or-nothing *publish* of a file set — not rollback of effects that already escaped, and not write-skew prevention across sessions.
+
+## BYO substrate: coherence over the store you already run
+
+`CoherentVolume` puts coherence over files on disk. But shared agent state often lives in a store you already run — a Postgres row, an S3 object. **BYO-substrate bindings** bring the same coherence *over that store*, with the coordinator holding only metadata (a version, per-agent MESI, a fixed-width `content_hash`, an opaque substrate token) — **never the bytes**:
+
+```python
+from ccs.adapters.coherent_row import CoherentRow      # pip install "agent-coherence[coherent-row]"
+from ccs.adapters.coherent_object import CoherentObject  # pip install "agent-coherence[coherent-object]"
+
+# agent A reads a row it will edit over several steps
+row = CoherentRow(dsn=..., table="workspaces", artifact_id="ws-42")
+data, token = row.read("ws-42")
+# ... meanwhile agent B commits a new version through the binding ...
+# A's next binding-mediated read/act is DENIED before A writes:
+row.commit("ws-42", expected_token=token, new_bytes=revised)  # -> StaleView; reacquire() and re-decide
+```
+
+The value over the substrate's own conditional write (`UPDATE … WHERE version=?`, S3 `If-Match`): a bare CAS rejects A's write *at write time*; the binding tells A its **cached view went stale before it acts**, in the **same typed vocabulary** a file (`CoherentVolume`) or a store key (`CCSStore`) uses — one coherence surface over a row, an object, or a file. A declarative [Coherence Manifest](docs/guide.md#byo-substrate-bindings-coherentrow--coherentobject) wires each artifact to a substrate and an honest guarantee **tier**, with credentials as references (`secret-file:` / `aws-default`, never literals) and SSRF-constrained connection targets.
+
+**Scope, honestly.** v1 ships two `native-CAS` bindings (Postgres + S3) and a `forward-only` tier for action backends (a Slack post, a Gmail send — decision-input freshness only, no CAS). The value is **invalidation-before-act + cross-substrate uniformity**; the read-generation fence over a substrate is a documented roadmap item, **not claimed** — v1 OCC writers ride admit-on-absent + the version-CAS. Single-host and cooperative; when the substrate is itself distributed (S3, managed Postgres) the no-lost-update guarantee is the *substrate's* and identical with or without this layer. Run it: `python -m examples.coherent_row.main` / `examples.coherent_object.main` (offline, deterministic, no keys — an in-memory substrate stand-in; production points the same binding at real Postgres / S3). Full API, per-binding least-privilege, and the honest tier table: [BYO substrate bindings](docs/guide.md#byo-substrate-bindings-coherentrow--coherentobject).
 
 ## Status
 

--- a/docs/examples/manifest.example.yaml
+++ b/docs/examples/manifest.example.yaml
@@ -1,0 +1,53 @@
+# Coherence Manifest — EXAMPLE.
+#
+# ==========================================================================
+# DO NOT COMMIT REAL VALUES. This file is a template.
+#   - Credentials are ALWAYS references, never literals. The loader rejects
+#     an inline DSN password, a bare key, or an unknown prefix as a suspected
+#     literal at load time.
+#   - Connection targets are SSRF-constrained: the loader denies a target that
+#     resolves into the cloud-metadata / link-local class, and (without the
+#     CCS_SUBSTRATE_ALLOW_PRIVATE opt-in) an RFC-1918/4193 private range.
+#   - A plaintext credential to a routable host is refused unless
+#     CCS_SUBSTRATE_INSECURE acknowledges an out-of-band-secured link. Prefer
+#     TLS: postgres sslmode=require/verify-full, or an https S3 endpoint.
+# ==========================================================================
+#
+# Credential reference forms (allowlist), most-preferred first:
+#   secret-file:/path        secret read from a 0600 file (never inline)
+#   aws-default              ambient IAM — zero secret in the manifest
+#   secret:<provider>:<id>   an allowlisted secret manager
+#   env:VARNAME              least-preferred (leaks in `ps` / crash dumps)
+
+artifacts:
+  # A native-CAS Postgres row. native-cas REQUIRES a version_source (the whole
+  # guarantee rides the substrate-minted token). The DSN carries the host + TLS
+  # mode ONLY — the password is a separate secret-file reference.
+  - id: agent-workspace-config
+    substrate: postgres
+    tier: native-cas
+    version_source: trigger-managed version column
+    connection:
+      dsn: "host=db.internal.example.com port=5432 dbname=app sslmode=verify-full"
+      credential: "secret-file:/run/secrets/pg_password"
+
+  # A native-CAS S3 object with ambient IAM (no secret in the manifest). The
+  # ETag is the substrate-minted version. Omitting endpoint_url uses the region's
+  # public AWS endpoint (https); set an https endpoint_url only for an
+  # S3-compatible store, never an MRAP / cross-region replica.
+  - id: agent-brief-object
+    substrate: s3
+    tier: native-cas
+    version_source: object ETag
+    connection:
+      region: "us-east-1"
+      credential: "aws-default"
+
+  # A forward-only (effectful) action backend — an RPC-style "write" (posting a
+  # message) with no token and nothing to compare. forward-only FORBIDS a
+  # version_source; the honest offer is decision-input freshness before the
+  # effect fires, never CAS/rollback/duplicate-effect prevention.
+  - id: incident-notify
+    substrate: slack
+    tier: forward-only
+    connection: "secret-file:/run/secrets/slack_token"

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -28,21 +28,22 @@ full command-line toolset, and the API reference.
 8. [Crash recovery](#crash-recovery)
 9. [Version retention and read-at-version](#version-retention-and-read-at-version)
 10. [Coherent workspace (`CoherentVolume`)](#coherent-workspace-coherentvolume)
-11. [Multi-artifact snapshot sessions](#multi-artifact-snapshot-sessions)
-12. [`stale-write-guard-fs` MCP server](#stale-write-guard-fs-mcp-server)
-13. [Inline benchmark mode](#inline-benchmark-mode)
-14. [Telemetry](#telemetry)
-15. [Graceful degradation](#graceful-degradation)
-16. [Examples](#examples)
-17. [Real-workload benchmarks](#real-workload-benchmarks)
-18. [Benchmarking your own workload](#benchmarking-your-own-workload)
-19. [`ccs-diagnose` — detect stale reads](#ccs-diagnose--detect-stale-reads)
-20. [Replay (v0.8.2+)](#replay-v082)
-21. [Command-line tools](#command-line-tools)
-22. [API reference](#api-reference)
-23. [Low-level adapter API](#low-level-adapter-api)
-24. [CrewAI and AutoGen adapters](#crewai-and-autogen-adapters)
-25. [OpenAI Agents SDK adapter (experimental)](#openai-agents-sdk-adapter-experimental)
+11. [BYO substrate bindings (`CoherentRow`, `CoherentObject`)](#byo-substrate-bindings-coherentrow--coherentobject)
+12. [Multi-artifact snapshot sessions](#multi-artifact-snapshot-sessions)
+13. [`stale-write-guard-fs` MCP server](#stale-write-guard-fs-mcp-server)
+14. [Inline benchmark mode](#inline-benchmark-mode)
+15. [Telemetry](#telemetry)
+16. [Graceful degradation](#graceful-degradation)
+17. [Examples](#examples)
+18. [Real-workload benchmarks](#real-workload-benchmarks)
+19. [Benchmarking your own workload](#benchmarking-your-own-workload)
+20. [`ccs-diagnose` — detect stale reads](#ccs-diagnose--detect-stale-reads)
+21. [Replay (v0.8.2+)](#replay-v082)
+22. [Command-line tools](#command-line-tools)
+23. [API reference](#api-reference)
+24. [Low-level adapter API](#low-level-adapter-api)
+25. [CrewAI and AutoGen adapters](#crewai-and-autogen-adapters)
+26. [OpenAI Agents SDK adapter (experimental)](#openai-agents-sdk-adapter-experimental)
 
 ---
 
@@ -726,6 +727,71 @@ certificate requirements live in
 > An internal, experimental seam formalizes what a networked registry backend
 > would have to provide; it is not a public extension point, and there is nothing
 > for end users to configure today.
+
+## BYO substrate bindings (`CoherentRow`, `CoherentObject`)
+
+`CoherentVolume` brings coherence to files on disk. **BYO-substrate bindings** bring the same coherence to shared state that lives in a store you already run — a Postgres row, an S3 object — while the coordinator holds only coherence metadata (a monotonic version, per-agent MESI, a fixed-width `content_hash`, and optionally an opaque substrate token) and **never the bytes**. The bytes stay in your substrate; the coherence layer drops *under* it.
+
+Install the binding you need (the drivers are optional extras):
+
+```bash
+pip install "agent-coherence[coherent-row]"     # Postgres — psycopg v3
+pip install "agent-coherence[coherent-object]"  # S3 — boto3
+```
+
+### What you get over the substrate's own CAS
+
+A substrate's native conditional write (`UPDATE … WHERE version = ?`, S3 `If-Match`) already rejects a single lost update — *at write time*. The binding adds the **cross-agent** layer over it:
+
+- **Invalidation-before-act.** A peer's commit marks your cached read stale, so your next binding-mediated read/act is denied *before* you act on the moved state — the bare CAS never surfaces that.
+- **Cross-substrate uniformity.** The same typed conflict (`StaleView` / `CasVersionConflict`) and the same `deny → reacquire()` recovery over a row, an object, a file (`CoherentVolume`), or a store key (`CCSStore`) — one coherence surface, not per-substrate error handling.
+
+```python
+from ccs.adapters.coherent_row import CoherentRow
+
+row = CoherentRow(dsn="postgresql://…", table="workspaces")
+data, token = row.read("ws-42")               # (bytes, token) from ONE read
+# ... a peer commits a new version through the binding ...
+row.commit("ws-42", expected_token=token, new_bytes=revised)
+#   -> StaleView: your cached view moved. reacquire() for fresh bytes, re-decide, retry.
+```
+
+`CoherentObject` (S3) has the identical surface; its token is the object ETag, captured from the `put_object` response (never computed).
+
+### Guarantee tiers (honest by construction)
+
+Every binding declares a `CapabilityDescriptor` with a **tier**; the guarantee wording a user sees is derived from the tier, so a weaker binding can never present as enforcement:
+
+| Tier | Substrate shape | Honest guarantee |
+|---|---|---|
+| `native-CAS` | atomic conditional write (PG version column, S3 `If-Match`) | no-lost-update on the version-CAS axis, **single-host**, with the timeout asterisk below |
+| `detect-only` | no atomic conditional write | catches a *sequential* stale-read→write; cannot prevent a concurrent race |
+| `forward-only` | an action / RPC (a Slack post, a Gmail send) — no object, no token | **effect ordering only**: decision-input freshness via deny-before-act; no CAS, no rollback, no duplicate-effect prevention |
+
+### Coherence Manifest
+
+A declarative manifest binds each artifact to a substrate + connection + tier, and is a named **trust boundary**. Credentials are references, never literals (`secret-file:PATH`, `aws-default`, `secret:uri`, or a least-preferred `env:VAR`); connection targets are SSRF-constrained — the deny runs on the *resolved* address (metadata/link-local hard-denied, RFC-1918 allowed only under an explicit `CCS_SUBSTRATE_ALLOW_PRIVATE` opt-in), and a plaintext credential to a routable host is refused unless `CCS_SUBSTRATE_INSECURE` is acked. `dry_run()` prints each artifact's tier at config time. See `docs/examples/manifest.example.yaml`.
+
+### Least-privilege (provision the substrate down to what the binding needs)
+
+- **Postgres** — a dedicated, login-limited **non-owner** role granted only `SELECT, UPDATE` on the one table (no `ALTER` / `TRIGGER` / `DELETE` / re-grant, `NOSUPERUSER NOCREATEDB NOCREATEROLE`), plus an **owner-managed** `BEFORE INSERT/UPDATE` trigger that mints `version := OLD.version + 1` from the *stored* prior — so a client that supplies its own `NEW.version` cannot forge it. `CoherentRow.provisioning_sql(...)` emits (never executes) both.
+- **S3** — an IAM policy scoped to the exact key/prefix ARN with `s3:GetObject` + `s3:PutObject` only and explicit denies (no `s3:*`, no `s3:DeleteObject`), plus an **owner-managed** bucket policy that *requires* conditional writes (`Deny s3:PutObject` when `Null s3:if-match true`, with the `s3:ObjectCreationOperation` multipart exemption). `CoherentObject.conditional_write_bucket_policy(...)` / `least_privilege_iam_policy(...)` emit the verified shape.
+
+### Honest scope
+
+- **The read-generation fence over a substrate is a roadmap item, not shipped.** v1 OCC writers ride the fence's admit-on-absent path + the version-CAS. Nothing in these bindings claims the fence.
+- **`native-CAS`, with the timeout asterisk.** The substrate CAS prevents the concurrent single-host lost update on the token axis; a coordinator-timeout *after* a durable substrate write is reconverged by a token-identity re-read, and registry↔substrate agreement is a *detectable signal*, not a held guarantee.
+- **Single-host, subtractive.** When the substrate is itself distributed (S3, managed Postgres), the no-lost-update guarantee is the *substrate's* and is identical with or without this layer; the adapter's contribution (invalidation, uniformity) is single-host. Never run the S3 CAS loop through a Multi-Region Access Point / cross-Region replica, and never place agents on two hosts against one distributed substrate.
+- **Coordinator-behind-substrate is unbounded in v1.** If a writer's substrate write lands but its process dies before the coordinator bump, peers are not invalidated until the *next* binding-mediated read of that artifact — a peer acting on an already-cached read is unprotected until it re-reads. Repair-forward is a roadmap item.
+
+### Try it, then harden
+
+```bash
+python -m examples.coherent_row.main               # offline, no keys — an in-memory substrate stand-in
+python -m examples.coherent_object.main --baseline # see the silent stale act the binding catches
+```
+
+The demos run offline against a local coordinator with an in-memory substrate stand-in so the coordinator-mediated value (invalidation-before-act) is visible with zero setup. For production, point the same binding at a real Postgres / S3 and provision the least-privilege role/policy above. The tier-honesty conformance suite exercises both bindings against **real** substrates behind the `real_substrate` pytest marker (credentialed; `CCS_TEST_PG_DSN`, `CCS_REAL_S3_BUCKET`) — Moto/LocalStack are excluded because they serialize and would false-green a concurrency test.
 
 ## Multi-artifact snapshot sessions
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -783,6 +783,7 @@ A declarative manifest binds each artifact to a substrate + connection + tier, a
 - **`native-CAS`, with the timeout asterisk.** The substrate CAS prevents the concurrent single-host lost update on the token axis; a coordinator-timeout *after* a durable substrate write is reconverged by a token-identity re-read, and registry↔substrate agreement is a *detectable signal*, not a held guarantee.
 - **Single-host, subtractive.** When the substrate is itself distributed (S3, managed Postgres), the no-lost-update guarantee is the *substrate's* and is identical with or without this layer; the adapter's contribution (invalidation, uniformity) is single-host. Never run the S3 CAS loop through a Multi-Region Access Point / cross-Region replica, and never place agents on two hosts against one distributed substrate.
 - **Coordinator-behind-substrate is unbounded in v1.** If a writer's substrate write lands but its process dies before the coordinator bump, peers are not invalidated until the *next* binding-mediated read of that artifact — a peer acting on an already-cached read is unprotected until it re-reads. Repair-forward is a roadmap item.
+- **More backends are demand-gated, not shipped.** A Letta vendor-memory sidecar is a post-v1 candidate: Letta exposes no atomic conditional-write token, so a binding could only *detect* a sequential stale write via a client-held content shadow, not prevent a concurrent one — it would be a `detect-only` tier and lands only when a concrete need pulls it in.
 
 ### Try it, then harden
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,21 +8,45 @@ published wheel.
 
 ## Outbound network destinations
 
-`agent-coherence` and its `[diagnose]` extra make **zero outbound network
-requests** in v0. No submission code ships in v0.
+The core `agent-coherence` package and its `[diagnose]` extra make **zero
+outbound network requests** in v0 — no telemetry, no submission code, no phoning
+home. Exactly two capabilities make deliberate, opt-in, **user-configured**
+outbound connections, and nothing else does: cross-host coordinator mode and the
+bring-your-own-substrate bindings (both below). Each connects only to an endpoint
+you configure — never the internet at large, never an agent-coherence-controlled
+host.
 
-If you find any outbound traffic from this package in v0, please [open a
-security advisory](https://github.com/Cohexa-ai/agent-coherence/security/advisories)
+If you find outbound traffic from this package that is neither of those two
+opt-in paths, please [open a security advisory](https://github.com/Cohexa-ai/agent-coherence/security/advisories)
 — it would be a bug.
 
 **Cross-host mode (default OFF).** Setting `CCS_REMOTE_COORDINATOR=1` and pointing
 a `CoherentVolume` at a remote coordinator (`CCS_REMOTE_HOST` / `CCS_REMOTE_PORT` /
 `CCS_REMOTE_SECRET_FILE`) makes the client open connections to that
 **user-configured, private-range coordinator endpoint** — never the internet, and
-no telemetry. This is the only host-leaving traffic the library generates, it is opt-in,
-and the coordinator only binds beyond loopback to an RFC-1918/4193 address (see the
-cross-host demo, `examples/cross_host/`). With the flag unset the zero-outbound
-posture above is unchanged.
+no telemetry. This host-leaving traffic is opt-in, and the coordinator only binds
+beyond loopback to an RFC-1918/4193 address (see the cross-host demo,
+`examples/cross_host/`). With the flag unset the zero-outbound posture above is
+unchanged.
+
+**BYO substrate bindings (default OFF).** The optional `[coherent-row]` (Postgres)
+and `[coherent-object]` (S3) extras connect to the substrate you declare in a
+Coherence Manifest — your own database or object store, never the internet at
+large and never an agent-coherence-controlled host. Every connection target is
+egress-controlled at manifest-load time, before any driver is built: the SSRF deny
+runs on the **resolved** address (cloud-metadata, link-local, and CGNAT ranges are
+hard-denied; RFC-1918/4193 private ranges require `CCS_SUBSTRATE_ALLOW_PRIVATE=1`),
+TLS is required unless you acknowledge a plaintext link with
+`CCS_SUBSTRATE_INSECURE=1`, an inline secret in a DSN or endpoint URL is refused
+(supply a credential *reference*, never a literal), and a target this loader
+cannot classify — a Postgres `service=` entry whose host lives in an unreadable
+`pg_service.conf` — is refused outright. Two residuals to know: libpq and botocore
+re-resolve DNS at connect time, so a bare hostname carries a narrow connect-time
+rebind window; and the `PGHOST` / `PGHOSTADDR` / `PGSERVICE` environment variables
+are invisible to a DSN-text parser — pin `host`/`hostaddr` in the manifest if you
+rely on egress control. The coordinator itself still receives metadata only (a
+content hash, never your bytes); the bytes live in your substrate, which is the
+whole point.
 
 **Client TLS (verified https).** The client can speak `https://` to a
 TLS-terminating front with **enforced certificate verification**. Set

--- a/docs/usage/byo-substrate.md
+++ b/docs/usage/byo-substrate.md
@@ -1,0 +1,219 @@
+# BYO substrate: a hands-on walkthrough
+
+This is the task-oriented companion to the reference in
+[the guide](../guide.md#byo-substrate-bindings-coherentrow-coherentobject). It
+walks from the zero-setup demo to a real Postgres row and a real S3 object, and
+explains — in operational terms — what happens when two agents race.
+
+**What a BYO-substrate binding is.** Coherence over shared state that lives in a
+store *you already run* — a Postgres row, an S3 object — instead of a store this
+library ships. The coordinator holds only coherence metadata (a monotonic
+version, per-agent MESI state, a fixed-width `content_hash`, and an opaque
+substrate token); it **never holds your bytes**. The bytes stay in your
+substrate. The coherence layer drops *under* it.
+
+**What it buys you over the substrate's own conditional write.** A native
+`UPDATE … WHERE version = ?` or an S3 `If-Match` already rejects a single lost
+update — but only *at the moment you write*. The binding adds the cross-agent
+layer on top: a peer's commit marks your cached read **stale**, so your next
+read or write is denied *before* you act on state that already moved — the thing
+a bare conditional write can never surface — and every substrate speaks the
+**same** typed conflict and the same `reacquire()` recovery.
+
+---
+
+## 1. Sixty seconds, offline, no credentials
+
+Both demos run against a local coordinator with an in-memory substrate stand-in,
+so the cross-agent value is visible with zero setup:
+
+```bash
+python -m examples.coherent_row.main                # the two-agent race, guarded
+python -m examples.coherent_object.main --baseline  # the SAME race, unguarded — the silent clobber
+```
+
+Run the `--baseline` form first: it shows the stale write landing silently (the
+lost update). The guarded form shows the second agent denied with a typed
+`StaleView` before it can clobber, then recovering. That contrast is the whole
+product.
+
+---
+
+## 2. A real Postgres row
+
+Install the driver (an optional extra):
+
+```bash
+pip install "agent-coherence[coherent-row]"     # psycopg v3
+```
+
+### 2a. Provision the table once (least privilege)
+
+The binding never runs DDL for you — it *emits* it so you (or your DBA) apply it
+deliberately. `provisioning_sql()` returns a version-guard trigger, the
+least-privilege role, and a one-time backfill:
+
+```python
+from ccs.adapters.coherent_row import provisioning_sql
+
+print(provisioning_sql("workspaces").as_script())
+```
+
+What it emits, and why:
+
+- An **owner-managed** `BEFORE INSERT/UPDATE` trigger that sets the new version
+  from the *stored* prior row (`COALESCE(OLD.version, 0) + 1`) — so a client that
+  supplies its own `NEW.version` cannot forge one, and a pre-existing row sitting
+  at `NULL`/`0` still advances to a usable value.
+- A **dedicated, non-owner, login-limited** role granted only `SELECT, UPDATE` on
+  the one table — no `ALTER`, no `TRIGGER`, no `DELETE`, no re-grant — so the
+  coherence role cannot disable the guard it runs under.
+- A one-time **backfill** (`UPDATE … SET version = 1 WHERE version IS NULL OR
+  version <= 0`) so rows that predate the version column can be onboarded — the
+  binding refuses a version `<= 0` as a comparand, so without this a legacy row
+  would be unreadable and therefore un-writable through the binding.
+
+Apply the script as the table owner. The agents then connect as the limited role.
+
+### 2b. Use it
+
+```python
+from ccs.adapters.coherent_row import CoherentRow
+
+row = CoherentRow(dsn="postgresql://coherence_writer@db.internal/app", table="workspaces")
+
+data, token = row.read("ws-42")                 # (bytes, token) from ONE read
+revised = transform(data)
+row.commit("ws-42", expected_token=token, new_bytes=revised)
+# If a peer committed since your read, this raises StaleView — reacquire and retry:
+#   data, token = row.reacquire("ws-42"); revised = transform(data); row.commit(...)
+```
+
+A self-owned connection (constructed from a `dsn`) carries a `connect_timeout`
+and a per-statement `statement_timeout` by default, so a hung database surfaces a
+reconcilable error instead of blocking forever; tune them via the constructor.
+An injected `connection=` is treated as caller-owned — its pool and its timeouts
+are yours to manage.
+
+---
+
+## 3. A real S3 object
+
+```bash
+pip install "agent-coherence[coherent-object]"  # boto3
+```
+
+The surface is identical; the token is the object **ETag**, captured from the
+`put_object` response (never computed client-side):
+
+```python
+from ccs.adapters.coherent_object import CoherentObject
+
+obj = CoherentObject(bucket="briefs", key_prefix="ws/")
+data, token = obj.read("ws-42")
+obj.commit("ws-42", expected_token=token, new_bytes=revise(data))
+```
+
+### Provision the bucket down to what the binding needs
+
+`CoherentObject` emits (never applies) two verified policy shapes:
+
+- `least_privilege_iam_policy(...)` — a role policy scoped to the exact
+  key/prefix ARN with `s3:GetObject` + `s3:PutObject` only, and explicit denies
+  (no `s3:*`, no `s3:DeleteObject`).
+- `conditional_write_bucket_policy(...)` — an **owner-managed** bucket policy that
+  *requires* conditional writes (`Deny s3:PutObject` when `s3:if-match` is null),
+  so a writer that skips the `If-Match` guard is refused by the bucket itself.
+
+---
+
+## 4. Wiring several artifacts declaratively (the manifest)
+
+Instead of constructing bindings in code, a **Coherence Manifest** binds each
+artifact id to a substrate, a connection, a credential *reference*, and a tier.
+It is a named trust boundary: every security decision is taken at load time,
+before any driver is built.
+
+```yaml
+# see docs/examples/manifest.example.yaml for the full annotated form
+artifacts:
+  - id: workspace-row
+    substrate: postgres
+    tier: native-cas
+    version_source: trigger-managed version column
+    connection:
+      dsn: "postgresql://coherence_writer@db.internal/app"
+      credential: "secret-file:/run/secrets/pg"     # a reference, never a literal
+```
+
+```python
+from ccs.adapters.substrate_manifest import load_manifest
+
+manifest = load_manifest("coherence.yaml")   # SSRF + credential-form + TLS checks run HERE
+manifest.dry_run()                            # prints each artifact's tier before anything is touched
+```
+
+Load-time guarantees (see [the security guide](../security.md#outbound-network-destinations)
+for the full posture):
+
+- **Credentials are references, never literals** — a `dsn` (or S3 `endpoint_url`)
+  carrying an inline password/userinfo is refused.
+- **Connection targets are SSRF-constrained** — the deny runs on the *resolved*
+  address (cloud-metadata, link-local, and carrier-NAT ranges are hard-denied;
+  private ranges require an explicit `CCS_SUBSTRATE_ALLOW_PRIVATE=1` opt-in).
+- **Plaintext to a routable host is refused** unless you acknowledge it with
+  `CCS_SUBSTRATE_INSECURE=1`.
+
+---
+
+## 5. What happens when two agents race
+
+| You see | It means | You do |
+|---|---|---|
+| `StaleView` | a peer committed since your read; your cached view is stale | `reacquire()` for fresh bytes, recompute, retry |
+| `CasVersionConflict` | your write lost the version race at the substrate | re-read at the current version, recompute, retry |
+| `CommitUnconfirmed` | the write may or may not have landed (a driver/coordinator blip) | **do not blind-retry** — re-read; the binding's reconciliation decides whether it already landed |
+| `ViewWedged` | the substrate moved out of band of the coordinator (e.g. a foreign edit, or a writer that died between its two commit legs) | `reacquire()` and re-decide |
+
+The one rule that matters: **never blind-retry an unconfirmed write.** The binding
+reconciles by re-reading and comparing the stored version and content fingerprint
+against what you intended — so a write that *did* land is recognized as yours (no
+double-apply), and one that didn't is retried cleanly.
+
+---
+
+## 6. Honest scope (read before you rely on it)
+
+The full list is in [the guide](../guide.md#honest-scope); the load-bearing
+points:
+
+- **Single-host.** The cross-agent guarantee (invalidation, uniformity) is
+  single-host. When the substrate is itself distributed (S3, managed Postgres),
+  the no-lost-update guarantee is the *substrate's* and is identical with or
+  without this layer. Do not run the S3 loop through a Multi-Region Access Point
+  or a cross-Region replica, and do not place agents on two hosts against one
+  distributed substrate.
+- **A crash between the two commit legs is unbounded in v1.** If a writer's
+  substrate write lands but its process dies before the coordinator bump, peers
+  are not invalidated until their *next* read of that artifact. Repair-forward is
+  on the roadmap.
+- **More backends are demand-gated.** A Letta vendor-memory sidecar is a post-v1
+  candidate, not shipped: Letta exposes no atomic conditional-write token, so a
+  binding could only *detect* a sequential stale write (via a client-held content
+  shadow), not prevent a concurrent one — it would be a `detect-only` tier, and
+  it lands only when a concrete need pulls it in.
+
+---
+
+## 7. Prove it against a real substrate
+
+The tier-honesty conformance suite exercises both bindings against **real**
+Postgres / S3 behind the `real_substrate` pytest marker (excluded from the
+default run; Moto/LocalStack are deliberately excluded because they serialize and
+would false-green a concurrency test):
+
+```bash
+export CCS_TEST_PG_DSN="postgresql://…"
+export CCS_REAL_S3_BUCKET="…"
+pytest -m real_substrate
+```

--- a/examples/coherent_object/README.md
+++ b/examples/coherent_object/README.md
@@ -1,0 +1,76 @@
+# CoherentObject demo — invalidation before act, over a shared object
+
+Two agents share one object. Agent A reads it and starts a multi-step edit. Agent
+B commits a new version. The binding tells A its **cached view went stale before A
+acts** — A's next binding-mediated write is denied before the object is touched,
+and A reacquires fresh state and re-decides.
+
+```
+python -m examples.coherent_object.main             # the with-binding demo
+python -m examples.coherent_object.main --baseline  # negative control first, then the binding
+```
+
+Offline, no credentials — it spawns a local coordinator subprocess. Exit code `0`
+iff the contract holds: with the binding the stale act is **denied before the
+object is touched** and A recovers via `reacquire`; with `--baseline` the
+un-coordinated agent acts on its stale cache (the failure the binding catches), so
+the deny is measured against its absence rather than asserted.
+
+## What it shows
+
+A reads the object and caches it, then reasons for a while. B commits a new
+version through the binding. On A's next act, the binding's coordinator pre-read
+finds A's view was invalidated by B's commit and **denies the act before A's write
+reaches the object** — surfaced as the same typed `StaleView` that A's file and
+store artifacts already speak. A calls `reacquire()`, reads fresh state,
+re-decides, and commits.
+
+## The value over the object's own compare-and-set
+
+S3 already gives you a lost-update reject: a conditional write
+
+```
+aws s3api put-object --bucket b --key k --if-match "$prior_etag" --body ...
+```
+
+fails with `412 PreconditionFailed` when a peer moved the object's ETag first.
+That is real and the binding rides it — but it fires **at write time**, and it
+hands A an S3-shaped error. What a bare CAS never does:
+
+- **Tell A its cached VIEW went stale before A acts.** A read the object, then
+  spent time deciding. The bare CAS says nothing until A finally writes; the
+  binding's next read/act is denied the moment A's view is invalid — the case that
+  actually bites an agent that reads, reasons, then acts.
+- **Speak one vocabulary across substrates.** The deny is the same typed
+  `StaleView` / `reacquire` surface A uses for a file (`CoherentVolume`) or a
+  store key (`CCSStore`) — one coherence vocabulary over an object, a row, a file,
+  a store key. That uniformity is what the binding adds; it is not the object's
+  CAS.
+
+A builder who serializes every read and write and never caches a read can
+rationally stay on the bare CAS. The binding is for the agent that reads, reasons,
+then acts.
+
+## Honest scope
+
+- **The read-generation fence is NOT demoed and NOT claimed.** v1 OCC writers ride
+  admit-on-absent + the version-CAS; the binding surfaces invalidation, not a
+  fence. The fence is a documented roadmap item, not shipped behaviour.
+- **In-memory stand-in.** This demo models the object with a tiny in-memory
+  dictionary so it runs offline with no credentials. The value it proves — the
+  coordinator-mediated invalidation-before-act — is exercised faithfully by the
+  real coordinator subprocess. The object's own atomic `If-Match` CAS is the
+  substrate's, and it is proven against real S3 in the conformance kit's
+  `real_substrate` arm. In production you point the same binding at a real bucket.
+- **Single-host, cooperative.** Two agents/processes coordinate one local
+  coordinator over one shared object. Placing agents on two hosts against one
+  distributed substrate — an S3 Multi-Region Access Point or a cross-region
+  replica — is a different (harder) problem and is out of scope; do not configure
+  it, and never run the CAS loop through an MRAP.
+
+## The escaping-effect sibling
+
+This demo is the *state-write* analog of `examples/effect_gate` — where `gate()`
+holds an agent's **escaping effect** (a deploy, a PR) on a moved input. The object
+binding holds a **state write** on an invalidated cached read. Same ordering
+principle, two effect shapes.

--- a/examples/coherent_object/__init__.py
+++ b/examples/coherent_object/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+"""CoherentObject cross-agent demo — invalidation-before-act over a shared object."""

--- a/examples/coherent_object/main.py
+++ b/examples/coherent_object/main.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+"""CoherentObject demo — a peer's commit invalidates the other agent's cached read
+before it acts, over a shared object.
+
+Two agents share ONE object. Agent A reads the object and begins a multi-step
+edit; agent B commits a new version through the binding; the coordinator marks
+A's cached view INVALID; **A's next binding-mediated act is DENIED before it
+touches the object** — A reacquires fresh state and re-decides. The ``--baseline``
+arm drops the binding: A acts on its stale cache with no signal (the failure the
+binding catches).
+
+    python -m examples.coherent_object.main             # the with-binding demo
+    python -m examples.coherent_object.main --baseline  # negative control first
+
+Offline, no credentials — it spawns a local coordinator subprocess and models the
+object with a tiny in-memory stand-in so the demo runs anywhere. In production the
+SAME binding points at a real S3 bucket (see docs/usage/byo-substrate.md and the
+conformance kit's real_substrate arm). Exit code 0 iff the contract holds: with
+the binding the stale act is DENIED before the object is touched and A recovers
+via reacquire; with ``--baseline`` the un-coordinated agent acts on stale state.
+
+Single-host, cooperative — two agents/processes against one coordinator. NEVER
+two hosts against one distributed substrate (no Multi-Region Access Point, no
+cross-region replica).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from ccs.adapters.claude_code.lifecycle import (  # noqa: E402  (after sys.path setup)
+    LifecycleConfig,
+    stop_coordinator,
+)
+from ccs.adapters.substrate import (  # noqa: E402
+    CasConflict,
+    CasWriteResult,
+    CasWritten,
+    CoordinatedSubstrate,
+    ReconcileDecision,
+    ReconcileVerdict,
+    SubstrateCoordinatorSession,
+)
+from ccs.core.exceptions import StaleView  # noqa: E402
+from ccs.core.substrate import CapabilityDescriptor, Tier  # noqa: E402
+
+REF = "shared/agent_scratchpad.json"
+SEED = b'{"plan": "draft", "step": 1}'
+PEER_EDIT = b'{"plan": "revised", "step": 2}'
+
+
+def _fast_cfg() -> LifecycleConfig:
+    return LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0.1,
+        notice_evict_max_age_sec=1.0,
+        port_file_retry_attempts=20,
+        port_file_retry_interval_sec=0.05,
+        connect_retry_attempts=10,
+        connect_retry_interval_sec=0.05,
+    )
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+class _Bucket:
+    """The shared object state (bytes + an opaque ETag), shared by every agent's
+    binding view — one underlying artifact, distinct agents."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, tuple[bytes, str]] = {}
+        self._counter = 0
+
+    def set(self, ref: str, data: bytes) -> str:
+        self._counter += 1
+        etag = f'"etag-{self._counter}"'
+        self._data[ref] = (data, etag)
+        return etag
+
+    def get(self, ref: str) -> tuple[bytes, str] | None:
+        return self._data.get(ref)
+
+
+class _InMemoryObject:
+    """A tiny in-memory stand-in for a real S3 object, so the demo runs offline.
+    Production swaps this for ``ccs.adapters.coherent_object.CoherentObject``
+    pointed at a real bucket — the coordinator-mediated behaviour is identical."""
+
+    #: The object body never reaches the coordinator (never-ship-a-store).
+    SENDS_CONTENT_TO_COORDINATOR: bool = False
+
+    def __init__(self, store: _Bucket) -> None:
+        self._store = store
+        self.cas_calls: list[str] = []
+        self._descriptor = CapabilityDescriptor(
+            tier=Tier.NATIVE_CAS,
+            version_source="object ETag",
+            least_privilege="in-memory demo stand-in",
+            consistency_note="read-after-write per key (demo)",
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def coordinator_commit_content(self) -> None:
+        return None
+
+    def read(self, artifact_ref: str) -> tuple[bytes, str]:
+        entry = self._store.get(artifact_ref)
+        if entry is None:
+            raise KeyError(artifact_ref)
+        return entry
+
+    def cas_write(self, artifact_ref: str, *, expected_token: str, new_bytes: bytes) -> CasWriteResult:
+        self.cas_calls.append(expected_token)
+        entry = self._store.get(artifact_ref)
+        if entry is None or entry[1] != expected_token:
+            return CasConflict()
+        return CasWritten(token=self._store.set(artifact_ref, bytes(new_bytes)))
+
+    def reconcile_after_unknown(
+        self, artifact_ref: str, *, expected_token: str, intended_hash: str
+    ) -> ReconcileDecision:
+        entry = self._store.get(artifact_ref)
+        if entry is None:
+            return ReconcileDecision(ReconcileVerdict.HOLD, None, None)
+        observed_bytes, observed_token = entry
+        if observed_token == expected_token:
+            return ReconcileDecision(ReconcileVerdict.RE_DRIVE, observed_bytes, observed_token)
+        if _sha256(observed_bytes) == intended_hash:
+            return ReconcileDecision(ReconcileVerdict.CONVERGE, observed_bytes, observed_token)
+        return ReconcileDecision(ReconcileVerdict.CONFLICT, observed_bytes, observed_token)
+
+
+def _decide(scratchpad: bytes) -> str:
+    """A trivial decision derived from the object the agent read."""
+    return f"append_note(to={scratchpad.decode()})"
+
+
+def run_with_binding(root: Path) -> dict:
+    """A peer's commit invalidates A's cached read; A's next act is DENIED before
+    the object is touched; A reacquires and commits on fresh state."""
+    store = _Bucket()
+    store.set(REF, SEED)
+    session_a = SubstrateCoordinatorSession(root, managed=("**",), config=_fast_cfg())
+    session_b = SubstrateCoordinatorSession(root, managed=("**",), config=_fast_cfg())
+    trace: dict = {"denied_before_act": False, "substrate_untouched": False, "committed_on_fresh": False}
+    try:
+        fake_a = _InMemoryObject(store)
+        agent_a = CoordinatedSubstrate(fake_a, session_a)
+        agent_b = CoordinatedSubstrate(_InMemoryObject(store), session_b)
+
+        a_bytes, a_tok = agent_a.read(REF)
+        print(f"  A reads {REF} -> {a_bytes.decode()!r} and starts a multi-step edit")
+        _b_bytes, b_tok = agent_b.read(REF)
+
+        committed = agent_b.commit(REF, expected_token=b_tok, new_bytes=PEER_EDIT)
+        print(f"  B commits a new version through the binding (coordinator v{committed.version}); A is now INVALID")
+
+        try:
+            agent_a.commit(REF, expected_token=a_tok, new_bytes=b'{"plan": "draft", "step": 1, "A": true}')
+            print("  x A's stale edit was NOT denied — coherence FAILED")
+        except StaleView:
+            trace["denied_before_act"] = True
+            trace["substrate_untouched"] = fake_a.cas_calls == []
+            print("  ok A's cached view was invalidated -> edit DENIED before the object was touched")
+
+        fresh_bytes, fresh_tok = agent_a.reacquire(REF)
+        landed = agent_a.commit(REF, expected_token=fresh_tok, new_bytes=fresh_bytes + b" +A")
+        trace["committed_on_fresh"] = True
+        print(f"  ok A reacquired fresh state {fresh_bytes.decode()!r} and committed (coordinator v{landed.version})")
+        return trace
+    finally:
+        stop_coordinator(root)
+
+
+def run_baseline(root: Path) -> dict:
+    """Negative control: no binding. A caches a read, a peer moves the object, and
+    A acts on the stale cache with no signal."""
+    del root  # the baseline needs no coordinator — a bare cache + the object's CAS
+    store = _Bucket()
+    store.set(REF, SEED)
+    trace: dict = {"acted_on_stale": False}
+
+    a_cached, _a_tok = store.get(REF)
+    print(f"  A reads and caches {REF} -> {a_cached.decode()!r}, starts a multi-step edit")
+    store.set(REF, PEER_EDIT)
+    print("  B changes the object (step 1 -> step 2) while A is mid-decision")
+
+    decision = _decide(a_cached)
+    trace["acted_on_stale"] = True
+    print(f"  x A acts on its STALE cache: {decision} (the object already moved; no signal)")
+    print("    the object's bare put-object --if-match would reject A's WRITE, but only at")
+    print("    write time — nothing told A its cached VIEW went stale before it acted")
+    return trace
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="CoherentObject cross-agent demo (single-host).")
+    parser.add_argument(
+        "--baseline",
+        action="store_true",
+        help="run the no-binding negative control first (A acts on a stale cache)",
+    )
+    args = parser.parse_args(argv)
+
+    print("CoherentObject demo — a peer's commit invalidates A's cached read before A acts.\n")
+
+    baseline_ok = True
+    if args.baseline:
+        print("Baseline (no binding — a bare cache + the object's own CAS):")
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline = run_baseline(Path(tmp))
+        baseline_ok = bool(baseline["acted_on_stale"])
+        print("")
+
+    print("With the binding (coordinator-mediated):")
+    with tempfile.TemporaryDirectory() as tmp:
+        gated = run_with_binding(Path(tmp))
+
+    print("\nTakeaway: the binding tells A its CACHED view went stale BEFORE it acts, in the")
+    print("same typed vocabulary A's file and store artifacts use (uniformity). The bare")
+    print("object CAS only rejects at write time. The read-generation fence is NOT demoed and")
+    print("NOT claimed — v1 OCC writers ride admit-on-absent + version-CAS. See effect_gate")
+    print("for the escaping-effect sibling of this state-write ordering.")
+
+    gated_ok = (
+        gated["denied_before_act"] and gated["substrate_untouched"] and gated["committed_on_fresh"]
+    )
+    return 0 if (gated_ok and baseline_ok) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+# Comparing notes on multi-agent coherence?
+# https://github.com/Cohexa-ai/agent-coherence/discussions

--- a/examples/coherent_row/README.md
+++ b/examples/coherent_row/README.md
@@ -1,0 +1,74 @@
+# CoherentRow demo — invalidation before act, over a shared row
+
+Two agents share one row. Agent A reads it and starts a multi-step edit. Agent B
+commits a new version. The binding tells A its **cached view went stale before A
+acts** — A's next binding-mediated write is denied before the row is touched, and
+A reacquires fresh state and re-decides.
+
+```
+python -m examples.coherent_row.main             # the with-binding demo
+python -m examples.coherent_row.main --baseline  # negative control first, then the binding
+```
+
+Offline, no credentials — it spawns a local coordinator subprocess. Exit code `0`
+iff the contract holds: with the binding the stale act is **denied before the row
+is touched** and A recovers via `reacquire`; with `--baseline` the un-coordinated
+agent acts on its stale cache (the failure the binding catches), so the deny is
+measured against its absence rather than asserted.
+
+## What it shows
+
+A reads the row and caches it, then reasons for a while. B commits a new version
+through the binding. On A's next act, the binding's coordinator pre-read finds A's
+view was invalidated by B's commit and **denies the act before A's write reaches
+the row** — surfaced as the same typed `StaleView` that A's file and store
+artifacts already speak. A calls `reacquire()`, reads fresh state, re-decides, and
+commits.
+
+## The value over the row's own compare-and-set
+
+Postgres already gives you a lost-update reject: a conditional write
+
+```sql
+UPDATE profiles SET value = $1, version = version + 1 WHERE id = $2 AND version = $3
+```
+
+comes back with `rowcount = 0` when a peer moved the version first. That is real
+and the binding rides it — but it fires **at write time**, and it hands A a
+Postgres-shaped error. What a bare CAS never does:
+
+- **Tell A its cached VIEW went stale before A acts.** A read the row, then spent
+  time deciding. The bare CAS says nothing until A finally writes; the binding's
+  next read/act is denied the moment A's view is invalid — the case that actually
+  bites an agent that reads, reasons, then acts.
+- **Speak one vocabulary across substrates.** The deny is the same typed
+  `StaleView` / `reacquire` surface A uses for a file (`CoherentVolume`) or a
+  store key (`CCSStore`) — one coherence vocabulary over a row, a file, an object,
+  a store key. That uniformity is what the binding adds; it is not the row's CAS.
+
+A builder who wraps every read and write in a `pg_advisory_lock` and never caches
+a read can rationally stay on the bare CAS. The binding is for the agent that
+reads, reasons, then acts.
+
+## Honest scope
+
+- **The read-generation fence is NOT demoed and NOT claimed.** v1 OCC writers ride
+  admit-on-absent + the version-CAS; the binding surfaces invalidation, not a
+  fence. The fence is a documented roadmap item, not shipped behaviour.
+- **In-memory stand-in.** This demo models the row with a tiny in-memory
+  dictionary so it runs offline with no credentials. The value it proves — the
+  coordinator-mediated invalidation-before-act — is exercised faithfully by the
+  real coordinator subprocess. The row's own atomic CAS is the substrate's, and it
+  is proven against real Postgres in the conformance kit's `real_substrate` arm.
+  In production you point the same binding at a real DSN.
+- **Single-host, cooperative.** Two agents/processes coordinate one local
+  coordinator over one shared row. Placing agents on two hosts against one
+  distributed substrate is a different (harder) problem and is out of scope — do
+  not configure it.
+
+## The escaping-effect sibling
+
+This demo is the *state-write* analog of `examples/effect_gate` — where `gate()`
+holds an agent's **escaping effect** (a deploy, a PR) on a moved input. The row
+binding holds a **state write** on an invalidated cached read. Same ordering
+principle, two effect shapes.

--- a/examples/coherent_row/__init__.py
+++ b/examples/coherent_row/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+"""CoherentRow cross-agent demo — invalidation-before-act over a shared row."""

--- a/examples/coherent_row/main.py
+++ b/examples/coherent_row/main.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+"""CoherentRow demo — a peer's commit invalidates the other agent's cached read
+before it acts, over a shared row.
+
+Two agents share ONE row. Agent A reads the row and begins a multi-step edit;
+agent B commits a new version through the binding; the coordinator marks A's
+cached view INVALID; **A's next binding-mediated act is DENIED before it touches
+the row** — A reacquires fresh state and re-decides. The ``--baseline`` arm drops
+the binding: A acts on its stale cache with no signal (the failure the binding
+catches).
+
+    python -m examples.coherent_row.main             # the with-binding demo
+    python -m examples.coherent_row.main --baseline  # negative control first
+
+Offline, no credentials — it spawns a local coordinator subprocess and models the
+row with a tiny in-memory stand-in so the demo runs anywhere. In production the
+SAME binding points at real Postgres (see docs/usage/byo-substrate.md and the
+conformance kit's real_substrate arm). Exit code 0 iff the contract holds: with
+the binding the stale act is DENIED before the row is touched and A recovers via
+reacquire; with ``--baseline`` the un-coordinated agent acts on stale state.
+
+Single-host, cooperative — two agents/processes against one coordinator. NEVER
+two hosts against one distributed substrate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from ccs.adapters.claude_code.lifecycle import (  # noqa: E402  (after sys.path setup)
+    LifecycleConfig,
+    stop_coordinator,
+)
+from ccs.adapters.substrate import (  # noqa: E402
+    CasConflict,
+    CasWriteResult,
+    CasWritten,
+    CoordinatedSubstrate,
+    ReconcileDecision,
+    ReconcileVerdict,
+    SubstrateCoordinatorSession,
+)
+from ccs.core.exceptions import StaleView  # noqa: E402
+from ccs.core.substrate import CapabilityDescriptor, Tier  # noqa: E402
+
+REF = "workspace/customer_profile.row"
+SEED = b"tier=basic balance=100"
+PEER_EDIT = b"tier=pro balance=500"
+
+
+def _fast_cfg() -> LifecycleConfig:
+    return LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0.1,
+        notice_evict_max_age_sec=1.0,
+        port_file_retry_attempts=20,
+        port_file_retry_interval_sec=0.05,
+        connect_retry_attempts=10,
+        connect_retry_interval_sec=0.05,
+    )
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+class _Row:
+    """The shared row state (bytes + an opaque row-version token), shared by every
+    agent's binding view — one underlying artifact, distinct agents."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, tuple[bytes, str]] = {}
+        self._counter = 0
+
+    def set(self, ref: str, data: bytes) -> str:
+        self._counter += 1
+        token = f"rowver-{self._counter}"
+        self._data[ref] = (data, token)
+        return token
+
+    def get(self, ref: str) -> tuple[bytes, str] | None:
+        return self._data.get(ref)
+
+
+class _InMemoryRow:
+    """A tiny in-memory stand-in for a real Postgres row, so the demo runs
+    offline. Production swaps this for ``ccs.adapters.coherent_row.CoherentRow``
+    pointed at a real DSN — the coordinator-mediated behaviour is identical."""
+
+    #: The row body never reaches the coordinator (never-ship-a-store).
+    SENDS_CONTENT_TO_COORDINATOR: bool = False
+
+    def __init__(self, store: _Row) -> None:
+        self._store = store
+        self.cas_calls: list[str] = []
+        self._descriptor = CapabilityDescriptor(
+            tier=Tier.NATIVE_CAS,
+            version_source="trigger-managed version column",
+            least_privilege="in-memory demo stand-in",
+            consistency_note="single-primary (demo)",
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def coordinator_commit_content(self) -> None:
+        return None
+
+    def read(self, artifact_ref: str) -> tuple[bytes, str]:
+        entry = self._store.get(artifact_ref)
+        if entry is None:
+            raise KeyError(artifact_ref)
+        return entry
+
+    def cas_write(self, artifact_ref: str, *, expected_token: str, new_bytes: bytes) -> CasWriteResult:
+        self.cas_calls.append(expected_token)
+        entry = self._store.get(artifact_ref)
+        if entry is None or entry[1] != expected_token:
+            return CasConflict()
+        return CasWritten(token=self._store.set(artifact_ref, bytes(new_bytes)))
+
+    def reconcile_after_unknown(
+        self, artifact_ref: str, *, expected_token: str, intended_hash: str
+    ) -> ReconcileDecision:
+        entry = self._store.get(artifact_ref)
+        if entry is None:
+            return ReconcileDecision(ReconcileVerdict.HOLD, None, None)
+        observed_bytes, observed_token = entry
+        if observed_token == expected_token:
+            return ReconcileDecision(ReconcileVerdict.RE_DRIVE, observed_bytes, observed_token)
+        if _sha256(observed_bytes) == intended_hash:
+            return ReconcileDecision(ReconcileVerdict.CONVERGE, observed_bytes, observed_token)
+        return ReconcileDecision(ReconcileVerdict.RE_DERIVE, observed_bytes, observed_token)
+
+
+def _decide(profile: bytes) -> str:
+    """A trivial decision derived from the profile the agent read."""
+    return f"grant_discount(on={profile.decode()})"
+
+
+def run_with_binding(root: Path) -> dict:
+    """A peer's commit invalidates A's cached read; A's next act is DENIED before
+    the row is touched; A reacquires and commits on fresh state."""
+    store = _Row()
+    store.set(REF, SEED)
+    session_a = SubstrateCoordinatorSession(root, managed=("**",), config=_fast_cfg())
+    session_b = SubstrateCoordinatorSession(root, managed=("**",), config=_fast_cfg())
+    trace: dict = {"denied_before_act": False, "substrate_untouched": False, "committed_on_fresh": False}
+    try:
+        fake_a = _InMemoryRow(store)
+        agent_a = CoordinatedSubstrate(fake_a, session_a)
+        agent_b = CoordinatedSubstrate(_InMemoryRow(store), session_b)
+
+        a_bytes, a_tok = agent_a.read(REF)
+        print(f"  A reads {REF} -> {a_bytes.decode()!r} and starts a multi-step edit")
+        _b_bytes, b_tok = agent_b.read(REF)
+
+        committed = agent_b.commit(REF, expected_token=b_tok, new_bytes=PEER_EDIT)
+        print(f"  B commits a new version through the binding (coordinator v{committed.version}); A is now INVALID")
+
+        try:
+            agent_a.commit(REF, expected_token=a_tok, new_bytes=b"tier=basic balance=100 +A-edit")
+            print("  x A's stale edit was NOT denied — coherence FAILED")
+        except StaleView:
+            trace["denied_before_act"] = True
+            trace["substrate_untouched"] = fake_a.cas_calls == []
+            print("  ok A's cached view was invalidated -> edit DENIED before the row was touched")
+
+        fresh_bytes, fresh_tok = agent_a.reacquire(REF)
+        landed = agent_a.commit(REF, expected_token=fresh_tok, new_bytes=fresh_bytes + b" +A-edit")
+        trace["committed_on_fresh"] = True
+        print(f"  ok A reacquired fresh state {fresh_bytes.decode()!r} and committed (coordinator v{landed.version})")
+        return trace
+    finally:
+        stop_coordinator(root)
+
+
+def run_baseline(root: Path) -> dict:
+    """Negative control: no binding. A caches a read, a peer moves the row, and A
+    acts on the stale cache with no signal."""
+    del root  # the baseline needs no coordinator — a bare cache + the row's CAS
+    store = _Row()
+    store.set(REF, SEED)
+    trace: dict = {"acted_on_stale": False}
+
+    a_cached, _a_tok = store.get(REF)
+    print(f"  A reads and caches {REF} -> {a_cached.decode()!r}, starts a multi-step edit")
+    store.set(REF, PEER_EDIT)
+    print("  B changes the row (tier=basic -> tier=pro) while A is mid-decision")
+
+    decision = _decide(a_cached)
+    trace["acted_on_stale"] = True
+    print(f"  x A acts on its STALE cache: {decision} (the row already moved; no signal)")
+    print("    the row's bare UPDATE...WHERE version=? would reject A's WRITE, but only at")
+    print("    write time — nothing told A its cached VIEW went stale before it acted")
+    return trace
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="CoherentRow cross-agent demo (single-host).")
+    parser.add_argument(
+        "--baseline",
+        action="store_true",
+        help="run the no-binding negative control first (A acts on a stale cache)",
+    )
+    args = parser.parse_args(argv)
+
+    print("CoherentRow demo — a peer's commit invalidates A's cached read before A acts.\n")
+
+    baseline_ok = True
+    if args.baseline:
+        print("Baseline (no binding — a bare cache + the row's own CAS):")
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline = run_baseline(Path(tmp))
+        baseline_ok = bool(baseline["acted_on_stale"])
+        print("")
+
+    print("With the binding (coordinator-mediated):")
+    with tempfile.TemporaryDirectory() as tmp:
+        gated = run_with_binding(Path(tmp))
+
+    print("\nTakeaway: the binding tells A its CACHED view went stale BEFORE it acts, in the")
+    print("same typed vocabulary A's file and store artifacts use (uniformity). The bare")
+    print("row CAS only rejects at write time. The read-generation fence is NOT demoed and")
+    print("NOT claimed — v1 OCC writers ride admit-on-absent + version-CAS. See effect_gate")
+    print("for the escaping-effect sibling of this state-write ordering.")
+
+    gated_ok = (
+        gated["denied_before_act"] and gated["substrate_untouched"] and gated["committed_on_fresh"]
+    )
+    return 0 if (gated_ok and baseline_ok) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+# Comparing notes on multi-agent coherence?
+# https://github.com/Cohexa-ai/agent-coherence/discussions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,12 @@ mistral = ["mistralai>=2.0"]
 # The stale-write-guard-fs stdio MCP server (ccs.mcp). The official `mcp` SDK
 # is the only new runtime dep; v2-alpha renames FastMCP, so pin <2.
 mcp = ["mcp>=1.27,<2"]
-all = ["agent-coherence[langgraph,crewai,otel,langsmith,benchmark,diagnose,openai-agents,mistral,mcp]"]
+# BYO-substrate native-CAS bindings. `psycopg[binary]` (v3) is the CoherentRow
+# driver; `boto3` is the CoherentObject driver. Both are lazily imported, so the
+# adapters package stays importable without them.
+coherent-row = ["psycopg[binary]>=3.1"]
+coherent-object = ["boto3>=1.34"]
+all = ["agent-coherence[langgraph,crewai,otel,langsmith,benchmark,diagnose,openai-agents,mistral,mcp,coherent-row,coherent-object]"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -115,11 +120,13 @@ markers = [
     "launch_gate_pilot_matrix: Per-PR cheap launch-gate pilot (1 scenario × {haiku, sonnet, opus}). Requires live claude CLI; ~$0.50 per run. Run via `pytest -m launch_gate_pilot_matrix`.",
     "protocol_corpus: Cross-implementation wire-shape parity corpus. Spawns Python + Node coordinators against shared JSON fixtures. Requires the agent-coherence-plugin checkout built (`npm ci && npm run build`) or `AGENT_COHERENCE_PLUGIN_DIST_PATH` set; Node scenarios xfail with a clear reason if the dist path can't resolve. Run via `pytest -m protocol_corpus`.",
     "live_api: OpenAI/Mistral Conversations live-API tests (stale-read probe + adapter smoke). Requires OPENAI_API_KEY and/or MISTRAL_API_KEY and the `[openai,mistral]` extras; ~$10 per full probe run. Excluded from default `pytest -q`. Run via `pytest -m live_api`.",
+    "real_substrate: BYO-substrate conformance against a REAL Postgres / S3 (no Moto/LocalStack — they serialize and false-green concurrency). Requires the `[coherent-row]`/`[coherent-object]` extras plus credentials (CCS_TEST_PG_DSN, CCS_REAL_S3_BUCKET, etc.). Excluded from default `pytest -q`. Run via `pytest -m real_substrate`.",
 ]
-# Skip launch_gate + protocol_corpus + live_api markers in default unit test
-# runs. live_api makes paid network calls and needs credentials; keep it opt-in
-# so the normal `pytest -q` loop stays fast, offline, and free.
-addopts = "-m 'not launch_gate and not launch_gate_pilot and not launch_gate_strict and not launch_gate_pilot_matrix and not protocol_corpus and not live_api'"
+# Skip launch_gate + protocol_corpus + live_api + real_substrate markers in
+# default unit test runs. live_api / real_substrate need credentials and real
+# backends; keep them opt-in so the normal `pytest -q` loop stays fast, offline,
+# and free.
+addopts = "-m 'not launch_gate and not launch_gate_pilot and not launch_gate_strict and not launch_gate_pilot_matrix and not protocol_corpus and not live_api and not real_substrate'"
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/src/ccs/adapters/coherent_object.py
+++ b/src/ccs/adapters/coherent_object.py
@@ -39,7 +39,6 @@ the ETag round-trip and the conditional-write semantics well-defined.
 from __future__ import annotations
 
 import hashlib
-from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Final
 
@@ -48,6 +47,8 @@ from ccs.adapters.substrate import (
     CasUnknown,
     CasWriteResult,
     CasWritten,
+    ReconcileDecision,
+    ReconcileVerdict,
     SubstrateToken,
 )
 from ccs.core.exceptions import CasVersionConflict, CoherenceError
@@ -193,101 +194,14 @@ def _cas_result_for_outcome(outcome: S3PutOutcome) -> CasWriteResult:
 
 
 # --- unknown-after-put reconciliation (the total four-arm branch) --------------
-
-
-class ReconcileVerdict(Enum):
-    """What the caller must do after an unconfirmed put, once the object is re-read.
-
-    The total four-arm branch. Every arm runs under the client-held pending intent
-    ``(T_old, intended_hash, intended_bytes, expected coordinator V)`` and does
-    exactly ONE ``get_object`` (never Head-then-Get), Region/endpoint-pinned to
-    the write's:
-
-    - ``HOLD`` — 404 (raced delete / delete-marker-current): UNCONFIRMED. Reacquire
-      and re-decide; NEVER auto re-create — a delete is itself an update. Never a
-      match against ``sha256(b"")``.
-    - ``RE_DRIVE`` — the ETag is UNMOVED (``== T_old``): the write has not landed.
-      Re-drive is eligible ONLY here and ONLY under ``If-Match=T_old`` — the
-      possibly-in-flight ghost and the re-drive carry identical bytes and the same
-      precondition, so at most one lands; a 412 loops back into this branch.
-    - ``CONVERGE`` — the ETag MOVED and the observed bytes hash to ``intended_hash``.
-      Adopt the observed ``(bytes, ETag)`` as the comparand AND still fire the
-      coordinator bump (:attr:`ReconcileDecision.bump_fires`). Convergence settles
-      the substrate leg only; the coordinator version-CAS arbitrates the
-      mine-vs-byte-identical-peer ambiguity. The surface says "converged", NEVER
-      "landed" — attribution is not claimed.
-    - ``CONFLICT`` — the ETag MOVED and the bytes DIFFER: a real peer write.
-      Reacquire and re-decide; NEVER re-drive a superseded write.
-    """
-
-    HOLD = "hold"
-    RE_DRIVE = "re_drive"
-    CONVERGE = "converge"
-    CONFLICT = "conflict"
-
-
-_VERDICT_SUMMARY: Final[dict["ReconcileVerdict", str]] = {
-    ReconcileVerdict.HOLD: (
-        "unconfirmed: the object or its token is absent (404 / delete-marker) — "
-        "reacquire and re-decide; never auto re-create (a delete is itself an update)"
-    ),
-    ReconcileVerdict.RE_DRIVE: (
-        "not confirmed yet: the ETag is unmoved, so re-drive the identical bytes "
-        "under If-Match=T_old (at most one of the in-flight ghost and the re-drive wins)"
-    ),
-    ReconcileVerdict.CONVERGE: (
-        "converged: the observed bytes are byte-identical to the intended write, so "
-        "adopt the observed ETag as the comparand and STILL fire the coordinator bump. "
-        "Attribution is not claimed — this is convergence, not confirmation"
-    ),
-    ReconcileVerdict.CONFLICT: (
-        "conflict: the ETag moved and the bytes differ — reacquire and re-decide; "
-        "never re-drive a superseded write"
-    ),
-}
-
-
-@dataclass(frozen=True)
-class ReconcileDecision:
-    """The verdict of :meth:`CoherentObject.reconcile_after_unknown` plus what the
-    reconciliation read observed.
-
-    ``observed_bytes`` / ``observed_token`` carry the consistent ``(bytes, ETag)``
-    pair from the single reconciliation read (both ``None`` on a HOLD, where the
-    object was absent). ``CONVERGE`` is the ONLY verdict on which a caller settles
-    the substrate leg without re-deriving — and even then the "did MY write land"
-    question is left to the coordinator version-CAS, never to a bare content match.
-    """
-
-    verdict: ReconcileVerdict
-    observed_bytes: bytes | None
-    observed_token: SubstrateToken | None
-
-    @property
-    def bump_fires(self) -> bool:
-        """Whether Unit 5 must STILL drive the coordinator version bump.
-
-        True on ``CONVERGE`` ONLY. Refusing to bump on a converged write (the
-        "never converge" mistake) strands the coordinator behind the substrate and
-        wedges every peer (``ViewWedged``, no v1 repair-forward); firing it on any
-        other verdict would advance the version for a write that did not land.
-        """
-        return self.verdict is ReconcileVerdict.CONVERGE
-
-    @property
-    def re_drive_token(self) -> SubstrateToken | None:
-        """The ``If-Match`` precondition to re-drive under — set only on ``RE_DRIVE``.
-
-        Equal to ``T_old`` (the ETag is unmoved). Re-driving under any other
-        precondition is forbidden; every other verdict returns ``None``.
-        """
-        return self.observed_token if self.verdict is ReconcileVerdict.RE_DRIVE else None
-
-    @property
-    def summary(self) -> str:
-        """Human-facing wording for the verdict. The ``CONVERGE`` surface says
-        "converged", never "landed" — attribution is not claimed."""
-        return _VERDICT_SUMMARY[self.verdict]
+#
+# The verdict vocabulary (:class:`ReconcileVerdict`) and the decision type
+# (:class:`ReconcileDecision`, with ``bump_fires`` / ``re_drive_token`` /
+# ``summary``) are the UNIFIED types from ``ccs.adapters.substrate`` — one
+# language shared with the Postgres arm so the cross-agent commit dispatches
+# uniformly. This binding's four-arm branch reaches HOLD (404 / delete-marker),
+# RE_DRIVE (ETag unmoved), CONVERGE (ETag moved + bytes match — the bump STILL
+# fires), and CONFLICT (ETag moved + bytes differ). Re-exported below for callers.
 
 
 # --- the binding ---------------------------------------------------------------

--- a/src/ccs/adapters/coherent_object.py
+++ b/src/ccs/adapters/coherent_object.py
@@ -38,7 +38,6 @@ the ETag round-trip and the conditional-write semantics well-defined.
 
 from __future__ import annotations
 
-import hashlib
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Final
 
@@ -51,8 +50,9 @@ from ccs.adapters.substrate import (
     ReconcileVerdict,
     SubstrateToken,
 )
-from ccs.core.exceptions import CasVersionConflict, CoherenceError
+from ccs.core.exceptions import CoherenceError
 from ccs.core.substrate import CapabilityDescriptor, Tier
+from ccs.core.substrate import sha256_hex as _sha256_hex
 
 if TYPE_CHECKING:
     from ccs.adapters.substrate import CoherenceSubstrate
@@ -109,10 +109,6 @@ _CODE_CONDITIONAL_CONFLICT: Final[str] = "ConditionalRequestConflict"  # 409 —
 # conflict — re-create is a CALLER decision (via CREATE_IF_ABSENT after
 # reacquire), never an automatic re-drive: a delete is itself an update.
 _NOT_FOUND_CODES: Final[frozenset[str]] = frozenset({"NoSuchKey", "NoSuchVersion", "404"})
-
-
-def _sha256_hex(data: bytes) -> str:
-    return hashlib.sha256(data).hexdigest()
 
 
 def _s3_error_code(exc: BaseException) -> str | None:
@@ -241,8 +237,11 @@ class CoherentObject:
 
     #: Bytes threaded to the coordinator on commit: never any. The coordinator
     #: holds only a version + a fixed-width fingerprint for this binding, so the
-    #: object body is never shadowed coordinator-side (never-ship-a-store). Unit 5's
-    #: two-part-commit mixin reads this to pass ``content=None`` into the commit.
+    #: object body is never shadowed coordinator-side (never-ship-a-store). This is
+    #: the binding's self-declaration; the conformance kit asserts it, and
+    #: :class:`~ccs.adapters.substrate.CoordinatedSubstrate` refuses at composition
+    #: any binding that sets it True. The runtime enforcement lives in
+    #: ``SubstrateCoordinatorSession.commit_cas`` (a content_hash-only payload).
     SENDS_CONTENT_TO_COORDINATOR: bool = False
 
     def __init__(
@@ -269,8 +268,10 @@ class CoherentObject:
         """The content threaded to the coordinator on commit: always ``None``.
 
         The object body stays in S3; the coordinator holds only a version +
-        fingerprint. Unit 5's mixin calls this so both native-CAS bindings share
-        one content-free commit seam (no retention shadow — never-ship-a-store).
+        fingerprint (no retention shadow — never-ship-a-store). A declarative
+        companion to :attr:`SENDS_CONTENT_TO_COORDINATOR`, asserted by the
+        conformance kit; the actual content-free payload is built in
+        ``SubstrateCoordinatorSession.commit_cas``.
         """
         return None
 
@@ -387,26 +388,6 @@ class CoherentObject:
             return ReconcileDecision(ReconcileVerdict.CONVERGE, observed_bytes, observed_token)
         # (iv) token moved AND bytes differ → a real peer write → typed conflict.
         return ReconcileDecision(ReconcileVerdict.CONFLICT, observed_bytes, observed_token)
-
-    # --- public-conflict mapping seam (Unit 5 supplies the coordinator versions) --
-
-    @staticmethod
-    def as_version_conflict(
-        artifact_ref: str,
-        *,
-        expected_version: int,
-        current_version: int,
-    ) -> CasVersionConflict:
-        """Map a substrate ``CasConflict`` to the shipped public conflict.
-
-        The substrate leg speaks ETags; the shipped :class:`~ccs.core.exceptions.CasVersionConflict`
-        (exact-type mapped by ``ccs.mcp.deny``, the uniform typed conflict every
-        adapter speaks) speaks the coordinator's integer versions. Unit 5 holds
-        those versions (the pending intent's expected ``V`` and the coordinator's
-        current), so it calls this to raise the conflict a caller already knows how
-        to handle — re-read at ``current_version``, re-derive, retry.
-        """
-        return CasVersionConflict(artifact_ref, expected_version, current_version)
 
     # --- internals ------------------------------------------------------------
 

--- a/src/ccs/adapters/coherent_object.py
+++ b/src/ccs/adapters/coherent_object.py
@@ -1,0 +1,628 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""CoherentObject — coherence over an S3 object (native-CAS binding).
+
+Bring coherence to an object you already keep in S3. The object body never
+leaves S3 — the coordinator holds only a monotonic version plus a fixed-width
+fingerprint, never the bytes. No-lost-update rides S3's own conditional write:
+a write is ``put_object(Body=..., IfMatch=prior_etag)``, so a peer who moved the
+object's ETag wins the race and the stale writer's put fails with ``412
+PreconditionFailed``.
+
+**The version is the object's ETag, minted by S3, captured from the write
+response.** The binding holds zero version state and never computes the ETag —
+under SSE-KMS/SSE-C, multipart, or a directory bucket the ETag is not a content
+digest, so it is treated as an OPAQUE token. It is also NOT portable across
+artifact refs: identical bytes elsewhere can mint an identical ETag, so a token
+for one key must never arbitrate a write to another.
+
+The binding reads ``(bytes, ETag)`` from a single ``get_object`` — the token and
+the bytes it vouches for always come from the same response, so a concurrent
+update can never be silently lost across a split read (never Head-then-Get for
+the pair).
+
+Install::
+
+    pip install "agent-coherence[coherent-object]"
+
+The ``boto3`` driver is imported lazily, so importing this module without the
+driver installed is fine — the clear install error only fires when a real client
+is actually built (a caller may instead inject a client at construction).
+
+**Writes are single-request puts, structurally.** The binding writes via
+``put_object`` exclusively — never the multipart API or boto3's transfer manager
+— so ``put_object``'s 5 GiB request ceiling is the size bound. This is what keeps
+the ETag round-trip and the conditional-write semantics well-defined.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Final
+
+from ccs.adapters.substrate import (
+    CasConflict,
+    CasUnknown,
+    CasWriteResult,
+    CasWritten,
+    SubstrateToken,
+)
+from ccs.core.exceptions import CasVersionConflict, CoherenceError
+from ccs.core.substrate import CapabilityDescriptor, Tier
+
+if TYPE_CHECKING:
+    from ccs.adapters.substrate import CoherenceSubstrate
+
+__all__ = [
+    "CREATE_IF_ABSENT",
+    "CoherentObject",
+    "ReconcileDecision",
+    "ReconcileVerdict",
+    "S3PutOutcome",
+    "classify_put_exception",
+    "conditional_write_bucket_policy",
+    "least_privilege_iam_policy",
+    "s3_policy_docs",
+]
+
+# The one capability this binding declares. NATIVE_CAS because S3's own atomic
+# conditional write (put_object with If-Match) rejects a lost update on the
+# version axis; the guarantee wording is derived from the tier, not written here.
+_DESCRIPTOR = CapabilityDescriptor(
+    tier=Tier.NATIVE_CAS,
+    version_source="object ETag",
+    least_privilege=(
+        "a writer principal with s3:GetObject + s3:PutObject scoped to the exact "
+        "key/prefix ARN only — the If-Match writer needs s3:GetObject to fetch the "
+        "ETag; explicit denies for s3:DeleteObject and any wildcard (no s3:*), and "
+        "no s3:PutBucketPolicy so the conditional-write bucket policy stays "
+        "owner-managed and agent-unremovable"
+    ),
+    consistency_note=(
+        "reconciliation reads target the SAME Region/endpoint as the write (one "
+        "pinned client); GET/HEAD-after-PUT is strongly consistent per key. Never "
+        "run the CAS loop through a Multi-Region Access Point or a read "
+        "replica/CRR target — either can serve a stale or missing object and miss "
+        "a conflict."
+    ),
+)
+
+# Pass as ``expected_token`` to request a CREATE (maps to S3 ``IfNoneMatch="*"``):
+# the write lands only if the object is ABSENT; a second create → 412. A distinct
+# control-char-wrapped sentinel so it can never collide with a real (opaque) ETag,
+# and so the Sentinel rule holds — an absent comparand is made explicit, never a
+# blank token silently used as an If-Match.
+CREATE_IF_ABSENT: Final[str] = "\x00ccs-create-if-absent\x00"
+
+# S3 error codes we classify as compare-and-set outcomes. Branch on
+# ``response["Error"]["Code"]`` (the typed signal) — 412/409 are NOT modeled
+# boto3 exceptions, and 404 may surface as the modeled ``NoSuchKey`` subclass, so
+# never write except-ordering that assumes 404 is a bare ClientError.
+_CODE_PRECONDITION_FAILED: Final[str] = "PreconditionFailed"  # 412 — definitive loss
+_CODE_CONDITIONAL_CONFLICT: Final[str] = "ConditionalRequestConflict"  # 409 — retryable
+# 404 on the If-Match path: a raced delete OR a delete-marker-current on a
+# versioned bucket (both fail If-Match with 404, not 412). Surfaced as a typed
+# conflict — re-create is a CALLER decision (via CREATE_IF_ABSENT after
+# reacquire), never an automatic re-drive: a delete is itself an update.
+_NOT_FOUND_CODES: Final[frozenset[str]] = frozenset({"NoSuchKey", "NoSuchVersion", "404"})
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _s3_error_code(exc: BaseException) -> str | None:
+    """The S3 error code from a botocore ``ClientError``-shaped exception, or None.
+
+    Duck-typed on the ``.response`` payload so the real ``ClientError`` (and its
+    modeled ``NoSuchKey`` subclass) and a driver-free test stub classify
+    identically. A connection/timeout error carries no ``.response`` → ``None``.
+    """
+    response = getattr(exc, "response", None)
+    if not isinstance(response, dict):
+        return None
+    error = response.get("Error")
+    if not isinstance(error, dict):
+        return None
+    code = error.get("Code")
+    return code if isinstance(code, str) else None
+
+
+# --- put-outcome classification (fine-grained; the contract 3-way is coarser) --
+
+
+class S3PutOutcome(Enum):
+    """The fine-grained outcome of one conditional ``put_object``.
+
+    Richer than the contract's three-way :data:`CasWriteResult` so a caller
+    (Unit 5) can distinguish a definitive loss from a retryable conflict:
+
+    - ``WON`` — the put landed; the response minted a fresh ETag.
+    - ``CONFLICT`` — 412 ``PreconditionFailed``: the ETag moved, NOTHING landed;
+      re-read and re-derive (never re-drive the stale comparand).
+    - ``RETRYABLE`` — 409 ``ConditionalRequestConflict``: a transient S3-internal
+      conflict, nothing landed; re-read the ETag and retry the same intent.
+    - ``RACED_DELETE`` — 404 on the If-Match path (raced delete / delete-marker):
+      nothing landed; re-create is a CALLER decision after reacquire, never auto.
+    - ``UNKNOWN`` — a connect/timeout/ambiguous failure: the put may or may not
+      have landed; reconcile by re-reading before doing anything else.
+
+    ``CONFLICT`` / ``RETRYABLE`` / ``RACED_DELETE`` all map to the contract's
+    :class:`~ccs.adapters.substrate.CasConflict` (no write landed); ``UNKNOWN``
+    maps to :class:`~ccs.adapters.substrate.CasUnknown`.
+    """
+
+    WON = "won"
+    CONFLICT = "conflict"
+    RETRYABLE = "retryable"
+    RACED_DELETE = "raced_delete"
+    UNKNOWN = "unknown"
+
+
+def classify_put_exception(exc: BaseException) -> S3PutOutcome | None:
+    """Classify a ``put_object`` failure into an :class:`S3PutOutcome`, or None.
+
+    ``None`` means the error is NOT a compare-and-set outcome (an ``AccessDenied``,
+    a missing bucket, a client-side param fault) and must PROPAGATE — it is a
+    configuration fault, never a CAS state. A failure with no S3 error code is an
+    ambiguous transport failure → ``UNKNOWN`` (the put's outcome is two-world).
+    """
+    code = _s3_error_code(exc)
+    if code is None:
+        return S3PutOutcome.UNKNOWN
+    if code == _CODE_PRECONDITION_FAILED:
+        return S3PutOutcome.CONFLICT
+    if code == _CODE_CONDITIONAL_CONFLICT:
+        return S3PutOutcome.RETRYABLE
+    if code in _NOT_FOUND_CODES:
+        return S3PutOutcome.RACED_DELETE
+    return None
+
+
+def _cas_result_for_outcome(outcome: S3PutOutcome) -> CasWriteResult:
+    """Map a non-win :class:`S3PutOutcome` to the contract's three-way result."""
+    if outcome is S3PutOutcome.UNKNOWN:
+        # UNKNOWN, not failed: the write may or may not have landed. The finer
+        # retryable/raced-delete distinction that a landed-nothing conflict carries
+        # is preserved by classify_put_exception for callers that branch on it.
+        return CasUnknown()
+    return CasConflict()
+
+
+# --- unknown-after-put reconciliation (the total four-arm branch) --------------
+
+
+class ReconcileVerdict(Enum):
+    """What the caller must do after an unconfirmed put, once the object is re-read.
+
+    The total four-arm branch. Every arm runs under the client-held pending intent
+    ``(T_old, intended_hash, intended_bytes, expected coordinator V)`` and does
+    exactly ONE ``get_object`` (never Head-then-Get), Region/endpoint-pinned to
+    the write's:
+
+    - ``HOLD`` — 404 (raced delete / delete-marker-current): UNCONFIRMED. Reacquire
+      and re-decide; NEVER auto re-create — a delete is itself an update. Never a
+      match against ``sha256(b"")``.
+    - ``RE_DRIVE`` — the ETag is UNMOVED (``== T_old``): the write has not landed.
+      Re-drive is eligible ONLY here and ONLY under ``If-Match=T_old`` — the
+      possibly-in-flight ghost and the re-drive carry identical bytes and the same
+      precondition, so at most one lands; a 412 loops back into this branch.
+    - ``CONVERGE`` — the ETag MOVED and the observed bytes hash to ``intended_hash``.
+      Adopt the observed ``(bytes, ETag)`` as the comparand AND still fire the
+      coordinator bump (:attr:`ReconcileDecision.bump_fires`). Convergence settles
+      the substrate leg only; the coordinator version-CAS arbitrates the
+      mine-vs-byte-identical-peer ambiguity. The surface says "converged", NEVER
+      "landed" — attribution is not claimed.
+    - ``CONFLICT`` — the ETag MOVED and the bytes DIFFER: a real peer write.
+      Reacquire and re-decide; NEVER re-drive a superseded write.
+    """
+
+    HOLD = "hold"
+    RE_DRIVE = "re_drive"
+    CONVERGE = "converge"
+    CONFLICT = "conflict"
+
+
+_VERDICT_SUMMARY: Final[dict["ReconcileVerdict", str]] = {
+    ReconcileVerdict.HOLD: (
+        "unconfirmed: the object or its token is absent (404 / delete-marker) — "
+        "reacquire and re-decide; never auto re-create (a delete is itself an update)"
+    ),
+    ReconcileVerdict.RE_DRIVE: (
+        "not confirmed yet: the ETag is unmoved, so re-drive the identical bytes "
+        "under If-Match=T_old (at most one of the in-flight ghost and the re-drive wins)"
+    ),
+    ReconcileVerdict.CONVERGE: (
+        "converged: the observed bytes are byte-identical to the intended write, so "
+        "adopt the observed ETag as the comparand and STILL fire the coordinator bump. "
+        "Attribution is not claimed — this is convergence, not confirmation"
+    ),
+    ReconcileVerdict.CONFLICT: (
+        "conflict: the ETag moved and the bytes differ — reacquire and re-decide; "
+        "never re-drive a superseded write"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ReconcileDecision:
+    """The verdict of :meth:`CoherentObject.reconcile_after_unknown` plus what the
+    reconciliation read observed.
+
+    ``observed_bytes`` / ``observed_token`` carry the consistent ``(bytes, ETag)``
+    pair from the single reconciliation read (both ``None`` on a HOLD, where the
+    object was absent). ``CONVERGE`` is the ONLY verdict on which a caller settles
+    the substrate leg without re-deriving — and even then the "did MY write land"
+    question is left to the coordinator version-CAS, never to a bare content match.
+    """
+
+    verdict: ReconcileVerdict
+    observed_bytes: bytes | None
+    observed_token: SubstrateToken | None
+
+    @property
+    def bump_fires(self) -> bool:
+        """Whether Unit 5 must STILL drive the coordinator version bump.
+
+        True on ``CONVERGE`` ONLY. Refusing to bump on a converged write (the
+        "never converge" mistake) strands the coordinator behind the substrate and
+        wedges every peer (``ViewWedged``, no v1 repair-forward); firing it on any
+        other verdict would advance the version for a write that did not land.
+        """
+        return self.verdict is ReconcileVerdict.CONVERGE
+
+    @property
+    def re_drive_token(self) -> SubstrateToken | None:
+        """The ``If-Match`` precondition to re-drive under — set only on ``RE_DRIVE``.
+
+        Equal to ``T_old`` (the ETag is unmoved). Re-driving under any other
+        precondition is forbidden; every other verdict returns ``None``.
+        """
+        return self.observed_token if self.verdict is ReconcileVerdict.RE_DRIVE else None
+
+    @property
+    def summary(self) -> str:
+        """Human-facing wording for the verdict. The ``CONVERGE`` surface says
+        "converged", never "landed" — attribution is not claimed."""
+        return _VERDICT_SUMMARY[self.verdict]
+
+
+# --- the binding ---------------------------------------------------------------
+
+
+def _require_boto3_client(region: str | None, endpoint_url: str | None) -> Any:
+    """Build a real boto3 S3 client, or raise a clear install error naming the extra."""
+    try:
+        import boto3  # deferred by design — see the module docstring
+    except ImportError as exc:  # pragma: no cover - exercised only without the driver
+        raise ImportError(
+            "CoherentObject requires the boto3 driver. Install it with: "
+            'pip install "agent-coherence[coherent-object]"'
+        ) from exc
+    return boto3.client("s3", region_name=region, endpoint_url=endpoint_url)
+
+
+class CoherentObject:
+    """Coherence over a single S3 object, keyed by its object key.
+
+    Construct with either an injected ``client`` (any object exposing S3's
+    ``get_object`` / ``put_object``) or a ``region`` / ``endpoint_url`` from which
+    a boto3 client is built lazily on construction. The binding implements the
+    :class:`~ccs.adapters.substrate.CoherenceSubstrate` surface: :meth:`read`
+    returns ``(bytes, ETag)`` from one ``get_object`` and :meth:`cas_write` maps
+    to a conditional ``put_object`` and returns a typed win / conflict / unknown.
+
+    The token is the object's ETag, captured from the response and treated as
+    OPAQUE. It is NOT portable across artifact refs — the coordinator record is
+    keyed by artifact id, so a token minted for one key can never arbitrate a
+    write to another.
+
+    A single client serves BOTH read and write, so a reconciliation read is
+    inherently pinned to the write's Region/endpoint (never routed through an MRAP)
+    — the consistency the four-arm reconciliation depends on.
+    """
+
+    #: Bytes threaded to the coordinator on commit: never any. The coordinator
+    #: holds only a version + a fixed-width fingerprint for this binding, so the
+    #: object body is never shadowed coordinator-side (never-ship-a-store). Unit 5's
+    #: two-part-commit mixin reads this to pass ``content=None`` into the commit.
+    SENDS_CONTENT_TO_COORDINATOR: bool = False
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        client: Any | None = None,
+        region: str | None = None,
+        endpoint_url: str | None = None,
+    ) -> None:
+        if not bucket:
+            raise ValueError("CoherentObject needs a bucket name (fail-closed)")
+        self._bucket = bucket
+        self._client = client if client is not None else _require_boto3_client(region, endpoint_url)
+
+    # --- capability -----------------------------------------------------------
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        """The binding's honest capability declaration (native-CAS)."""
+        return _DESCRIPTOR
+
+    def coordinator_commit_content(self) -> None:
+        """The content threaded to the coordinator on commit: always ``None``.
+
+        The object body stays in S3; the coordinator holds only a version +
+        fingerprint. Unit 5's mixin calls this so both native-CAS bindings share
+        one content-free commit seam (no retention shadow — never-ship-a-store).
+        """
+        return None
+
+    # --- read -----------------------------------------------------------------
+
+    def read(self, artifact_ref: str) -> tuple[bytes, SubstrateToken]:
+        """Return ``(bytes, ETag)`` for one object from a single ``get_object``.
+
+        Both values come from the SAME response (never Head-then-Get — a token
+        fetched by a second call can vouch for bytes it never described). Raises
+        :class:`KeyError` if the object is absent (404 / ``NoSuchKey``); any other
+        error propagates.
+        """
+        try:
+            resp = self._client.get_object(Bucket=self._bucket, Key=artifact_ref)
+        except Exception as exc:
+            if _s3_error_code(exc) in _NOT_FOUND_CODES:
+                raise KeyError(f"no object {artifact_ref!r} in s3://{self._bucket}") from None
+            raise
+        return resp["Body"].read(), self._require_response_etag(resp)
+
+    # --- compare-and-set (the Protocol write leg) -----------------------------
+
+    def cas_write(
+        self,
+        artifact_ref: str,
+        *,
+        expected_token: SubstrateToken,
+        new_bytes: bytes,
+    ) -> CasWriteResult:
+        """Conditionally write ``new_bytes`` iff the object is still at ``expected_token``.
+
+        Maps to ``put_object(Body=new_bytes, IfMatch=expected_token)`` (or, when
+        ``expected_token`` is :data:`CREATE_IF_ABSENT`, ``IfNoneMatch="*"`` — the
+        write lands only if the object is absent). Returns a typed outcome: a win
+        carries the ETag minted BY S3 for this write (from the response, never
+        computed); a 412/409/404 is a :class:`~ccs.adapters.substrate.CasConflict`
+        (no write landed); a connect/timeout/ambiguous failure is a
+        :class:`~ccs.adapters.substrate.CasUnknown` — the write may or may not have
+        landed, so reconcile via :meth:`reconcile_after_unknown` before anything else.
+        """
+        kwargs = self._put_kwargs(artifact_ref, expected_token, new_bytes)
+        try:
+            resp = self._client.put_object(**kwargs)
+        except Exception as exc:
+            outcome = classify_put_exception(exc)
+            if outcome is None:
+                raise  # not a CAS state (AccessDenied, missing bucket, param fault)
+            return _cas_result_for_outcome(outcome)
+        return CasWritten(token=self._require_response_etag(resp))
+
+    def cas_write_if_changed(
+        self,
+        artifact_ref: str,
+        *,
+        expected_token: SubstrateToken,
+        new_bytes: bytes,
+        current_hash: str,
+    ) -> CasWriteResult | None:
+        """CAS-write ``new_bytes`` UNLESS they already equal the current object.
+
+        Returns ``None`` for the byte-identical no-op — NO ``put_object`` is issued
+        and the caller MUST skip the coordinator bump too (issuing either would
+        advance the version for a no-change write, a phantom advance every peer
+        would then reconcile against). Otherwise delegates to :meth:`cas_write`.
+        """
+        if self.is_noop_write(current_hash=current_hash, intended_hash=_sha256_hex(bytes(new_bytes))):
+            return None
+        return self.cas_write(artifact_ref, expected_token=expected_token, new_bytes=new_bytes)
+
+    @staticmethod
+    def is_noop_write(*, current_hash: str, intended_hash: str) -> bool:
+        """True when the intended bytes already equal the object's current bytes.
+
+        A byte-identical write must skip the put AND the coordinator bump; the
+        caller checks this before :meth:`cas_write` (or uses
+        :meth:`cas_write_if_changed`, which folds the check in).
+        """
+        return current_hash == intended_hash
+
+    # --- unknown reconciliation (the total four-arm branch) -------------------
+
+    def reconcile_after_unknown(
+        self,
+        artifact_ref: str,
+        *,
+        expected_token: SubstrateToken,
+        intended_hash: str,
+    ) -> ReconcileDecision:
+        """Decide what an unconfirmed put should do, from ONE consistent re-read.
+
+        Runs under the client-held pending intent ``(T_old=expected_token,
+        intended_hash, ...)``. Does exactly one ``get_object`` (never Head-then-Get)
+        and returns exactly one verdict — see :class:`ReconcileVerdict` for the four
+        arms. The read is inherently Region/endpoint-pinned to the write (one
+        client), so it is authoritative (strong read-after-write per key).
+
+        A transport failure DURING the reconciliation read is not a decision — it
+        propagates so the caller can retry the reconcile; only a definitive 404
+        becomes ``HOLD``.
+        """
+        try:
+            observed_bytes, observed_token = self.read(artifact_ref)
+        except KeyError:
+            # (i) 404 / delete-marker-current → UNCONFIRMED → HOLD. Never a match
+            # against sha256(b"") and never an auto re-create.
+            return ReconcileDecision(ReconcileVerdict.HOLD, None, None)
+        if observed_token == expected_token:
+            # (ii) token unmoved → not landed yet → re-drive under If-Match=T_old.
+            return ReconcileDecision(ReconcileVerdict.RE_DRIVE, observed_bytes, observed_token)
+        if _sha256_hex(observed_bytes) == intended_hash:
+            # (iii) token moved AND bytes byte-identical → converge on the token
+            # axis; the coordinator bump STILL fires (never-converge would strand it).
+            return ReconcileDecision(ReconcileVerdict.CONVERGE, observed_bytes, observed_token)
+        # (iv) token moved AND bytes differ → a real peer write → typed conflict.
+        return ReconcileDecision(ReconcileVerdict.CONFLICT, observed_bytes, observed_token)
+
+    # --- public-conflict mapping seam (Unit 5 supplies the coordinator versions) --
+
+    @staticmethod
+    def as_version_conflict(
+        artifact_ref: str,
+        *,
+        expected_version: int,
+        current_version: int,
+    ) -> CasVersionConflict:
+        """Map a substrate ``CasConflict`` to the shipped public conflict.
+
+        The substrate leg speaks ETags; the shipped :class:`~ccs.core.exceptions.CasVersionConflict`
+        (exact-type mapped by ``ccs.mcp.deny``, the uniform typed conflict every
+        adapter speaks) speaks the coordinator's integer versions. Unit 5 holds
+        those versions (the pending intent's expected ``V`` and the coordinator's
+        current), so it calls this to raise the conflict a caller already knows how
+        to handle — re-read at ``current_version``, re-derive, retry.
+        """
+        return CasVersionConflict(artifact_ref, expected_version, current_version)
+
+    # --- internals ------------------------------------------------------------
+
+    def _put_kwargs(
+        self, artifact_ref: str, expected_token: SubstrateToken, new_bytes: bytes
+    ) -> dict[str, Any]:
+        if not isinstance(new_bytes, (bytes, bytearray)):
+            raise TypeError("CoherentObject.cas_write expects bytes")
+        kwargs: dict[str, Any] = {
+            "Bucket": self._bucket,
+            "Key": artifact_ref,
+            "Body": bytes(new_bytes),
+        }
+        if expected_token == CREATE_IF_ABSENT:
+            kwargs["IfNoneMatch"] = "*"
+        else:
+            kwargs["IfMatch"] = self._require_usable_token(expected_token)
+        return kwargs
+
+    @staticmethod
+    def _require_usable_token(token: SubstrateToken) -> SubstrateToken:
+        """Fail closed on an absent/sentinel token (the Sentinel rule).
+
+        An absent/blank ETag is UNCONFIRMED and may never seed an If-Match
+        comparand — hold and reacquire, or create explicitly via
+        :data:`CREATE_IF_ABSENT`.
+        """
+        if not isinstance(token, str) or not token.strip():
+            raise CoherenceError(
+                "unusable substrate token (absent/sentinel); it may not seed a CAS "
+                "comparand — hold and reacquire, or create via CREATE_IF_ABSENT"
+            )
+        return token
+
+    @staticmethod
+    def _require_response_etag(resp: object) -> SubstrateToken:
+        """The ETag from an S3 response, or fail closed — NEVER computed.
+
+        The ETag is opaque (SSE-KMS/SSE-C/multipart/directory-bucket ETags are not
+        content digests), so it is only ever read from the response. An absent ETag
+        means the write's outcome is unverifiable → fail closed rather than mint a
+        token that vouches for bytes S3 never acknowledged.
+        """
+        etag = resp.get("ETag") if isinstance(resp, dict) else None
+        if not isinstance(etag, str) or not etag:
+            raise CoherenceError(
+                "S3 response carried no ETag; cannot mint a token for a write whose "
+                "outcome is unverifiable — hold and reconcile"
+            )
+        return etag
+
+
+# --- least-privilege / bucket-policy doc helpers (never applied at runtime) ----
+
+
+def least_privilege_iam_policy(bucket: str, key_or_prefix: str) -> dict[str, Any]:
+    """The minimal WRITER IAM policy: read the ETag + conditional-put the key.
+
+    Grants only ``s3:GetObject`` (an If-Match writer must fetch the ETag) and
+    ``s3:PutObject`` on the exact key/prefix ARN, and explicitly DENIES delete and
+    bucket-policy writes — the object can never be removed out from under
+    coherence, and the writer can never relax the conditional-write bucket policy.
+    """
+    obj_arn = f"arn:aws:s3:::{bucket}/{key_or_prefix}"
+    bucket_arn = f"arn:aws:s3:::{bucket}"
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "CoherenceWriterLeastPrivilege",
+                "Effect": "Allow",
+                "Action": ["s3:GetObject", "s3:PutObject"],
+                "Resource": obj_arn,
+            },
+            {
+                "Sid": "CoherenceDenyDestructive",
+                "Effect": "Deny",
+                "Action": ["s3:DeleteObject", "s3:DeleteObjectVersion", "s3:PutBucketPolicy"],
+                "Resource": [obj_arn, bucket_arn],
+            },
+        ],
+    }
+
+
+def conditional_write_bucket_policy(bucket: str, key_or_prefix: str = "*") -> dict[str, Any]:
+    """The owner-managed bucket policy that REQUIRES a conditional write.
+
+    Denies any single-object ``s3:PutObject`` that carries no ``If-Match``
+    (``Null s3:if-match`` true), so a writer cannot bypass compare-and-set with an
+    unconditional overwrite. Multipart uploads cannot carry conditional headers, so
+    the Deny is scoped to ``s3:ObjectCreationOperation`` == ``PutObject`` and thus
+    exempts them (this binding never uses multipart — the exemption only keeps the
+    policy from blocking a legitimate MPU by another principal). Owner-managed and
+    agent-unremovable (the writer role holds no ``s3:PutBucketPolicy``).
+    """
+    obj_arn = f"arn:aws:s3:::{bucket}/{key_or_prefix}"
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "RequireIfMatchOnOverwrite",
+                "Effect": "Deny",
+                "Principal": "*",
+                "Action": "s3:PutObject",
+                "Resource": obj_arn,
+                "Condition": {
+                    "Null": {"s3:if-match": "true"},
+                    "StringEquals": {"s3:ObjectCreationOperation": "PutObject"},
+                },
+            },
+        ],
+    }
+
+
+def s3_policy_docs(bucket: str, key_or_prefix: str) -> dict[str, Any]:
+    """Both policies an operator applies to enforce coherence at the bucket.
+
+    Returns the writer's least-privilege IAM policy and the owner-managed
+    conditional-write-enforcing bucket policy. A documentation helper (the Unit-8
+    docs surface) — the binding never applies either at runtime.
+    """
+    return {
+        "writer_iam_policy": least_privilege_iam_policy(bucket, key_or_prefix),
+        "bucket_policy": conditional_write_bucket_policy(bucket, key_or_prefix),
+    }
+
+
+if TYPE_CHECKING:
+    # Structural conformance: CoherentObject must satisfy the CoherenceSubstrate
+    # Protocol (descriptor + read + cas_write). Checked statically, never by
+    # inheritance — mirrors the registry-contract discipline and the sibling
+    # CoherentRow binding.
+    _protocol_check: type[CoherenceSubstrate] = CoherentObject

--- a/src/ccs/adapters/coherent_row.py
+++ b/src/ccs/adapters/coherent_row.py
@@ -201,10 +201,14 @@ class ProvisioningSql:
     trigger_function: str
     trigger_bindings: str
     role_grants: str
+    version_backfill: str = ""
 
     def as_script(self) -> str:
         """The full provisioning script, in apply order."""
-        return "\n\n".join((self.trigger_function, self.trigger_bindings, self.role_grants))
+        parts = [self.trigger_function, self.trigger_bindings, self.role_grants]
+        if self.version_backfill:
+            parts.append(self.version_backfill)
+        return "\n\n".join(parts)
 
 
 def provisioning_sql(
@@ -212,15 +216,26 @@ def provisioning_sql(
     *,
     role: str = "coherence_writer",
     version_column: str = "version",
+    connection_limit: int = 16,
 ) -> ProvisioningSql:
     """Emit the version-guard trigger + least-privilege grants for one row table.
 
     The trigger derives the new version from the STORED prior row
-    (``NEW.version := OLD.version + 1``) so a client that supplies its own
-    ``NEW.version`` cannot forge one. The role is a dedicated non-owner login
-    with only ``SELECT, UPDATE`` on the one table — it holds no ``ALTER`` or
-    ``TRIGGER`` privilege, so it cannot drop or disable the guard.
+    (``NEW.version := COALESCE(OLD.version, 0) + 1``) so a client that supplies
+    its own ``NEW.version`` cannot forge one, and a pre-existing row with a
+    ``NULL``/``0`` version still advances to a usable value. The role is a
+    dedicated non-owner login with only ``SELECT, UPDATE`` on the one table — it
+    holds no ``ALTER`` or ``TRIGGER`` privilege, so it cannot drop or disable the
+    guard. ``connection_limit`` caps concurrent logins for the shared coherence
+    role (raise it for a larger agent fleet).
+
+    The emitted ``version_backfill`` seeds any pre-existing row sitting at
+    ``NULL``/``0`` to version ``1`` so it can be onboarded — the binding refuses a
+    version ``<= 0`` as a CAS comparand, so without this a legacy row would be
+    unreadable and therefore un-writable through this binding.
     """
+    if not isinstance(connection_limit, int) or isinstance(connection_limit, bool) or connection_limit < 1:
+        raise ValueError(f"connection_limit must be a positive int, got {connection_limit!r}")
     tbl = _quote_table(table)
     ver = _quote_identifier(version_column)
     _quote_identifier(role)  # validate the role name before interpolating it
@@ -238,7 +253,7 @@ def provisioning_sql(
         f"CREATE OR REPLACE FUNCTION {fn}() RETURNS trigger AS $$\n"
         "BEGIN\n"
         "    IF TG_OP = 'UPDATE' THEN\n"
-        f"        NEW.{ver} := OLD.{ver} + 1;\n"
+        f"        NEW.{ver} := COALESCE(OLD.{ver}, 0) + 1;\n"
         "    ELSE  -- INSERT: no stored prior, so the version starts at 1\n"
         f"        NEW.{ver} := 1;\n"
         "    END IF;\n"
@@ -258,14 +273,21 @@ def provisioning_sql(
         f'-- Dedicated, login-limited, NON-owner coherence role. It can read and\n'
         f'-- update the row, and nothing else — it cannot ALTER the table, drop or\n'
         f'-- disable the version trigger, or create databases/roles.\n'
-        f'CREATE ROLE "{role}" LOGIN CONNECTION LIMIT 4\n'
+        f'CREATE ROLE "{role}" LOGIN CONNECTION LIMIT {connection_limit}\n'
         f"    NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT;\n"
         f'REVOKE ALL ON {tbl} FROM "{role}";\n'
         f'GRANT SELECT, UPDATE ON {tbl} TO "{role}";\n'
         f"-- Deliberately withheld: table ALTER, the TRIGGER privilege, row DELETE,\n"
         f"-- and any re-grant right."
     )
-    return ProvisioningSql(trigger_function, trigger_bindings, role_grants)
+    version_backfill = (
+        f"-- One-time backfill: a row that predates the version column sits at\n"
+        f"-- NULL/0, which the binding refuses as a CAS comparand (must be > 0).\n"
+        f"-- Seed such rows to 1 so they can be onboarded. Idempotent, and the\n"
+        f"-- trigger's COALESCE keeps it safe whether the trigger is installed yet.\n"
+        f"UPDATE {tbl} SET {ver} = 1 WHERE {ver} IS NULL OR {ver} <= 0;"
+    )
+    return ProvisioningSql(trigger_function, trigger_bindings, role_grants, version_backfill)
 
 
 # --- the binding ------------------------------------------------------------
@@ -303,12 +325,19 @@ class CoherentRow:
         version_column: str = "version",
         connection: PgConnection | None = None,
         dsn: str | None = None,
+        connect_timeout: float | None = 10.0,
+        statement_timeout_ms: int | None = 30_000,
     ) -> None:
         if connection is None and dsn is None:
             raise ValueError("CoherentRow needs a connection or a dsn (fail-closed)")
         self._table = table
         self._connection = connection
         self._dsn = dsn
+        # Bounded waits for a self-owned (dsn) connection: a hung DB then raises
+        # (→ CasUnknown, which is reconcilable) instead of blocking the CAS loop
+        # forever. A caller-injected connection keeps its own settings.
+        self._connect_timeout = connect_timeout
+        self._statement_timeout_ms = statement_timeout_ms
         tbl = _quote_table(table)
         idc = _quote_identifier(id_column)
         val = _quote_identifier(value_column)
@@ -383,6 +412,7 @@ class CoherentRow:
         except Exception as exc:  # noqa: BLE001 - re-raised typed/scrubbed below
             self._rollback_quietly(conn)
             if _is_unconfirmed_error(exc):
+                self._discard_owned_connection()
                 return CasUnknown()
             raise self._scrubbed(exc, "cas_write") from None
         if rowcount == 0 or row is None:
@@ -452,9 +482,11 @@ class CoherentRow:
 
     # --- provisioning (convenience) -------------------------------------------
 
-    def provisioning_sql(self, *, role: str = "coherence_writer") -> ProvisioningSql:
+    def provisioning_sql(
+        self, *, role: str = "coherence_writer", connection_limit: int = 16
+    ) -> ProvisioningSql:
         """The version-guard DDL + least-privilege grants for this row's table."""
-        return provisioning_sql(self._table, role=role)
+        return provisioning_sql(self._table, role=role, connection_limit=connection_limit)
 
     # --- internals ------------------------------------------------------------
 
@@ -462,10 +494,29 @@ class CoherentRow:
         if self._connection is None:
             psycopg = _require_psycopg()
             try:
-                self._connection = psycopg.connect(self._dsn)
+                self._connection = psycopg.connect(self._dsn, **self._connect_kwargs())
             except Exception as exc:  # noqa: BLE001 - a DSN error carries the password
                 raise self._scrubbed(exc, "connect") from None
         return self._connection
+
+    def _connect_kwargs(self) -> dict[str, object]:
+        """Bounded-wait connect args (connect + per-statement timeout). Passed as
+        libpq conninfo kwargs, so they take precedence over the DSN string."""
+        kwargs: dict[str, object] = {}
+        if self._connect_timeout is not None:
+            kwargs["connect_timeout"] = self._connect_timeout
+        if self._statement_timeout_ms is not None:
+            kwargs["options"] = f"-c statement_timeout={self._statement_timeout_ms}"
+        return kwargs
+
+    def _discard_owned_connection(self) -> None:
+        """Drop a self-owned connection poisoned by an operational error so the
+        next :meth:`_conn` reconnects. Without this, one DB blip (restart, network
+        drop) leaves every later read/write hitting the same dead socket — the
+        documented 're-read then retry' recovery could never succeed. A
+        caller-injected connection (no dsn) is caller-owned and never dropped."""
+        if self._dsn is not None:
+            self._connection = None
 
     def _fetch_row(self, artifact_ref: str) -> tuple | None:
         conn = self._conn()
@@ -476,6 +527,8 @@ class CoherentRow:
             conn.rollback()  # end the read-only snapshot; nothing to commit
         except Exception as exc:  # noqa: BLE001 - re-raised scrubbed
             self._rollback_quietly(conn)
+            if _is_unconfirmed_error(exc):
+                self._discard_owned_connection()
             raise self._scrubbed(exc, "read") from None
         return row
 

--- a/src/ccs/adapters/coherent_row.py
+++ b/src/ccs/adapters/coherent_row.py
@@ -1,0 +1,563 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""CoherentRow — coherence over a Postgres row (native-CAS binding).
+
+Bring coherence to a row you already run in Postgres. The row's ``value`` never
+leaves Postgres — the coordinator holds only a monotonic version plus a
+fixed-width fingerprint, never the bytes. No-lost-update rides the row's own
+version column: a write is ``UPDATE ... SET value = ?, version = version + 1
+WHERE id = ? AND version = ?``, so a peer who moved the version wins the race and
+the stale writer's ``rowcount`` comes back ``0``.
+
+**The version is minted by the database, not the client.** A confused-deputy-proof
+``BEFORE INSERT`` / ``BEFORE UPDATE`` trigger owned by the table owner sets
+``NEW.version := OLD.version + 1`` from the *stored* prior row — never a
+client-supplied ``NEW.version``. The coherence login role is a dedicated,
+non-owner role with only ``SELECT, UPDATE`` on the one table, so it cannot
+``ALTER`` the table or disable the trigger to forge a version. :func:`provisioning_sql`
+emits the exact DDL + least-privilege grants an operator applies once.
+
+The binding reads ``(bytes, version)`` from a single query — the token and the
+bytes it vouches for always come from the same read, so a concurrent update can
+never be silently lost across a split read.
+
+Install::
+
+    pip install "agent-coherence[coherent-row]"
+
+The ``psycopg`` (v3) driver is imported lazily, so importing this module without
+the driver installed is fine — the clear install error only fires when a
+connection is actually needed.
+
+.. note::
+
+   ``xmin`` (Postgres' system row-version) is a *weaker* fallback and is **not**
+   shipped here. It is equality-only and 32-bit, so its value can repeat after
+   wraparound (or a ``VACUUM FREEZE``) — a repeat is a *missed* conflict, a
+   false CAS-pass that silently loses an update. The trigger-managed ``version``
+   column is the only version source this binding uses.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Protocol
+
+from ccs.adapters.substrate import (
+    CasConflict,
+    CasUnknown,
+    CasWriteResult,
+    CasWritten,
+    SubstrateToken,
+)
+from ccs.core.exceptions import (
+    CasVersionConflict,
+    CoherenceError,
+    CommitUnconfirmed,
+    ViewWedged,
+)
+from ccs.core.substrate import CapabilityDescriptor, Tier
+
+if TYPE_CHECKING:
+    from ccs.adapters.substrate import CoherenceSubstrate
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CoherentRow",
+    "ProvisioningSql",
+    "ReconcileDecision",
+    "ReconcileVerdict",
+    "provisioning_sql",
+]
+
+# The one capability this binding declares. NATIVE_CAS because the substrate's
+# own atomic conditional write (UPDATE ... WHERE version = ?) rejects a lost
+# update on the version axis; the guarantee wording is derived from the tier.
+_DESCRIPTOR = CapabilityDescriptor(
+    tier=Tier.NATIVE_CAS,
+    version_source="trigger-managed version column",
+    least_privilege=(
+        "a dedicated non-owner login role with SELECT, UPDATE on the single "
+        "coherence table only — no ALTER, no TRIGGER/DISABLE TRIGGER, no "
+        "CREATEDB/CREATEROLE/SUPERUSER"
+    ),
+    consistency_note=(
+        "single-primary Postgres: read-after-write is strongly consistent on the "
+        "primary. Never point the CAS loop at a read replica — replica lag can "
+        "serve a stale version and miss a conflict."
+    ),
+)
+
+# A Postgres identifier we are willing to interpolate into SQL. Config-supplied
+# table/column names are validated against this and then double-quoted, so a
+# crafted name cannot break out of the identifier position.
+_IDENTIFIER_RE = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+def _quote_identifier(name: str) -> str:
+    """Validate one identifier component and return it double-quoted."""
+    if not _IDENTIFIER_RE.match(name):
+        raise ValueError(f"unsafe Postgres identifier: {name!r}")
+    return f'"{name}"'
+
+
+def _quote_table(table: str) -> str:
+    """Validate and quote a possibly schema-qualified table name."""
+    return ".".join(_quote_identifier(part) for part in table.split("."))
+
+
+# --- the driver seam --------------------------------------------------------
+#
+# The binding depends on only this slice of the psycopg connection surface, so a
+# fake connection (unit tests) and a pooled real connection (Unit 5) both satisfy
+# it without pulling the driver into import time.
+
+
+class PgCursor(Protocol):
+    """The cursor surface the binding uses (a psycopg v3 cursor satisfies it)."""
+
+    rowcount: int
+
+    def execute(self, query: str, params: object = ...) -> object: ...
+
+    def fetchone(self) -> tuple | None: ...
+
+
+class PgConnection(Protocol):
+    """The connection surface the binding uses."""
+
+    def cursor(self) -> AbstractContextManager[PgCursor]: ...
+
+    def commit(self) -> None: ...
+
+    def rollback(self) -> None: ...
+
+
+def _require_psycopg():
+    """Import psycopg or raise a clear install error naming the extra."""
+    try:
+        import psycopg  # noqa: PLC0415  (deferred by design — see the module docstring)
+    except ImportError as exc:  # pragma: no cover - exercised only without the driver
+        raise ImportError(
+            "CoherentRow requires the psycopg v3 driver. Install it with: "
+            'pip install "agent-coherence[coherent-row]"'
+        ) from exc
+    return psycopg
+
+
+def _optional_psycopg():
+    """Return the psycopg module if importable, else ``None`` (fail-soft).
+
+    Used only to classify a driver error as an unconfirmed operational failure.
+    When the driver is absent there is nothing to classify against, so callers
+    treat an unrecognized error as a hard failure rather than guessing.
+    """
+    try:
+        import psycopg  # noqa: PLC0415
+    except ImportError:
+        return None
+    return psycopg
+
+
+def _is_unconfirmed_error(exc: BaseException) -> bool:
+    """True iff ``exc`` is a driver operational/interface error — i.e. the write
+    may or may not have landed and must be reconciled, not assumed failed."""
+    psycopg = _optional_psycopg()
+    if psycopg is None:
+        return False
+    return isinstance(exc, (psycopg.OperationalError, psycopg.InterfaceError))
+
+
+# --- reconciliation decision (local; Unit 5 unifies with the S3 arm) --------
+
+
+class ReconcileVerdict(Enum):
+    """What the caller should do after an unconfirmed write, once the row is re-read.
+
+    - ``CONVERGE`` — the re-read proves an ``expected + 1`` version *and* the
+      intended bytes, so adopt the observed ``(bytes, token)`` and settle the
+      substrate leg. Attribution is not claimed (a byte-identical concurrent
+      peer is arbitrated by the coordinator's version-CAS); the write is
+      "converged", never "landed".
+    - ``RE_DERIVE`` — the write did not land as mine (version unmoved, or moved
+      but not to ``expected + 1``, or bytes differ). Re-read fresh, rebuild the
+      intended bytes against the current state, and retry.
+    - ``HOLD`` — the outcome is unconfirmable (the row is absent, or its version
+      is an unusable sentinel). Never treat this as a match; ``reacquire`` and
+      re-decide. Coordinator state must never advance on a HOLD.
+    """
+
+    CONVERGE = "converge"
+    RE_DERIVE = "re_derive"
+    HOLD = "hold"
+
+
+@dataclass(frozen=True)
+class ReconcileDecision:
+    """The verdict of :meth:`CoherentRow.reconcile_after_unknown` plus what was
+    observed on the re-read.
+
+    ``observed_bytes`` / ``observed_token`` carry the consistent pair from the
+    reconciliation read (both ``None`` on a HOLD, where the row was absent or its
+    version unusable). The ``CONVERGE`` verdict is the ONLY one on which a caller
+    may settle the substrate leg without re-deriving; every verdict leaves the
+    "did MY write land" question to the coordinator version-CAS, never to a bare
+    content match.
+    """
+
+    verdict: ReconcileVerdict
+    observed_bytes: bytes | None
+    observed_token: SubstrateToken | None
+
+
+# --- provisioning DDL (emitted, never executed at runtime) ------------------
+
+
+@dataclass(frozen=True)
+class ProvisioningSql:
+    """The one-time DDL + least-privilege grants that make the version guard
+    agent-unremovable.
+
+    :attr:`trigger_function` + :attr:`trigger_bindings` install the
+    confused-deputy-proof version trigger (owned by the table owner);
+    :attr:`role_grants` create the limited coherence login role. An operator
+    applies :meth:`as_script` once, as the table owner — the binding never runs
+    DDL at write time.
+    """
+
+    trigger_function: str
+    trigger_bindings: str
+    role_grants: str
+
+    def as_script(self) -> str:
+        """The full provisioning script, in apply order."""
+        return "\n\n".join((self.trigger_function, self.trigger_bindings, self.role_grants))
+
+
+def provisioning_sql(
+    table: str,
+    *,
+    role: str = "coherence_writer",
+    version_column: str = "version",
+) -> ProvisioningSql:
+    """Emit the version-guard trigger + least-privilege grants for one row table.
+
+    The trigger derives the new version from the STORED prior row
+    (``NEW.version := OLD.version + 1``) so a client that supplies its own
+    ``NEW.version`` cannot forge one. The role is a dedicated non-owner login
+    with only ``SELECT, UPDATE`` on the one table — it holds no ``ALTER`` or
+    ``TRIGGER`` privilege, so it cannot drop or disable the guard.
+    """
+    tbl = _quote_table(table)
+    ver = _quote_identifier(version_column)
+    _quote_identifier(role)  # validate the role name before interpolating it
+    fn = _quote_identifier(f"{table.split('.')[-1]}_coherence_version")
+
+    trigger_function = (
+        f"-- Version guard: mint {ver} from the STORED prior row. Owned by the\n"
+        f"-- table owner; never trust a client-supplied NEW.{version_column}.\n"
+        f"CREATE OR REPLACE FUNCTION {fn}() RETURNS trigger AS $$\n"
+        "BEGIN\n"
+        "    IF TG_OP = 'UPDATE' THEN\n"
+        f"        NEW.{ver} := OLD.{ver} + 1;\n"
+        "    ELSE  -- INSERT: no stored prior, so the version starts at 1\n"
+        f"        NEW.{ver} := 1;\n"
+        "    END IF;\n"
+        "    RETURN NEW;\n"
+        "END;\n"
+        "$$ LANGUAGE plpgsql;"
+    )
+    trigger_bindings = (
+        f"DROP TRIGGER IF EXISTS {fn}_ins ON {tbl};\n"
+        f"CREATE TRIGGER {fn}_ins BEFORE INSERT ON {tbl}\n"
+        f"    FOR EACH ROW EXECUTE FUNCTION {fn}();\n"
+        f"DROP TRIGGER IF EXISTS {fn}_upd ON {tbl};\n"
+        f"CREATE TRIGGER {fn}_upd BEFORE UPDATE ON {tbl}\n"
+        f"    FOR EACH ROW EXECUTE FUNCTION {fn}();"
+    )
+    role_grants = (
+        f'-- Dedicated, login-limited, NON-owner coherence role. It can read and\n'
+        f'-- update the row, and nothing else — it cannot ALTER the table, drop or\n'
+        f'-- disable the version trigger, or create databases/roles.\n'
+        f'CREATE ROLE "{role}" LOGIN CONNECTION LIMIT 4\n'
+        f"    NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT;\n"
+        f'REVOKE ALL ON {tbl} FROM "{role}";\n'
+        f'GRANT SELECT, UPDATE ON {tbl} TO "{role}";\n'
+        f"-- Deliberately withheld: table ALTER, the TRIGGER privilege, row DELETE,\n"
+        f"-- and any re-grant right."
+    )
+    return ProvisioningSql(trigger_function, trigger_bindings, role_grants)
+
+
+# --- the binding ------------------------------------------------------------
+
+
+class CoherentRow:
+    """Coherence over a single Postgres row, keyed by its ``id``.
+
+    Construct with either a live/injected ``connection`` or a ``dsn`` (the driver
+    is connected lazily on first use). The binding implements the
+    :class:`~ccs.adapters.substrate.CoherenceSubstrate` surface: :meth:`read`
+    returns ``(bytes, token)`` from one query, and :meth:`cas_write` maps to
+    ``UPDATE ... WHERE version = ?`` and returns a typed win / conflict / unknown.
+
+    The token is the row's version rendered as a string. It is NOT portable
+    across artifact refs — the coordinator record is keyed by artifact id, so a
+    token minted for one row can never arbitrate a write to another.
+    """
+
+    #: Bytes threaded to the coordinator on commit: never any. The coordinator
+    #: holds only a version + a fixed-width fingerprint for this binding, so the
+    #: row body is never shadowed coordinator-side (never-ship-a-store). Unit 5's
+    #: two-part-commit mixin reads this to pass ``content=None`` into the commit.
+    SENDS_CONTENT_TO_COORDINATOR: bool = False
+
+    def __init__(
+        self,
+        table: str,
+        *,
+        id_column: str = "id",
+        value_column: str = "value",
+        version_column: str = "version",
+        connection: PgConnection | None = None,
+        dsn: str | None = None,
+    ) -> None:
+        if connection is None and dsn is None:
+            raise ValueError("CoherentRow needs a connection or a dsn (fail-closed)")
+        self._table = table
+        self._connection = connection
+        self._dsn = dsn
+        tbl = _quote_table(table)
+        idc = _quote_identifier(id_column)
+        val = _quote_identifier(value_column)
+        ver = _quote_identifier(version_column)
+        self._select_sql = f"SELECT {val}, {ver} FROM {tbl} WHERE {idc} = %s"
+        # The client also increments version; the owner-trigger overrides it from
+        # the stored prior, so the two agree and the guard holds even mid-rollout.
+        self._update_sql = (
+            f"UPDATE {tbl} SET {val} = %s, {ver} = {ver} + 1 "
+            f"WHERE {idc} = %s AND {ver} = %s RETURNING {ver}"
+        )
+
+    # --- capability -----------------------------------------------------------
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        """The binding's honest capability declaration (native-CAS)."""
+        return _DESCRIPTOR
+
+    def coordinator_commit_content(self) -> None:
+        """The content threaded to the coordinator on commit: always ``None``.
+
+        The row body stays in Postgres; the coordinator holds only a version +
+        fingerprint. Unit 5's mixin calls this so both native-CAS bindings share
+        one content-free commit seam.
+        """
+        return None
+
+    # --- read -----------------------------------------------------------------
+
+    def read(self, artifact_ref: str) -> tuple[bytes, SubstrateToken]:
+        """Return ``(bytes, token)`` for one row from a single ``SELECT``.
+
+        Raises :class:`KeyError` if the row is absent and
+        :class:`~ccs.core.exceptions.CoherenceError` if the stored version is an
+        unusable sentinel (fail-closed — a bogus version must never seed a CAS
+        comparand).
+        """
+        row = self._fetch_row(artifact_ref)
+        if row is None:
+            raise KeyError(f"no row {artifact_ref!r} in {self._table}")
+        value, version = row
+        return bytes(value), str(self._require_valid_version(version))
+
+    # --- compare-and-set (the Protocol write leg) -----------------------------
+
+    def cas_write(
+        self,
+        artifact_ref: str,
+        *,
+        expected_token: SubstrateToken,
+        new_bytes: bytes,
+    ) -> CasWriteResult:
+        """Conditionally write ``new_bytes`` iff the row is still at ``expected_token``.
+
+        Returns a typed outcome: :class:`~ccs.adapters.substrate.CasWritten` (the
+        new token from ``RETURNING``), :class:`~ccs.adapters.substrate.CasConflict`
+        (``rowcount == 0`` — the version moved, nothing landed), or
+        :class:`~ccs.adapters.substrate.CasUnknown` (a driver operational failure
+        mid-write — the write may or may not be durable; reconcile via
+        :meth:`reconcile_after_unknown`).
+        """
+        expected_version = self._parse_token(expected_token)
+        conn = self._conn()
+        params = (new_bytes, artifact_ref, expected_version)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(self._update_sql, params)
+                row, rowcount = cur.fetchone(), cur.rowcount
+            conn.commit()
+        except Exception as exc:  # noqa: BLE001 - re-raised typed/scrubbed below
+            self._rollback_quietly(conn)
+            if _is_unconfirmed_error(exc):
+                return CasUnknown()
+            raise self._scrubbed(exc, "cas_write") from None
+        if rowcount == 0 or row is None:
+            return CasConflict()
+        (new_version,) = row
+        return CasWritten(token=str(self._require_valid_version(new_version)))
+
+    def write(
+        self,
+        artifact_ref: str,
+        *,
+        expected_token: SubstrateToken,
+        new_bytes: bytes,
+    ) -> SubstrateToken:
+        """The caller-facing write: like :meth:`cas_write`, but a conflict/unknown
+        surfaces as the shipped typed exceptions instead of a return value.
+
+        Returns the new token on a win. Raises
+        :class:`~ccs.core.exceptions.CasVersionConflict` (carrying the artifact
+        id, expected, and current version) on a conflict — the same typed
+        retryable conflict the other adapters speak — and
+        :class:`~ccs.core.exceptions.CommitUnconfirmed` on an unconfirmed write.
+        """
+        expected_version = self._parse_token(expected_token)
+        outcome = self.cas_write(artifact_ref, expected_token=expected_token, new_bytes=new_bytes)
+        if isinstance(outcome, CasWritten):
+            return outcome.token
+        if isinstance(outcome, CasConflict):
+            raise CasVersionConflict(
+                artifact_ref, expected_version, self._current_version_or_wedged(artifact_ref)
+            )
+        raise CommitUnconfirmed(
+            f"Postgres CAS on {self._table} could not be confirmed; the write may or "
+            "may not have landed — reconcile by re-reading before retrying."
+        )
+
+    # --- unknown reconciliation (token-identity authority) --------------------
+
+    def reconcile_after_unknown(
+        self,
+        artifact_ref: str,
+        *,
+        expected_token: SubstrateToken,
+        intended_hash: str,
+    ) -> ReconcileDecision:
+        """Decide what an unconfirmed write should do, by re-reading the row.
+
+        Converges ONLY when the re-read shows the version advanced to exactly
+        ``expected + 1`` AND the bytes hash to ``intended_hash`` — the version is
+        the authority (a write-counting receipt), the hash is corroboration that
+        never converges on its own (byte-identical concurrent writers and no-op
+        rewrites would lie). An absent row or an unusable sentinel version holds
+        (never a match against ``sha256(b"")``); anything else re-derives.
+        """
+        expected_version = self._parse_token(expected_token)
+        row = self._fetch_row(artifact_ref)
+        if row is None:
+            return ReconcileDecision(ReconcileVerdict.HOLD, None, None)
+        value, version = row
+        if not _is_usable_version(version):
+            return ReconcileDecision(ReconcileVerdict.HOLD, None, None)
+        observed = bytes(value)
+        token = str(version)
+        landed_as_mine = version == expected_version + 1 and _sha256_hex(observed) == intended_hash
+        verdict = ReconcileVerdict.CONVERGE if landed_as_mine else ReconcileVerdict.RE_DERIVE
+        return ReconcileDecision(verdict, observed, token)
+
+    # --- provisioning (convenience) -------------------------------------------
+
+    def provisioning_sql(self, *, role: str = "coherence_writer") -> ProvisioningSql:
+        """The version-guard DDL + least-privilege grants for this row's table."""
+        return provisioning_sql(self._table, role=role)
+
+    # --- internals ------------------------------------------------------------
+
+    def _conn(self) -> PgConnection:
+        if self._connection is None:
+            psycopg = _require_psycopg()
+            try:
+                self._connection = psycopg.connect(self._dsn)
+            except Exception as exc:  # noqa: BLE001 - a DSN error carries the password
+                raise self._scrubbed(exc, "connect") from None
+        return self._connection
+
+    def _fetch_row(self, artifact_ref: str) -> tuple | None:
+        conn = self._conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(self._select_sql, (artifact_ref,))
+                row = cur.fetchone()
+            conn.rollback()  # end the read-only snapshot; nothing to commit
+        except Exception as exc:  # noqa: BLE001 - re-raised scrubbed
+            self._rollback_quietly(conn)
+            raise self._scrubbed(exc, "read") from None
+        return row
+
+    def _current_version_or_wedged(self, artifact_ref: str) -> int:
+        row = self._fetch_row(artifact_ref)
+        if row is None:
+            raise ViewWedged(
+                f"row {artifact_ref!r} in {self._table} vanished during a CAS conflict; "
+                "reacquire and re-decide (a delete is itself an update)."
+            )
+        return self._require_valid_version(row[1])
+
+    def _scrubbed(self, exc: BaseException, op: str) -> CoherenceError:
+        """A typed error that never echoes the driver message (it may carry the DSN
+        password). Only the exception TYPE and the table name are surfaced."""
+        return CoherenceError(
+            f"Postgres substrate {op} on {self._table} failed with "
+            f"{type(exc).__name__}; details suppressed to avoid leaking DSN credentials"
+        )
+
+    @staticmethod
+    def _rollback_quietly(conn: PgConnection) -> None:
+        try:
+            conn.rollback()
+        except Exception:  # noqa: BLE001 - best effort; a rollback failure must not mask the cause
+            logger.debug("CoherentRow rollback after error failed", exc_info=True)
+
+    @staticmethod
+    def _parse_token(token: SubstrateToken) -> int:
+        """Parse a token to its integer version, failing closed on a sentinel."""
+        try:
+            version = int(token)
+        except (TypeError, ValueError):
+            raise CoherenceError("unusable substrate token (not an integer version)") from None
+        return CoherentRow._require_valid_version(version)
+
+    @staticmethod
+    def _require_valid_version(version: object) -> int:
+        """Return a positive int version, or fail closed on a sentinel/absent one."""
+        if not _is_usable_version(version):
+            raise CoherenceError(
+                "unconfirmed substrate version (absent/zero/sentinel); it may not "
+                "seed a CAS comparand — hold and reacquire"
+            )
+        return int(version)  # type: ignore[arg-type]
+
+
+def _is_usable_version(version: object) -> bool:
+    """True iff ``version`` is a positive integer (not a bool, sentinel, or None)."""
+    return isinstance(version, int) and not isinstance(version, bool) and version > 0
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+if TYPE_CHECKING:
+    # Structural conformance: CoherentRow must satisfy the CoherenceSubstrate
+    # Protocol (descriptor + read + cas_write). Checked statically, never by
+    # inheritance — mirrors the registry-contract discipline.
+    _protocol_check: type[CoherenceSubstrate] = CoherentRow

--- a/src/ccs/adapters/coherent_row.py
+++ b/src/ccs/adapters/coherent_row.py
@@ -46,7 +46,6 @@ import logging
 import re
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
-from enum import Enum
 from typing import TYPE_CHECKING, Protocol
 
 from ccs.adapters.substrate import (
@@ -54,6 +53,8 @@ from ccs.adapters.substrate import (
     CasUnknown,
     CasWriteResult,
     CasWritten,
+    ReconcileDecision,
+    ReconcileVerdict,
     SubstrateToken,
 )
 from ccs.core.exceptions import (
@@ -175,46 +176,11 @@ def _is_unconfirmed_error(exc: BaseException) -> bool:
     return isinstance(exc, (psycopg.OperationalError, psycopg.InterfaceError))
 
 
-# --- reconciliation decision (local; Unit 5 unifies with the S3 arm) --------
-
-
-class ReconcileVerdict(Enum):
-    """What the caller should do after an unconfirmed write, once the row is re-read.
-
-    - ``CONVERGE`` — the re-read proves an ``expected + 1`` version *and* the
-      intended bytes, so adopt the observed ``(bytes, token)`` and settle the
-      substrate leg. Attribution is not claimed (a byte-identical concurrent
-      peer is arbitrated by the coordinator's version-CAS); the write is
-      "converged", never "landed".
-    - ``RE_DERIVE`` — the write did not land as mine (version unmoved, or moved
-      but not to ``expected + 1``, or bytes differ). Re-read fresh, rebuild the
-      intended bytes against the current state, and retry.
-    - ``HOLD`` — the outcome is unconfirmable (the row is absent, or its version
-      is an unusable sentinel). Never treat this as a match; ``reacquire`` and
-      re-decide. Coordinator state must never advance on a HOLD.
-    """
-
-    CONVERGE = "converge"
-    RE_DERIVE = "re_derive"
-    HOLD = "hold"
-
-
-@dataclass(frozen=True)
-class ReconcileDecision:
-    """The verdict of :meth:`CoherentRow.reconcile_after_unknown` plus what was
-    observed on the re-read.
-
-    ``observed_bytes`` / ``observed_token`` carry the consistent pair from the
-    reconciliation read (both ``None`` on a HOLD, where the row was absent or its
-    version unusable). The ``CONVERGE`` verdict is the ONLY one on which a caller
-    may settle the substrate leg without re-deriving; every verdict leaves the
-    "did MY write land" question to the coordinator version-CAS, never to a bare
-    content match.
-    """
-
-    verdict: ReconcileVerdict
-    observed_bytes: bytes | None
-    observed_token: SubstrateToken | None
+# The reconciliation seam (:class:`ReconcileVerdict` / :class:`ReconcileDecision`)
+# is the UNIFIED type from ``ccs.adapters.substrate`` — one vocabulary shared with
+# the S3 arm so the cross-agent commit dispatches uniformly. This binding uses
+# only its Postgres-honest arms: CONVERGE (version ``expected + 1`` under MY
+# identity), RE_DERIVE, and HOLD. Re-exported below for callers.
 
 
 # --- provisioning DDL (emitted, never executed at runtime) ------------------

--- a/src/ccs/adapters/coherent_row.py
+++ b/src/ccs/adapters/coherent_row.py
@@ -41,7 +41,6 @@ connection is actually needed.
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import re
 from contextlib import AbstractContextManager
@@ -64,6 +63,7 @@ from ccs.core.exceptions import (
     ViewWedged,
 )
 from ccs.core.substrate import CapabilityDescriptor, Tier
+from ccs.core.substrate import sha256_hex as _sha256_hex
 
 if TYPE_CHECKING:
     from ccs.adapters.substrate import CoherenceSubstrate
@@ -224,7 +224,13 @@ def provisioning_sql(
     tbl = _quote_table(table)
     ver = _quote_identifier(version_column)
     _quote_identifier(role)  # validate the role name before interpolating it
-    fn = _quote_identifier(f"{table.split('.')[-1]}_coherence_version")
+    base = table.split(".")[-1]
+    fn = _quote_identifier(f"{base}_coherence_version")
+    # Trigger names are WHOLE quoted identifiers, not a suffix concatenated onto
+    # the already-quoted function name: `"..."_ins` is two tokens where Postgres
+    # wants one (a syntax error at "_ins"), which would break the one-time setup.
+    trig_ins = _quote_identifier(f"{base}_coherence_version_ins")
+    trig_upd = _quote_identifier(f"{base}_coherence_version_upd")
 
     trigger_function = (
         f"-- Version guard: mint {ver} from the STORED prior row. Owned by the\n"
@@ -241,11 +247,11 @@ def provisioning_sql(
         "$$ LANGUAGE plpgsql;"
     )
     trigger_bindings = (
-        f"DROP TRIGGER IF EXISTS {fn}_ins ON {tbl};\n"
-        f"CREATE TRIGGER {fn}_ins BEFORE INSERT ON {tbl}\n"
+        f"DROP TRIGGER IF EXISTS {trig_ins} ON {tbl};\n"
+        f"CREATE TRIGGER {trig_ins} BEFORE INSERT ON {tbl}\n"
         f"    FOR EACH ROW EXECUTE FUNCTION {fn}();\n"
-        f"DROP TRIGGER IF EXISTS {fn}_upd ON {tbl};\n"
-        f"CREATE TRIGGER {fn}_upd BEFORE UPDATE ON {tbl}\n"
+        f"DROP TRIGGER IF EXISTS {trig_upd} ON {tbl};\n"
+        f"CREATE TRIGGER {trig_upd} BEFORE UPDATE ON {tbl}\n"
         f"    FOR EACH ROW EXECUTE FUNCTION {fn}();"
     )
     role_grants = (
@@ -281,8 +287,11 @@ class CoherentRow:
 
     #: Bytes threaded to the coordinator on commit: never any. The coordinator
     #: holds only a version + a fixed-width fingerprint for this binding, so the
-    #: row body is never shadowed coordinator-side (never-ship-a-store). Unit 5's
-    #: two-part-commit mixin reads this to pass ``content=None`` into the commit.
+    #: row body is never shadowed coordinator-side (never-ship-a-store). This is
+    #: the binding's self-declaration; the conformance kit asserts it, and
+    #: :class:`~ccs.adapters.substrate.CoordinatedSubstrate` refuses at composition
+    #: any binding that sets it True. The runtime enforcement lives in
+    #: ``SubstrateCoordinatorSession.commit_cas`` (a content_hash-only payload).
     SENDS_CONTENT_TO_COORDINATOR: bool = False
 
     def __init__(
@@ -323,8 +332,9 @@ class CoherentRow:
         """The content threaded to the coordinator on commit: always ``None``.
 
         The row body stays in Postgres; the coordinator holds only a version +
-        fingerprint. Unit 5's mixin calls this so both native-CAS bindings share
-        one content-free commit seam.
+        fingerprint. A declarative companion to
+        :attr:`SENDS_CONTENT_TO_COORDINATOR`, asserted by the conformance kit; the
+        actual content-free payload is built in ``SubstrateCoordinatorSession.commit_cas``.
         """
         return None
 
@@ -516,10 +526,6 @@ class CoherentRow:
 def _is_usable_version(version: object) -> bool:
     """True iff ``version`` is a positive integer (not a bool, sentinel, or None)."""
     return isinstance(version, int) and not isinstance(version, bool) and version > 0
-
-
-def _sha256_hex(data: bytes) -> str:
-    return hashlib.sha256(data).hexdigest()
 
 
 if TYPE_CHECKING:

--- a/src/ccs/adapters/substrate.py
+++ b/src/ccs/adapters/substrate.py
@@ -23,10 +23,40 @@ drift apart on what a win, a conflict, or an unknown outcome means.
 
 from __future__ import annotations
 
+import hashlib
+import logging
+import os
+import urllib.error
+import uuid
 from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
 from typing import Protocol, TypeAlias, runtime_checkable
 
+import yaml
+
+from ccs.cli._coherence_client import (
+    CoordinatorEndpoint,
+    CoordinatorUnavailable,
+    resolve_endpoint,
+)
+from ccs.cli._coherence_client import (
+    post as _coordinator_post,
+)
+from ccs.core.exceptions import (
+    COMMIT_UNCONFIRMED_REASON,
+    OCC_CALLER_TRANSIENT_REASON,
+    STALE_READ_GENERATION_REASON,
+    VERSION_MISMATCH_REASON,
+    CasVersionConflict,
+    CoherenceError,
+    CommitUnconfirmed,
+    StaleView,
+    ViewWedged,
+)
 from ccs.core.substrate import CapabilityDescriptor
+
+logger = logging.getLogger(__name__)
 
 # The substrate-minted version token: an object ETag, a row-version rendered
 # opaque, etc. Two properties are contractual: it comes from the SAME read (or
@@ -71,6 +101,129 @@ class CasUnknown:
 # The three-way compare-and-set outcome. A typed return, never an exception:
 # conflict and unknown are expected protocol states a caller must branch on.
 CasWriteResult: TypeAlias = "CasWritten | CasConflict | CasUnknown"
+
+
+# --- the UNIFIED reconciliation seam ---------------------------------------
+#
+# A binding's ``reconcile_after_unknown`` re-reads the substrate after an
+# UNKNOWN write and returns one of these verdicts. Both native-CAS bindings
+# share this ONE vocabulary so the cross-agent commit dispatches uniformly —
+# a Postgres row and an S3 object speak the same reconciliation language even
+# though each derives its verdict from a different token shape.
+
+
+class ReconcileVerdict(Enum):
+    """What the cross-agent commit must do after an unconfirmed substrate write.
+
+    The union across both native-CAS bindings. A binding uses only the arms its
+    token shape can honestly reach — Postgres (a write-counting version) uses
+    ``CONVERGE`` / ``RE_DERIVE`` / ``HOLD``; S3 (a content-derived ETag) uses
+    ``CONVERGE`` / ``RE_DRIVE`` / ``CONFLICT`` / ``HOLD`` — but the caller
+    dispatches on the ONE enum regardless of which binding produced it.
+
+    - ``CONVERGE`` — the re-read proves the intended bytes landed under this
+      writer's identity (Postgres: version ``expected + 1`` AND the intended
+      hash; S3: the token moved AND the observed bytes hash to the intended).
+      Adopt the observed ``(bytes, token)`` and STILL drive the coordinator
+      bump (:attr:`ReconcileDecision.bump_fires`). Attribution is not claimed —
+      a byte-identical concurrent peer is arbitrated by the coordinator's
+      version-CAS; the write is "converged", never "landed".
+    - ``RE_DRIVE`` — the token is UNMOVED, so the write has not landed. Re-drive
+      the identical bytes ONCE, and ONLY under the held token
+      (:attr:`ReconcileDecision.re_drive_token`): the possibly-in-flight ghost
+      and the re-drive carry the same precondition, so at most one lands.
+    - ``RE_DERIVE`` — the write did not land as mine (Postgres: version moved but
+      not to ``expected + 1``, or the bytes differ). Re-read fresh, rebuild the
+      intended bytes against the current state, and retry.
+    - ``CONFLICT`` — the token MOVED and the observed bytes DIFFER: a real peer
+      write. Reacquire and re-decide; never re-drive a superseded write.
+    - ``HOLD`` — the outcome is unconfirmable (the row/object is absent, or the
+      token is an unusable sentinel). Reacquire and re-decide; never a match
+      against ``sha256(b"")`` and never an auto re-create. Coordinator state
+      must never advance on a HOLD.
+    """
+
+    CONVERGE = "converge"
+    RE_DERIVE = "re_derive"
+    RE_DRIVE = "re_drive"
+    CONFLICT = "conflict"
+    HOLD = "hold"
+
+
+# Verdict wording is a closed table (never free text) so a converged write is
+# always surfaced as "converged", never "landed" — attribution is disclaimed on
+# every convergence path.
+_VERDICT_SUMMARY: dict[ReconcileVerdict, str] = {
+    ReconcileVerdict.CONVERGE: (
+        "converged: the re-read is byte-identical to the intended write, so "
+        "adopt the observed token as the comparand and STILL fire the "
+        "coordinator bump. Attribution is not claimed — this is convergence, "
+        "not confirmation"
+    ),
+    ReconcileVerdict.RE_DERIVE: (
+        "did not land as mine: the token moved but not under my identity (or "
+        "the bytes differ) — re-read fresh, rebuild the intended bytes, and retry"
+    ),
+    ReconcileVerdict.RE_DRIVE: (
+        "not confirmed yet: the token is unmoved, so re-drive the identical "
+        "bytes under the held token (at most one of the in-flight ghost and the "
+        "re-drive wins)"
+    ),
+    ReconcileVerdict.CONFLICT: (
+        "conflict: the token moved and the bytes differ — reacquire and "
+        "re-decide; never re-drive a superseded write"
+    ),
+    ReconcileVerdict.HOLD: (
+        "unconfirmed: the row/object or its token is absent — reacquire and "
+        "re-decide; never auto re-create (a delete is itself an update)"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ReconcileDecision:
+    """A binding's verdict after an unconfirmed write, plus what the re-read saw.
+
+    ``observed_bytes`` / ``observed_token`` carry the consistent pair from the
+    single reconciliation read (both ``None`` on a ``HOLD``, where the operand
+    was absent). ``CONVERGE`` is the ONLY verdict on which the caller settles
+    the substrate leg without re-deriving — and even then "did MY write land" is
+    left to the coordinator version-CAS, never to a bare content match.
+
+    The three derived properties are what let the cross-agent commit dispatch on
+    the ONE decision type regardless of which binding produced it.
+    """
+
+    verdict: ReconcileVerdict
+    observed_bytes: bytes | None
+    observed_token: "SubstrateToken | None"
+
+    @property
+    def bump_fires(self) -> bool:
+        """Whether the caller must STILL drive the coordinator bump.
+
+        True on ``CONVERGE`` ONLY. Refusing to bump on a converged write (the
+        "never converge" mistake) strands the coordinator behind the substrate
+        and wedges every peer; firing it on any other verdict would advance the
+        version for a write that did not land.
+        """
+        return self.verdict is ReconcileVerdict.CONVERGE
+
+    @property
+    def re_drive_token(self) -> "SubstrateToken | None":
+        """The precondition token to re-drive under — set only on ``RE_DRIVE``.
+
+        Equal to the held token (the substrate token is unmoved). Re-driving
+        under any other precondition is forbidden; every other verdict is
+        ``None``.
+        """
+        return self.observed_token if self.verdict is ReconcileVerdict.RE_DRIVE else None
+
+    @property
+    def summary(self) -> str:
+        """Human-facing wording. A converged write says "converged", never
+        "landed" — attribution is not claimed."""
+        return _VERDICT_SUMMARY[self.verdict]
 
 
 @runtime_checkable
@@ -179,3 +332,550 @@ class TwoPartCommitMixin:
         raise NotImplementedError(
             "the binding wires the coordinator bump for a confirmed substrate win"
         )
+
+
+# ---------------------------------------------------------------------------
+# The cross-agent layer (Unit 5): coordinator-mediated pull invalidation + the
+# divergence contract, over the SHIPPED coordinator HTTP surface. No coordinator
+# file is modified and no route is added — binding reads ride the shipped
+# ``/hooks/pre-read`` (SHARED grant) and version bumps ride ``/hooks/post-edit-cas``
+# (content_hash ONLY — the never-ship-a-store commit path). The read-generation
+# fence is NEITHER wired NOR claimed here: v1 OCC writers sit on the fence's
+# admit-on-absent path by design, the same posture as ``CoherentVolume.write_cas``.
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ReconcilingSubstrate(CoherenceSubstrate, Protocol):
+    """A :class:`CoherenceSubstrate` that can also reconcile an unknown write.
+
+    The cross-agent commit needs one method beyond the bytes-I/O surface: after
+    a substrate ``CasUnknown`` it asks the binding to re-read and decide (per its
+    own token shape) which unified :class:`ReconcileDecision` applies. Both v1
+    native-CAS bindings satisfy this structurally.
+    """
+
+    def reconcile_after_unknown(
+        self,
+        artifact_ref: str,
+        *,
+        expected_token: SubstrateToken,
+        intended_hash: str,
+    ) -> ReconcileDecision:
+        """Re-read the substrate and return the unified reconciliation verdict."""
+        ...
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _as_int(value: object, fallback: int) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) else fallback
+
+
+def _maybe_int(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _pre_read_version(resp: dict) -> int:
+    """The coordinator's authoritative version from a pre-read body (fresh or
+    stale shape). ``0`` when absent — a CAS against ``expected_version=0`` on a
+    seeded artifact loses cleanly, so the fallback never causes a silent write."""
+    version = resp.get("version")
+    if isinstance(version, int) and not isinstance(version, bool):
+        return version
+    summary = resp.get("summary")
+    if isinstance(summary, dict):
+        current = summary.get("current_version")
+        if isinstance(current, int) and not isinstance(current, bool):
+            return current
+    return 0
+
+
+def _pre_read_denied(resp: dict) -> bool:
+    """True on a strict-mode deny (the caller is INVALID, or a fresh reader whose
+    bytes diverge from the coordinator's record) — matched on the typed
+    ``permissionDecision == "deny"`` signal, never a substring."""
+    hook_output = resp.get("hookSpecificOutput")
+    return isinstance(hook_output, dict) and hook_output.get("permissionDecision") == "deny"
+
+
+def _pre_read_prior_seen(resp: dict) -> int | None:
+    summary = resp.get("summary")
+    if isinstance(summary, dict):
+        return _maybe_int(summary.get("prior_version_seen_by_session"))
+    return None
+
+
+def _pre_read_hash_differs(resp: dict) -> bool:
+    top = resp.get("hash_differs")
+    if isinstance(top, bool):
+        return top
+    summary = resp.get("summary")
+    if isinstance(summary, dict):
+        return bool(summary.get("hash_differs"))
+    return False
+
+
+def _deny_is_peer_invalidation(version: int, prior_seen: int | None) -> bool:
+    """A deny is a PEER-invalidation (StaleView) when the caller last saw a
+    strictly older version — a peer's commit moved the coordinator ahead of it.
+    Otherwise the substrate moved out of band of the coordinator
+    (coordinator-behind), which is a wedged view (ViewWedged)."""
+    return prior_seen is not None and prior_seen < version
+
+
+def _merge_yaml_list(path: Path, globs: tuple[str, ...]) -> None:
+    """Idempotently merge ``globs`` into a coordinator policy YAML list file."""
+    existing: list[str] = []
+    if path.is_file():
+        try:
+            loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (yaml.YAMLError, OSError):
+            loaded = None
+        if isinstance(loaded, list):
+            existing = [x for x in loaded if isinstance(x, str)]
+    merged = sorted(set(existing) | set(globs))
+    if merged == sorted(existing):
+        return
+    tmp = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
+    tmp.write_text(yaml.safe_dump(merged, default_flow_style=False), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _write_strict_policy(coherence_dir: Path, managed: tuple[str, ...]) -> None:
+    """Enable strict mode on the managed artifact globs BEFORE the coordinator
+    spawns (policy is load-once-at-startup): a path must be tracked AND strict
+    for a peer commit to invalidate this reader's cached view."""
+    if not managed:
+        return
+    coherence_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("tracked.yaml", "strict_mode.yaml"):
+        _merge_yaml_list(coherence_dir / name, managed)
+
+
+@dataclass(frozen=True)
+class PreReadResult:
+    """What a coordinator pre-read told this session about an artifact."""
+
+    version: int
+    stale_denied: bool
+    hash_differs: bool
+    prior_version_seen: int | None
+
+
+@dataclass(frozen=True)
+class CoordinatorWin:
+    """The coordinator committed the version bump; peers are now invalidated."""
+
+    version: int
+
+
+@dataclass(frozen=True)
+class CoordinatorConflict:
+    """The coordinator rejected the bump — a peer moved the version first."""
+
+    current_version: int | None
+
+
+CoordinatorCommit: TypeAlias = "CoordinatorWin | CoordinatorConflict"
+
+# The coordinator commit reasons that mean "a peer won this version" (re-read +
+# re-decide), matched EXACTLY against the wire reason — never a substring.
+_RETRYABLE_COMMIT_REASONS: frozenset[str] = frozenset(
+    {VERSION_MISMATCH_REASON, OCC_CALLER_TRANSIENT_REASON, STALE_READ_GENERATION_REASON}
+)
+
+
+def _classify_commit(resp: dict, expected_version: int) -> CoordinatorCommit:
+    """Map a ``/hooks/post-edit-cas`` 200 body to win / conflict, raising the
+    typed unknown on the fail-closed degrade body (deny AND degrade both raise —
+    an unconfirmed CAS must never read as success)."""
+    if resp.get("ok") is True:
+        return CoordinatorWin(version=_as_int(resp.get("version"), expected_version + 1))
+    reason = resp.get("reason")
+    if resp.get("degraded") or reason == COMMIT_UNCONFIRMED_REASON:
+        raise CommitUnconfirmed(
+            "coordinator commit_cas was unconfirmed (degraded); reconcile by "
+            "re-reading before retrying — never blind re-drive"
+        )
+    if reason in _RETRYABLE_COMMIT_REASONS:
+        return CoordinatorConflict(current_version=_maybe_int(resp.get("current_version")))
+    raise CoherenceError(f"coordinator commit_cas rejected (fail-closed): {reason}")
+
+
+class SubstrateCoordinatorSession:
+    """A single agent's client to the SHIPPED coordinator, for a substrate binding.
+
+    Spawns-or-attaches the local-HTTP coordinator for ``root`` (reusing the
+    shipped lifecycle) and rides its ``/hooks/pre-read`` + ``/hooks/post-edit-cas``
+    routes under ONE stable ``session_id`` (a v4 UUID) used on BOTH legs — the
+    same-agent identity a bump-after-read requires. :meth:`reacquire` mints a
+    fresh identity (shedding a sticky INVALID); a fresh identity is minted
+    NOWHERE else.
+
+    Every coordinator call is fail-closed: a transport error, a non-2xx, or a
+    ``{degraded: true}`` body RAISES (deny AND degrade both map to a raise) — the
+    client never silently degrades open. Two sessions over one ``root`` are two
+    distinct agents; the first spawns, the rest attach.
+    """
+
+    def __init__(
+        self,
+        root: "str | os.PathLike[str]",
+        *,
+        managed: tuple[str, ...],
+        config: object | None = None,
+        bind_host: str = "127.0.0.1",
+    ) -> None:
+        # Deferred so importing a binding never pulls in the coordinator server.
+        from ccs.adapters.claude_code.lifecycle import (  # noqa: PLC0415
+            LifecycleConfig,
+            connect_or_spawn,
+            read_port_from_file,
+            tcp_probe,
+        )
+
+        self._root = Path(root).resolve()
+        self._managed = tuple(managed)
+        cfg = config or LifecycleConfig()
+        coherence_dir = self._root / ".coherence"
+        pid_file = coherence_dir / "server.pid"
+        pre_existing = (port := read_port_from_file(pid_file)) is not None and tcp_probe(
+            port, cfg, bind_host=bind_host
+        )
+        # Only the SPAWNER writes policy (load-once); a sibling must not clobber it.
+        if not pre_existing:
+            _write_strict_policy(coherence_dir, self._managed)
+        if connect_or_spawn(self._root, config=cfg, bind_host=bind_host) == -1:
+            raise CoherenceError(
+                "substrate coordinator unavailable (could not spawn or attach; fail-closed)"
+            )
+        try:
+            self._endpoint: CoordinatorEndpoint = resolve_endpoint(self._root)
+        except CoordinatorUnavailable as exc:
+            raise CoherenceError(
+                f"substrate coordinator endpoint unresolved (fail-closed): {exc}"
+            ) from exc
+        self._session_id = str(uuid.uuid4())
+
+    @property
+    def session_id(self) -> str:
+        """The stable per-agent coordinator identity (a v4 UUID)."""
+        return self._session_id
+
+    @property
+    def root(self) -> Path:
+        """The coordinator workspace root (for ``stop_coordinator``)."""
+        return self._root
+
+    def reacquire(self) -> None:
+        """Mint a fresh identity, shedding a sticky INVALID. The ONLY place a new
+        identity is minted — read and commit always share one identity between
+        them."""
+        self._session_id = str(uuid.uuid4())
+
+    def pre_read(self, artifact_ref: str, content_hash: str | None) -> PreReadResult:
+        """Register a SHARED view and return the coordinator's version + deny
+        state. This is what makes a later peer commit invalidate this reader
+        (pull invalidation, surfaced at THIS reader's next binding-mediated act).
+        """
+        payload: dict[str, object] = {"session_id": self._session_id, "path": artifact_ref}
+        if content_hash is not None:
+            payload["content_hash"] = content_hash
+        resp = self._post("/hooks/pre-read", payload, unknown=CoherenceError)
+        if resp.get("degraded"):
+            raise CoherenceError("coordinator watchdog timeout on pre-read (fail-closed)")
+        return PreReadResult(
+            version=_pre_read_version(resp),
+            stale_denied=_pre_read_denied(resp),
+            hash_differs=_pre_read_hash_differs(resp),
+            prior_version_seen=_pre_read_prior_seen(resp),
+        )
+
+    def commit_cas(
+        self, artifact_ref: str, *, expected_version: int, content_hash: str
+    ) -> CoordinatorCommit:
+        """Drive the version bump — ``content_hash`` ONLY, content is NEVER sent
+        (the never-ship-a-store commit path). Raises :class:`CommitUnconfirmed`
+        on a transport/degrade UNKNOWN (a false-negative ack), returns win /
+        conflict otherwise."""
+        payload = {
+            "session_id": self._session_id,
+            "path": artifact_ref,
+            "success": True,
+            "content_hash": content_hash,
+            "expected_version": expected_version,
+        }
+        resp = self._post("/hooks/post-edit-cas", payload, unknown=CommitUnconfirmed)
+        return _classify_commit(resp, expected_version)
+
+    def coordinator_hash_matches(self, artifact_ref: str, content_hash: str) -> bool:
+        """True iff the coordinator's recorded hash equals ``content_hash`` — the
+        token-identity signal that a byte-identical peer already carried this
+        writer's intended content to the coordinator (so the bump is complete)."""
+        return not self.pre_read(artifact_ref, content_hash).hash_differs
+
+    def _post(
+        self, endpoint_path: str, payload: dict, *, unknown: type[CoherenceError]
+    ) -> dict:
+        """POST with fail-closed classification. A transport error / non-2xx /
+        non-dict body raises ``unknown`` (``CoherenceError`` for a read leg,
+        ``CommitUnconfirmed`` for the commit leg) — never a silent degrade-open."""
+        try:
+            resp = _coordinator_post(self._endpoint, endpoint_path, payload)
+        except (urllib.error.HTTPError, CoordinatorUnavailable) as exc:
+            raise unknown(
+                f"coordinator {endpoint_path} failed (fail-closed): {exc}"
+            ) from exc
+        if not isinstance(resp, dict):
+            raise unknown(f"coordinator {endpoint_path} returned a non-dict body (fail-closed)")
+        return resp
+
+
+@dataclass(frozen=True)
+class CommitResult:
+    """The outcome of a landed cross-agent commit.
+
+    ``converged`` is True when the write landed via reconciliation of an unknown
+    (attribution is not claimed) rather than a clean coordinator win.
+    """
+
+    version: int
+    converged: bool
+
+    @property
+    def summary(self) -> str:
+        """"converged" for a reconciled write, "committed" for a clean win —
+        never "landed", since a converged write's attribution is disclaimed."""
+        return "converged" if self.converged else "committed"
+
+
+@dataclass(frozen=True)
+class _PendingCommit:
+    """The client-held intent carried across the two commit legs + reconciliation."""
+
+    artifact_ref: str
+    expected_token: "SubstrateToken"
+    new_bytes: bytes
+    expected_version: int
+    intended_hash: str
+
+
+class CoordinatedSubstrate:
+    """A substrate binding made coordinator-mediated (the Unit-5 public surface).
+
+    Composes ONE :class:`ReconcilingSubstrate` binding (a Postgres row, an S3
+    object, or a scripted fake) with ONE :class:`SubstrateCoordinatorSession`.
+    Two instances over the same coordinator ``root`` — each with its own session
+    — are two agents sharing one artifact.
+
+    The value over the substrate's bare CAS: a peer's commit invalidates this
+    instance's cached read BEFORE it acts (pull invalidation, surfaced as the
+    uniform typed :class:`~ccs.core.exceptions.StaleView`), with the same
+    typed-conflict vocabulary over a row, an object, a file, or a store key. The
+    read-generation fence is NOT part of v1 — OCC writers ride admit-on-absent +
+    version-CAS, stated honestly.
+
+    Commit ordering is load-bearing: the substrate CAS runs FIRST, the
+    coordinator bump SECOND. A coordinator-bump-first path does not exist — the
+    bump is reached only through a confirmed (or reconciled-converged) substrate
+    write, so a write that fails the substrate CAS can never invalidate a peer.
+    """
+
+    def __init__(
+        self,
+        substrate: ReconcilingSubstrate,
+        coordinator: SubstrateCoordinatorSession,
+    ) -> None:
+        self._substrate = substrate
+        self._coordinator = coordinator
+        # Per-artifact last-observed content hash (seeded on read), so a commit's
+        # pre-read carries the hash the coordinator recorded — a fresh-SHARED
+        # holder is never falsely foreign-denied by its own intended hash.
+        self._observed_hash: dict[str, str] = {}
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        """The binding's honest capability declaration (passthrough)."""
+        return self._substrate.descriptor
+
+    @property
+    def session_id(self) -> str:
+        """This agent's stable coordinator identity."""
+        return self._coordinator.session_id
+
+    def read(
+        self, artifact_ref: str, *, on_stale: str = "allow"
+    ) -> tuple[bytes, "SubstrateToken"]:
+        """Read ``(bytes, token)`` from the substrate and register a SHARED view.
+
+        Under ``on_stale="allow"`` (default, R10) a peer-invalidation deny returns
+        the current bytes (the instance stays sticky-INVALID); under ``"raise"``
+        it surfaces :class:`~ccs.core.exceptions.StaleView`. A coordinator-behind
+        deny (the substrate moved out of band) always raises
+        :class:`~ccs.core.exceptions.ViewWedged` — the view is wedged, not merely
+        stale.
+        """
+        observed_bytes, token = self._substrate.read(artifact_ref)
+        content_hash = _sha256_hex(observed_bytes)
+        pre = self._coordinator.pre_read(artifact_ref, content_hash)
+        self._observed_hash[artifact_ref] = content_hash
+        self._raise_on_deny(artifact_ref, pre, on_stale=on_stale)
+        return observed_bytes, token
+
+    def reacquire(self, artifact_ref: str) -> tuple[bytes, "SubstrateToken"]:
+        """Shed a sticky deny: mint a fresh identity, then re-read under it
+        (SHARED@current). The caller MUST rebuild any pending write from these
+        fresh bytes."""
+        self._coordinator.reacquire()
+        observed_bytes, token = self._substrate.read(artifact_ref)
+        content_hash = _sha256_hex(observed_bytes)
+        self._coordinator.pre_read(artifact_ref, content_hash)
+        self._observed_hash[artifact_ref] = content_hash
+        return observed_bytes, token
+
+    def commit(
+        self, artifact_ref: str, *, expected_token: "SubstrateToken", new_bytes: bytes
+    ) -> CommitResult:
+        """Two-part commit: pull-invalidation check, substrate CAS, coordinator bump.
+
+        Step 1 is a coordinator pre-read: if a peer committed since this instance
+        read, the instance is INVALID and this raises
+        :class:`~ccs.core.exceptions.StaleView` BEFORE the substrate is touched
+        (the invalidation headline; a bare CAS never surfaces this). Otherwise the
+        substrate CAS runs FIRST and only a confirmed win reaches the coordinator
+        bump. Divergence (substrate/coordinator UNKNOWN) is reconciled by
+        token-identity — never a blind re-drive, never a stranded converged bump.
+        """
+        pending = _PendingCommit(
+            artifact_ref=artifact_ref,
+            expected_token=expected_token,
+            new_bytes=new_bytes,
+            expected_version=0,
+            intended_hash=_sha256_hex(new_bytes),
+        )
+        pre = self._coordinator.pre_read(artifact_ref, self._observed_hash.get(artifact_ref))
+        # A write is a data-loss surface — a deny ALWAYS raises before acting.
+        self._raise_on_deny(artifact_ref, pre, on_stale="raise")
+        pending = _replace_expected_version(pending, pre.version)
+        outcome = self._substrate.cas_write(
+            artifact_ref, expected_token=expected_token, new_bytes=new_bytes
+        )
+        return self._after_substrate_write(pending, outcome)
+
+    # --- internals ------------------------------------------------------------
+
+    def _raise_on_deny(self, artifact_ref: str, pre: PreReadResult, *, on_stale: str) -> None:
+        if not pre.stale_denied:
+            return
+        if _deny_is_peer_invalidation(pre.version, pre.prior_version_seen):
+            if on_stale == "raise":
+                raise StaleView(
+                    f"a peer commit invalidated the cached view of {artifact_ref!r} "
+                    "before this act; reacquire() and act on the fresh state"
+                )
+            return
+        # Coordinator-behind: the substrate token moved but the coordinator did
+        # not — a foreign out-of-band write, or a writer crash between the two
+        # commit legs. Unbounded in v1 (a peer on an already-cached read is
+        # unprotected until its next binding-mediated read); recover via reacquire.
+        raise ViewWedged(
+            f"the substrate for {artifact_ref!r} moved out of band of the coordinator "
+            "(coordinator-behind); reacquire() and re-decide"
+        )
+
+    def _after_substrate_write(
+        self, pending: _PendingCommit, outcome: CasWriteResult
+    ) -> CommitResult:
+        if isinstance(outcome, CasWritten):
+            return self._drive_bump(pending)
+        if isinstance(outcome, CasConflict):
+            # No coordinator leg — no write landed; a foreign writer moved the token.
+            raise CasVersionConflict(
+                pending.artifact_ref, pending.expected_version, pending.expected_version
+            )
+        return self._reconcile_unknown(pending)
+
+    def _drive_bump(self, pending: _PendingCommit, *, converged: bool = False) -> CommitResult:
+        try:
+            result = self._coordinator.commit_cas(
+                pending.artifact_ref,
+                expected_version=pending.expected_version,
+                content_hash=pending.intended_hash,
+            )
+        except CommitUnconfirmed:
+            # Case 1: the substrate write is durable but the coordinator leg is
+            # unknown. NEVER blind re-drive (it would conflict against the moved
+            # token). Surface the false-negative ack — the caller re-reads.
+            raise
+        if isinstance(result, CoordinatorWin):
+            self._observed_hash[pending.artifact_ref] = pending.intended_hash
+            return CommitResult(version=result.version, converged=converged)
+        return self._resolve_bump_conflict(pending, result, converged=converged)
+
+    def _resolve_bump_conflict(
+        self, pending: _PendingCommit, result: CoordinatorConflict, *, converged: bool
+    ) -> CommitResult:
+        # A converged write whose bump lost to a byte-identical peer is COMPLETE
+        # if the coordinator already holds the intended hash — no re-drive, no
+        # second bump (that would be a phantom advance).
+        if converged and self._coordinator.coordinator_hash_matches(
+            pending.artifact_ref, pending.intended_hash
+        ):
+            self._observed_hash[pending.artifact_ref] = pending.intended_hash
+            return CommitResult(
+                version=result.current_version or pending.expected_version, converged=True
+            )
+        raise CasVersionConflict(
+            pending.artifact_ref,
+            pending.expected_version,
+            result.current_version or pending.expected_version,
+        )
+
+    def _reconcile_unknown(self, pending: _PendingCommit) -> CommitResult:
+        decision = self._substrate.reconcile_after_unknown(
+            pending.artifact_ref,
+            expected_token=pending.expected_token,
+            intended_hash=pending.intended_hash,
+        )
+        if decision.verdict is ReconcileVerdict.HOLD:
+            raise ViewWedged(
+                f"unconfirmed substrate write to {pending.artifact_ref!r}: the operand "
+                "is absent — reacquire() and re-decide (never auto re-create)"
+            )
+        if decision.bump_fires:  # CONVERGE — the intended bytes landed; drive the bump.
+            return self._drive_bump(pending, converged=True)
+        if decision.re_drive_token is not None:  # RE_DRIVE — token unmoved, retry once.
+            return self._re_drive(pending, decision.re_drive_token)
+        # RE_DERIVE / CONFLICT — the write did not land as mine; reacquire + re-decide.
+        raise CasVersionConflict(
+            pending.artifact_ref, pending.expected_version, pending.expected_version
+        )
+
+    def _re_drive(self, pending: _PendingCommit, token: "SubstrateToken") -> CommitResult:
+        retry = self._substrate.cas_write(
+            pending.artifact_ref, expected_token=token, new_bytes=pending.new_bytes
+        )
+        if isinstance(retry, CasWritten):
+            return self._drive_bump(pending)
+        if isinstance(retry, CasConflict):
+            raise CasVersionConflict(
+                pending.artifact_ref, pending.expected_version, pending.expected_version
+            )
+        # A SECOND unknown — surface rather than loop unbounded (fail-closed).
+        raise CommitUnconfirmed(
+            f"re-drive of {pending.artifact_ref!r} is again unconfirmed; reconcile by "
+            "re-reading before retrying"
+        )
+
+
+def _replace_expected_version(pending: _PendingCommit, version: int) -> _PendingCommit:
+    return _PendingCommit(
+        artifact_ref=pending.artifact_ref,
+        expected_token=pending.expected_token,
+        new_bytes=pending.new_bytes,
+        expected_version=version,
+        intended_hash=pending.intended_hash,
+    )

--- a/src/ccs/adapters/substrate.py
+++ b/src/ccs/adapters/substrate.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""The bytes-I/O contract a bring-your-own-substrate binding implements.
+
+This module is the CONTRACT half that lives with its callers: every
+implementer and consumer of the byte-level substrate surface is an adapter,
+so the Protocol sits in the adapters layer while the capability descriptor,
+tier vocabulary, and never-ship-a-store floor live in
+:mod:`ccs.core.substrate` (importable by the conformance kit without pulling
+in any I/O).
+
+Conformance is structural, mirroring the registry-contract discipline: the
+Protocol is :func:`~typing.runtime_checkable` so ``isinstance`` verifies
+presence of the surface, each binding adds a ``TYPE_CHECKING``-guarded static
+assertion, and the descriptor-parametrized conformance suite is the parity
+test. Bindings never inherit the Protocol.
+
+Shared contract vocabulary (type aliases and the typed compare-and-set
+outcomes) is DEFINED here and imported by bindings, so no two bindings can
+drift apart on what a win, a conflict, or an unknown outcome means.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, TypeAlias, runtime_checkable
+
+from ccs.core.substrate import CapabilityDescriptor
+
+# The substrate-minted version token: an object ETag, a row-version rendered
+# opaque, etc. Two properties are contractual: it comes from the SAME read (or
+# write response) as the bytes it vouches for, and it is never portable across
+# artifact refs — identical bytes elsewhere can mint an identical token, so a
+# token for one ref must never arbitrate a write to another.
+SubstrateToken: TypeAlias = str
+
+
+@dataclass(frozen=True)
+class CasWritten:
+    """WIN: the substrate accepted the compare-and-set write.
+
+    ``token`` is the token the substrate minted FOR THIS WRITE, captured from
+    the write response — never recomputed client-side (a recomputed token can
+    silently vouch for bytes the substrate never acknowledged).
+    """
+
+    token: SubstrateToken
+
+
+@dataclass(frozen=True)
+class CasConflict:
+    """LOSS: the substrate rejected the compare-and-set — the token moved.
+
+    No write landed. Recovery is a fresh read (bytes and token from ONE read),
+    re-derive, retry; the stale comparand must never be re-driven.
+    """
+
+
+@dataclass(frozen=True)
+class CasUnknown:
+    """UNKNOWN, not failed: the write's outcome could not be confirmed.
+
+    A transport failure after the request left the client means the write may
+    or may not be durable. Treat it as unconfirmed: reconcile by re-reading the
+    token before doing anything else, never blindly re-drive the write, and
+    never advance coordinator state on it.
+    """
+
+
+# The three-way compare-and-set outcome. A typed return, never an exception:
+# conflict and unknown are expected protocol states a caller must branch on.
+CasWriteResult: TypeAlias = "CasWritten | CasConflict | CasUnknown"
+
+
+@runtime_checkable
+class CoherenceSubstrate(Protocol):
+    """The byte-level surface a substrate binding exposes to the coherence layer.
+
+    Implementations wrap one substrate (a Postgres row, an S3 object) and keep
+    ALL content substrate-side; the coherence layer above only ever sees the
+    bytes in transit plus the opaque token. A binding for an action backend
+    (the ``forward_only`` tier) does not implement this Protocol — an action
+    surface has no bytes to read back and no token to compare; it declares a
+    descriptor only.
+    """
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        """The binding's declared capability tier and guarantee metadata.
+
+        Part of the Protocol so a binding cannot satisfy ``isinstance`` while
+        omitting its honesty declaration — the conformance suite reads the
+        tier from here.
+        """
+        ...
+
+    def read(self, artifact_ref: str) -> tuple[bytes, SubstrateToken]:
+        """Return ``(bytes, token)`` observed by ONE substrate read.
+
+        Both values must come from the same read operation: a token fetched by
+        a second call can vouch for bytes it never described, which silently
+        loses a concurrent update.
+        """
+        ...
+
+    def cas_write(
+        self,
+        artifact_ref: str,
+        *,
+        expected_token: SubstrateToken,
+        new_bytes: bytes,
+    ) -> CasWriteResult:
+        """Conditionally write ``new_bytes`` keyed on ``expected_token``.
+
+        The comparison is the SUBSTRATE'S atomic conditional write, never a
+        client-side check-then-write. Returns a typed outcome: a win carries
+        the newly minted token; a conflict means no write landed; an unknown
+        outcome means unconfirmed and must be reconciled by re-read.
+        """
+        ...
+
+
+class TwoPartCommitMixin:
+    """Ordering seam for the binding commit: substrate CAS first, coordinator
+    bump second.
+
+    The order is load-bearing. Bumping the coordinator first would advance the
+    version and invalidate peers for a write that can still lose the substrate
+    compare-and-set — a phantom invalidation with the coordinator ahead of the
+    substrate, indistinguishable from a real advance and therefore
+    unrecoverable. Substrate-first is self-healing: if the coordinator leg is
+    lost, the next read reconciles because the token moved.
+
+    This mixin defines the seam only. The substrate leg is the binding's
+    :meth:`~CoherenceSubstrate.cas_write`; the coordinator leg
+    (:meth:`_bump_coordinator`) is wired by each binding.
+    """
+
+    def commit_two_part(
+        self,
+        artifact_ref: str,
+        *,
+        expected_token: SubstrateToken,
+        new_bytes: bytes,
+    ) -> CasWriteResult:
+        """Run the two-part commit and return the substrate outcome.
+
+        The coordinator leg fires ONLY on a confirmed substrate win: a conflict
+        never reaches the coordinator (no write landed), and an unknown outcome
+        never advances coordinator state (the write is unconfirmed until a
+        re-read proves otherwise).
+        """
+        outcome = self.cas_write(
+            artifact_ref, expected_token=expected_token, new_bytes=new_bytes
+        )
+        if isinstance(outcome, CasWritten):
+            self._bump_coordinator(artifact_ref, written=outcome)
+        return outcome
+
+    def cas_write(
+        self,
+        artifact_ref: str,
+        *,
+        expected_token: SubstrateToken,
+        new_bytes: bytes,
+    ) -> CasWriteResult:
+        """The substrate leg — supplied by the binding's substrate surface."""
+        raise NotImplementedError(
+            "the binding supplies the substrate leg (CoherenceSubstrate.cas_write)"
+        )
+
+    def _bump_coordinator(self, artifact_ref: str, *, written: CasWritten) -> None:
+        """The coordinator leg — version bump plus peer invalidation.
+
+        Wired by each binding; this seam only guarantees WHEN it may run
+        (after, and only after, a confirmed substrate win).
+        """
+        raise NotImplementedError(
+            "the binding wires the coordinator bump for a confirmed substrate win"
+        )

--- a/src/ccs/adapters/substrate.py
+++ b/src/ccs/adapters/substrate.py
@@ -23,7 +23,6 @@ drift apart on what a win, a conflict, or an unknown outcome means.
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 import urllib.error
@@ -55,6 +54,7 @@ from ccs.core.exceptions import (
     ViewWedged,
 )
 from ccs.core.substrate import CapabilityDescriptor
+from ccs.core.substrate import sha256_hex as _sha256_hex
 
 logger = logging.getLogger(__name__)
 
@@ -274,64 +274,13 @@ class CoherenceSubstrate(Protocol):
         ...
 
 
-class TwoPartCommitMixin:
-    """Ordering seam for the binding commit: substrate CAS first, coordinator
-    bump second.
-
-    The order is load-bearing. Bumping the coordinator first would advance the
-    version and invalidate peers for a write that can still lose the substrate
-    compare-and-set — a phantom invalidation with the coordinator ahead of the
-    substrate, indistinguishable from a real advance and therefore
-    unrecoverable. Substrate-first is self-healing: if the coordinator leg is
-    lost, the next read reconciles because the token moved.
-
-    This mixin defines the seam only. The substrate leg is the binding's
-    :meth:`~CoherenceSubstrate.cas_write`; the coordinator leg
-    (:meth:`_bump_coordinator`) is wired by each binding.
-    """
-
-    def commit_two_part(
-        self,
-        artifact_ref: str,
-        *,
-        expected_token: SubstrateToken,
-        new_bytes: bytes,
-    ) -> CasWriteResult:
-        """Run the two-part commit and return the substrate outcome.
-
-        The coordinator leg fires ONLY on a confirmed substrate win: a conflict
-        never reaches the coordinator (no write landed), and an unknown outcome
-        never advances coordinator state (the write is unconfirmed until a
-        re-read proves otherwise).
-        """
-        outcome = self.cas_write(
-            artifact_ref, expected_token=expected_token, new_bytes=new_bytes
-        )
-        if isinstance(outcome, CasWritten):
-            self._bump_coordinator(artifact_ref, written=outcome)
-        return outcome
-
-    def cas_write(
-        self,
-        artifact_ref: str,
-        *,
-        expected_token: SubstrateToken,
-        new_bytes: bytes,
-    ) -> CasWriteResult:
-        """The substrate leg — supplied by the binding's substrate surface."""
-        raise NotImplementedError(
-            "the binding supplies the substrate leg (CoherenceSubstrate.cas_write)"
-        )
-
-    def _bump_coordinator(self, artifact_ref: str, *, written: CasWritten) -> None:
-        """The coordinator leg — version bump plus peer invalidation.
-
-        Wired by each binding; this seam only guarantees WHEN it may run
-        (after, and only after, a confirmed substrate win).
-        """
-        raise NotImplementedError(
-            "the binding wires the coordinator bump for a confirmed substrate win"
-        )
+# The two-part commit ordering (substrate CAS first, coordinator bump second) is
+# load-bearing, and it lives in ONE place: CoordinatedSubstrate below. Bumping
+# the coordinator first would advance the version and invalidate peers for a
+# write that can still lose the substrate compare-and-set — a phantom
+# invalidation, indistinguishable from a real advance and therefore
+# unrecoverable. Substrate-first is self-healing: if the coordinator leg is lost,
+# the next read reconciles because the token moved.
 
 
 # ---------------------------------------------------------------------------
@@ -364,10 +313,6 @@ class ReconcilingSubstrate(CoherenceSubstrate, Protocol):
     ) -> ReconcileDecision:
         """Re-read the substrate and return the unified reconciliation verdict."""
         ...
-
-
-def _sha256_hex(data: bytes) -> str:
-    return hashlib.sha256(data).hexdigest()
 
 
 def _as_int(value: object, fallback: int) -> int:
@@ -639,16 +584,23 @@ class CommitResult:
     """The outcome of a landed cross-agent commit.
 
     ``converged`` is True when the write landed via reconciliation of an unknown
-    (attribution is not claimed) rather than a clean coordinator win.
+    (attribution is not claimed) rather than a clean coordinator win. ``noop`` is
+    True when the commit was byte-identical to the last-observed bytes and so
+    touched neither the substrate nor the coordinator — the version did not
+    advance and no peer was invalidated.
     """
 
     version: int
     converged: bool
+    noop: bool = False
 
     @property
     def summary(self) -> str:
-        """"converged" for a reconciled write, "committed" for a clean win —
-        never "landed", since a converged write's attribution is disclaimed."""
+        """"unchanged" for a byte-identical no-op, "converged" for a reconciled
+        write, "committed" for a clean win — never "landed", since a converged
+        write's attribution is disclaimed and a no-op landed nothing."""
+        if self.noop:
+            return "unchanged"
         return "converged" if self.converged else "committed"
 
 
@@ -689,6 +641,15 @@ class CoordinatedSubstrate:
         substrate: ReconcilingSubstrate,
         coordinator: SubstrateCoordinatorSession,
     ) -> None:
+        # never-ship-a-store, made load-bearing: a binding that declares it sends
+        # content to the coordinator is refused at composition, so the content-free
+        # commit path (commit_cas sends content_hash only) cannot be undercut by a
+        # binding that shadows the body coordinator-side.
+        if getattr(substrate, "SENDS_CONTENT_TO_COORDINATOR", False):
+            raise CoherenceError(
+                "substrate binding declares SENDS_CONTENT_TO_COORDINATOR=True; the "
+                "coordinator holds a content_hash only (never-ship-a-store) — refused"
+            )
         self._substrate = substrate
         self._coordinator = coordinator
         # Per-artifact last-observed content hash (seeded on read), so a commit's
@@ -759,6 +720,12 @@ class CoordinatedSubstrate:
         pre = self._coordinator.pre_read(artifact_ref, self._observed_hash.get(artifact_ref))
         # A write is a data-loss surface — a deny ALWAYS raises before acting.
         self._raise_on_deny(artifact_ref, pre, on_stale="raise")
+        # No-op guard: committing the exact bytes this instance last observed
+        # changes nothing. Skip BOTH legs so a byte-identical rewrite never mints a
+        # phantom version advance that would invalidate every peer (Open Q C). The
+        # deny check above still ran, so a stale no-op surfaces rather than passing.
+        if self._observed_hash.get(artifact_ref) == pending.intended_hash:
+            return CommitResult(version=pre.version, converged=False, noop=True)
         pending = _replace_expected_version(pending, pre.version)
         outcome = self._substrate.cas_write(
             artifact_ref, expected_token=expected_token, new_bytes=new_bytes
@@ -793,6 +760,8 @@ class CoordinatedSubstrate:
             return self._drive_bump(pending)
         if isinstance(outcome, CasConflict):
             # No coordinator leg — no write landed; a foreign writer moved the token.
+            # current_version is best-effort (no coordinator re-read); recover via
+            # reacquire(), not the numeric (see CasVersionConflict).
             raise CasVersionConflict(
                 pending.artifact_ref, pending.expected_version, pending.expected_version
             )
@@ -850,6 +819,8 @@ class CoordinatedSubstrate:
         if decision.re_drive_token is not None:  # RE_DRIVE — token unmoved, retry once.
             return self._re_drive(pending, decision.re_drive_token)
         # RE_DERIVE / CONFLICT — the write did not land as mine; reacquire + re-decide.
+        # current_version is best-effort (no coordinator re-read); recover via
+        # reacquire(), not the numeric (see CasVersionConflict).
         raise CasVersionConflict(
             pending.artifact_ref, pending.expected_version, pending.expected_version
         )
@@ -861,6 +832,21 @@ class CoordinatedSubstrate:
         if isinstance(retry, CasWritten):
             return self._drive_bump(pending)
         if isinstance(retry, CasConflict):
+            # The token moved between the reconcile read and this re-drive. Either
+            # MY own in-flight ghost put landed (converge — complete the bump) or a
+            # peer superseded me (a real conflict). Reconcile ONCE more to tell them
+            # apart rather than raising a misleading conflict on my own write. Only
+            # CONVERGE is acted on here; any other verdict is surfaced as a conflict,
+            # so this cannot loop back into another re-drive.
+            decision = self._substrate.reconcile_after_unknown(
+                pending.artifact_ref,
+                expected_token=pending.expected_token,
+                intended_hash=pending.intended_hash,
+            )
+            if decision.bump_fires:  # CONVERGE — my ghost carried my bytes; complete it.
+                return self._drive_bump(pending, converged=True)
+            # current_version is best-effort here — no coordinator re-read; the
+            # caller recovers via reacquire(), not the numeric (see CasVersionConflict).
             raise CasVersionConflict(
                 pending.artifact_ref, pending.expected_version, pending.expected_version
             )

--- a/src/ccs/adapters/substrate.py
+++ b/src/ccs/adapters/substrate.py
@@ -23,14 +23,13 @@ drift apart on what a win, a conflict, or an unknown outcome means.
 
 from __future__ import annotations
 
-import logging
 import os
 import urllib.error
 import uuid
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Protocol, TypeAlias, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, TypeAlias, runtime_checkable
 
 import yaml
 
@@ -56,7 +55,8 @@ from ccs.core.exceptions import (
 from ccs.core.substrate import CapabilityDescriptor
 from ccs.core.substrate import sha256_hex as _sha256_hex
 
-logger = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from ccs.adapters.claude_code.lifecycle import LifecycleConfig
 
 # The substrate-minted version token: an object ETag, a row-version rendered
 # opaque, etc. Two properties are contractual: it comes from the SAME read (or
@@ -471,7 +471,7 @@ class SubstrateCoordinatorSession:
         root: "str | os.PathLike[str]",
         *,
         managed: tuple[str, ...],
-        config: object | None = None,
+        config: LifecycleConfig | None = None,
         bind_host: str = "127.0.0.1",
     ) -> None:
         # Deferred so importing a binding never pulls in the coordinator server.
@@ -679,6 +679,8 @@ class CoordinatedSubstrate:
         :class:`~ccs.core.exceptions.ViewWedged` — the view is wedged, not merely
         stale.
         """
+        if on_stale not in ("allow", "raise"):
+            raise ValueError(f"on_stale must be 'allow' or 'raise', got {on_stale!r}")
         observed_bytes, token = self._substrate.read(artifact_ref)
         content_hash = _sha256_hex(observed_bytes)
         pre = self._coordinator.pre_read(artifact_ref, content_hash)

--- a/src/ccs/adapters/substrate_manifest.py
+++ b/src/ccs/adapters/substrate_manifest.py
@@ -1,0 +1,663 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""The Coherence Manifest: a declarative, secret-safe, SSRF-constrained wiring
+of artifact identities to substrate connections.
+
+The manifest is a named TRUST BOUNDARY. It binds an artifact id to a substrate
+type, a connection target, a credential REFERENCE (never a literal), a
+version-source, and an honest guarantee :class:`~ccs.core.substrate.Tier`. Every
+security decision is taken at LOAD/VALIDATE time — before any driver is
+constructed — so a bad target or an inline literal secret can never reach a
+substrate. The discipline mirrors the shipped plaintext-bearer guard
+(:func:`ccs.cli._coherence_client._guard_plaintext_bearer`): classify the target
+deterministically, fail closed on anything unclassifiable, and log the HOST and
+POSTURE only — never the credential.
+
+Two guards are distinct from the coordinator's own remote-mode flags on purpose
+(relaxing coordinator transport must never relax substrate egress):
+
+- ``CCS_SUBSTRATE_ALLOW_PRIVATE`` — opt in to RFC-1918/4193 private targets (a
+  customer's internal RDS/Postgres is commonly RFC-1918). NOT
+  ``CCS_REMOTE_COORDINATOR``.
+- ``CCS_SUBSTRATE_INSECURE`` — acknowledge a plaintext credential to a routable
+  host (an out-of-band-secured link). NOT ``CCS_REMOTE_INSECURE``.
+
+The DNS resolver is an INJECTABLE seam (:data:`HostResolver`): the SSRF deny
+runs on the RESOLVED address(es), and injecting the resolver keeps validation
+hermetic and lets later bindings (Postgres/S3) reuse the same
+resolve-then-check primitive.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import re
+import socket
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import TypeAlias
+from urllib.parse import parse_qs, urlsplit
+
+import yaml
+
+from ccs.core.exceptions import (
+    ManifestError,
+    SubstrateCredentialRefused,
+    SubstrateInsecureTransport,
+    SubstrateTargetDenied,
+)
+from ccs.core.substrate import CapabilityDescriptor, Tier
+
+logger = logging.getLogger(__name__)
+
+#: Opt-in for RFC-1918/4193 private substrate targets (distinct from the
+#: coordinator's ``CCS_REMOTE_COORDINATOR`` — see the module docstring).
+ALLOW_PRIVATE_ENV = "CCS_SUBSTRATE_ALLOW_PRIVATE"
+#: Acknowledge a plaintext credential to a routable host (distinct from
+#: ``CCS_REMOTE_INSECURE``).
+INSECURE_ACK_ENV = "CCS_SUBSTRATE_INSECURE"
+
+#: Truthy env values (mirrors the shipped remote-flag parser).
+_TRUTHY_ENV_VALUES: frozenset[str] = frozenset({"1", "true", "yes", "on"})
+
+# --- schema keys ------------------------------------------------------------
+_ALLOWED_TOP_LEVEL_KEYS: frozenset[str] = frozenset({"artifacts"})
+_ALLOWED_ARTIFACT_KEYS: frozenset[str] = frozenset(
+    {"id", "substrate", "tier", "version_source", "connection"}
+)
+_ALLOWED_TARGET_KEYS: frozenset[str] = frozenset({"dsn", "endpoint_url", "region"})
+
+# --- credential reference forms (allowlist; anything else is a suspected literal)
+_ZERO_SECRET_FORMS: frozenset[str] = frozenset({"aws-default"})
+_SECRET_FILE_PREFIX = "secret-file:"
+_ENV_PREFIX = "env:"
+_SECRET_URI_PREFIX = "secret:"
+#: ``secret:`` resolvers are constrained to an allowlisted provider set.
+_ALLOWED_SECRET_PROVIDERS: frozenset[str] = frozenset(
+    {"aws-secretsmanager", "vault", "gcp-secretmanager", "azure-keyvault"}
+)
+
+# --- SSRF classification (explicit networks; NO reliance on stdlib is_private/
+#     is_link_local, which vary across CPython patch releases) -----------------
+_LINK_LOCAL_V4_NET = ipaddress.ip_network("169.254.0.0/16")  # AWS/Azure IMDS
+_CGNAT_V4_NET = ipaddress.ip_network("100.64.0.0/10")  # Alibaba metadata
+_HARD_DENY_V4_NETS = (_LINK_LOCAL_V4_NET, _CGNAT_V4_NET)
+_LINK_LOCAL_V6_NET = ipaddress.ip_network("fe80::/10")
+#: EC2 IMDS over IPv6 lives inside ``fc00::/7`` (ULA), so "private ⇒ allowed" is
+#: unsafe for egress — hard-deny the exact address.
+_HARD_DENY_V6_ADDRS: frozenset[ipaddress.IPv6Address] = frozenset(
+    {ipaddress.IPv6Address("fd00:ec2::254")}
+)
+_METADATA_HOSTNAMES: frozenset[str] = frozenset({"metadata.google.internal"})
+_PRIVATE_V4_NETS = (
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+)
+_ULA_V6_NET = ipaddress.ip_network("fc00::/7")
+_LOOPBACK_V4_NET = ipaddress.ip_network("127.0.0.0/8")
+_IPV6_LOOPBACK = ipaddress.IPv6Address("::1")
+
+#: Postgres sslmodes that guarantee an encrypted link; ``disable``/``allow``/
+#: ``prefer`` (and unset → libpq ``prefer``) can silently ship the credential in
+#: cleartext.
+_TLS_SAFE_SSLMODES: frozenset[str] = frozenset({"require", "verify-ca", "verify-full"})
+
+#: A DNS resolver seam: a hostname maps to a tuple of resolved IP strings (empty
+#: ⇒ unresolvable ⇒ fail closed). Injected in tests and reused by later bindings.
+HostResolver: TypeAlias = Callable[[str], "tuple[str, ...]"]
+
+
+def resolve_host_addresses(host: str) -> tuple[str, ...]:
+    """Default resolver: the deduplicated ``getaddrinfo`` addresses for ``host``.
+
+    Returns an empty tuple on resolution failure so the caller can fail closed
+    (an unresolvable target is denied, never admitted). An IP literal is echoed
+    back with no network round-trip.
+    """
+    try:
+        infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except OSError:
+        return ()
+    return tuple(dict.fromkeys(info[4][0] for info in infos))
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ManifestArtifact:
+    """One validated artifact wiring.
+
+    ``connection`` is the read-only, form-validated reference bundle (a
+    ``credential`` reference plus any target — ``dsn`` / ``endpoint_url`` /
+    ``region``) that a later binding resolves; it never carries a literal
+    secret. ``descriptor`` is the tier-derived honesty declaration.
+    """
+
+    id: str
+    substrate: str
+    tier: Tier
+    descriptor: CapabilityDescriptor
+    connection: Mapping[str, str]
+    version_source: str | None = None
+
+
+@dataclass(frozen=True)
+class SubstrateManifest:
+    """A loaded, validated set of artifact wirings."""
+
+    artifacts: tuple[ManifestArtifact, ...]
+
+    def validate(self) -> None:
+        """Re-assert per-artifact tier consistency (reusing the descriptor's own
+        validation): a ``forward-only`` artifact must declare no version_source,
+        a ``native-cas`` artifact must declare one. Raises :class:`ManifestError`."""
+        for artifact in self.artifacts:
+            _build_descriptor(artifact.tier, artifact.version_source)
+
+    def dry_run(self) -> tuple[tuple[str, str, Tier], ...]:
+        """Print and return each artifact's ``(id, substrate, tier)`` so the tier
+        is visible at config time before any substrate is touched."""
+        rows = tuple((a.id, a.substrate, a.tier) for a in self.artifacts)
+        for artifact_id, substrate, tier in rows:
+            print(f"  {artifact_id}\t{substrate}\t{tier.value}")
+        return rows
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def load_manifest(
+    path: str | Path,
+    *,
+    resolver: HostResolver = resolve_host_addresses,
+    env: Mapping[str, str] | None = None,
+) -> SubstrateManifest:
+    """Load, secret-form-validate, and SSRF/TLS-check a coherence manifest.
+
+    Rejects (all at load, before any driver): unknown top-level/artifact keys, a
+    missing/unknown tier, a non-reference-form credential, a target that
+    resolves into the metadata/link-local class or (without opt-in) a private
+    range, and a plaintext credential to a routable host (without the ack).
+    Warns on a world-readable manifest and on a multi-region/replica endpoint.
+    """
+    manifest_path = Path(path)
+    resolved_env = os.environ if env is None else env
+    _warn_if_world_readable(manifest_path)
+    data = _load_yaml(manifest_path)
+    _reject_unknown_keys(data, _ALLOWED_TOP_LEVEL_KEYS, "manifest top-level")
+    raw_artifacts = data.get("artifacts")
+    if not isinstance(raw_artifacts, list) or not raw_artifacts:
+        raise ManifestError("manifest requires a non-empty 'artifacts' list")
+    artifacts = tuple(
+        _parse_artifact(entry, resolver=resolver, env=resolved_env)
+        for entry in raw_artifacts
+    )
+    manifest = SubstrateManifest(artifacts=artifacts)
+    manifest.validate()
+    return manifest
+
+
+def _load_yaml(path: Path) -> Mapping[str, object]:
+    """Read + ``yaml.safe_load`` the manifest; require a mapping root."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ManifestError(f"cannot read manifest {str(path)!r}: {exc}") from exc
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ManifestError(f"manifest {str(path)!r} is not valid YAML: {exc}") from exc
+    if not isinstance(data, Mapping):
+        raise ManifestError("manifest root must be a mapping with an 'artifacts' key")
+    return data
+
+
+def _warn_if_world_readable(path: Path) -> None:
+    """Warn on a world-readable manifest (it names hosts + secret-ref paths)."""
+    try:
+        mode = path.stat().st_mode
+    except OSError:
+        return
+    if mode & 0o004:
+        logger.warning(
+            "manifest %s is world-readable (mode %o); it names connection targets "
+            "and secret-reference paths — tighten it (e.g. 0600)",
+            str(path),
+            mode & 0o777,
+        )
+
+
+def _reject_unknown_keys(
+    mapping: Mapping[str, object], allowed: frozenset[str], label: str
+) -> None:
+    """Fail closed on any key outside ``allowed`` (strict schema discipline)."""
+    unknown = set(mapping) - allowed
+    if unknown:
+        raise ManifestError(f"unknown {label} key(s): {sorted(unknown)}")
+
+
+# ---------------------------------------------------------------------------
+# Per-artifact parse + validate
+# ---------------------------------------------------------------------------
+
+
+def _parse_artifact(
+    entry: object, *, resolver: HostResolver, env: Mapping[str, str]
+) -> ManifestArtifact:
+    """Validate one artifact entry end-to-end and build its wiring."""
+    if not isinstance(entry, Mapping):
+        raise ManifestError(f"each artifact must be a mapping (got {type(entry).__name__})")
+    _reject_unknown_keys(entry, _ALLOWED_ARTIFACT_KEYS, "artifact")
+    artifact_id = _require_str(entry, "id")
+    substrate = _require_str(entry, "substrate")
+    tier = _parse_tier(entry.get("tier"))
+    version_source = _optional_str(entry, "version_source")
+    credential_ref, target = _extract_connection(entry)
+    _validate_credential_form(credential_ref)
+    _check_target(target, resolver=resolver, env=env)
+    descriptor = _build_descriptor(tier, version_source)
+    connection = MappingProxyType({"credential": credential_ref, **target})
+    return ManifestArtifact(
+        id=artifact_id,
+        substrate=substrate,
+        tier=tier,
+        descriptor=descriptor,
+        connection=connection,
+        version_source=version_source,
+    )
+
+
+def _require_str(mapping: Mapping[str, object], key: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value:
+        raise ManifestError(f"artifact key {key!r} must be a non-empty string")
+    return value
+
+
+def _optional_str(mapping: Mapping[str, object], key: str) -> str | None:
+    value = mapping.get(key)
+    if value is not None and not isinstance(value, str):
+        raise ManifestError(f"artifact key {key!r} must be a string when present")
+    return value
+
+
+def _parse_tier(raw: object) -> Tier:
+    if not isinstance(raw, str) or not raw:
+        raise ManifestError(f"artifact 'tier' is required and must be a string (got {raw!r})")
+    try:
+        return Tier(raw.strip().lower().replace("-", "_"))
+    except ValueError as exc:
+        valid = ", ".join(t.value.replace("_", "-") for t in Tier)
+        raise ManifestError(f"unknown tier {raw!r}; expected one of: {valid}") from exc
+
+
+def _build_descriptor(tier: Tier, version_source: str | None) -> CapabilityDescriptor:
+    """Reuse the descriptor's own tier/version_source validation."""
+    try:
+        return CapabilityDescriptor(tier=tier, version_source=version_source)
+    except ValueError as exc:
+        raise ManifestError(str(exc)) from exc
+
+
+def _extract_connection(entry: Mapping[str, object]) -> tuple[str, dict[str, str]]:
+    """Split ``connection`` into ``(credential_ref, target)``.
+
+    A bare string is a credential-only reference (no network target — the
+    forward-only / ambient-credential case). A mapping carries the credential
+    plus an allowlisted target (``dsn`` / ``endpoint_url`` / ``region``).
+    """
+    conn = entry.get("connection")
+    if isinstance(conn, str):
+        return conn, {}
+    if isinstance(conn, Mapping):
+        credential = conn.get("credential")
+        if not isinstance(credential, str):
+            raise ManifestError("connection mapping requires a string 'credential'")
+        target = {key: value for key, value in conn.items() if key != "credential"}
+        _reject_unknown_keys(target, _ALLOWED_TARGET_KEYS, "connection")
+        for key, value in target.items():
+            if not isinstance(value, str):
+                raise ManifestError(f"connection {key!r} must be a string")
+        return credential, target
+    raise ManifestError("connection must be a reference string or a mapping")
+
+
+# ---------------------------------------------------------------------------
+# Credential reference forms
+# ---------------------------------------------------------------------------
+
+
+def _validate_credential_form(ref: str) -> None:
+    """Accept only an allowlisted reference form; reject a suspected literal.
+
+    NEVER echoes ``ref`` (it may be the secret) — the message names the
+    category of violation only.
+    """
+    if not ref:
+        raise SubstrateCredentialRefused("the credential is empty")
+    if ref in _ZERO_SECRET_FORMS:
+        return
+    if ref.startswith(_SECRET_FILE_PREFIX):
+        if not ref[len(_SECRET_FILE_PREFIX):]:
+            raise SubstrateCredentialRefused("a secret-file: reference has no path")
+        return
+    if ref.startswith(_ENV_PREFIX):
+        if not ref[len(_ENV_PREFIX):]:
+            raise SubstrateCredentialRefused("an env: reference has no variable name")
+        return
+    if ref.startswith(_SECRET_URI_PREFIX):
+        _validate_secret_uri(ref)
+        return
+    raise SubstrateCredentialRefused("the credential value is not a recognized reference form")
+
+
+def _validate_secret_uri(ref: str) -> None:
+    body = ref[len(_SECRET_URI_PREFIX):]
+    provider = re.split(r"[:/]", body, maxsplit=1)[0].lower() if body else ""
+    if provider not in _ALLOWED_SECRET_PROVIDERS:
+        raise SubstrateCredentialRefused("a secret: reference names a non-allowlisted provider")
+
+
+# ---------------------------------------------------------------------------
+# Connection targets (SSRF + TLS)
+# ---------------------------------------------------------------------------
+
+
+def _check_target(
+    target: Mapping[str, str], *, resolver: HostResolver, env: Mapping[str, str]
+) -> None:
+    """Run the substrate-appropriate SSRF/TLS checks for a target."""
+    if "dsn" in target:
+        _check_pg_dsn(target["dsn"], resolver=resolver, env=env)
+    if "endpoint_url" in target or "region" in target:
+        _check_s3_endpoint(
+            endpoint_url=target.get("endpoint_url"),
+            region=target.get("region"),
+            resolver=resolver,
+            env=env,
+        )
+
+
+@dataclass(frozen=True)
+class _PgTarget:
+    hosts: list[str]
+    hostaddrs: list[str]
+    sslmode: str | None
+    has_inline_password: bool
+
+
+def _check_pg_dsn(dsn: str, *, resolver: HostResolver, env: Mapping[str, str]) -> None:
+    """SSRF-check every dialed Postgres host and enforce TLS for a routable one."""
+    target = _parse_pg_dsn(dsn)
+    if target.has_inline_password:
+        raise SubstrateCredentialRefused("the connection DSN carries an inline password")
+    routable, network_hosts = _check_pg_hosts(target, resolver=resolver, env=env)
+    if routable and target.sslmode not in _TLS_SAFE_SSLMODES:
+        _require_tls_or_ack(network_hosts[0], "plaintext-capable sslmode", env=env)
+    if len(network_hosts) > 1:
+        logger.warning(
+            "manifest postgres target lists %d network hosts %r; coordinating agents "
+            "against a multi-host/replica substrate is out of scope (single-host only)",
+            len(network_hosts),
+            network_hosts,
+        )
+
+
+def _check_pg_hosts(
+    target: _PgTarget, *, resolver: HostResolver, env: Mapping[str, str]
+) -> tuple[bool, list[str]]:
+    """Classify the dialed hosts; return ``(routable, checked_network_hosts)``.
+
+    ``hostaddr=`` is the authoritative dialed target when present; a leading
+    ``/`` host is a unix socket — a local target, exempt and NOT resolved.
+    """
+    dialed = target.hostaddrs if target.hostaddrs else target.hosts
+    routable = False
+    network_hosts: list[str] = []
+    for host in dialed:
+        if host.startswith("/"):
+            continue
+        if not _reject_denied_target(host, resolver=resolver, env=env):
+            routable = True
+        network_hosts.append(host)
+    return routable, network_hosts
+
+
+def _check_s3_endpoint(
+    *,
+    endpoint_url: str | None,
+    region: str | None,
+    resolver: HostResolver,
+    env: Mapping[str, str],
+) -> None:
+    """SSRF-check an explicit S3 ``endpoint_url`` and enforce TLS for a routable one.
+
+    There is no psycopg-style resolve-then-pin for S3 (pinning the endpoint to
+    the resolved IP breaks SigV4 host signing + TLS SNI, and botocore re-resolves
+    at connect time), so this is a resolve-and-re-check with a documented narrow
+    rebind residual. A custom endpoint is a privileged opt-in, not free-form.
+    """
+    if endpoint_url:
+        parts = urlsplit(endpoint_url)
+        scheme = (parts.scheme or "").lower()
+        if scheme not in ("http", "https"):
+            raise ManifestError(f"S3 endpoint_url scheme must be http or https (got {scheme!r})")
+        host = parts.hostname
+        if not host:
+            raise ManifestError("S3 endpoint_url is missing a host")
+        is_loopback = _reject_denied_target(host, resolver=resolver, env=env)
+        if not is_loopback and scheme == "http":
+            _require_tls_or_ack(host, "plaintext endpoint_url (http)", env=env)
+        _warn_mrap(host)
+    if region:
+        _warn_mrap(region)
+
+
+# ---------------------------------------------------------------------------
+# Postgres DSN decomposition
+# ---------------------------------------------------------------------------
+
+
+def _parse_pg_dsn(dsn: str) -> _PgTarget:
+    text = dsn.strip()
+    if text.startswith(("postgresql://", "postgres://")):
+        return _parse_pg_uri(text)
+    return _parse_pg_keywords(text)
+
+
+def _parse_pg_keywords(dsn: str) -> _PgTarget:
+    params: dict[str, str] = {}
+    for token in dsn.split():
+        key, sep, value = token.partition("=")
+        if sep:
+            params[key.strip()] = value.strip()
+    hosts = [_debracket(h) for h in _split_csv(params.get("host"))]
+    hostaddrs = [_debracket(h) for h in _split_csv(params.get("hostaddr"))]
+    sslmode = (params.get("sslmode") or "").lower() or None
+    return _PgTarget(hosts, hostaddrs, sslmode, has_inline_password=bool(params.get("password")))
+
+
+def _parse_pg_uri(dsn: str) -> _PgTarget:
+    parts = urlsplit(dsn)
+    userinfo, _, hostpart = parts.netloc.rpartition("@")
+    has_password = ":" in userinfo and userinfo.split(":", 1)[1] != ""
+    hosts = [_strip_port(h) for h in _split_csv(hostpart)]
+    sslmode = _first_query_value(parts.query, "sslmode")
+    return _PgTarget(hosts, hostaddrs=[], sslmode=sslmode, has_inline_password=has_password)
+
+
+def _split_csv(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [part for part in (item.strip() for item in value.split(",")) if part]
+
+
+def _debracket(host: str) -> str:
+    stripped = host.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        return stripped[1:-1]
+    return stripped
+
+
+def _strip_port(hostport: str) -> str:
+    text = hostport.strip()
+    if text.startswith("["):
+        end = text.find("]")
+        return text[1:end] if end != -1 else text
+    head, sep, tail = text.rpartition(":")
+    return head if sep and tail.isdigit() else text
+
+
+def _first_query_value(query: str, key: str) -> str | None:
+    values = parse_qs(query).get(key)
+    return values[0].lower() if values else None
+
+
+# ---------------------------------------------------------------------------
+# Resolved-address SSRF classification
+# ---------------------------------------------------------------------------
+
+
+def _reject_denied_target(host: str, *, resolver: HostResolver, env: Mapping[str, str]) -> bool:
+    """Reject a target resolving into a denied range; return whether it is loopback.
+
+    A hostname in the metadata denylist is rejected pre-resolution; otherwise the
+    deny runs on the resolved IP(s) so a DNS-rebind and decimal/octal/hex IPv4
+    encodings are all classified. An unresolvable host fails closed (denied).
+    """
+    if host.lower() in _METADATA_HOSTNAMES:
+        raise SubstrateTargetDenied(host, "cloud metadata alias hostname")
+    is_loopback = True
+    for ip in _resolve_ips(host, resolver):
+        _reject_denied_ip(ip, host, env=env)
+        if not _is_loopback_ip(ip):
+            is_loopback = False
+    return is_loopback
+
+
+def _resolve_ips(
+    host: str, resolver: HostResolver
+) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    try:
+        return [ipaddress.ip_address(host)]
+    except ValueError:
+        pass
+    resolved = resolver(host)
+    if not resolved:
+        raise SubstrateTargetDenied(host, "unresolvable host (fail-closed)")
+    try:
+        return [ipaddress.ip_address(address) for address in resolved]
+    except ValueError as exc:
+        raise SubstrateTargetDenied(host, "resolver returned an unparseable address") from exc
+
+
+def _reject_denied_ip(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    host: str,
+    *,
+    env: Mapping[str, str],
+) -> None:
+    """Reject a hard-denied address (metadata/link-local) or, absent the opt-in,
+    a private-range address — evaluated through any mapped/compat IPv6 wrapper."""
+    for candidate in _denylist_candidates(ip):
+        if _is_hard_denied(candidate):
+            raise SubstrateTargetDenied(host, _posture(candidate))
+        if _is_private(candidate) and not _env_truthy(env, ALLOW_PRIVATE_ENV):
+            raise SubstrateTargetDenied(
+                host, "RFC-1918/4193 private range (set CCS_SUBSTRATE_ALLOW_PRIVATE to allow)"
+            )
+
+
+def _denylist_candidates(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> Iterator[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """The address plus any IPv4 embedded in a mapped/6to4/Teredo IPv6 wrapper.
+
+    Unwrapping is the denylist INVERSION of ``verify_host``'s deliberate
+    no-unwrap allowlist rule: a mapped form (``::ffff:169.254.169.254``) must not
+    slip past the IPv4 denylist.
+    """
+    yield ip
+    if ip.version == 6:
+        for attr in ("ipv4_mapped", "sixtofour"):
+            embedded = getattr(ip, attr, None)
+            if embedded is not None:
+                yield embedded
+        teredo = getattr(ip, "teredo", None)
+        if teredo is not None:
+            yield teredo[1]
+
+
+def _is_hard_denied(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    if ip.version == 4:
+        return any(ip in net for net in _HARD_DENY_V4_NETS)
+    return ip in _LINK_LOCAL_V6_NET or ip in _HARD_DENY_V6_ADDRS
+
+
+def _is_private(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    if ip.version == 4:
+        return any(ip in net for net in _PRIVATE_V4_NETS)
+    return ip in _ULA_V6_NET
+
+
+def _is_loopback_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    if ip.version == 4:
+        return ip in _LOOPBACK_V4_NET
+    return ip == _IPV6_LOOPBACK
+
+
+def _posture(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str:
+    if ip.version == 4:
+        if ip in _LINK_LOCAL_V4_NET:
+            return "link-local / cloud metadata range (169.254.0.0/16)"
+        return "CGNAT / cloud metadata range (100.64.0.0/10)"
+    if ip in _LINK_LOCAL_V6_NET:
+        return "IPv6 link-local range (fe80::/10)"
+    return "IPv6 cloud metadata address"
+
+
+# ---------------------------------------------------------------------------
+# TLS + locality guards
+# ---------------------------------------------------------------------------
+
+
+def _require_tls_or_ack(host: str, posture: str, *, env: Mapping[str, str]) -> None:
+    """Refuse a plaintext credential to a routable host without the distinct ack."""
+    if _env_truthy(env, INSECURE_ACK_ENV):
+        logger.warning(
+            "sending a substrate credential to routable host %r over plaintext (%s); "
+            "%s acknowledged — ensure the link is encrypted out-of-band",
+            host,
+            posture,
+            INSECURE_ACK_ENV,
+        )
+        return
+    raise SubstrateInsecureTransport(host, posture)
+
+
+def _warn_mrap(value: str) -> None:
+    """Warn on a multi-region access point / replica endpoint (out-of-scope
+    distributed-substrate locality)."""
+    lowered = value.lower()
+    if "mrap" in lowered or "s3-global" in lowered or lowered == "aws-global":
+        logger.warning(
+            "manifest S3 target %r looks like a multi-region access point / replica; "
+            "coordinating agents across hosts against one distributed substrate is out "
+            "of scope (single-host only)",
+            value,
+        )
+
+
+def _env_truthy(env: Mapping[str, str], name: str) -> bool:
+    return env.get(name, "").strip().lower() in _TRUTHY_ENV_VALUES

--- a/src/ccs/adapters/substrate_manifest.py
+++ b/src/ccs/adapters/substrate_manifest.py
@@ -419,8 +419,14 @@ def _check_pg_hosts(
 ) -> tuple[bool, list[str]]:
     """Classify the dialed hosts; return ``(routable, checked_network_hosts)``.
 
-    ``hostaddr=`` is the authoritative dialed target when present; a leading
-    ``/`` host is a unix socket — a local target, exempt and NOT resolved.
+    Every ``host`` AND every ``hostaddr`` entry is checked — the UNION, not
+    ``hostaddr`` alone. libpq pairs ``host[i]``/``hostaddr[i]`` per position and
+    dials whichever the position resolves to, and a comma-list count mismatch (a
+    trailing/empty slot) can leave a ``host`` entry unpaired and dialed. Checking
+    the union never skips a candidate a positional ``hostaddr``-authoritative rule
+    would miss; over-checking a name used only for TLS SNI fails closed, which is
+    the safe direction. A leading ``/`` host is a unix socket — a local target,
+    exempt and NOT resolved.
 
     Rebind residual (parity with :func:`_check_s3_endpoint`): for a bare-hostname
     target (no ``hostaddr=``), libpq re-resolves the name at connect time,
@@ -430,12 +436,13 @@ def _check_pg_hosts(
     resolved IP into ``hostaddr`` (host retained for TLS SNI) would close the
     window and is the intended future hardening.
     """
-    dialed = target.hostaddrs if target.hostaddrs else target.hosts
+    seen: set[str] = set()
     routable = False
     network_hosts: list[str] = []
-    for host in dialed:
-        if host.startswith("/"):
+    for host in (*target.hostaddrs, *target.hosts):
+        if host.startswith("/") or host in seen:
             continue
+        seen.add(host)
         if not _reject_denied_target(host, resolver=resolver, env=env):
             routable = True
         network_hosts.append(host)
@@ -554,18 +561,23 @@ def _parse_pg_uri(dsn: str) -> _PgTarget:
     userinfo, _, hostpart = parts.netloc.rpartition("@")
     query = parse_qs(parts.query)
     # libpq honors host/hostaddr/password/sslmode given as URI query parameters and
-    # dials them — hostaddr in particular is the authoritative dialed IP, and host
-    # is used only for TLS SNI/cert. Parsing them here closes the URI-form
-    # equivalent of the keyword-form guards (an unchecked ``?hostaddr=`` would
-    # otherwise reach cloud metadata past a benign-looking hostname).
-    has_password = (":" in userinfo and userinfo.split(":", 1)[1] != "") or bool(
-        _query_first(query, "password")
+    # dials them. A repeated query key is merged by libpq to a SINGLE value
+    # (documented last-wins, but version-dependent), so this parser never picks one
+    # occurrence: it collects ALL host/hostaddr values (the union, checked by
+    # _check_pg_hosts) and takes the most-restrictive sslmode — immune to the merge
+    # order. This closes the URI-form guards (an unchecked ``?hostaddr=``, or a
+    # ``?host=safe&host=metadata`` duplicate, would otherwise reach a denied target
+    # past a benign-looking value).
+    has_password = (":" in userinfo and userinfo.split(":", 1)[1] != "") or any(
+        _query_all(query, "password")
     )
     hosts = [_strip_port(h) for h in _split_csv(hostpart)]
-    hosts += [_debracket(h) for h in _split_csv(_query_first(query, "host"))]
-    hostaddrs = [_debracket(h) for h in _split_csv(_query_first(query, "hostaddr"))]
-    sslmode_raw = _query_first(query, "sslmode")
-    sslmode = sslmode_raw.lower() if sslmode_raw else None
+    for value in _query_all(query, "host"):
+        hosts += [_debracket(h) for h in _split_csv(value)]
+    hostaddrs: list[str] = []
+    for value in _query_all(query, "hostaddr"):
+        hostaddrs += [_debracket(h) for h in _split_csv(value)]
+    sslmode = _least_safe_sslmode(_query_all(query, "sslmode"))
     return _PgTarget(hosts, hostaddrs=hostaddrs, sslmode=sslmode, has_inline_password=has_password)
 
 
@@ -591,14 +603,31 @@ def _strip_port(hostport: str) -> str:
     return head if sep and tail.isdigit() else text
 
 
-def _query_first(query: dict[str, list[str]], key: str) -> str | None:
-    """The first value for ``key`` in a ``parse_qs`` mapping, or None.
+def _query_all(query: dict[str, list[str]], key: str) -> list[str]:
+    """Every value for ``key`` in a ``parse_qs`` mapping (order preserved).
 
-    Case is preserved (a password is case-sensitive); the caller lowercases the
-    keys where case is irrelevant (``sslmode``).
+    All occurrences are returned, not one: a repeated security-relevant key must
+    have every candidate checked, since a parser that picked a single occurrence
+    could disagree with libpq's merge order and miss a denied target. Case is
+    preserved (a password is case-sensitive).
     """
-    values = query.get(key)
-    return values[0] if values else None
+    return list(query.get(key, ()))
+
+
+def _least_safe_sslmode(values: list[str]) -> str | None:
+    """The most-restrictive sslmode across ``values`` (duplicate-key safe).
+
+    Returns None when unset (treated as plaintext-capable downstream). If ANY
+    occurrence is not TLS-safe, that unsafe mode is returned so the TLS guard
+    fires — never trusting a safe occurrence to mask an unsafe one.
+    """
+    lowered = [v.lower() for v in values]
+    if not lowered:
+        return None
+    for mode in lowered:
+        if mode not in _TLS_SAFE_SSLMODES:
+            return mode
+    return lowered[0]
 
 
 # ---------------------------------------------------------------------------

--- a/src/ccs/adapters/substrate_manifest.py
+++ b/src/ccs/adapters/substrate_manifest.py
@@ -159,8 +159,17 @@ class SubstrateManifest:
     def validate(self) -> None:
         """Re-assert per-artifact tier consistency (reusing the descriptor's own
         validation): a ``forward-only`` artifact must declare no version_source,
-        a ``native-cas`` artifact must declare one. Raises :class:`ManifestError`."""
+        a ``native-cas`` artifact must declare one. Also reject a duplicate
+        artifact ``id`` — a second entry would silently shadow the first's wiring.
+        Raises :class:`ManifestError`."""
+        seen: set[str] = set()
         for artifact in self.artifacts:
+            if artifact.id in seen:
+                raise ManifestError(
+                    f"duplicate artifact id {artifact.id!r}: each id must be unique — "
+                    "a second entry would silently shadow the first's wiring"
+                )
+            seen.add(artifact.id)
             _build_descriptor(artifact.tier, artifact.version_source)
 
     def dry_run(self) -> tuple[tuple[str, str, Tier], ...]:
@@ -417,9 +426,9 @@ def _check_pg_dsn(dsn: str, *, resolver: HostResolver, env: Mapping[str, str]) -
         )
     if target.has_inline_password:
         raise SubstrateCredentialRefused("the connection DSN carries an inline password")
-    routable, network_hosts = _check_pg_hosts(target, resolver=resolver, env=env)
-    if routable and target.sslmode not in _TLS_SAFE_SSLMODES:
-        _require_tls_or_ack(network_hosts[0], "plaintext-capable sslmode", env=env)
+    routable_host, network_hosts = _check_pg_hosts(target, resolver=resolver, env=env)
+    if routable_host is not None and target.sslmode not in _TLS_SAFE_SSLMODES:
+        _require_tls_or_ack(routable_host, "plaintext-capable sslmode", env=env)
     if len(network_hosts) > 1:
         logger.warning(
             "manifest postgres target lists %d network hosts %r; coordinating agents "
@@ -431,8 +440,8 @@ def _check_pg_dsn(dsn: str, *, resolver: HostResolver, env: Mapping[str, str]) -
 
 def _check_pg_hosts(
     target: _PgTarget, *, resolver: HostResolver, env: Mapping[str, str]
-) -> tuple[bool, list[str]]:
-    """Classify the dialed hosts; return ``(routable, checked_network_hosts)``.
+) -> tuple[str | None, list[str]]:
+    """Classify the dialed hosts; return ``(first_routable_host, checked_hosts)``.
 
     Every ``host`` AND every ``hostaddr`` entry is checked — the UNION, not
     ``hostaddr`` alone. libpq pairs ``host[i]``/``hostaddr[i]`` per position and
@@ -452,16 +461,16 @@ def _check_pg_hosts(
     window and is the intended future hardening.
     """
     seen: set[str] = set()
-    routable = False
+    routable_host: str | None = None
     network_hosts: list[str] = []
     for host in (*target.hostaddrs, *target.hosts):
         if host.startswith("/") or host in seen:
             continue
         seen.add(host)
-        if not _reject_denied_target(host, resolver=resolver, env=env):
-            routable = True
+        if not _reject_denied_target(host, resolver=resolver, env=env) and routable_host is None:
+            routable_host = host
         network_hosts.append(host)
-    return routable, network_hosts
+    return routable_host, network_hosts
 
 
 def _check_s3_endpoint(

--- a/src/ccs/adapters/substrate_manifest.py
+++ b/src/ccs/adapters/substrate_manifest.py
@@ -483,6 +483,11 @@ def _check_s3_endpoint(
         scheme = (parts.scheme or "").lower()
         if scheme not in ("http", "https"):
             raise ManifestError(f"S3 endpoint_url scheme must be http or https (got {scheme!r})")
+        if parts.username or parts.password:
+            raise SubstrateCredentialRefused(
+                "the S3 endpoint_url carries inline userinfo; supply a credential "
+                "reference, never a literal in the URL"
+            )
         host = parts.hostname
         if not host:
             raise ManifestError("S3 endpoint_url is missing a host")

--- a/src/ccs/adapters/substrate_manifest.py
+++ b/src/ccs/adapters/substrate_manifest.py
@@ -395,11 +395,26 @@ class _PgTarget:
     hostaddrs: list[str]
     sslmode: str | None
     has_inline_password: bool
+    service: str | None = None
 
 
 def _check_pg_dsn(dsn: str, *, resolver: HostResolver, env: Mapping[str, str]) -> None:
-    """SSRF-check every dialed Postgres host and enforce TLS for a routable one."""
+    """SSRF-check every dialed Postgres host and enforce TLS for a routable one.
+
+    Fail-closed residual: libpq can also draw host/hostaddr from sources this
+    text parser cannot see — a ``service=`` entry in ``pg_service.conf`` (refused
+    here, since the real target is unclassifiable), and the ``PGHOST`` /
+    ``PGHOSTADDR`` / ``PGSERVICE`` environment variables (invisible in the DSN
+    string). An operator relying on egress control should pin host/hostaddr in
+    the manifest, not inherit them.
+    """
     target = _parse_pg_dsn(dsn)
+    if target.service is not None:
+        raise SubstrateTargetDenied(
+            f"service={target.service}",
+            "target is resolved from a pg_service.conf this loader cannot read, so "
+            "it cannot be SSRF-checked — refused (fail-closed); inline host/hostaddr",
+        )
     if target.has_inline_password:
         raise SubstrateCredentialRefused("the connection DSN carries an inline password")
     routable, network_hosts = _check_pg_hosts(target, resolver=resolver, env=env)
@@ -496,7 +511,13 @@ def _parse_pg_keywords(dsn: str) -> _PgTarget:
     hosts = [_debracket(h) for h in _split_csv(params.get("host"))]
     hostaddrs = [_debracket(h) for h in _split_csv(params.get("hostaddr"))]
     sslmode = (params.get("sslmode") or "").lower() or None
-    return _PgTarget(hosts, hostaddrs, sslmode, has_inline_password=bool(params.get("password")))
+    return _PgTarget(
+        hosts,
+        hostaddrs,
+        sslmode,
+        has_inline_password=bool(params.get("password")),
+        service=params.get("service") or None,
+    )
 
 
 def _conninfo_params(dsn: str) -> dict[str, str]:
@@ -578,7 +599,14 @@ def _parse_pg_uri(dsn: str) -> _PgTarget:
     for value in _query_all(query, "hostaddr"):
         hostaddrs += [_debracket(h) for h in _split_csv(value)]
     sslmode = _least_safe_sslmode(_query_all(query, "sslmode"))
-    return _PgTarget(hosts, hostaddrs=hostaddrs, sslmode=sslmode, has_inline_password=has_password)
+    service = next(iter(_query_all(query, "service")), None)
+    return _PgTarget(
+        hosts,
+        hostaddrs=hostaddrs,
+        sslmode=sslmode,
+        has_inline_password=has_password,
+        service=service,
+    )
 
 
 def _split_csv(value: str | None) -> list[str]:

--- a/src/ccs/adapters/substrate_manifest.py
+++ b/src/ccs/adapters/substrate_manifest.py
@@ -421,6 +421,14 @@ def _check_pg_hosts(
 
     ``hostaddr=`` is the authoritative dialed target when present; a leading
     ``/`` host is a unix socket — a local target, exempt and NOT resolved.
+
+    Rebind residual (parity with :func:`_check_s3_endpoint`): for a bare-hostname
+    target (no ``hostaddr=``), libpq re-resolves the name at connect time,
+    decoupled from this load-time resolver check, so a hostname whose DNS is
+    attacker-controlled can rebind to a denied target after validation passes.
+    The load-time check still catches static misconfiguration; pinning the
+    resolved IP into ``hostaddr`` (host retained for TLS SNI) would close the
+    window and is the intended future hardening.
     """
     dialed = target.hostaddrs if target.hostaddrs else target.hosts
     routable = False
@@ -477,24 +485,88 @@ def _parse_pg_dsn(dsn: str) -> _PgTarget:
 
 
 def _parse_pg_keywords(dsn: str) -> _PgTarget:
-    params: dict[str, str] = {}
-    for token in dsn.split():
-        key, sep, value = token.partition("=")
-        if sep:
-            params[key.strip()] = value.strip()
+    params = _conninfo_params(dsn)
     hosts = [_debracket(h) for h in _split_csv(params.get("host"))]
     hostaddrs = [_debracket(h) for h in _split_csv(params.get("hostaddr"))]
     sslmode = (params.get("sslmode") or "").lower() or None
     return _PgTarget(hosts, hostaddrs, sslmode, has_inline_password=bool(params.get("password")))
 
 
+def _conninfo_params(dsn: str) -> dict[str, str]:
+    """Decompose a libpq keyword/value conninfo string the way libpq parses it.
+
+    Tolerates whitespace around ``=`` and single-quoted values with backslash
+    escapes, so a space-padded DSN (``host = h  password = p``) cannot tokenize to
+    nothing and slip a host/password/sslmode past the SSRF, inline-secret, and TLS
+    guards. Fails closed (:class:`ManifestError`) on a malformed pair or an
+    unterminated quote rather than silently dropping it. Keyword case is preserved
+    (libpq keywords are canonical lowercase; an uppercase key is an unknown libpq
+    keyword that would not dial anyway), and the security-relevant keys are looked
+    up lowercase by the caller.
+    """
+    params: dict[str, str] = {}
+    i, n = 0, len(dsn)
+    while i < n:
+        while i < n and dsn[i].isspace():
+            i += 1
+        if i >= n:
+            break
+        start = i
+        while i < n and not dsn[i].isspace() and dsn[i] != "=":
+            i += 1
+        keyword = dsn[start:i]
+        while i < n and dsn[i].isspace():
+            i += 1
+        if i >= n or dsn[i] != "=":
+            raise ManifestError("malformed Postgres DSN: expected '=' after keyword")
+        i += 1
+        while i < n and dsn[i].isspace():
+            i += 1
+        value, i = _read_conninfo_value(dsn, i, n)
+        if keyword:
+            params[keyword] = value
+    return params
+
+
+def _read_conninfo_value(dsn: str, i: int, n: int) -> tuple[str, int]:
+    """Read one conninfo value (single-quoted or bare) from ``dsn[i:]``."""
+    chars: list[str] = []
+    if i < n and dsn[i] == "'":
+        i += 1
+        while i < n and dsn[i] != "'":
+            if dsn[i] == "\\" and i + 1 < n:
+                i += 1
+            chars.append(dsn[i])
+            i += 1
+        if i >= n:
+            raise ManifestError("malformed Postgres DSN: unterminated quoted value")
+        return "".join(chars), i + 1
+    while i < n and not dsn[i].isspace():
+        if dsn[i] == "\\" and i + 1 < n:
+            i += 1
+        chars.append(dsn[i])
+        i += 1
+    return "".join(chars), i
+
+
 def _parse_pg_uri(dsn: str) -> _PgTarget:
     parts = urlsplit(dsn)
     userinfo, _, hostpart = parts.netloc.rpartition("@")
-    has_password = ":" in userinfo and userinfo.split(":", 1)[1] != ""
+    query = parse_qs(parts.query)
+    # libpq honors host/hostaddr/password/sslmode given as URI query parameters and
+    # dials them — hostaddr in particular is the authoritative dialed IP, and host
+    # is used only for TLS SNI/cert. Parsing them here closes the URI-form
+    # equivalent of the keyword-form guards (an unchecked ``?hostaddr=`` would
+    # otherwise reach cloud metadata past a benign-looking hostname).
+    has_password = (":" in userinfo and userinfo.split(":", 1)[1] != "") or bool(
+        _query_first(query, "password")
+    )
     hosts = [_strip_port(h) for h in _split_csv(hostpart)]
-    sslmode = _first_query_value(parts.query, "sslmode")
-    return _PgTarget(hosts, hostaddrs=[], sslmode=sslmode, has_inline_password=has_password)
+    hosts += [_debracket(h) for h in _split_csv(_query_first(query, "host"))]
+    hostaddrs = [_debracket(h) for h in _split_csv(_query_first(query, "hostaddr"))]
+    sslmode_raw = _query_first(query, "sslmode")
+    sslmode = sslmode_raw.lower() if sslmode_raw else None
+    return _PgTarget(hosts, hostaddrs=hostaddrs, sslmode=sslmode, has_inline_password=has_password)
 
 
 def _split_csv(value: str | None) -> list[str]:
@@ -519,9 +591,14 @@ def _strip_port(hostport: str) -> str:
     return head if sep and tail.isdigit() else text
 
 
-def _first_query_value(query: str, key: str) -> str | None:
-    values = parse_qs(query).get(key)
-    return values[0].lower() if values else None
+def _query_first(query: dict[str, list[str]], key: str) -> str | None:
+    """The first value for ``key`` in a ``parse_qs`` mapping, or None.
+
+    Case is preserved (a password is case-sensitive); the caller lowercases the
+    keys where case is irrelevant (``sslmode``).
+    """
+    values = query.get(key)
+    return values[0] if values else None
 
 
 # ---------------------------------------------------------------------------

--- a/src/ccs/core/__init__.py
+++ b/src/ccs/core/__init__.py
@@ -10,11 +10,17 @@ from ccs.core.granularity import (
     GranularityLevel,
     GranularitySpec,
 )
+from ccs.core.substrate import (
+    CapabilityDescriptor,
+    Tier,
+)
 
 __all__ = [
     "CANONICAL_ARTIFACT_TOKENS",
+    "CapabilityDescriptor",
     "DEFAULT_GRANULARITY",
     "GRANULARITY_SPECS",
     "GranularityLevel",
     "GranularitySpec",
+    "Tier",
 ]

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -648,6 +648,92 @@ class ScenarioValidationError(CoherenceError):
         self.path = path
 
 
+# ---------------------------------------------------------------------------
+# Coherence-manifest load/validation errors (BYO-substrate, Unit 2 / R8, R9)
+# ---------------------------------------------------------------------------
+#
+# The manifest is a named TRUST BOUNDARY: it wires artifact identities to
+# substrate connection targets and credential references supplied by the
+# builder. Every failure below is caught at LOAD/VALIDATE time — before any
+# substrate connection is attempted — so a bad target or an inline literal
+# secret can never reach a driver. Discipline mirrors the shipped
+# plaintext-bearer guard (``ccs.cli._coherence_client._guard_plaintext_bearer``):
+# the message names the HOST and the POSTURE only, NEVER a resolved credential
+# value or a DSN that could carry one.
+
+
+class ManifestError(CoherenceError):
+    """A coherence manifest is malformed or fails validation (Unit 2 / R8, R9).
+
+    The base for every load/validate rejection: an unknown top-level key, a
+    missing/unknown tier, a forward-only artifact declaring a version_source
+    (rejected via the descriptor's own validation), and the security subclasses
+    below. Raised at config time, never mid-run."""
+
+
+class SubstrateCredentialRefused(ManifestError):
+    """A manifest connection credential is a suspected inline literal, not a
+    reference form (Unit 2 / R8).
+
+    Credentials must be one of the allowlisted reference forms
+    (``secret-file:PATH``, ``secret:URI``, ``env:VARNAME``, ``aws-default``) so
+    the secret value never lives in the manifest. An inline DSN, a bare key, an
+    unknown prefix, or an inline password inside a DSN target is refused here.
+    The message states the CATEGORY of violation only — it NEVER echoes the
+    offending value, which may itself be the secret."""
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(
+            f"refusing a suspected inline secret in the manifest connection: {detail}. "
+            "Credentials must be a reference form: secret-file:PATH (preferred), "
+            "aws-default (zero-secret), secret:URI (allowlisted providers), or "
+            "env:VARNAME (least-preferred)"
+        )
+        self.detail = detail
+
+
+class SubstrateTargetDenied(ManifestError):
+    """A manifest connection target resolves to a denied address (Unit 2 / R8, SSRF).
+
+    The deny runs on the ``getaddrinfo``-RESOLVED address(es), not the literal
+    string, so a DNS-rebind hostname and decimal/octal/hex IPv4 encodings are
+    all classified. Hard-denied: the cloud metadata / link-local class
+    (169.254.0.0/16, 100.64.0.0/10, metadata.google.internal, fd00:ec2::254,
+    fe80::/10), unwrapped through any mapped/compat IPv6 wrapper. RFC-1918/4193
+    private ranges are denied unless the per-manifest opt-in
+    (``CCS_SUBSTRATE_ALLOW_PRIVATE``) is set. Carries ``host`` and a ``posture``
+    describing the denied range — never a credential."""
+
+    def __init__(self, host: str, posture: str) -> None:
+        super().__init__(
+            f"manifest connection target {host!r} is denied: {posture}"
+        )
+        self.host = host
+        self.posture = posture
+
+
+class SubstrateInsecureTransport(ManifestError):
+    """A plaintext-credential substrate config points at a routable host without
+    an ack (Unit 2 / R8 — the substrate analog of the plaintext-bearer guard).
+
+    A Postgres DSN with ``sslmode=disable``/unset (libpq silently downgrades to
+    plaintext) or a boto3 ``endpoint_url=http://`` to a non-loopback host ships
+    the credential in cleartext. Refused unless the operator sets the DISTINCT
+    ack ``CCS_SUBSTRATE_INSECURE`` (deliberately NOT ``CCS_REMOTE_INSECURE`` /
+    ``CCS_REMOTE_COORDINATOR`` — relaxing coordinator transport must not relax
+    substrate egress). Carries ``host`` and ``posture``; never the credential."""
+
+    def __init__(self, host: str, posture: str) -> None:
+        super().__init__(
+            f"refusing a plaintext substrate credential to routable host {host!r} "
+            f"({posture}); set CCS_SUBSTRATE_INSECURE to acknowledge an "
+            "out-of-band-secured link, or use TLS (postgres sslmode=require/"
+            "verify-full, or an https S3 endpoint_url)"
+        )
+        self.host = host
+        self.posture = posture
+
+
 class WatchdogAbandoned(RuntimeError):
     """A handler's 4s watchdog fired, so its still-running work was told to abort
     before it could mutate the registry (finding A6).

--- a/src/ccs/core/exceptions.py
+++ b/src/ccs/core/exceptions.py
@@ -626,6 +626,12 @@ class CasVersionConflict(CoherenceError):
     between, OR the caller's comparand was stale. Typed-conflict, NOT auto-merge:
     NO write landed; the agent re-reads at ``current_version``, re-merges, and
     retries. Carries both versions so the client can re-CAS without another read.
+
+    ``current_version`` is authoritative when the coordinator itself reported it
+    (a bump-conflict). On a substrate-side CAS loss — where the coordinator was
+    not re-read — it is best-effort (the version observed at pre-read time); a
+    caller keys recovery on ``reacquire()`` (which re-reads fresh), not on the
+    numeric.
     """
 
     reason = VERSION_MISMATCH_REASON

--- a/src/ccs/core/substrate.py
+++ b/src/ccs/core/substrate.py
@@ -21,11 +21,22 @@ rows — and pass it in.
 
 from __future__ import annotations
 
+import hashlib
 import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import Iterable, Iterator, Mapping
 from uuid import UUID
+
+
+def sha256_hex(data: bytes) -> str:
+    """The one content fingerprint the coordinator may hold: a sha-256 hex digest.
+
+    Single source of truth for what ``content_hash`` means, shared by every
+    substrate binding — so a future change to the fingerprint (normalization,
+    encoding) can never silently diverge one binding from another.
+    """
+    return hashlib.sha256(data).hexdigest()
 
 
 class Tier(Enum):
@@ -127,6 +138,11 @@ _SHA256_HEX_RE = re.compile(r"\A[0-9a-f]{64}\Z")
 # content-proportional shadow: the floor fails closed rather than trusting a
 # field name.
 _MAX_OPAQUE_TEXT_LEN = 256
+# Coherence metadata is a handful of scalars per artifact. A large collection or
+# an arbitrary-precision integer is a body wearing another shape (bytes as a list
+# of byte-value ints, or as one big int), so both are bounded, not just strings.
+_MAX_COLLECTION_LEN = 256
+_MAX_INT_BITS = 64
 _ALLOWED_SCALARS = (bool, int, float, UUID, type(None))
 
 
@@ -166,8 +182,25 @@ def _walk_violations(value: object, path: str) -> Iterator[str]:
                 "chars is treated as content-proportional"
             )
     elif isinstance(value, (list, tuple, set, frozenset)):
+        if len(value) > _MAX_COLLECTION_LEN:
+            # A body encoded as a list of byte-value ints is content-proportional;
+            # name it and stop (walking a body-sized collection is itself a cost).
+            yield (
+                f"{path or '<root>'}: collection of {len(value)} items exceeds "
+                f"{_MAX_COLLECTION_LEN} (content-proportional)"
+            )
+            return
         for index, item in enumerate(value):
             yield from _walk_violations(item, f"{path}[{index}]")
+    elif isinstance(value, bool):
+        pass  # a flag, not a magnitude
+    elif isinstance(value, int):
+        if value.bit_length() > _MAX_INT_BITS:
+            # A body packed into one big integer (int.from_bytes) is a shadow too.
+            yield (
+                f"{path or '<root>'}: integer wider than {_MAX_INT_BITS} bits is "
+                "content-proportional"
+            )
     elif not isinstance(value, _ALLOWED_SCALARS):
         # Fail closed: a value type this floor cannot classify is rejected
         # rather than waved through.

--- a/src/ccs/core/substrate.py
+++ b/src/ccs/core/substrate.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Capability descriptor and honesty floor for bring-your-own-substrate bindings.
+
+A substrate binding brings coherence to shared mutable state the builder
+already runs — a Postgres row, an S3 object, an action backend. Each binding
+declares what it can honestly guarantee through a :class:`CapabilityDescriptor`
+carrying a :class:`Tier`; the guarantee wording a user sees is DERIVED from the
+tier, so a weaker binding can never present itself as enforcement.
+
+This module also holds the never-ship-a-store floor: the coordinator keeps
+coherence metadata only — a fixed-width content fingerprint plus an opaque
+substrate token — never content, nor anything whose size is proportional to
+content (a body, a compressed body, a diff, a sample). The checks are data-in
+by design: this module cannot import coordinator state (the layering boundary
+puts ``core`` below the application layer), so callers extract the
+coordinator-side state — a payload mapping, a dump of the retention table's
+rows — and pass it in.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Iterator, Mapping
+from uuid import UUID
+
+
+class Tier(Enum):
+    """Honest guarantee tier a substrate binding declares.
+
+    - ``NATIVE_CAS`` — the substrate offers an atomic compare-and-set (a
+      conditional write keyed on a substrate-minted token), so the binding can
+      reject a lost update on the version axis.
+    - ``DETECT_ONLY`` — the substrate offers no atomic conditional write; the
+      binding can only detect a sequential stale-read-then-write after the
+      fact, never prevent a concurrent race.
+    - ``FORWARD_ONLY`` — the substrate "write" is an action (an RPC-style
+      effect such as posting a message), not an object mutation: there is no
+      token and nothing to compare, so the only honest offer is freshness of
+      the decision inputs before the effect fires.
+    """
+
+    NATIVE_CAS = "native_cas"
+    DETECT_ONLY = "detect_only"
+    FORWARD_ONLY = "forward_only"
+
+
+# Guarantee wording is a closed, tier-keyed table rather than free text so the
+# honesty floor is enforceable: the non-native tiers must never carry
+# enforcement or compare-and-set claims, and a per-binding rewording cannot
+# drift past that line.
+_GUARANTEE_TEXT_BY_TIER: dict[Tier, str] = {
+    Tier.NATIVE_CAS: (
+        "enforces no-lost-update on the version-CAS axis only; a "
+        "coordinator-timeout after a durable substrate write is reconverged by "
+        "the token-identity reconciliation; single-host"
+    ),
+    Tier.DETECT_ONLY: (
+        "detection only: catches a sequential stale-read→write; "
+        "cannot prevent a concurrent race; single-host"
+    ),
+    Tier.FORWARD_ONLY: (
+        "effect ordering only: decision-input freshness via the coordinator's "
+        "invalidation and deny-before-act gating on the coherence-managed "
+        "inputs a decision is derived from; the effect itself is forward-only "
+        "— this layer does not compare-and-swap it, does not undo it, and "
+        "does not prevent a duplicate effect"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class CapabilityDescriptor:
+    """Machine-readable capability declaration for one substrate binding.
+
+    - ``tier`` — the binding's honest guarantee class; it alone determines the
+      surfaced :attr:`guarantee_text`.
+    - ``version_source`` — where the substrate-minted version token comes from
+      (a trigger-managed version column, an object ETag). Required for
+      ``NATIVE_CAS`` (its whole claim rides on the token), optional for
+      ``DETECT_ONLY``, and forbidden for ``FORWARD_ONLY`` — an action has no
+      token.
+    - ``least_privilege`` — the minimal substrate credential the binding needs,
+      stated so an operator can scope access down to it.
+    - ``consistency_note`` — the substrate's own consistency caveat, surfaced
+      verbatim so the builder sees the substrate's limits, not just ours.
+    """
+
+    tier: Tier
+    version_source: str | None = None
+    least_privilege: str = ""
+    consistency_note: str = ""
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.tier, Tier):
+            valid = ", ".join(tier.value for tier in Tier)
+            raise ValueError(f"unknown tier: {self.tier!r} (expected one of: {valid})")
+        if self.tier is Tier.FORWARD_ONLY and self.version_source is not None:
+            raise ValueError(
+                "forward_only forbids a version_source: an action/RPC mints no "
+                f"token to compare (got {self.version_source!r})"
+            )
+        if self.tier is Tier.NATIVE_CAS and self.version_source is None:
+            raise ValueError(
+                "native_cas requires a version_source: the tier's guarantee is "
+                "keyed on the substrate-minted token"
+            )
+
+    @property
+    def guarantee_text(self) -> str:
+        """The user-facing guarantee wording, derived from the tier only."""
+        return _GUARANTEE_TEXT_BY_TIER[self.tier]
+
+
+# --- never-ship-a-store -----------------------------------------------------
+
+# Field names that carry content or a content-proportional shadow. Their
+# presence with ANY value (other than None, the shipped content-free shape) is
+# a violation regardless of size — a one-byte body is still a body.
+_CONTENT_FIELD_NAMES = frozenset({"content", "body", "compressed_body", "diff", "sample"})
+# The one fingerprint the coordinator may hold: a fixed-width sha-256 hex digest.
+_SHA256_HEX_RE = re.compile(r"\A[0-9a-f]{64}\Z")
+# Opaque tokens and identifiers are short. Longer text is treated as a
+# content-proportional shadow: the floor fails closed rather than trusting a
+# field name.
+_MAX_OPAQUE_TEXT_LEN = 256
+_ALLOWED_SCALARS = (bool, int, float, UUID, type(None))
+
+
+def never_ship_a_store(state: Mapping[str, object]) -> bool:
+    """True iff extracted coordinator-side state holds coherence metadata only.
+
+    Data-in predicate: pass a mapping extracted from the coordinator (a wire
+    payload, a registry-record summary, nested rows). Allowed values are the
+    fixed-width ``content_hash`` fingerprint, opaque bounded text (tokens,
+    names), numbers, booleans, UUIDs, ``None``, and nested mappings/sequences
+    of the same. Raw bytes, any content-named field, oversized text, and
+    unrecognized value types are violations — the floor fails closed.
+    """
+    return not never_ship_violations(state)
+
+
+def never_ship_violations(state: Mapping[str, object]) -> tuple[str, ...]:
+    """Name every content-proportional leak in extracted coordinator-side state.
+
+    The diagnostic companion of :func:`never_ship_a_store`: each entry is a
+    ``"path: reason"`` string so a failing conformance run says exactly which
+    field crossed the floor.
+    """
+    return tuple(_walk_violations(state, path=""))
+
+
+def _walk_violations(value: object, path: str) -> Iterator[str]:
+    """Recursively yield floor violations for one extracted value."""
+    if isinstance(value, Mapping):
+        yield from _mapping_violations(value, path)
+    elif isinstance(value, (bytes, bytearray, memoryview)):
+        yield f"{path or '<root>'}: raw bytes are content"
+    elif isinstance(value, str):
+        if len(value) > _MAX_OPAQUE_TEXT_LEN:
+            yield (
+                f"{path or '<root>'}: text longer than {_MAX_OPAQUE_TEXT_LEN} "
+                "chars is treated as content-proportional"
+            )
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        for index, item in enumerate(value):
+            yield from _walk_violations(item, f"{path}[{index}]")
+    elif not isinstance(value, _ALLOWED_SCALARS):
+        # Fail closed: a value type this floor cannot classify is rejected
+        # rather than waved through.
+        yield f"{path or '<root>'}: unrecognized value type {type(value).__name__}"
+
+
+def _mapping_violations(state: Mapping[str, object], path: str) -> Iterator[str]:
+    """Yield floor violations for one mapping level."""
+    for key, item in state.items():
+        key_path = f"{path}.{key}" if path else str(key)
+        if key in _CONTENT_FIELD_NAMES:
+            if item is not None:
+                yield f"{key_path}: content-proportional field"
+        elif key == "content_hash":
+            if item is not None and not (
+                isinstance(item, str) and _SHA256_HEX_RE.match(item)
+            ):
+                yield f"{key_path}: fingerprint must be a fixed-width sha-256 hex digest"
+        else:
+            yield from _walk_violations(item, key_path)
+
+
+# --- retention-table leg ----------------------------------------------------
+
+
+def retention_is_empty_for(
+    rows: Iterable[Mapping[str, object]],
+    artifact_ids: Iterable[UUID],
+) -> bool:
+    """True iff the retention table holds ZERO rows for the binding's artifacts.
+
+    Even with retention enabled, a substrate binding's artifacts must leave the
+    coordinator's version-history table empty — retained rows are bodies, and
+    bodies never live coordinator-side for a binding. The check is
+    leg-agnostic on purpose: it takes rows regardless of whether the
+    registration leg or the commit leg produced them, so a binding cannot pass
+    by keeping only its commit path content-free.
+    """
+    return not retained_rows_for(rows, artifact_ids)
+
+
+def retained_rows_for(
+    rows: Iterable[Mapping[str, object]],
+    artifact_ids: Iterable[UUID],
+) -> tuple[Mapping[str, object], ...]:
+    """The retention-table rows belonging to the binding's artifacts.
+
+    Data-in: the caller dumps the retention table and passes the rows (each a
+    mapping with at least an ``artifact_id`` key). Any returned row is a
+    violation of the zero-rows floor — including a row with no body column, as
+    the floor is zero ROWS, not zero bytes per row.
+    """
+    wanted = set(artifact_ids)
+    return tuple(row for row in rows if row.get("artifact_id") in wanted)

--- a/tests/adapters/test_coherent_object.py
+++ b/tests/adapters/test_coherent_object.py
@@ -1,0 +1,493 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Driver-free unit tests for the CoherentObject S3 native-CAS binding.
+
+The unit tests inject a FAKE S3 client (``FakeS3Client``) that scripts
+``get_object`` / ``put_object`` and raises botocore-``ClientError``-shaped stubs
+— no boto3, no real S3. The ``real_substrate`` integration tests below document
+the same guarantees against a real S3 / S3-compatible endpoint; they are gated on
+a bucket env var so they never run (or error) in a driver-free environment.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+
+import pytest
+
+from ccs.adapters.coherent_object import (
+    CREATE_IF_ABSENT,
+    CoherentObject,
+    ReconcileVerdict,
+    S3PutOutcome,
+    classify_put_exception,
+    conditional_write_bucket_policy,
+    least_privilege_iam_policy,
+    s3_policy_docs,
+)
+from ccs.adapters.substrate import (
+    CasConflict,
+    CasUnknown,
+    CasWritten,
+    CoherenceSubstrate,
+)
+from ccs.core.exceptions import CasVersionConflict, CoherenceError
+from ccs.core.substrate import Tier
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _md5_etag(data: bytes) -> str:
+    """A quoted MD5 ETag, mimicking a general-purpose bucket's plaintext ETag."""
+    return '"' + hashlib.md5(data).hexdigest() + '"'
+
+
+# --- botocore-shaped stubs (no boto3) ------------------------------------------
+
+
+class _FakeClientError(Exception):
+    """A botocore ``ClientError``-shaped stub: carries ``.response['Error']['Code']``."""
+
+    def __init__(self, code: str, message: str = "") -> None:
+        self.response = {"Error": {"Code": code, "Message": message}}
+        super().__init__(f"{code}: {message}")
+
+
+class _FakeConnectionError(Exception):
+    """A botocore connection-error-shaped stub: NO ``.response`` (ambiguous transport)."""
+
+
+class _FakeBody:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+
+class FakeS3Client:
+    """A minimal in-memory S3 client honoring If-Match / If-None-Match.
+
+    ``objects`` maps key -> (bytes, etag). Set ``put_error`` / ``get_error`` to
+    inject a scripted exception on the NEXT put / get (consumed once). Set
+    ``next_etag`` to force the ETag the next put mints (used for opaque
+    multipart/SSE-shaped ETags).
+    """
+
+    def __init__(self, objects: dict[str, tuple[bytes, str]] | None = None) -> None:
+        self.objects: dict[str, tuple[bytes, str]] = dict(objects or {})
+        self.put_calls: list[dict[str, object]] = []
+        self.get_calls: list[dict[str, object]] = []
+        self.put_error: Exception | None = None
+        self.get_error: Exception | None = None
+        self.next_etag: str | None = None
+
+    def get_object(self, *, Bucket: str, Key: str) -> dict[str, object]:  # noqa: N803 (boto3 kwargs)
+        self.get_calls.append({"Bucket": Bucket, "Key": Key})
+        if self.get_error is not None:
+            err, self.get_error = self.get_error, None
+            raise err
+        if Key not in self.objects:
+            raise _FakeClientError("NoSuchKey", "missing")
+        data, etag = self.objects[Key]
+        return {"Body": _FakeBody(data), "ETag": etag}
+
+    def put_object(  # noqa: N803 (boto3 kwargs)
+        self,
+        *,
+        Bucket: str,
+        Key: str,
+        Body: bytes,
+        IfMatch: str | None = None,
+        IfNoneMatch: str | None = None,
+    ) -> dict[str, object]:
+        self.put_calls.append(
+            {"Bucket": Bucket, "Key": Key, "Body": Body, "IfMatch": IfMatch, "IfNoneMatch": IfNoneMatch}
+        )
+        if self.put_error is not None:
+            err, self.put_error = self.put_error, None
+            raise err
+        exists = Key in self.objects
+        if IfNoneMatch == "*" and exists:
+            raise _FakeClientError("PreconditionFailed", "object exists")
+        if IfMatch is not None:
+            if not exists:
+                raise _FakeClientError("NoSuchKey", "raced delete")
+            if self.objects[Key][1] != IfMatch:
+                raise _FakeClientError("PreconditionFailed", "etag moved")
+        etag = self.next_etag or _md5_etag(Body)
+        self.next_etag = None
+        self.objects[Key] = (Body, etag)
+        return {"ETag": etag}
+
+
+def _make(objects: dict[str, tuple[bytes, str]] | None = None) -> tuple[CoherentObject, FakeS3Client]:
+    client = FakeS3Client(objects)
+    return CoherentObject("test-bucket", client=client), client
+
+
+# --- module import / descriptor / conformance ----------------------------------
+
+
+def test_module_imports_without_boto3() -> None:
+    # boto3 is not installed in this environment; the module (and an injected-client
+    # construction) must work regardless — the driver import is deferred.
+    import importlib.util
+
+    assert importlib.util.find_spec("boto3") is None
+    obj, _ = _make()
+    assert isinstance(obj, CoherentObject)
+
+
+def test_descriptor_is_native_cas_over_object_etag() -> None:
+    obj, _ = _make()
+    desc = obj.descriptor
+    assert desc.tier is Tier.NATIVE_CAS
+    assert desc.version_source == "object ETag"
+    # Guarantee wording is derived from the tier (never hand-written per binding).
+    assert "version-CAS" in desc.guarantee_text
+
+
+def test_satisfies_coherence_substrate_protocol_structurally() -> None:
+    obj, _ = _make()
+    # runtime_checkable structural conformance — presence of descriptor/read/cas_write.
+    assert isinstance(obj, CoherenceSubstrate)
+
+
+def test_coordinator_content_is_none_and_flag_false() -> None:
+    obj, _ = _make()
+    # content=None exposure: the mixin reads BOTH the method (what to pass) and the
+    # class flag (the honest signal) — never thread bytes coordinator-side.
+    assert obj.coordinator_commit_content() is None
+    assert CoherentObject.SENDS_CONTENT_TO_COORDINATOR is False
+
+
+# --- read ----------------------------------------------------------------------
+
+
+def test_read_returns_bytes_and_etag_from_one_response() -> None:
+    obj, client = _make({"k": (b"hello", '"etag-1"')})
+    data, token = obj.read("k")
+    assert data == b"hello"
+    assert token == '"etag-1"'
+    # ONE get_object — never Head-then-Get for the (bytes, token) pair.
+    assert len(client.get_calls) == 1
+
+
+def test_read_absent_object_raises_keyerror() -> None:
+    obj, _ = _make()
+    with pytest.raises(KeyError):
+        obj.read("missing")
+
+
+# --- cas_write: happy update ---------------------------------------------------
+
+
+def test_cas_write_update_wins_with_response_etag() -> None:
+    obj, client = _make({"k": (b"v1", '"old"')})
+    result = obj.cas_write("k", expected_token='"old"', new_bytes=b"v2")
+    assert isinstance(result, CasWritten)
+    # The token is the ETag from the put RESPONSE, never computed client-side.
+    assert result.token == _md5_etag(b"v2")
+    assert client.put_calls[-1]["IfMatch"] == '"old"'
+
+
+def test_cas_write_update_is_single_request_put_not_multipart() -> None:
+    obj, client = _make({"k": (b"v1", '"old"')})
+    obj.cas_write("k", expected_token='"old"', new_bytes=b"v2")
+    # Structural pin: exactly one put_object, no transfer-manager / multipart calls.
+    assert len(client.put_calls) == 1
+    assert not hasattr(client, "create_multipart_upload")
+
+
+# --- cas_write: create (If-None-Match) -----------------------------------------
+
+
+def test_cas_write_create_on_absent_succeeds_then_second_conflicts() -> None:
+    obj, client = _make()
+    first = obj.cas_write("k", expected_token=CREATE_IF_ABSENT, new_bytes=b"seed")
+    assert isinstance(first, CasWritten)
+    assert client.put_calls[-1]["IfNoneMatch"] == "*"
+    # A second create → 412 → CasConflict (the object already exists).
+    second = obj.cas_write("k", expected_token=CREATE_IF_ABSENT, new_bytes=b"again")
+    assert isinstance(second, CasConflict)
+
+
+# --- cas_write: typed classification (412 / 409 / 404 / transport) -------------
+
+
+def test_cas_write_412_precondition_failed_is_conflict() -> None:
+    obj, client = _make({"k": (b"v1", '"current"')})
+    # Stale comparand: the object is at "current", we present "stale".
+    result = obj.cas_write("k", expected_token='"stale"', new_bytes=b"v2")
+    assert isinstance(result, CasConflict)
+
+
+def test_conflict_maps_to_public_cas_version_conflict() -> None:
+    # The substrate leg returns CasConflict; Unit 5 (which holds the coordinator
+    # versions) maps it to the shipped, exact-type-mapped CasVersionConflict.
+    obj, _ = _make({"k": (b"v1", '"current"')})
+    assert isinstance(obj.cas_write("k", expected_token='"stale"', new_bytes=b"v2"), CasConflict)
+    exc = CoherentObject.as_version_conflict("k", expected_version=3, current_version=4)
+    assert isinstance(exc, CasVersionConflict)
+    assert exc.expected_version == 3 and exc.current_version == 4
+
+
+def test_cas_write_409_classified_retryable_but_no_write_landed() -> None:
+    obj, client = _make({"k": (b"v1", '"cur"')})
+    client.put_error = _FakeClientError("ConditionalRequestConflict", "retry")
+    result = obj.cas_write("k", expected_token='"cur"', new_bytes=b"v2")
+    # Contract 3-way: no write landed → CasConflict...
+    assert isinstance(result, CasConflict)
+    # ...but the fine-grained classifier marks it RETRYABLE (re-read etag, retry).
+    assert classify_put_exception(_FakeClientError("ConditionalRequestConflict")) is S3PutOutcome.RETRYABLE
+
+
+def test_cas_write_404_raced_delete_is_conflict_not_recreate() -> None:
+    obj, client = _make()  # object absent → If-Match put 404s
+    result = obj.cas_write("k", expected_token='"gone"', new_bytes=b"v2")
+    assert isinstance(result, CasConflict)
+    assert classify_put_exception(_FakeClientError("NoSuchKey")) is S3PutOutcome.RACED_DELETE
+
+
+def test_cas_write_transport_failure_is_unknown() -> None:
+    obj, client = _make({"k": (b"v1", '"cur"')})
+    client.put_error = _FakeConnectionError("connection reset")
+    result = obj.cas_write("k", expected_token='"cur"', new_bytes=b"v2")
+    # "may or may not have landed" — never a confirmed loss.
+    assert isinstance(result, CasUnknown)
+
+
+def test_cas_write_non_cas_error_propagates() -> None:
+    # A modeled but non-CAS error (AccessDenied) must NOT be swallowed as a CAS
+    # outcome — it is a configuration fault, so it propagates.
+    obj, client = _make({"k": (b"v1", '"cur"')})
+    client.put_error = _FakeClientError("AccessDenied", "no perms")
+    with pytest.raises(_FakeClientError):
+        obj.cas_write("k", expected_token='"cur"', new_bytes=b"v2")
+    assert classify_put_exception(_FakeClientError("AccessDenied")) is None
+
+
+def test_cas_write_rejects_sentinel_token() -> None:
+    # An absent/blank token may never seed an If-Match comparand (the Sentinel rule).
+    obj, _ = _make({"k": (b"v1", '"cur"')})
+    with pytest.raises(CoherenceError):
+        obj.cas_write("k", expected_token="   ", new_bytes=b"v2")
+
+
+def test_cas_write_never_computes_missing_etag() -> None:
+    # A put response without an ETag is unverifiable → fail closed, never mint a token.
+    class _NoEtagClient(FakeS3Client):
+        def put_object(self, **kwargs: object) -> dict[str, object]:  # type: ignore[override]
+            super().put_object(**kwargs)  # type: ignore[arg-type]
+            return {}  # response missing ETag
+
+    obj = CoherentObject("b", client=_NoEtagClient({"k": (b"v1", '"cur"')}))
+    with pytest.raises(CoherenceError):
+        obj.cas_write("k", expected_token='"cur"', new_bytes=b"v2")
+
+
+# --- the four reconciliation arms ----------------------------------------------
+
+
+def test_reconcile_404_holds() -> None:
+    # (i) absent object / delete-marker → HOLD; never auto re-create, never a match
+    # against sha256(b"").
+    obj, _ = _make()
+    decision = obj.reconcile_after_unknown("k", expected_token='"T_old"', intended_hash=_sha256_hex(b""))
+    assert decision.verdict is ReconcileVerdict.HOLD
+    assert decision.observed_bytes is None and decision.observed_token is None
+    assert decision.bump_fires is False
+
+
+def test_reconcile_etag_unmoved_re_drives_under_if_match_t_old() -> None:
+    # (ii) token unmoved → not landed → RE_DRIVE, only under If-Match=T_old.
+    obj, _ = _make({"k": (b"old", '"T_old"')})
+    decision = obj.reconcile_after_unknown(
+        "k", expected_token='"T_old"', intended_hash=_sha256_hex(b"intended")
+    )
+    assert decision.verdict is ReconcileVerdict.RE_DRIVE
+    assert decision.re_drive_token == '"T_old"'
+    assert decision.bump_fires is False
+
+
+def test_reconcile_moved_and_bytes_match_converges_and_bump_still_fires() -> None:
+    # (iii) token moved AND bytes byte-identical → CONVERGE; the coordinator bump
+    # STILL fires and the surface says "converged", never "landed".
+    intended = b"the-intended-bytes"
+    obj, _ = _make({"k": (intended, '"T_new"')})
+    decision = obj.reconcile_after_unknown(
+        "k", expected_token='"T_old"', intended_hash=_sha256_hex(intended)
+    )
+    assert decision.verdict is ReconcileVerdict.CONVERGE
+    assert decision.bump_fires is True  # the load-bearing invariant
+    assert decision.observed_token == '"T_new"'  # adopt the observed ETag as comparand
+    assert "converged" in decision.summary
+    assert "landed" not in decision.summary  # attribution is NOT claimed
+
+
+def test_reconcile_moved_and_bytes_differ_conflicts() -> None:
+    # (iv) token moved AND bytes differ → typed conflict; never re-drive.
+    obj, _ = _make({"k": (b"a-peer-write", '"T_new"')})
+    decision = obj.reconcile_after_unknown(
+        "k", expected_token='"T_old"', intended_hash=_sha256_hex(b"my-intended")
+    )
+    assert decision.verdict is ReconcileVerdict.CONFLICT
+    assert decision.re_drive_token is None
+    assert decision.bump_fires is False
+
+
+def test_never_converge_wedge_negative_control() -> None:
+    # NEGATIVE CONTROL: in the my-write-landed world (token moved + bytes match), a
+    # decision that REFUSED to converge would strand the coordinator bump and wedge
+    # every peer (ViewWedged, no v1 repair-forward). Assert this impl converges AND
+    # signals the bump — never HOLD/CONFLICT here.
+    intended = b"landed-write"
+    obj, _ = _make({"k": (intended, '"T_new"')})
+    decision = obj.reconcile_after_unknown(
+        "k", expected_token='"T_old"', intended_hash=_sha256_hex(intended)
+    )
+    assert decision.verdict is ReconcileVerdict.CONVERGE
+    assert decision.bump_fires is True
+    assert decision.verdict not in {ReconcileVerdict.HOLD, ReconcileVerdict.CONFLICT}
+
+
+def test_reconcile_converges_under_opaque_multipart_shaped_etag() -> None:
+    # The converge test keys on sha256(bytes) and adopts the ETag as OPAQUE, so an
+    # SSE-KMS/multipart-shaped ETag (not a content digest) still converges safely —
+    # never fail closed on an opaque ETag format when the bytes match.
+    intended = b"converge-me"
+    opaque_etag = '"a1b2c3d4-9"'  # multipart-shaped: not an MD5 of the bytes
+    obj, _ = _make({"k": (intended, opaque_etag)})
+    decision = obj.reconcile_after_unknown(
+        "k", expected_token='"T_old"', intended_hash=_sha256_hex(intended)
+    )
+    assert decision.verdict is ReconcileVerdict.CONVERGE
+    assert decision.observed_token == opaque_etag
+
+
+def test_reconcile_read_transport_failure_propagates() -> None:
+    # A transport failure DURING the reconcile read is not a decision — it must
+    # propagate (retry the reconcile), never silently become HOLD/CONVERGE.
+    obj, client = _make({"k": (b"v", '"T_new"')})
+    client.get_error = _FakeConnectionError("reset mid-reconcile")
+    with pytest.raises(_FakeConnectionError):
+        obj.reconcile_after_unknown("k", expected_token='"T_old"', intended_hash=_sha256_hex(b"v"))
+
+
+# --- no-op short-circuit -------------------------------------------------------
+
+
+def test_noop_write_short_circuits_before_the_put() -> None:
+    # intended hash == current hash → no put, no coordinator bump (no phantom advance).
+    current = b"unchanged"
+    obj, client = _make({"k": (current, '"cur"')})
+    result = obj.cas_write_if_changed(
+        "k", expected_token='"cur"', new_bytes=current, current_hash=_sha256_hex(current)
+    )
+    assert result is None  # the None signals: skip the coordinator bump too
+    assert client.put_calls == []  # the put was never issued
+
+
+def test_changed_write_falls_through_to_cas_write() -> None:
+    obj, client = _make({"k": (b"old", '"cur"')})
+    result = obj.cas_write_if_changed(
+        "k", expected_token='"cur"', new_bytes=b"new", current_hash=_sha256_hex(b"old")
+    )
+    assert isinstance(result, CasWritten)
+    assert len(client.put_calls) == 1
+
+
+# --- least-privilege / bucket-policy doc helpers -------------------------------
+
+
+def test_policy_helpers_return_verified_shape() -> None:
+    docs = s3_policy_docs("my-bucket", "prefix/key")
+    blob = json.dumps(docs)
+    # The verified 2026-07 shape: conditional-write enforcement + multipart
+    # exemption + the writer's GetObject grant.
+    assert "s3:if-match" in blob
+    assert "s3:ObjectCreationOperation" in blob
+    assert "s3:GetObject" in blob
+
+
+def test_writer_iam_denies_delete_and_grants_get_put() -> None:
+    policy = least_privilege_iam_policy("b", "k")
+    statements = policy["Statement"]
+    allow = next(s for s in statements if s["Effect"] == "Allow")
+    deny = next(s for s in statements if s["Effect"] == "Deny")
+    assert set(allow["Action"]) == {"s3:GetObject", "s3:PutObject"}
+    assert "s3:DeleteObject" in deny["Action"]
+
+
+def test_bucket_policy_denies_unconditional_put() -> None:
+    policy = conditional_write_bucket_policy("b")
+    stmt = policy["Statement"][0]
+    assert stmt["Effect"] == "Deny"
+    assert stmt["Condition"]["Null"] == {"s3:if-match": "true"}
+
+
+# --- integration (real S3 / S3-compatible; deselected by default) --------------
+#
+# Marked ``real_substrate`` (deselected via ``-m 'not real_substrate'``, added by
+# the Unit-5 orchestrator) AND gated on a real bucket env var, so they never run
+# — or error — in this driver-free environment. They document the same guarantees
+# against a real endpoint; Moto/LocalStack are excluded (they serialize → false
+# green). Written to run correctly against a real bucket, not runnable here.
+
+real_substrate = pytest.mark.real_substrate
+
+_REAL_BUCKET = os.environ.get("CCS_REAL_S3_BUCKET")
+_needs_real_s3 = pytest.mark.skipif(
+    not _REAL_BUCKET, reason="set CCS_REAL_S3_BUCKET to a real (non-Moto) S3 bucket to run"
+)
+
+
+@real_substrate
+@_needs_real_s3
+def test_real_concurrent_lost_update_one_winner_loser_converges() -> None:
+    # Two writers read the same ETag; one wins the If-Match put, the loser 412s →
+    # CasConflict; the loser re-reads and converges/re-derives against the winner.
+    obj = CoherentObject(_REAL_BUCKET, region=os.environ.get("CCS_REAL_S3_REGION"))
+    key = "coherence-it/lost-update"
+    obj.cas_write(key, expected_token=CREATE_IF_ABSENT, new_bytes=b"seed")
+    _seed_bytes, token = obj.read(key)
+    winner = obj.cas_write(key, expected_token=token, new_bytes=b"winner")
+    assert isinstance(winner, CasWritten)
+    loser = obj.cas_write(key, expected_token=token, new_bytes=b"loser-stale")
+    assert isinstance(loser, CasConflict)
+
+
+@real_substrate
+@_needs_real_s3
+def test_real_timed_out_put_that_landed_converges_on_moved_bytes_match() -> None:
+    # A put whose ack was lost but which DID land: the reconcile read shows the ETag
+    # moved and the bytes match intended → CONVERGE, adopting the observed ETag; the
+    # coordinator bump still fires (the leg is never stranded). Surface says
+    # "converged", never "landed".
+    obj = CoherentObject(_REAL_BUCKET, region=os.environ.get("CCS_REAL_S3_REGION"))
+    key = "coherence-it/timeout-landed"
+    obj.cas_write(key, expected_token=CREATE_IF_ABSENT, new_bytes=b"seed")
+    _bytes, t_old = obj.read(key)
+    intended = b"landed-despite-timeout"
+    obj.cas_write(key, expected_token=t_old, new_bytes=intended)  # simulate: ack lost
+    decision = obj.reconcile_after_unknown(key, expected_token=t_old, intended_hash=_sha256_hex(intended))
+    assert decision.verdict is ReconcileVerdict.CONVERGE
+    assert decision.bump_fires is True
+    assert "landed" not in decision.summary
+
+
+@real_substrate
+@_needs_real_s3
+def test_real_raced_delete_404_holds_caller_recreates() -> None:
+    # A foreign DELETE during UNKNOWN → the If-Match re-read 404s → HOLD; re-create
+    # is the CALLER's decision via CREATE_IF_ABSENT after reacquire, never automatic.
+    obj = CoherentObject(_REAL_BUCKET, region=os.environ.get("CCS_REAL_S3_REGION"))
+    key = "coherence-it/raced-delete"
+    decision = obj.reconcile_after_unknown(key, expected_token='"stale"', intended_hash=_sha256_hex(b"x"))
+    assert decision.verdict is ReconcileVerdict.HOLD

--- a/tests/adapters/test_coherent_object.py
+++ b/tests/adapters/test_coherent_object.py
@@ -34,7 +34,7 @@ from ccs.adapters.substrate import (
     CasWritten,
     CoherenceSubstrate,
 )
-from ccs.core.exceptions import CasVersionConflict, CoherenceError
+from ccs.core.exceptions import CoherenceError
 from ccs.core.substrate import Tier
 
 
@@ -228,14 +228,13 @@ def test_cas_write_412_precondition_failed_is_conflict() -> None:
     assert isinstance(result, CasConflict)
 
 
-def test_conflict_maps_to_public_cas_version_conflict() -> None:
-    # The substrate leg returns CasConflict; Unit 5 (which holds the coordinator
-    # versions) maps it to the shipped, exact-type-mapped CasVersionConflict.
+def test_stale_token_write_returns_cas_conflict() -> None:
+    # The substrate leg returns the typed CasConflict on a stale token; the
+    # mapping to the coordinator-versioned CasVersionConflict is the cross-agent
+    # layer's job (tested in tests/adapters/test_substrate_cross_agent.py), so the
+    # binding no longer carries a private mapping seam.
     obj, _ = _make({"k": (b"v1", '"current"')})
     assert isinstance(obj.cas_write("k", expected_token='"stale"', new_bytes=b"v2"), CasConflict)
-    exc = CoherentObject.as_version_conflict("k", expected_version=3, current_version=4)
-    assert isinstance(exc, CasVersionConflict)
-    assert exc.expected_version == 3 and exc.current_version == 4
 
 
 def test_cas_write_409_classified_retryable_but_no_write_landed() -> None:

--- a/tests/adapters/test_coherent_row.py
+++ b/tests/adapters/test_coherent_row.py
@@ -1,0 +1,522 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for the CoherentRow Postgres native-CAS binding.
+
+The unit tests are DRIVER-FREE: a fake connection stands in for psycopg at the
+binding's connection seam, so no real driver and no database are needed. Where a
+test needs psycopg's exception taxonomy (classifying an unconfirmed write), a
+minimal stub ``psycopg`` module is installed for that test only.
+
+The ``real_substrate``-marked tests exercise a live Postgres and skip unless
+``CCS_TEST_PG_DSN`` (an owner DSN) — and, for the negative-grant test,
+``CCS_TEST_PG_LIMITED_DSN`` (the non-owner coherence role) — are set. They are
+deselected from the default suite by the orchestrator's marker configuration.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+from ccs.adapters.coherent_row import (
+    CoherentRow,
+    ReconcileVerdict,
+    provisioning_sql,
+)
+from ccs.adapters.substrate import CasConflict, CasUnknown, CasWritten
+from ccs.core.exceptions import CasVersionConflict, CoherenceError, CommitUnconfirmed
+from ccs.core.substrate import Tier
+
+
+def _sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+# --- driver-free fakes ------------------------------------------------------
+
+
+class _FakeCursor:
+    """A cursor context manager over one fake connection."""
+
+    def __init__(self, conn: "_FakeConnection") -> None:
+        self._conn = conn
+        self.rowcount = 0
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def execute(self, sql: str, params: tuple | None = None) -> None:
+        self._conn._run(sql, params or ())
+        self.rowcount = self._conn._last_rowcount
+
+    def fetchone(self) -> tuple | None:
+        return self._conn._last_row
+
+
+class _FakeConnection:
+    """A minimal psycopg-shaped connection that models the version trigger.
+
+    ``rows`` maps an id to ``(value, version)``. An ``UPDATE ... WHERE version =
+    ?`` only matches when the stored version equals the expected one, and lands
+    ``OLD.version + 1`` (the owner-trigger semantics). Set ``raise_on_execute`` /
+    ``raise_on_commit`` to simulate a driver failure.
+    """
+
+    def __init__(self, rows: dict[str, tuple[bytes, int]] | None = None) -> None:
+        self.rows: dict[str, tuple[bytes, int]] = dict(rows or {})
+        self.executed: list[tuple[str, tuple]] = []
+        self.committed = 0
+        self.rolled_back = 0
+        self.raise_on_execute: BaseException | None = None
+        self.raise_on_commit: BaseException | None = None
+        self._last_row: tuple | None = None
+        self._last_rowcount = 0
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self)
+
+    def commit(self) -> None:
+        if self.raise_on_commit is not None:
+            raise self.raise_on_commit
+        self.committed += 1
+
+    def rollback(self) -> None:
+        self.rolled_back += 1
+
+    def _run(self, sql: str, params: tuple) -> None:
+        self.executed.append((sql, params))
+        if self.raise_on_execute is not None:
+            raise self.raise_on_execute
+        if sql.lstrip().upper().startswith("SELECT"):
+            (ref,) = params
+            row = self.rows.get(ref)
+            self._last_row = row
+            self._last_rowcount = 1 if row is not None else 0
+        else:  # UPDATE ... WHERE id = %s AND version = %s RETURNING version
+            new_value, ref, expected = params
+            current = self.rows.get(ref)
+            if current is not None and current[1] == expected:
+                new_version = current[1] + 1
+                self.rows[ref] = (new_value, new_version)
+                self._last_row = (new_version,)
+                self._last_rowcount = 1
+            else:
+                self._last_row = None
+                self._last_rowcount = 0
+
+
+@pytest.fixture
+def fake_psycopg(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    """Install a stub ``psycopg`` module exposing the DB-API exception taxonomy."""
+    mod = types.ModuleType("psycopg")
+
+    class Error(Exception):
+        pass
+
+    class DatabaseError(Error):
+        pass
+
+    class OperationalError(DatabaseError):
+        pass
+
+    class InterfaceError(Error):
+        pass
+
+    class ProgrammingError(DatabaseError):
+        pass
+
+    mod.Error = Error  # type: ignore[attr-defined]
+    mod.DatabaseError = DatabaseError  # type: ignore[attr-defined]
+    mod.OperationalError = OperationalError  # type: ignore[attr-defined]
+    mod.InterfaceError = InterfaceError  # type: ignore[attr-defined]
+    mod.ProgrammingError = ProgrammingError  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "psycopg", mod)
+    return mod
+
+
+def _row(conn: _FakeConnection) -> CoherentRow:
+    return CoherentRow(table="workspace_rows", connection=conn)
+
+
+# --- read -------------------------------------------------------------------
+
+
+def test_read_returns_bytes_and_token_from_one_query() -> None:
+    conn = _FakeConnection({"k": (b"data", 3)})
+    assert _row(conn).read("k") == (b"data", "3")
+
+
+def test_read_absent_row_raises_keyerror() -> None:
+    with pytest.raises(KeyError):
+        _row(_FakeConnection()).read("missing")
+
+
+def test_read_sentinel_version_fails_closed() -> None:
+    conn = _FakeConnection({"k": (b"x", 0)})
+    with pytest.raises(CoherenceError):
+        _row(conn).read("k")
+
+
+# --- cas_write (typed Protocol outcomes) ------------------------------------
+
+
+def test_cas_write_happy_bumps_version_and_returns_token() -> None:
+    conn = _FakeConnection({"k": (b"old", 5)})
+    outcome = _row(conn).cas_write("k", expected_token="5", new_bytes=b"new")
+    assert isinstance(outcome, CasWritten)
+    assert outcome.token == "6"
+    assert conn.rows["k"] == (b"new", 6)
+    assert conn.committed == 1
+
+
+def test_cas_write_conflict_on_zero_rowcount() -> None:
+    conn = _FakeConnection({"k": (b"old", 6)})  # a peer already moved the version
+    outcome = _row(conn).cas_write("k", expected_token="5", new_bytes=b"new")
+    assert isinstance(outcome, CasConflict)
+    assert conn.rows["k"] == (b"old", 6)  # nothing landed
+
+
+def test_cas_write_unknown_on_operational_error_during_execute(
+    fake_psycopg: types.ModuleType,
+) -> None:
+    conn = _FakeConnection({"k": (b"old", 5)})
+    conn.raise_on_execute = fake_psycopg.OperationalError(  # type: ignore[attr-defined]
+        "server closed the connection; dsn=postgresql://u:hunter2@db/app"
+    )
+    outcome = _row(conn).cas_write("k", expected_token="5", new_bytes=b"new")
+    assert isinstance(outcome, CasUnknown)
+    assert conn.rolled_back >= 1
+
+
+def test_cas_write_unknown_on_operational_error_during_commit(
+    fake_psycopg: types.ModuleType,
+) -> None:
+    conn = _FakeConnection({"k": (b"old", 5)})
+    conn.raise_on_commit = fake_psycopg.OperationalError("connection reset")  # type: ignore[attr-defined]
+    outcome = _row(conn).cas_write("k", expected_token="5", new_bytes=b"new")
+    assert isinstance(outcome, CasUnknown)
+
+
+def test_cas_write_rejects_sentinel_token() -> None:
+    with pytest.raises(CoherenceError):
+        _row(_FakeConnection({"k": (b"x", 5)})).cas_write("k", expected_token="0", new_bytes=b"y")
+
+
+def test_cas_write_rejects_non_integer_token() -> None:
+    with pytest.raises(CoherenceError):
+        _row(_FakeConnection({"k": (b"x", 5)})).cas_write("k", expected_token="abc", new_bytes=b"y")
+
+
+# --- public write (typed exceptions at the caller surface) ------------------
+
+
+def test_write_happy_returns_new_token() -> None:
+    conn = _FakeConnection({"k": (b"old", 5)})
+    assert _row(conn).write("k", expected_token="5", new_bytes=b"new") == "6"
+
+
+def test_write_maps_conflict_to_cas_version_conflict() -> None:
+    conn = _FakeConnection({"k": (b"old", 6)})
+    with pytest.raises(CasVersionConflict) as excinfo:
+        _row(conn).write("k", expected_token="5", new_bytes=b"new")
+    assert excinfo.value.artifact_id == "k"
+    assert excinfo.value.expected_version == 5
+    assert excinfo.value.current_version == 6
+
+
+def test_write_maps_unknown_to_commit_unconfirmed(fake_psycopg: types.ModuleType) -> None:
+    conn = _FakeConnection({"k": (b"old", 5)})
+    conn.raise_on_execute = fake_psycopg.OperationalError("dropped")  # type: ignore[attr-defined]
+    with pytest.raises(CommitUnconfirmed):
+        _row(conn).write("k", expected_token="5", new_bytes=b"new")
+
+
+# --- credential scrubbing ---------------------------------------------------
+
+
+def test_non_operational_error_reraised_scrubbed(fake_psycopg: types.ModuleType) -> None:
+    conn = _FakeConnection({"k": (b"old", 5)})
+    conn.raise_on_execute = fake_psycopg.ProgrammingError(  # type: ignore[attr-defined]
+        "boom near dsn=postgresql://u:hunter2@db/app password=hunter2"
+    )
+    with pytest.raises(CoherenceError) as excinfo:
+        _row(conn).cas_write("k", expected_token="5", new_bytes=b"new")
+    message = str(excinfo.value)
+    assert "hunter2" not in message
+    assert "password" not in message
+    assert "postgresql://" not in message
+    # `raise ... from None` suppresses the chained driver error, so the traceback
+    # cannot leak the DSN either.
+    assert excinfo.value.__cause__ is None
+
+
+# --- unknown reconciliation (token-identity authority) ----------------------
+
+
+def test_reconcile_converges_only_on_expected_plus_one_and_bytes() -> None:
+    intended = b"new"
+    conn = _FakeConnection({"k": (intended, 6)})  # expected 5 -> landed at 6
+    decision = _row(conn).reconcile_after_unknown(
+        "k", expected_token="5", intended_hash=_sha(intended)
+    )
+    assert decision.verdict is ReconcileVerdict.CONVERGE
+    assert decision.observed_bytes == intended
+    assert decision.observed_token == "6"
+
+
+def test_reconcile_bytes_match_but_wrong_version_does_not_converge() -> None:
+    intended = b"new"
+    conn = _FakeConnection({"k": (intended, 7)})  # version jumped past expected+1
+    decision = _row(conn).reconcile_after_unknown(
+        "k", expected_token="5", intended_hash=_sha(intended)
+    )
+    assert decision.verdict is ReconcileVerdict.RE_DERIVE
+
+
+def test_reconcile_right_version_but_different_bytes_re_derives() -> None:
+    conn = _FakeConnection({"k": (b"peer-content", 6)})  # a different writer won
+    decision = _row(conn).reconcile_after_unknown(
+        "k", expected_token="5", intended_hash=_sha(b"new")
+    )
+    assert decision.verdict is ReconcileVerdict.RE_DERIVE
+
+
+def test_reconcile_version_unchanged_re_derives() -> None:
+    conn = _FakeConnection({"k": (b"old", 5)})  # write never landed
+    decision = _row(conn).reconcile_after_unknown(
+        "k", expected_token="5", intended_hash=_sha(b"new")
+    )
+    assert decision.verdict is ReconcileVerdict.RE_DERIVE
+
+
+def test_reconcile_absent_row_holds_never_matches_empty_hash() -> None:
+    conn = _FakeConnection()  # row absent — intended_hash is sha256(b"") on purpose
+    decision = _row(conn).reconcile_after_unknown(
+        "k", expected_token="5", intended_hash=_sha(b"")
+    )
+    assert decision.verdict is ReconcileVerdict.HOLD
+    assert decision.observed_bytes is None
+    assert decision.observed_token is None
+
+
+def test_reconcile_sentinel_version_holds() -> None:
+    conn = _FakeConnection({"k": (b"", 0)})  # present-but-sentinel version
+    decision = _row(conn).reconcile_after_unknown(
+        "k", expected_token="5", intended_hash=_sha(b"")
+    )
+    assert decision.verdict is ReconcileVerdict.HOLD
+
+
+# --- descriptor + honesty ---------------------------------------------------
+
+
+def test_descriptor_is_native_cas_with_version_source() -> None:
+    descriptor = _row(_FakeConnection()).descriptor
+    assert descriptor.tier is Tier.NATIVE_CAS
+    assert descriptor.version_source == "trigger-managed version column"
+    assert "SELECT, UPDATE" in descriptor.least_privilege
+
+
+def test_binding_never_threads_content_to_coordinator() -> None:
+    assert CoherentRow.SENDS_CONTENT_TO_COORDINATOR is False
+    assert _row(_FakeConnection()).coordinator_commit_content() is None
+
+
+def test_satisfies_coherence_substrate_protocol() -> None:
+    from ccs.adapters.substrate import CoherenceSubstrate
+
+    assert isinstance(_row(_FakeConnection()), CoherenceSubstrate)
+
+
+# --- deferred driver import -------------------------------------------------
+
+
+def test_module_imports_without_psycopg_and_defers_error() -> None:
+    if importlib.util.find_spec("psycopg") is not None:
+        pytest.skip("psycopg installed; the deferred-import path only fires when it is absent")
+    # Construction with a dsn does NOT import the driver...
+    row = CoherentRow(table="workspace_rows", dsn="postgresql://u:secret@db/app")
+    # ...the clear, extra-naming ImportError fires only on actual use.
+    with pytest.raises(ImportError, match="coherent-row"):
+        row.read("k")
+
+
+# --- provisioning DDL / negative grants -------------------------------------
+
+
+def test_provisioning_sql_emits_version_guard_and_negative_grants() -> None:
+    script = provisioning_sql("workspace_rows", role="coherence_writer").as_script()
+    # The version is minted from the STORED prior row, never a client value.
+    assert 'OLD."version" + 1' in script
+    assert "never trust a client-supplied NEW.version" in script
+    # Least privilege: SELECT, UPDATE only; no escalation.
+    assert "GRANT SELECT, UPDATE" in script
+    assert "NOSUPERUSER" in script
+    assert "NOCREATEDB" in script
+    assert "NOCREATEROLE" in script
+    # No GRANT confers ALTER / TRIGGER / DELETE, and no grant is re-grantable.
+    grant_lines = [ln for ln in script.splitlines() if ln.strip().upper().startswith("GRANT")]
+    assert grant_lines
+    for line in grant_lines:
+        upper = line.upper()
+        assert "ALTER" not in upper
+        assert "TRIGGER" not in upper
+        assert "DELETE" not in upper
+    assert "WITH GRANT OPTION" not in script
+
+
+def test_provisioning_sql_rejects_unsafe_identifiers() -> None:
+    with pytest.raises(ValueError):
+        provisioning_sql('rows"; DROP TABLE users; --')
+
+
+def test_binding_rejects_unsafe_table_identifier() -> None:
+    with pytest.raises(ValueError):
+        CoherentRow(table="rows; DROP TABLE users", connection=_FakeConnection())
+
+
+# ---------------------------------------------------------------------------
+# Integration tests against a REAL Postgres (deselected by default).
+# ---------------------------------------------------------------------------
+
+_IT_TABLE = "coherence_row_it"
+
+
+@pytest.fixture
+def real_pg():
+    """Provision a real Postgres table + version trigger; yield ``(dsn, table)``."""
+    dsn = os.environ.get("CCS_TEST_PG_DSN")
+    if not dsn:
+        pytest.skip("set CCS_TEST_PG_DSN (owner DSN) to run real Postgres tests")
+    import psycopg  # noqa: PLC0415
+
+    ddl = provisioning_sql(_IT_TABLE)
+    with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute(f'DROP TABLE IF EXISTS "{_IT_TABLE}" CASCADE')
+        cur.execute(
+            f'CREATE TABLE "{_IT_TABLE}" '
+            "(id text PRIMARY KEY, value bytea NOT NULL, version int NOT NULL DEFAULT 0)"
+        )
+        cur.execute(ddl.trigger_function)
+        cur.execute(ddl.trigger_bindings)
+        cur.execute(f'INSERT INTO "{_IT_TABLE}" (id, value) VALUES (%s, %s)', ("row1", b"seed"))
+        conn.commit()
+    try:
+        yield dsn, _IT_TABLE
+    finally:
+        with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute(f'DROP TABLE IF EXISTS "{_IT_TABLE}" CASCADE')
+            conn.commit()
+
+
+@pytest.mark.real_substrate
+def test_it_concurrent_lost_update_one_winner_then_converge(real_pg) -> None:
+    dsn, table = real_pg
+    agent_a = CoherentRow(table=table, dsn=dsn)
+    agent_b = CoherentRow(table=table, dsn=dsn)
+    _bytes_a, token_a = agent_a.read("row1")
+    _bytes_b, token_b = agent_b.read("row1")  # both hold the same stale version
+    assert token_a == token_b
+
+    token_after = agent_a.write("row1", expected_token=token_a, new_bytes=b"from-a")
+    with pytest.raises(CasVersionConflict):
+        agent_b.write("row1", expected_token=token_b, new_bytes=b"from-b")
+
+    _fresh, token_fresh = agent_b.read("row1")  # re-read the winner's version
+    assert token_fresh == token_after
+    agent_b.write("row1", expected_token=token_fresh, new_bytes=b"from-b")
+    final_bytes, _ = agent_b.read("row1")
+    assert final_bytes == b"from-b"
+
+
+@pytest.mark.real_substrate
+def test_it_trigger_authority_ignores_client_new_version(real_pg) -> None:
+    dsn, table = real_pg
+    import psycopg  # noqa: PLC0415
+
+    with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute(f'SELECT version FROM "{table}" WHERE id = %s', ("row1",))
+        (before,) = cur.fetchone()
+        # A raw client UPDATE that forges an arbitrary NEW.version...
+        cur.execute(
+            f'UPDATE "{table}" SET value = %s, version = %s WHERE id = %s',
+            (b"x", 999_999, "row1"),
+        )
+        cur.execute(f'SELECT version FROM "{table}" WHERE id = %s', ("row1",))
+        (after,) = cur.fetchone()
+        conn.commit()
+    assert after == before + 1  # the owner trigger overrode 999999 with OLD.version + 1
+
+
+@pytest.mark.real_substrate
+def test_it_foreign_write_moves_version_agent_cas_fails(real_pg) -> None:
+    dsn, table = real_pg
+    import psycopg  # noqa: PLC0415
+
+    agent = CoherentRow(table=table, dsn=dsn)
+    _bytes, token = agent.read("row1")
+    with psycopg.connect(dsn) as conn, conn.cursor() as cur:  # a non-agent writer
+        cur.execute(f'UPDATE "{table}" SET value = %s WHERE id = %s', (b"foreign", "row1"))
+        conn.commit()
+    with pytest.raises(CasVersionConflict):
+        agent.write("row1", expected_token=token, new_bytes=b"from-agent")
+
+
+@pytest.mark.real_substrate
+def test_it_unknown_write_reconciles_on_token_identity(real_pg) -> None:
+    dsn, table = real_pg
+    agent = CoherentRow(table=table, dsn=dsn)
+    _bytes, token = agent.read("row1")
+    intended = b"from-agent"
+    # A committed write is the "the UPDATE actually landed" leg of an unknown; the
+    # reconciliation converges only because the version is exactly expected + 1
+    # under our identity AND the bytes hash to what we intended.
+    new_token = agent.write("row1", expected_token=token, new_bytes=intended)
+    decision = agent.reconcile_after_unknown(
+        "row1", expected_token=token, intended_hash=hashlib.sha256(intended).hexdigest()
+    )
+    assert decision.verdict is ReconcileVerdict.CONVERGE
+    assert decision.observed_token == new_token
+
+
+@pytest.mark.real_substrate
+def test_it_limited_role_cannot_disable_the_trigger() -> None:
+    limited_dsn = os.environ.get("CCS_TEST_PG_LIMITED_DSN")
+    if not limited_dsn:
+        pytest.skip("set CCS_TEST_PG_LIMITED_DSN (non-owner coherence role) to run this test")
+    import psycopg  # noqa: PLC0415
+
+    with psycopg.connect(limited_dsn) as conn, conn.cursor() as cur:
+        # The coherence role holds only SELECT, UPDATE — it is not the owner, so it
+        # cannot ALTER the table or disable the version guard.
+        with pytest.raises(psycopg.errors.InsufficientPrivilege):
+            cur.execute(f'ALTER TABLE "{_IT_TABLE}" DISABLE TRIGGER ALL')
+
+
+@pytest.mark.real_substrate
+def test_it_xmin_wraparound_is_the_missed_conflict_hazard(real_pg) -> None:
+    # Documents WHY xmin is not shipped: xmin is equality-only and 32-bit, so after
+    # wraparound (or VACUUM FREEZE) a fresh xmin can EQUAL a stale captured one — a
+    # missed conflict (false CAS-pass) the trigger version column cannot suffer.
+    dsn, table = real_pg
+    import psycopg  # noqa: PLC0415
+
+    with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute(f'SELECT xmin::text::bigint FROM "{table}" WHERE id = %s', ("row1",))
+        (xmin_before,) = cur.fetchone()
+        cur.execute(f'UPDATE "{table}" SET value = %s WHERE id = %s', (b"y", "row1"))
+        conn.commit()
+        cur.execute(f'SELECT xmin::text::bigint FROM "{table}" WHERE id = %s', ("row1",))
+        (xmin_after,) = cur.fetchone()
+    # xmin moves on this update, but it is NOT monotonic and can repeat — unlike the
+    # trigger version column, which only ever increases.
+    assert xmin_after != xmin_before

--- a/tests/adapters/test_coherent_row.py
+++ b/tests/adapters/test_coherent_row.py
@@ -374,6 +374,18 @@ def test_provisioning_sql_emits_version_guard_and_negative_grants() -> None:
     assert "WITH GRANT OPTION" not in script
 
 
+def test_provisioning_sql_trigger_names_are_single_quoted_identifiers() -> None:
+    # Regression: each trigger name must be ONE quoted identifier, never the
+    # quoted function name with a bareword suffix (`"..."_ins`), which Postgres
+    # parses as two tokens — a syntax error at "_ins" that breaks the one-time
+    # setup the whole NATIVE_CAS guarantee rides on.
+    script = provisioning_sql("workspace_rows").as_script()
+    assert '"_ins' not in script and '"_upd' not in script  # no quote-then-bareword
+    assert 'CREATE TRIGGER "workspace_rows_coherence_version_ins"' in script
+    assert 'CREATE TRIGGER "workspace_rows_coherence_version_upd"' in script
+    assert 'DROP TRIGGER IF EXISTS "workspace_rows_coherence_version_ins"' in script
+
+
 def test_provisioning_sql_rejects_unsafe_identifiers() -> None:
     with pytest.raises(ValueError):
         provisioning_sql('rows"; DROP TABLE users; --')

--- a/tests/adapters/test_coherent_row.py
+++ b/tests/adapters/test_coherent_row.py
@@ -30,7 +30,7 @@ from ccs.adapters.coherent_row import (
     provisioning_sql,
 )
 from ccs.adapters.substrate import CasConflict, CasUnknown, CasWritten
-from ccs.core.exceptions import CasVersionConflict, CoherenceError, CommitUnconfirmed
+from ccs.core.exceptions import CasVersionConflict, CoherenceError, CommitUnconfirmed, ViewWedged
 from ccs.core.substrate import Tier
 
 
@@ -240,6 +240,61 @@ def test_write_maps_unknown_to_commit_unconfirmed(fake_psycopg: types.ModuleType
         _row(conn).write("k", expected_token="5", new_bytes=b"new")
 
 
+def test_write_view_wedged_when_row_absent_on_conflict_refetch() -> None:
+    # A CAS conflict whose post-conflict re-fetch finds the row gone → ViewWedged
+    # (a delete is itself an update). Exercises _current_version_or_wedged's
+    # absent branch, which the row-present conflict path never reaches.
+    conn = _FakeConnection({})  # absent: UPDATE finds nothing → conflict; refetch → absent
+    with pytest.raises(ViewWedged):
+        _row(conn).write("k", expected_token="5", new_bytes=b"new")
+
+
+def test_dsn_owned_connection_reconnects_after_operational_error(
+    fake_psycopg: types.ModuleType,
+) -> None:
+    # A DB blip must not permanently poison a self-owned connection: after an
+    # operational error the dead connection is discarded, so the next call
+    # reconnects instead of replaying the same failure forever.
+    conns: list[_FakeConnection] = []
+
+    def fake_connect(dsn, **kwargs):
+        conn = _FakeConnection({"k": (b"v", 3)})
+        if not conns:  # the first connection is born broken (server closed)
+            conn.raise_on_execute = fake_psycopg.OperationalError("server closed")  # type: ignore[attr-defined]
+        conns.append(conn)
+        return conn
+
+    fake_psycopg.connect = fake_connect  # type: ignore[attr-defined]
+    row = CoherentRow(table="workspace_rows", dsn="postgresql://u:sec@db/app")
+
+    assert isinstance(row.cas_write("k", expected_token="3", new_bytes=b"n"), CasUnknown)
+    assert row.read("k") == (b"v", "3")  # reconnected to a fresh, healthy socket
+    assert len(conns) == 2  # discarded the poisoned one and dialed again
+
+
+def test_dsn_connection_applies_connect_and_statement_timeouts(
+    fake_psycopg: types.ModuleType,
+) -> None:
+    # A hung DB must raise (→ reconcilable CasUnknown), not block forever: the
+    # self-owned connection carries a connect_timeout and a statement_timeout.
+    captured: dict[str, object] = {}
+
+    def fake_connect(dsn, **kwargs):
+        captured.update(kwargs)
+        return _FakeConnection({"k": (b"v", 1)})
+
+    fake_psycopg.connect = fake_connect  # type: ignore[attr-defined]
+    row = CoherentRow(
+        table="workspace_rows",
+        dsn="postgresql://u@db/app",
+        connect_timeout=7.5,
+        statement_timeout_ms=12345,
+    )
+    row.read("k")
+    assert captured["connect_timeout"] == 7.5
+    assert "statement_timeout=12345" in str(captured["options"])
+
+
 # --- credential scrubbing ---------------------------------------------------
 
 
@@ -355,9 +410,12 @@ def test_module_imports_without_psycopg_and_defers_error() -> None:
 
 def test_provisioning_sql_emits_version_guard_and_negative_grants() -> None:
     script = provisioning_sql("workspace_rows", role="coherence_writer").as_script()
-    # The version is minted from the STORED prior row, never a client value.
-    assert 'OLD."version" + 1' in script
+    # The version is minted from the STORED prior row, never a client value; the
+    # COALESCE lets a pre-existing NULL/0 row advance to a usable version.
+    assert 'COALESCE(OLD."version", 0) + 1' in script
     assert "never trust a client-supplied NEW.version" in script
+    # A one-time backfill seeds pre-existing NULL/0 rows so they can be onboarded.
+    assert 'UPDATE "workspace_rows" SET "version" = 1 WHERE "version" IS NULL OR "version" <= 0' in script
     # Least privilege: SELECT, UPDATE only; no escalation.
     assert "GRANT SELECT, UPDATE" in script
     assert "NOSUPERUSER" in script

--- a/tests/adapters/test_substrate_cross_agent.py
+++ b/tests/adapters/test_substrate_cross_agent.py
@@ -225,6 +225,23 @@ def test_peer_commit_denies_next_act_before_write(
         stop_coordinator(tmp_path)
 
 
+def test_read_rejects_unknown_on_stale_value(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    # A typo'd on_stale must fail closed (ValueError) rather than silently falling
+    # through to the permissive 'allow' path — validated before the substrate is
+    # even touched.
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    sa = _session(tmp_path, fast_cfg)
+    try:
+        a, _fake_a = _agent(store, sa)
+        with pytest.raises(ValueError):
+            a.read(REF, on_stale="raize")
+    finally:
+        stop_coordinator(tmp_path)
+
+
 def test_read_time_deny_surfaces_stale_view(
     tmp_path: Path, fast_cfg: LifecycleConfig
 ) -> None:

--- a/tests/adapters/test_substrate_cross_agent.py
+++ b/tests/adapters/test_substrate_cross_agent.py
@@ -31,12 +31,17 @@ from ccs.adapters.substrate import (
     CasWriteResult,
     CasWritten,
     CoordinatedSubstrate,
+    CoordinatorConflict,
+    CoordinatorWin,
     ReconcileDecision,
     ReconcileVerdict,
     SubstrateCoordinatorSession,
 )
 from ccs.core.exceptions import (
+    COMMIT_UNCONFIRMED_REASON,
+    VERSION_MISMATCH_REASON,
     CasVersionConflict,
+    CoherenceError,
     CommitUnconfirmed,
     StaleView,
     ViewWedged,
@@ -89,6 +94,9 @@ class _FakeStore:
     def set(self, ref: str, data: bytes) -> str:
         return self.seed(ref, data)
 
+    def delete(self, ref: str) -> None:
+        self._data.pop(ref, None)
+
 
 def _descriptor(arm: str) -> CapabilityDescriptor:
     return CapabilityDescriptor(
@@ -108,7 +116,9 @@ class _FakeSubstrate:
         self._arm = arm
         self._descriptor = _descriptor(arm)
         self.cas_calls: list[tuple[str, str, bytes]] = []
-        self._script: tuple[str, bool] | None = None
+        # A QUEUE of scripted outcomes (not a single slot): a re-drive path issues
+        # a second cas_write, so tests must script both legs independently.
+        self._scripts: list[tuple[str, bool]] = []
         # Runs inside reconcile_after_unknown (before the verdict) — a seam to
         # inject a byte-identical peer's coordinator bump mid-commit.
         self.reconcile_hook = None
@@ -118,12 +128,20 @@ class _FakeSubstrate:
         return self._descriptor
 
     def script_unknown(self, *, landed: bool) -> None:
-        """Next ``cas_write`` returns ``CasUnknown``; ``landed`` applies the write."""
-        self._script = ("unknown", landed)
+        """Enqueue: the next scripted ``cas_write`` returns ``CasUnknown``;
+        ``landed`` applies the write to the store."""
+        self._scripts.append(("unknown", landed))
 
     def script_conflict(self) -> None:
-        """Next ``cas_write`` returns ``CasConflict`` (no write landed)."""
-        self._script = ("conflict", False)
+        """Enqueue: the next scripted ``cas_write`` returns ``CasConflict`` (no
+        write landed)."""
+        self._scripts.append(("conflict", False))
+
+    def script_ghost_conflict(self) -> None:
+        """Enqueue: the next scripted ``cas_write`` applies the write (my bytes
+        land under a fresh token — an in-flight ghost) THEN returns ``CasConflict``,
+        so the re-drive sees a moved token carrying its own intended bytes."""
+        self._scripts.append(("ghost", True))
 
     def read(self, artifact_ref: str) -> tuple[bytes, str]:
         entry = self._store.get(artifact_ref)
@@ -135,13 +153,17 @@ class _FakeSubstrate:
         self, artifact_ref: str, *, expected_token: str, new_bytes: bytes
     ) -> CasWriteResult:
         self.cas_calls.append((artifact_ref, expected_token, bytes(new_bytes)))
-        script, self._script = self._script, None
-        if script is not None:
-            kind, landed = script
+        if self._scripts:
+            kind, landed = self._scripts.pop(0)
             if kind == "unknown":
                 if landed:
                     self._store.set(artifact_ref, bytes(new_bytes))
                 return CasUnknown()
+            if kind == "ghost":
+                # The in-flight ghost landed my bytes under a fresh token, then the
+                # (late) response is a conflict — the re-drive must detect the ghost.
+                self._store.set(artifact_ref, bytes(new_bytes))
+                return CasConflict()
             return CasConflict()
         entry = self._store.get(artifact_ref)
         if entry is None or entry[1] != expected_token:
@@ -532,3 +554,264 @@ def test_admit_on_absent_occ_writer_commits(
         assert result.converged is False
     finally:
         stop_coordinator(tmp_path)
+
+
+# --- no-op: byte-identical commit mints no phantom advance ------------------
+
+
+def test_noop_commit_touches_neither_leg(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Committing the exact bytes last observed advances NOTHING — no substrate
+    write, no coordinator bump — so a byte-identical rewrite never invalidates a
+    peer (Open Q C)."""
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    posts: list[str] = []
+    real_post = substrate_module._coordinator_post
+
+    def spy(endpoint, path, payload):  # noqa: ANN001, ANN202
+        posts.append(path)
+        return real_post(endpoint, path, payload)
+
+    monkeypatch.setattr(substrate_module, "_coordinator_post", spy)
+    sa = _session(tmp_path, fast_cfg)
+    try:
+        a, fake_a = _agent(store, sa)
+        _bytes, tok = a.read(REF)
+        result = a.commit(REF, expected_token=tok, new_bytes=b"v1")  # identical
+
+        assert result.noop is True
+        assert result.summary == "unchanged"
+        assert fake_a.cas_calls == []  # no substrate write
+        assert "/hooks/post-edit-cas" not in posts  # no coordinator bump
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- re-drive: retry outcomes (the honesty boundary) ------------------------
+
+
+def test_re_drive_retry_conflict_is_typed_conflict(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """RE_DRIVE whose retry loses to a peer (token still unmoved for me) surfaces
+    the typed conflict after EXACTLY two substrate writes — never a third, never a
+    blind win."""
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    sa = _session(tmp_path, fast_cfg)
+    try:
+        a, fake_a = _agent(store, sa, arm="object")
+        _ab, a_tok = a.read(REF)
+
+        fake_a.script_unknown(landed=False)  # 1st: unknown, not landed → RE_DRIVE
+        fake_a.script_conflict()  # 2nd (the re-drive): conflict → typed conflict
+        with pytest.raises(CasVersionConflict):
+            a.commit(REF, expected_token=a_tok, new_bytes=b"v2")
+        assert len(fake_a.cas_calls) == 2
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_re_drive_retry_second_unknown_is_unconfirmed(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A SECOND unknown on the re-drive fails closed (CommitUnconfirmed) — it does
+    NOT loop unbounded and NEVER bumps the coordinator."""
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    posts: list[str] = []
+    real_post = substrate_module._coordinator_post
+
+    def spy(endpoint, path, payload):  # noqa: ANN001, ANN202
+        posts.append(path)
+        return real_post(endpoint, path, payload)
+
+    monkeypatch.setattr(substrate_module, "_coordinator_post", spy)
+    sa = _session(tmp_path, fast_cfg)
+    try:
+        a, fake_a = _agent(store, sa, arm="object")
+        _ab, a_tok = a.read(REF)
+
+        fake_a.script_unknown(landed=False)  # 1st: unknown → RE_DRIVE
+        fake_a.script_unknown(landed=False)  # 2nd: unknown again → fail-closed
+        with pytest.raises(CommitUnconfirmed):
+            a.commit(REF, expected_token=a_tok, new_bytes=b"v2")
+        assert len(fake_a.cas_calls) == 2  # no third attempt
+        assert "/hooks/post-edit-cas" not in posts  # never bumped
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_re_drive_detects_own_ghost_and_converges(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """RE_DRIVE whose retry conflicts because MY OWN in-flight ghost put landed
+    converges (my bytes are present) and drives the bump — not a misleading peer
+    conflict."""
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    sa = _session(tmp_path, fast_cfg)
+    try:
+        a, fake_a = _agent(store, sa, arm="object")
+        _ab, a_tok = a.read(REF)
+
+        fake_a.script_unknown(landed=False)  # 1st: unknown, not landed → RE_DRIVE
+        fake_a.script_ghost_conflict()  # 2nd: ghost lands my bytes, THEN conflicts
+        result = a.commit(REF, expected_token=a_tok, new_bytes=b"v2")
+
+        assert result.converged is True  # my ghost carried my bytes
+        assert len(fake_a.cas_calls) == 2
+        assert store.get(REF)[0] == b"v2"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- HOLD: absent operand wedges the view, never bumps ----------------------
+
+
+def test_hold_verdict_wedges_without_bump(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unknown write whose operand is ABSENT at reconcile (a raced delete)
+    HOLDs → ViewWedged, and NEVER fires the coordinator bump (no phantom advance
+    on a deleted operand)."""
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    posts: list[str] = []
+    real_post = substrate_module._coordinator_post
+
+    def spy(endpoint, path, payload):  # noqa: ANN001, ANN202
+        posts.append(path)
+        return real_post(endpoint, path, payload)
+
+    monkeypatch.setattr(substrate_module, "_coordinator_post", spy)
+    sa = _session(tmp_path, fast_cfg)
+    try:
+        a, fake_a = _agent(store, sa, arm="object")
+        _ab, a_tok = a.read(REF)
+
+        fake_a.script_unknown(landed=False)
+        fake_a.reconcile_hook = lambda: store.delete(REF)  # operand vanishes
+        with pytest.raises(ViewWedged):
+            a.commit(REF, expected_token=a_tok, new_bytes=b"v2")
+        assert len(fake_a.cas_calls) == 1
+        assert "/hooks/post-edit-cas" not in posts  # HOLD never bumps
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- converged/clean bump losing to a peer → typed conflict -----------------
+
+
+def test_converged_bump_conflict_on_different_peer_raises(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """A converged write whose bump loses to a DIFFERENT-bytes peer is a real
+    conflict (the coordinator hash does not match my intended) — NOT a false
+    converge that would mask a lost update."""
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    sa, sb = _session(tmp_path, fast_cfg), _session(tmp_path, fast_cfg)
+    try:
+        a, fake_a = _agent(store, sa, arm="object")
+        b, _fb = _agent(store, sb, arm="object")
+        _ab, a_tok = a.read(REF)
+        _bb, _b_tok = b.read(REF)  # B is SHARED@v1 so it can bump the coordinator
+
+        def peer_bumps_different() -> None:
+            sb.commit_cas(REF, expected_version=1, content_hash=_sha256(b"peer-different"))
+
+        fake_a.script_unknown(landed=True)  # A's write landed (b"v2") → CONVERGE
+        fake_a.reconcile_hook = peer_bumps_different
+        with pytest.raises(CasVersionConflict):
+            a.commit(REF, expected_token=a_tok, new_bytes=b"v2")
+        assert len(fake_a.cas_calls) == 1  # no re-drive of a landed write
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_clean_win_bump_conflict_raises(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A clean substrate win whose coordinator bump loses to a peer (a peer bumped
+    between this agent's pre-read and its bump) surfaces the typed conflict."""
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    sa, sb = _session(tmp_path, fast_cfg), _session(tmp_path, fast_cfg)
+    injected = {"done": False}
+    real_post = substrate_module._coordinator_post
+
+    def spy(endpoint, path, payload):  # noqa: ANN001, ANN202
+        # Just before A's bump, let a peer bump the coordinator once (v1 → v2), so
+        # A's clean-win bump at expected_version=1 conflicts. The guard keeps the
+        # peer's own post-edit-cas from re-triggering the injection.
+        if (
+            path == "/hooks/post-edit-cas"
+            and payload.get("session_id") == sa.session_id
+            and not injected["done"]
+        ):
+            injected["done"] = True
+            sb.commit_cas(REF, expected_version=1, content_hash=_sha256(b"peer"))
+        return real_post(endpoint, path, payload)
+
+    monkeypatch.setattr(substrate_module, "_coordinator_post", spy)
+    try:
+        a, fake_a = _agent(store, sa, arm="object")
+        b, _fb = _agent(store, sb, arm="object")
+        _ab, a_tok = a.read(REF)
+        _bb, _b_tok = b.read(REF)  # B SHARED@v1 so its injected bump lands
+
+        with pytest.raises(CasVersionConflict):
+            a.commit(REF, expected_token=a_tok, new_bytes=b"vA")
+        assert len(fake_a.cas_calls) == 1  # a clean win, no reconcile/re-drive
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- never-ship-a-store, made load-bearing at composition -------------------
+
+
+def test_binding_declaring_it_sends_content_is_refused() -> None:
+    """A binding that declares SENDS_CONTENT_TO_COORDINATOR=True is refused at
+    composition — the never-ship-a-store floor is enforced, not merely declared."""
+
+    class _ContentLeakingBinding:
+        SENDS_CONTENT_TO_COORDINATOR = True
+
+    with pytest.raises(CoherenceError):
+        CoordinatedSubstrate(_ContentLeakingBinding(), object())  # type: ignore[arg-type]
+
+
+# --- coordinator commit classification (fail-closed) ------------------------
+
+
+def test_classify_commit_ok_is_win() -> None:
+    result = substrate_module._classify_commit({"ok": True, "version": 5}, expected_version=4)
+    assert isinstance(result, CoordinatorWin) and result.version == 5
+
+
+def test_classify_commit_degraded_body_is_unconfirmed() -> None:
+    with pytest.raises(CommitUnconfirmed):
+        substrate_module._classify_commit({"ok": False, "degraded": True}, expected_version=4)
+
+
+def test_classify_commit_unconfirmed_reason_is_unconfirmed() -> None:
+    with pytest.raises(CommitUnconfirmed):
+        substrate_module._classify_commit(
+            {"ok": False, "reason": COMMIT_UNCONFIRMED_REASON}, expected_version=4
+        )
+
+
+def test_classify_commit_retryable_reason_is_conflict() -> None:
+    result = substrate_module._classify_commit(
+        {"ok": False, "reason": VERSION_MISMATCH_REASON, "current_version": 7},
+        expected_version=4,
+    )
+    assert isinstance(result, CoordinatorConflict) and result.current_version == 7
+
+
+def test_classify_commit_unknown_reason_fails_closed() -> None:
+    with pytest.raises(CoherenceError):
+        substrate_module._classify_commit({"ok": False, "reason": "mystery"}, expected_version=4)

--- a/tests/adapters/test_substrate_cross_agent.py
+++ b/tests/adapters/test_substrate_cross_agent.py
@@ -1,0 +1,534 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Cross-agent coherence over a substrate binding (Unit 5).
+
+These drive the coordinator-mediated layer with a REAL coordinator subprocess
+(spawned via the shipped lifecycle, torn down in ``finally``) and a FAKE
+in-memory substrate, so the coordinator-mediated behaviour — pull invalidation,
+the divergence taxonomy, the never-ship-a-store commit path — is exercised
+without a real Postgres or S3.
+
+The fake models the shared substrate state (one row / one object) in a store
+shared by every agent's binding view, mirroring reality: distinct agents, one
+underlying artifact. It can script an ``UNKNOWN`` write (landed or not) so the
+reconciliation dispatch is reachable, and it reconciles by the same
+token-identity logic both real bindings use.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+import ccs.adapters.substrate as substrate_module
+from ccs.adapters.claude_code.lifecycle import LifecycleConfig, stop_coordinator
+from ccs.adapters.substrate import (
+    CasConflict,
+    CasUnknown,
+    CasWriteResult,
+    CasWritten,
+    CoordinatedSubstrate,
+    ReconcileDecision,
+    ReconcileVerdict,
+    SubstrateCoordinatorSession,
+)
+from ccs.core.exceptions import (
+    CasVersionConflict,
+    CommitUnconfirmed,
+    StaleView,
+    ViewWedged,
+)
+from ccs.core.substrate import CapabilityDescriptor, Tier
+
+REF = "workspace/shared.bin"
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@pytest.fixture
+def fast_cfg() -> LifecycleConfig:
+    """Coordinator config tuned for fast tests (no idle shutdown)."""
+    return LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0.1,
+        notice_evict_max_age_sec=1.0,
+        port_file_retry_attempts=20,
+        port_file_retry_interval_sec=0.05,
+        connect_retry_attempts=10,
+        connect_retry_interval_sec=0.05,
+    )
+
+
+# --- fake substrate ---------------------------------------------------------
+
+
+class _FakeStore:
+    """The shared substrate state (one row / one object), shared by all views."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, tuple[bytes, str]] = {}
+        self._counter = 0
+
+    def _mint(self) -> str:
+        self._counter += 1
+        return f"tok-{self._counter}"
+
+    def seed(self, ref: str, data: bytes) -> str:
+        token = self._mint()
+        self._data[ref] = (data, token)
+        return token
+
+    def get(self, ref: str) -> tuple[bytes, str] | None:
+        return self._data.get(ref)
+
+    def set(self, ref: str, data: bytes) -> str:
+        return self.seed(ref, data)
+
+
+def _descriptor(arm: str) -> CapabilityDescriptor:
+    return CapabilityDescriptor(
+        tier=Tier.NATIVE_CAS,
+        version_source="fake row-version" if arm == "row" else "fake object ETag",
+        least_privilege="fake",
+        consistency_note="fake single-primary",
+    )
+
+
+class _FakeSubstrate:
+    """A per-agent binding view over the shared store, implementing the
+    reconciling-substrate surface with realistic token-identity logic."""
+
+    def __init__(self, store: _FakeStore, arm: str = "object") -> None:
+        self._store = store
+        self._arm = arm
+        self._descriptor = _descriptor(arm)
+        self.cas_calls: list[tuple[str, str, bytes]] = []
+        self._script: tuple[str, bool] | None = None
+        # Runs inside reconcile_after_unknown (before the verdict) — a seam to
+        # inject a byte-identical peer's coordinator bump mid-commit.
+        self.reconcile_hook = None
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def script_unknown(self, *, landed: bool) -> None:
+        """Next ``cas_write`` returns ``CasUnknown``; ``landed`` applies the write."""
+        self._script = ("unknown", landed)
+
+    def script_conflict(self) -> None:
+        """Next ``cas_write`` returns ``CasConflict`` (no write landed)."""
+        self._script = ("conflict", False)
+
+    def read(self, artifact_ref: str) -> tuple[bytes, str]:
+        entry = self._store.get(artifact_ref)
+        if entry is None:
+            raise KeyError(artifact_ref)
+        return entry
+
+    def cas_write(
+        self, artifact_ref: str, *, expected_token: str, new_bytes: bytes
+    ) -> CasWriteResult:
+        self.cas_calls.append((artifact_ref, expected_token, bytes(new_bytes)))
+        script, self._script = self._script, None
+        if script is not None:
+            kind, landed = script
+            if kind == "unknown":
+                if landed:
+                    self._store.set(artifact_ref, bytes(new_bytes))
+                return CasUnknown()
+            return CasConflict()
+        entry = self._store.get(artifact_ref)
+        if entry is None or entry[1] != expected_token:
+            return CasConflict()
+        return CasWritten(token=self._store.set(artifact_ref, bytes(new_bytes)))
+
+    def reconcile_after_unknown(
+        self, artifact_ref: str, *, expected_token: str, intended_hash: str
+    ) -> ReconcileDecision:
+        if self.reconcile_hook is not None:
+            self.reconcile_hook()
+        entry = self._store.get(artifact_ref)
+        if entry is None:
+            return ReconcileDecision(ReconcileVerdict.HOLD, None, None)
+        observed_bytes, observed_token = entry
+        if observed_token == expected_token:
+            return ReconcileDecision(ReconcileVerdict.RE_DRIVE, observed_bytes, observed_token)
+        if _sha256(observed_bytes) == intended_hash:
+            return ReconcileDecision(ReconcileVerdict.CONVERGE, observed_bytes, observed_token)
+        # The token moved and the bytes differ: object → CONFLICT, row → RE_DERIVE.
+        verdict = ReconcileVerdict.CONFLICT if self._arm == "object" else ReconcileVerdict.RE_DERIVE
+        return ReconcileDecision(verdict, observed_bytes, observed_token)
+
+
+def _agent(
+    store: _FakeStore, session: SubstrateCoordinatorSession, *, arm: str = "object"
+) -> tuple[CoordinatedSubstrate, _FakeSubstrate]:
+    fake = _FakeSubstrate(store, arm)
+    return CoordinatedSubstrate(fake, session), fake
+
+
+def _session(tmp_path: Path, fast_cfg: LifecycleConfig) -> SubstrateCoordinatorSession:
+    return SubstrateCoordinatorSession(tmp_path, managed=("**",), config=fast_cfg)
+
+
+# --- happy: pull invalidation before act (LOAD-BEARING) ---------------------
+
+
+def test_peer_commit_denies_next_act_before_write(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    sa, sb = _session(tmp_path, fast_cfg), _session(tmp_path, fast_cfg)
+    try:
+        a, fake_a = _agent(store, sa)
+        b, _fake_b = _agent(store, sb)
+        _a_bytes, a_tok = a.read(REF)
+        _b_bytes, b_tok = b.read(REF)
+
+        b.commit(REF, expected_token=b_tok, new_bytes=b"v2")  # B wins; A invalidated
+
+        # A's NEXT binding-mediated act is DENIED as the uniform typed conflict,
+        # BEFORE the substrate is touched — the case a bare CAS never surfaces.
+        with pytest.raises(StaleView):
+            a.commit(REF, expected_token=a_tok, new_bytes=b"v2-from-A")
+        assert fake_a.cas_calls == []  # deny-before-act: no substrate write attempted
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_read_time_deny_surfaces_stale_view(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    sa, sb = _session(tmp_path, fast_cfg), _session(tmp_path, fast_cfg)
+    try:
+        a, _fa = _agent(store, sa)
+        b, _fb = _agent(store, sb)
+        a.read(REF)
+        _b_bytes, b_tok = b.read(REF)
+        b.commit(REF, expected_token=b_tok, new_bytes=b"v2")
+
+        # on_stale='allow' (default) returns bytes; 'raise' surfaces StaleView.
+        assert a.read(REF) == store.get(REF)
+        with pytest.raises(StaleView):
+            a.read(REF, on_stale="raise")
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_identity_stable_across_read_and_commit_fresh_after_reacquire(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    seen: list[str] = []
+    real_post = substrate_module._coordinator_post
+
+    def spy(endpoint, path, payload):  # noqa: ANN001, ANN202
+        if path in ("/hooks/pre-read", "/hooks/post-edit-cas"):
+            seen.append(payload["session_id"])
+        return real_post(endpoint, path, payload)
+
+    monkeypatch.setattr(substrate_module, "_coordinator_post", spy)
+    sa = _session(tmp_path, fast_cfg)
+    try:
+        a, _fa = _agent(store, sa)
+        before = a.session_id
+        _bytes, tok = a.read(REF)
+        a.commit(REF, expected_token=tok, new_bytes=b"v2")
+        # The pre-read AND the post-edit-cas resolve to the SAME identity.
+        assert set(seen) == {before}
+
+        a.reacquire(REF)
+        assert a.session_id != before  # a fresh id is minted ONLY on reacquire
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- divergence 1: coordinator-leg UNKNOWN (late-land / degrade) -------------
+
+
+def test_divergence1_coordinator_leg_unknown_no_re_drive(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    real_post = substrate_module._coordinator_post
+
+    def failing_commit(endpoint, path, payload):  # noqa: ANN001, ANN202
+        if path == "/hooks/post-edit-cas":
+            raise substrate_module.CoordinatorUnavailable("simulated commit timeout")
+        return real_post(endpoint, path, payload)
+
+    monkeypatch.setattr(substrate_module, "_coordinator_post", failing_commit)
+    sa = _session(tmp_path, fast_cfg)
+    try:
+        a, fake_a = _agent(store, sa)
+        _bytes, tok = a.read(REF)
+        # Substrate write LANDS (WIN), but the coordinator bump times out.
+        with pytest.raises(CommitUnconfirmed):
+            a.commit(REF, expected_token=tok, new_bytes=b"v2")
+        assert len(fake_a.cas_calls) == 1  # NEVER blind re-drive after a landed write
+        assert store.get(REF)[0] == b"v2"  # the substrate write is durable
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- divergence 2: substrate UNKNOWN, per arm -------------------------------
+
+
+def test_divergence2_converge_drives_bump_and_invalidates_peer(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """PG-arm / never-converge-wedge negative: a landed-unknown write CONVERGES
+    and its coordinator bump STILL fires — the peer is invalidated (the bump is
+    not stranded)."""
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    sa, sb = _session(tmp_path, fast_cfg), _session(tmp_path, fast_cfg)
+    try:
+        a, fake_a = _agent(store, sa, arm="row")
+        b, _fb = _agent(store, sb, arm="row")
+        _ab, _atok = a.read(REF)
+        _bb, b_tok = b.read(REF)
+
+        fake_a.script_unknown(landed=True)  # A's write lands but the ack is lost
+        result = a.commit(REF, expected_token=_atok, new_bytes=b"v2")
+
+        assert result.converged is True
+        assert result.summary == "converged"  # never "landed" — attribution disclaimed
+        assert len(fake_a.cas_calls) == 1  # no re-drive of a landed write
+        # The converge bump fired → the peer is invalidated (not stranded).
+        with pytest.raises(StaleView):
+            b.commit(REF, expected_token=b_tok, new_bytes=b"vB")
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_divergence2_re_drive_under_held_token(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """S3-arm: an UNKNOWN write that did NOT land (token unmoved) is re-driven
+    ONCE under the held token, then lands and bumps."""
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    sa = _session(tmp_path, fast_cfg)
+    try:
+        a, fake_a = _agent(store, sa, arm="object")
+        _ab, a_tok = a.read(REF)
+
+        fake_a.script_unknown(landed=False)  # not landed → token unmoved → RE_DRIVE
+        result = a.commit(REF, expected_token=a_tok, new_bytes=b"v2")
+
+        assert result.converged is False  # a clean re-drive win, not a converge
+        assert len(fake_a.cas_calls) == 2  # initial (unknown) + one re-drive
+        assert store.get(REF)[0] == b"v2"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_divergence2_converge_complete_on_byte_identical_peer(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """S3-arm: a landed-unknown write whose bump loses to a byte-IDENTICAL peer
+    completes as converged (coordinator already holds the intended hash) — NO
+    re-drive, NO second bump."""
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    sa, sb = _session(tmp_path, fast_cfg), _session(tmp_path, fast_cfg)
+    try:
+        a, fake_a = _agent(store, sa, arm="object")
+        b, _fb = _agent(store, sb, arm="object")
+        _ab, a_tok = a.read(REF)
+        _bb, _b_tok = b.read(REF)  # B is SHARED@v1 so it can bump the coordinator
+
+        intended = _sha256(b"v2")
+
+        def peer_bumps_first() -> None:
+            # A byte-identical peer carries b"v2" to the coordinator first.
+            sb.commit_cas(REF, expected_version=1, content_hash=intended)
+
+        fake_a.script_unknown(landed=True)  # A's substrate write landed (b"v2")
+        fake_a.reconcile_hook = peer_bumps_first
+        result = a.commit(REF, expected_token=a_tok, new_bytes=b"v2")
+
+        assert result.converged is True
+        assert len(fake_a.cas_calls) == 1  # no re-drive, no second substrate write
+    finally:
+        stop_coordinator(tmp_path)
+
+
+def test_divergence2_conflict_on_different_bytes(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """S3-arm: an UNKNOWN write where the token moved to DIFFERENT bytes is a
+    real peer conflict — typed, never re-driven."""
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    sa = _session(tmp_path, fast_cfg)
+    try:
+        a, fake_a = _agent(store, sa, arm="object")
+        _ab, a_tok = a.read(REF)
+
+        fake_a.script_unknown(landed=False)
+        store.set(REF, b"foreign")  # a foreign writer moved the substrate
+
+        with pytest.raises(CasVersionConflict):
+            a.commit(REF, expected_token=a_tok, new_bytes=b"v2")
+        assert len(fake_a.cas_calls) == 1  # never re-driven
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- never-ship-a-store on the wire -----------------------------------------
+
+
+def test_commit_wire_payload_carries_hash_not_content(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    captured: list[dict] = []
+    real_post = substrate_module._coordinator_post
+
+    def spy(endpoint, path, payload):  # noqa: ANN001, ANN202
+        if path == "/hooks/post-edit-cas":
+            captured.append(dict(payload))
+        return real_post(endpoint, path, payload)
+
+    monkeypatch.setattr(substrate_module, "_coordinator_post", spy)
+    sa = _session(tmp_path, fast_cfg)
+    try:
+        a, _fa = _agent(store, sa)
+        _bytes, tok = a.read(REF)
+        a.commit(REF, expected_token=tok, new_bytes=b"v2")
+
+        assert captured, "the commit must POST /hooks/post-edit-cas"
+        for payload in captured:
+            assert payload["content_hash"] == _sha256(b"v2")
+            assert "content" not in payload  # bytes are NEVER sent
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- forbidden: coordinator-bump-first --------------------------------------
+
+
+def test_coordinator_bump_first_is_forbidden(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A write that FAILS the substrate CAS must never reach the coordinator —
+    so a peer is never invalidated for a write that did not land."""
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    posts: list[str] = []
+    real_post = substrate_module._coordinator_post
+
+    def spy(endpoint, path, payload):  # noqa: ANN001, ANN202
+        posts.append(path)
+        return real_post(endpoint, path, payload)
+
+    monkeypatch.setattr(substrate_module, "_coordinator_post", spy)
+    sa, sb = _session(tmp_path, fast_cfg), _session(tmp_path, fast_cfg)
+    try:
+        a, _fa = _agent(store, sa)
+        b, fake_b = _agent(store, sb)
+        _ab, a_tok = a.read(REF)
+        _bb, b_tok = b.read(REF)
+
+        fake_b.script_conflict()  # B's substrate CAS fails
+        with pytest.raises(CasVersionConflict):
+            b.commit(REF, expected_token=b_tok, new_bytes=b"vB")
+        # The failed substrate CAS never drove a coordinator bump.
+        assert "/hooks/post-edit-cas" not in posts
+
+        # A was NOT invalidated → A commits cleanly (proof the bump never fired).
+        result = a.commit(REF, expected_token=a_tok, new_bytes=b"vA")
+        assert result.version >= 2
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- crash-between-legs → coordinator-behind → ViewWedged -------------------
+
+
+def test_crash_between_legs_surfaces_view_wedged(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """A substrate write that lands while the coordinator bump is skipped (a
+    crash between the legs) leaves the coordinator behind; a peer's next binding
+    read is a wedged view. Recovery is reacquire (the carve-out: a non-re-reading
+    peer stays unprotected)."""
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    sa, sb = _session(tmp_path, fast_cfg), _session(tmp_path, fast_cfg)
+    try:
+        a, _fa = _agent(store, sa)
+        b, _fb = _agent(store, sb)
+        a.read(REF)  # seeds the coordinator artifact @ v1 / hash(v1)
+
+        # A's substrate write lands but the coordinator bump never fires (crash).
+        store.set(REF, b"v2-crashed")
+
+        with pytest.raises(ViewWedged):
+            b.read(REF)
+        # reacquire recovers the fresh bytes without raising.
+        rec_bytes, _rec_tok = b.reacquire(REF)
+        assert rec_bytes == b"v2-crashed"
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- cross-substrate uniformity ---------------------------------------------
+
+
+@pytest.mark.parametrize("arm", ["row", "object"])
+def test_uniform_typed_conflict_across_substrates(
+    tmp_path: Path, fast_cfg: LifecycleConfig, arm: str
+) -> None:
+    """The SAME typed deny (StaleView) fires for a row-shaped fake AND an
+    object-shaped fake — the cross-substrate uniformity co-headline."""
+    ref = f"workspace/{arm}.bin"
+    store = _FakeStore()
+    store.seed(ref, b"v1")
+    sa, sb = _session(tmp_path, fast_cfg), _session(tmp_path, fast_cfg)
+    try:
+        a, _fa = _agent(store, sa, arm=arm)
+        b, _fb = _agent(store, sb, arm=arm)
+        _ab, a_tok = a.read(ref)
+        _bb, b_tok = b.read(ref)
+        b.commit(ref, expected_token=b_tok, new_bytes=b"v2")
+        with pytest.raises(StaleView):
+            a.commit(ref, expected_token=a_tok, new_bytes=b"vA")
+    finally:
+        stop_coordinator(tmp_path)
+
+
+# --- admit-on-absent (the fence is inert by design) -------------------------
+
+
+def test_admit_on_absent_occ_writer_commits(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """v1 captures no read_generation, so the OCC writer sits on the fence's
+    admit-on-absent path: a clean commit LANDS (the substrate CAS arbitrates) —
+    no fence rejection is claimed."""
+    store = _FakeStore()
+    store.seed(REF, b"v1")
+    sa = _session(tmp_path, fast_cfg)
+    try:
+        a, _fa = _agent(store, sa)
+        _bytes, tok = a.read(REF)
+        result = a.commit(REF, expected_token=tok, new_bytes=b"v2")
+        assert result.version >= 2  # admitted; no stale_read_generation rejection
+        assert result.converged is False
+    finally:
+        stop_coordinator(tmp_path)

--- a/tests/adapters/test_substrate_manifest.py
+++ b/tests/adapters/test_substrate_manifest.py
@@ -528,6 +528,56 @@ def test_s3_http_endpoint_loads_with_distinct_ack(tmp_path):
     assert len(manifest.artifacts) == 1
 
 
+def test_duplicate_artifact_id_refused(tmp_path):
+    # Two entries sharing an id would silently shadow each other's wiring.
+    art = pg_artifact("postgresql://u@db.example.com/app?sslmode=require")
+    data = {"artifacts": [art, dict(art)]}
+    resolver = make_resolver({"db.example.com": [PUBLIC_IP]})
+
+    with pytest.raises(ManifestError):
+        load(tmp_path, data, resolver=resolver)
+
+
+def test_multihost_tls_error_names_routable_host_not_first(tmp_path):
+    # First host is loopback (exempt); a later host is the routable one. The
+    # TLS-ack error must name the host that actually made the target routable.
+    resolver = make_resolver({"db.example.com": [PUBLIC_IP]})
+    dsn = "host=127.0.0.1,db.example.com dbname=app sslmode=disable"
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateInsecureTransport) as exc:
+        load(tmp_path, data, resolver=resolver)
+    assert "db.example.com" in str(exc.value)
+    assert "127.0.0.1" not in str(exc.value)
+
+
+def test_unresolvable_host_fails_closed(tmp_path):
+    # A host that resolves to nothing is denied (fail-closed), not admitted.
+    resolver = make_resolver({})  # every host resolves to ()
+    data = {"artifacts": [pg_artifact("host=nowhere.invalid dbname=app sslmode=require")]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data, resolver=resolver)
+
+
+def test_unparseable_resolved_address_fails_closed(tmp_path):
+    # A resolver returning a non-address string is denied, never dialed.
+    data = {"artifacts": [pg_artifact("host=db.example.com dbname=app sslmode=require")]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data, resolver=lambda host: ("not-an-ip-address",))
+
+
+def test_sixtofour_ipv6_unwraps_to_denied_v4(tmp_path):
+    # 2002:a9fe:a9fe:: embeds 169.254.169.254 (0xA9FEA9FE) as its 6to4 payload —
+    # the unwrap must classify it into the metadata denylist, not wave it past.
+    resolver = make_resolver({"db.example.com": ["2002:a9fe:a9fe::"]})
+    data = {"artifacts": [pg_artifact("host=db.example.com dbname=app sslmode=require")]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data, resolver=resolver)
+
+
 def test_s3_endpoint_inline_userinfo_refused(tmp_path):
     # Parity with the PG inline-password refusal: a literal secret in the endpoint
     # URL is refused, so "credential reference, never a literal" holds for S3 too.

--- a/tests/adapters/test_substrate_manifest.py
+++ b/tests/adapters/test_substrate_manifest.py
@@ -342,6 +342,67 @@ def test_uri_dsn_inline_password_rejected(tmp_path):
         load(tmp_path, data)
 
 
+def test_uri_dsn_hostaddr_query_param_denied(tmp_path):
+    # libpq honors ?hostaddr= in a URI DSN and dials it directly (host is only for
+    # TLS SNI). The URI form must apply the same hostaddr guard as the keyword
+    # form, or a metadata target slips past behind a benign hostname.
+    dsn = "postgresql://db.example.com/app?hostaddr=169.254.169.254&sslmode=require"
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data)
+
+
+def test_uri_dsn_password_query_param_rejected(tmp_path):
+    # An inline password given as a URI query parameter is refused, same as one in
+    # the userinfo — libpq honors ?password=.
+    dsn = "postgresql://db.example.com/app?password=s3cr3t&sslmode=require"
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateCredentialRefused):
+        load(tmp_path, data)
+
+
+def test_keyword_dsn_spaced_equals_metadata_denied(tmp_path):
+    # libpq tolerates whitespace around '='; the guard must too, or a space-padded
+    # host tokenizes to nothing and slips past the SSRF denylist.
+    dsn = "host = 169.254.169.254 sslmode = require"
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data)
+
+
+def test_keyword_dsn_spaced_inline_password_rejected(tmp_path):
+    # A space-padded inline password must still be refused (the same tokenization
+    # gap would otherwise drop it and skip the inline-secret guard).
+    dsn = "host = db.example.com  password = s3cr3t  sslmode = require"
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateCredentialRefused):
+        load(tmp_path, data)
+
+
+def test_keyword_dsn_quoted_host_metadata_denied(tmp_path):
+    # A single-quoted value is one token; the metadata host inside it is still
+    # resolved and denied.
+    dsn = "host = '169.254.169.254'  sslmode=require"
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data)
+
+
+def test_keyword_dsn_unterminated_quote_fails_closed(tmp_path):
+    # A malformed DSN (unterminated quote) fails closed rather than silently
+    # dropping the host and skipping the guards.
+    dsn = "host = 'db.example.com sslmode=require"
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(ManifestError):
+        load(tmp_path, data)
+
+
 def test_keyword_dsn_inline_password_rejected(tmp_path):
     dsn = "host=db.example.com sslmode=require password=S3cr3tP@ss"
     data = {"artifacts": [pg_artifact(dsn)]}

--- a/tests/adapters/test_substrate_manifest.py
+++ b/tests/adapters/test_substrate_manifest.py
@@ -403,6 +403,60 @@ def test_keyword_dsn_unterminated_quote_fails_closed(tmp_path):
         load(tmp_path, data)
 
 
+def test_uri_dsn_duplicate_host_metadata_denied(tmp_path):
+    # A repeated ?host= must have EVERY value checked (libpq merges duplicates to
+    # one value in a version-dependent order) — benign-first, metadata-last is
+    # still denied.
+    dsn = "postgresql:///app?host=safe.example&host=169.254.169.254&sslmode=require"
+    data = {"artifacts": [pg_artifact(dsn)]}
+    resolver = make_resolver({"safe.example": [PUBLIC_IP]})
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data, resolver=resolver)
+
+
+def test_uri_dsn_duplicate_hostaddr_metadata_denied(tmp_path):
+    # The fix's own headline case, reopened by a duplicate: benign-first,
+    # metadata-last hostaddr.
+    dsn = "postgresql:///app?hostaddr=1.2.3.4&hostaddr=169.254.169.254&sslmode=require"
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data)
+
+
+def test_uri_dsn_duplicate_sslmode_tls_downgrade_blocked(tmp_path):
+    # A safe-first, unsafe-last sslmode must not mask the plaintext mode: the
+    # most-restrictive wins, so the plaintext-credential guard still fires.
+    dsn = "postgresql:///app?hostaddr=203.0.113.9&sslmode=require&sslmode=disable"
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateInsecureTransport):
+        load(tmp_path, data)
+
+
+def test_keyword_dsn_hostaddr_comma_gap_checks_unpaired_host(tmp_path):
+    # host has more entries than hostaddr (a trailing comma drops a slot); libpq
+    # dials the unpaired host, so it must be checked — never skipped by an
+    # 'hostaddr is authoritative' shortcut.
+    dsn = "host=127.0.0.1,evil.example hostaddr=127.0.0.1, sslmode=require"
+    data = {"artifacts": [pg_artifact(dsn)]}
+    resolver = make_resolver({"evil.example": ["169.254.169.254"]})
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data, resolver=resolver)
+
+
+def test_uri_dsn_hostaddr_comma_gap_checks_unpaired_host(tmp_path):
+    # Same comma-gap, URI form: the unpaired ?host= entry is still checked.
+    dsn = "postgresql:///app?host=127.0.0.1,evil.example&hostaddr=127.0.0.1,"
+    data = {"artifacts": [pg_artifact(dsn)]}
+    resolver = make_resolver({"evil.example": ["169.254.169.254"]})
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data, resolver=resolver)
+
+
 def test_keyword_dsn_inline_password_rejected(tmp_path):
     dsn = "host=db.example.com sslmode=require password=S3cr3tP@ss"
     data = {"artifacts": [pg_artifact(dsn)]}

--- a/tests/adapters/test_substrate_manifest.py
+++ b/tests/adapters/test_substrate_manifest.py
@@ -1,0 +1,577 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Tests for the Coherence Manifest: secret-safe loader, SSRF-constrained
+connection targets, TLS-required guard, and config-time tier visibility.
+
+Security-first: the allowlist-of-forms credential reject and every SSRF/TLS
+reject are validation-layer assertions — none are gated behind a real
+substrate. The DNS resolver is INJECTED (a callable seam), so no test touches
+real DNS: a "hostname resolving to a denied IP" is expressed by the injected
+mapping, and decimal/octal/hex IPv4 literals are expressed as the resolver
+normalizing them to the real address a string check never classifies.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ccs.adapters.substrate_manifest import (
+    ALLOW_PRIVATE_ENV,
+    INSECURE_ACK_ENV,
+    ManifestArtifact,
+    SubstrateManifest,
+    load_manifest,
+    resolve_host_addresses,
+)
+from ccs.core.exceptions import (
+    ManifestError,
+    SubstrateCredentialRefused,
+    SubstrateInsecureTransport,
+    SubstrateTargetDenied,
+)
+from ccs.core.substrate import Tier
+
+PUBLIC_IP = "93.184.216.34"
+#: A distinctive credential value: asserted to NEVER appear in any log/exception.
+UNIQUE_SECRET_REF = "secret-file:/run/secrets/UNIQUE-do-not-leak-me"
+
+
+def make_resolver(mapping: dict[str, list[str]]):
+    """A hermetic DNS resolver seam: hostname -> resolved IP strings."""
+
+    def _resolve(host: str) -> tuple[str, ...]:
+        return tuple(mapping.get(host, ()))
+
+    return _resolve
+
+
+def write_manifest(tmp_path: Path, data: object, *, mode: int = 0o600) -> Path:
+    """Serialize ``data`` to a YAML manifest file and tighten its mode."""
+    path = tmp_path / "manifest.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    path.chmod(mode)
+    return path
+
+
+def load(
+    tmp_path: Path,
+    data: object,
+    *,
+    resolver=None,
+    env: dict[str, str] | None = None,
+    mode: int = 0o600,
+) -> SubstrateManifest:
+    """Write + load a manifest with an injected resolver and empty env."""
+    path = write_manifest(tmp_path, data, mode=mode)
+    return load_manifest(
+        path,
+        resolver=resolver or make_resolver({"db.example.com": [PUBLIC_IP]}),
+        env={} if env is None else env,
+    )
+
+
+def pg_artifact(dsn: str, *, credential: str = "secret-file:/run/secrets/pg") -> dict:
+    return {
+        "id": "config-row",
+        "substrate": "postgres",
+        "tier": "native-cas",
+        "version_source": "trigger-managed version column",
+        "connection": {"dsn": dsn, "credential": credential},
+    }
+
+
+def s3_artifact(connection: object) -> dict:
+    return {
+        "id": "brief-object",
+        "substrate": "s3",
+        "tier": "native-cas",
+        "version_source": "object ETag",
+        "connection": connection,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_secret_file_and_aws_default_manifest_loads(tmp_path):
+    data = {
+        "artifacts": [
+            pg_artifact("host=db.example.com port=5432 dbname=app sslmode=require"),
+            s3_artifact("aws-default"),
+        ]
+    }
+    manifest = load(tmp_path, data)
+
+    assert isinstance(manifest, SubstrateManifest)
+    assert len(manifest.artifacts) == 2
+    assert all(isinstance(a, ManifestArtifact) for a in manifest.artifacts)
+    assert manifest.artifacts[0].descriptor.tier is Tier.NATIVE_CAS
+
+
+def test_dry_run_prints_id_substrate_tier(tmp_path, capsys):
+    data = {
+        "artifacts": [
+            pg_artifact("host=db.example.com sslmode=require"),
+            s3_artifact("aws-default"),
+        ]
+    }
+    rows = load(tmp_path, data).dry_run()
+
+    assert ("config-row", "postgres", Tier.NATIVE_CAS) in rows
+    assert ("brief-object", "s3", Tier.NATIVE_CAS) in rows
+    out = capsys.readouterr().out
+    assert "config-row" in out and "postgres" in out and "native_cas" in out
+
+
+def test_forward_only_without_version_source_loads_and_prints_tier(tmp_path, capsys):
+    data = {
+        "artifacts": [
+            {
+                "id": "notify-slack",
+                "substrate": "slack",
+                "tier": "forward-only",
+                "connection": "secret-file:/run/secrets/slack_token",
+            }
+        ]
+    }
+    manifest = load(tmp_path, data)
+
+    assert manifest.artifacts[0].descriptor.tier is Tier.FORWARD_ONLY
+    assert manifest.artifacts[0].version_source is None
+    rows = manifest.dry_run()
+    assert ("notify-slack", "slack", Tier.FORWARD_ONLY) in rows
+    assert "forward_only" in capsys.readouterr().out
+
+
+def test_public_target_loads_normally(tmp_path):
+    data = {"artifacts": [pg_artifact("host=db.example.com sslmode=require")]}
+
+    assert len(load(tmp_path, data).artifacts) == 1
+
+
+# ---------------------------------------------------------------------------
+# Credential reference forms — allowlist; reject suspected literals
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "credential",
+    [
+        "postgresql://user:pass@db.example.com/app",  # inline DSN
+        "AKIAIOSFODNN7EXAMPLE",  # bare key
+        "vault-ref:/kv/data/pg",  # unknown prefix
+        "s3://bucket/key",  # unknown prefix
+        "",  # empty
+    ],
+)
+def test_non_reference_form_credential_rejected(tmp_path, credential):
+    data = {"artifacts": [s3_artifact({"credential": credential})]}
+
+    with pytest.raises(SubstrateCredentialRefused):
+        load(tmp_path, data)
+
+
+@pytest.mark.parametrize(
+    "credential",
+    ["aws-default", "secret-file:/run/secrets/pg", "env:PG_PASSWORD"],
+)
+def test_reference_form_credentials_accepted(tmp_path, credential):
+    data = {"artifacts": [s3_artifact({"credential": credential})]}
+
+    assert len(load(tmp_path, data).artifacts) == 1
+
+
+def test_secret_uri_allowlisted_provider_accepted(tmp_path):
+    data = {"artifacts": [s3_artifact({"credential": "secret:aws-secretsmanager:prod/pg"})]}
+
+    assert len(load(tmp_path, data).artifacts) == 1
+
+
+def test_secret_uri_unknown_provider_rejected(tmp_path):
+    data = {"artifacts": [s3_artifact({"credential": "secret:sketchy-provider:prod/pg"})]}
+
+    with pytest.raises(SubstrateCredentialRefused):
+        load(tmp_path, data)
+
+
+# ---------------------------------------------------------------------------
+# SSRF — deny on the RESOLVED address, not the literal string
+# ---------------------------------------------------------------------------
+
+
+def test_dns_rebind_to_metadata_rejected(tmp_path):
+    # A benign-looking hostname that RESOLVES to the AWS/GCP IMDS address.
+    resolver = make_resolver({"rebind.evil.test": ["169.254.169.254"]})
+    data = {"artifacts": [pg_artifact("host=rebind.evil.test sslmode=require")]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data, resolver=resolver)
+
+
+@pytest.mark.parametrize(
+    "literal",
+    ["2852039166", "0xA9FEA9FE", "0251.0376.0251.0376"],  # decimal/hex/octal 169.254.169.254
+)
+def test_decimal_octal_hex_ipv4_rejected_via_normalization(tmp_path, literal):
+    # These are not classifiable by a string/ipaddress check; getaddrinfo (here,
+    # the injected resolver) normalizes them to the real denied address.
+    resolver = make_resolver({literal: ["169.254.169.254"]})
+    data = {"artifacts": [pg_artifact(f"host={literal} sslmode=require")]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data, resolver=resolver)
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://[::ffff:169.254.169.254]:443",  # mapped IPv6 IMDS
+        "https://[::ffff:100.100.100.200]:443",  # mapped IPv6 CGNAT metadata
+    ],
+)
+def test_mapped_ipv6_metadata_rejected(tmp_path, endpoint):
+    # The mapped form must NOT bypass the IPv4 denylist — unwrap-or-fail-closed.
+    data = {"artifacts": [s3_artifact({"endpoint_url": endpoint, "credential": "aws-default"})]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data)
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "metadata.google.internal",  # GCP alias (hostname denylist)
+        "100.100.100.200",  # Alibaba CGNAT metadata
+        "169.254.169.254",  # AWS/Azure IMDS link-local
+    ],
+)
+def test_metadata_hostnames_and_ipv4_literals_rejected(tmp_path, host):
+    resolver = make_resolver({"metadata.google.internal": ["169.254.169.254"]})
+    data = {"artifacts": [pg_artifact(f"host={host} sslmode=require")]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data, resolver=resolver)
+
+
+@pytest.mark.parametrize("host", ["fd00:ec2::254", "fe80::1"])
+def test_ipv6_metadata_and_link_local_rejected(tmp_path, host):
+    # host= carries a bracketed literal so decomposition treats it as one host.
+    data = {"artifacts": [pg_artifact(f"host=[{host}] sslmode=require")]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data)
+
+
+# ---------------------------------------------------------------------------
+# RFC-1918 is SOFT/opt-in — a distinct per-manifest allow flag
+# ---------------------------------------------------------------------------
+
+
+def test_rfc1918_denied_without_optin(tmp_path):
+    data = {"artifacts": [pg_artifact("host=10.0.0.5 sslmode=require")]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data, env={})
+
+
+def test_rfc1918_loads_under_distinct_optin(tmp_path):
+    data = {"artifacts": [pg_artifact("host=10.0.0.5 sslmode=require")]}
+
+    manifest = load(tmp_path, data, env={ALLOW_PRIVATE_ENV: "1"})
+    assert len(manifest.artifacts) == 1
+
+
+def test_rfc1918_optin_is_not_the_coordinator_flag(tmp_path):
+    # The coordinator's remote-mode flag must NOT relax substrate SSRF.
+    data = {"artifacts": [pg_artifact("host=10.0.0.5 sslmode=require")]}
+
+    for foreign_flag in ("CCS_REMOTE_COORDINATOR", "CCS_REMOTE_INSECURE"):
+        with pytest.raises(SubstrateTargetDenied):
+            load(tmp_path, data, env={foreign_flag: "1"})
+
+
+# ---------------------------------------------------------------------------
+# Postgres host= DSN decomposition
+# ---------------------------------------------------------------------------
+
+
+def test_multi_host_metadata_in_second_slot_rejected(tmp_path):
+    resolver = make_resolver(
+        {"ok.example.com": [PUBLIC_IP], "evil.example.com": ["169.254.169.254"]}
+    )
+    dsn = "host=ok.example.com,evil.example.com sslmode=require"
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data, resolver=resolver)
+
+
+def test_hostaddr_denied_is_rejected(tmp_path):
+    # hostaddr is the authoritative dialed target when both are present.
+    dsn = "host=db.example.com hostaddr=169.254.169.254 sslmode=require"
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data)
+
+
+def test_unix_socket_host_allowed_and_not_resolved(tmp_path):
+    # A leading '/' is a unix socket — a local target, exempt from the IP
+    # denylist and NOT misclassified as a hostname to resolve.
+    def _boom(host: str):
+        raise AssertionError(f"unix socket must not be resolved (got {host!r})")
+
+    data = {"artifacts": [pg_artifact("host=/var/run/postgresql")]}
+    manifest = load(tmp_path, data, resolver=_boom)
+
+    assert len(manifest.artifacts) == 1
+
+
+def test_uri_dsn_inline_password_rejected(tmp_path):
+    dsn = "postgresql://user:S3cr3tP@ss@db.example.com/app"
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateCredentialRefused):
+        load(tmp_path, data)
+
+
+def test_keyword_dsn_inline_password_rejected(tmp_path):
+    dsn = "host=db.example.com sslmode=require password=S3cr3tP@ss"
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateCredentialRefused):
+        load(tmp_path, data)
+
+
+# ---------------------------------------------------------------------------
+# TLS-required for a routable target (distinct ack, NOT CCS_REMOTE_INSECURE)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dsn", ["host=db.example.com sslmode=disable", "host=db.example.com"])
+def test_pg_plaintext_routable_refused_without_ack(tmp_path, dsn):
+    # sslmode=disable AND unset (libpq 'prefer' silent downgrade) are both refused.
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateInsecureTransport):
+        load(tmp_path, data)
+
+
+def test_pg_plaintext_routable_loads_with_distinct_ack(tmp_path):
+    data = {"artifacts": [pg_artifact("host=db.example.com sslmode=disable")]}
+
+    manifest = load(tmp_path, data, env={INSECURE_ACK_ENV: "1"})
+    assert len(manifest.artifacts) == 1
+
+
+def test_pg_plaintext_ack_is_not_the_coordinator_flag(tmp_path):
+    data = {"artifacts": [pg_artifact("host=db.example.com sslmode=disable")]}
+
+    with pytest.raises(SubstrateInsecureTransport):
+        load(tmp_path, data, env={"CCS_REMOTE_INSECURE": "1"})
+
+
+def test_pg_plaintext_loopback_is_exempt(tmp_path):
+    # Loopback is byte-unchanged — no TLS ack required (local dev).
+    data = {"artifacts": [pg_artifact("host=127.0.0.1 sslmode=disable")]}
+
+    assert len(load(tmp_path, data).artifacts) == 1
+
+
+def test_s3_http_endpoint_routable_refused_without_ack(tmp_path):
+    resolver = make_resolver({"minio.example.com": [PUBLIC_IP]})
+    conn = {"endpoint_url": "http://minio.example.com:9000", "credential": "aws-default"}
+    data = {"artifacts": [s3_artifact(conn)]}
+
+    with pytest.raises(SubstrateInsecureTransport):
+        load(tmp_path, data, resolver=resolver)
+
+
+def test_s3_http_endpoint_loads_with_distinct_ack(tmp_path):
+    resolver = make_resolver({"minio.example.com": [PUBLIC_IP]})
+    conn = {"endpoint_url": "http://minio.example.com:9000", "credential": "aws-default"}
+    data = {"artifacts": [s3_artifact(conn)]}
+
+    manifest = load(tmp_path, data, resolver=resolver, env={INSECURE_ACK_ENV: "1"})
+    assert len(manifest.artifacts) == 1
+
+
+# ---------------------------------------------------------------------------
+# MRAP / replica endpoint -> warning (forbidden distributed-substrate locality)
+# ---------------------------------------------------------------------------
+
+
+def test_mrap_endpoint_warns(tmp_path, caplog):
+    host = "myapp.mrap.accesspoint.s3-global.amazonaws.com"
+    resolver = make_resolver({host: [PUBLIC_IP]})
+    conn = {"endpoint_url": f"https://{host}", "credential": "aws-default"}
+    data = {"artifacts": [s3_artifact(conn)]}
+
+    with caplog.at_level(logging.WARNING):
+        manifest = load(tmp_path, data, resolver=resolver)
+
+    assert len(manifest.artifacts) == 1
+    assert "multi-region" in caplog.text.lower() or "mrap" in caplog.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Secret never reaches a log or an exception
+# ---------------------------------------------------------------------------
+
+
+def test_credential_refused_message_has_no_password(tmp_path):
+    dsn = "postgresql://user:S3cr3tP@ss@db.example.com/app"
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateCredentialRefused) as exc:
+        load(tmp_path, data)
+    assert "S3cr3tP@ss" not in str(exc.value)
+
+
+def test_refused_target_warning_names_host_never_secret(tmp_path, caplog):
+    # The TLS-ack WARN names the host/posture; the credential ref never appears.
+    conn = {"endpoint_url": "http://minio.example.com:9000", "credential": UNIQUE_SECRET_REF}
+    data = {"artifacts": [s3_artifact(conn)]}
+    resolver = make_resolver({"minio.example.com": [PUBLIC_IP]})
+
+    with caplog.at_level(logging.WARNING):
+        load(tmp_path, data, resolver=resolver, env={INSECURE_ACK_ENV: "1"})
+
+    assert "minio.example.com" in caplog.text
+    assert UNIQUE_SECRET_REF not in caplog.text
+    assert "UNIQUE-do-not-leak-me" not in caplog.text
+
+
+def test_denied_target_exception_carries_host_and_posture(tmp_path):
+    data = {"artifacts": [pg_artifact("host=169.254.169.254 sslmode=require")]}
+
+    with pytest.raises(SubstrateTargetDenied) as exc:
+        load(tmp_path, data)
+    assert exc.value.host == "169.254.169.254"
+    assert exc.value.posture
+
+
+# ---------------------------------------------------------------------------
+# Schema discipline
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_top_level_key_rejected(tmp_path):
+    data = {"artifacts": [s3_artifact("aws-default")], "bogus_top_level": 1}
+
+    with pytest.raises(ManifestError):
+        load(tmp_path, data)
+
+
+def test_unknown_artifact_key_rejected(tmp_path):
+    art = s3_artifact("aws-default")
+    art["surprise"] = "value"
+    data = {"artifacts": [art]}
+
+    with pytest.raises(ManifestError):
+        load(tmp_path, data)
+
+
+def test_missing_tier_rejected(tmp_path):
+    art = s3_artifact("aws-default")
+    del art["tier"]
+    data = {"artifacts": [art]}
+
+    with pytest.raises(ManifestError):
+        load(tmp_path, data)
+
+
+def test_unknown_tier_rejected(tmp_path):
+    art = s3_artifact("aws-default")
+    art["tier"] = "make-believe"
+    data = {"artifacts": [art]}
+
+    with pytest.raises(ManifestError):
+        load(tmp_path, data)
+
+
+def test_non_mapping_root_rejected(tmp_path):
+    with pytest.raises(ManifestError):
+        load(tmp_path, ["not", "a", "mapping"])
+
+
+def test_missing_artifacts_key_rejected(tmp_path):
+    with pytest.raises(ManifestError):
+        load(tmp_path, {"version": 1})
+
+
+# ---------------------------------------------------------------------------
+# Forward-only + version_source -> reject (descriptor's own validation)
+# ---------------------------------------------------------------------------
+
+
+def test_forward_only_with_version_source_rejected(tmp_path):
+    data = {
+        "artifacts": [
+            {
+                "id": "notify-slack",
+                "substrate": "slack",
+                "tier": "forward-only",
+                "version_source": "etag",
+                "connection": "secret-file:/run/secrets/slack",
+            }
+        ]
+    }
+    with pytest.raises(ManifestError):
+        load(tmp_path, data)
+
+
+def test_native_cas_without_version_source_rejected(tmp_path):
+    art = s3_artifact("aws-default")
+    del art["version_source"]
+    data = {"artifacts": [art]}
+
+    with pytest.raises(ManifestError):
+        load(tmp_path, data)
+
+
+# ---------------------------------------------------------------------------
+# Manifest file permissions
+# ---------------------------------------------------------------------------
+
+
+def test_world_readable_manifest_warns(tmp_path, caplog):
+    data = {"artifacts": [s3_artifact("aws-default")]}
+
+    with caplog.at_level(logging.WARNING):
+        load(tmp_path, data, mode=0o644)
+
+    assert "world-readable" in caplog.text.lower() or "0644" in caplog.text
+
+
+def test_tight_manifest_does_not_warn_on_perms(tmp_path, caplog):
+    data = {"artifacts": [s3_artifact("aws-default")]}
+
+    with caplog.at_level(logging.WARNING):
+        load(tmp_path, data, mode=0o600)
+
+    assert "world-readable" not in caplog.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# validate() + default resolver
+# ---------------------------------------------------------------------------
+
+
+def test_validate_is_idempotent_on_a_good_manifest(tmp_path):
+    data = {"artifacts": [pg_artifact("host=db.example.com sslmode=require")]}
+    manifest = load(tmp_path, data)
+
+    manifest.validate()  # must not raise
+
+
+def test_default_resolver_returns_ip_literals_unchanged():
+    # An IP literal needs no network round-trip: getaddrinfo echoes it.
+    assert resolve_host_addresses("127.0.0.1") == ("127.0.0.1",)

--- a/tests/adapters/test_substrate_manifest.py
+++ b/tests/adapters/test_substrate_manifest.py
@@ -528,6 +528,17 @@ def test_s3_http_endpoint_loads_with_distinct_ack(tmp_path):
     assert len(manifest.artifacts) == 1
 
 
+def test_s3_endpoint_inline_userinfo_refused(tmp_path):
+    # Parity with the PG inline-password refusal: a literal secret in the endpoint
+    # URL is refused, so "credential reference, never a literal" holds for S3 too.
+    resolver = make_resolver({"minio.example.com": [PUBLIC_IP]})
+    conn = {"endpoint_url": "https://key:s3cr3t@minio.example.com", "credential": "aws-default"}
+    data = {"artifacts": [s3_artifact(conn)]}
+
+    with pytest.raises(SubstrateCredentialRefused):
+        load(tmp_path, data, resolver=resolver)
+
+
 # ---------------------------------------------------------------------------
 # MRAP / replica endpoint -> warning (forbidden distributed-substrate locality)
 # ---------------------------------------------------------------------------

--- a/tests/adapters/test_substrate_manifest.py
+++ b/tests/adapters/test_substrate_manifest.py
@@ -457,6 +457,16 @@ def test_uri_dsn_hostaddr_comma_gap_checks_unpaired_host(tmp_path):
         load(tmp_path, data, resolver=resolver)
 
 
+@pytest.mark.parametrize("dsn", ["service=prod sslmode=require", "postgresql:///app?service=prod"])
+def test_pg_dsn_service_keyword_refused_fail_closed(tmp_path, dsn):
+    # service= draws host/hostaddr from a pg_service.conf this loader cannot read,
+    # so the real target is unclassifiable — refused rather than silently admitted.
+    data = {"artifacts": [pg_artifact(dsn)]}
+
+    with pytest.raises(SubstrateTargetDenied):
+        load(tmp_path, data)
+
+
 def test_keyword_dsn_inline_password_rejected(tmp_path):
     dsn = "host=db.example.com sslmode=require password=S3cr3tP@ss"
     data = {"artifacts": [pg_artifact(dsn)]}

--- a/tests/conformance/__init__.py
+++ b/tests/conformance/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+"""BYO-substrate tier-honesty conformance kit (Unit 7)."""

--- a/tests/conformance/substrate_conformance.py
+++ b/tests/conformance/substrate_conformance.py
@@ -1,0 +1,604 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""The BYO-substrate tier-honesty conformance kit (Unit 7).
+
+A descriptor-parametrized kit that certifies a substrate binding's declared tier
+is HONEST and, crucially, that the **adapter's** invalidation value — not the
+bare substrate compare-and-set — is what passes. The scenarios are plain
+functions taking a :class:`ConformanceBinding` (a seam that mints binding views
+over ONE shared artifact) and a session factory (an agent identity on ONE
+coordinator). The default arm plugs an in-memory fake substrate; the
+``real_substrate``-gated arm plugs the real ``CoherentRow`` / ``CoherentObject``
+bindings against a real Postgres / S3 (see ``test_tier_honesty.py``).
+
+The two load-bearing native-CAS scenarios are deliberately distinct:
+
+- :func:`assert_racing_writers_one_winner` — a non-coordinated (fixed-stale)
+  writer moves the substrate; the loser gets the uniform typed retryable conflict
+  from the **substrate CAS**. This is the guarantee a bare CAS already gives —
+  ``(i)`` alone is the bare CAS.
+- :func:`assert_invalidation_before_act` — a peer commit denies the other's
+  binding-mediated act with a typed ``StaleView`` **before** its write reaches
+  the substrate CAS. The deny being ``StaleView`` (the coordinator's pull
+  invalidation), NOT the substrate's ``CasVersionConflict``, is the proof that the
+  coordinator layer is load-bearing — ``(ii)`` is what a bare CAS never surfaces.
+
+The kit REJECTS an overclaiming binding: the split-comparand scenario
+(:func:`assert_rejects_split_comparand`) is the PR-#107 negative control that a
+version-CAS / ``NoLostUpdate`` check does not catch, and it MUST fail a
+deliberately-split binding.
+
+Deferred with the fence work (do NOT write speculatively): (iii) fence-rejection
+and (iv) clock-domain sweep-liveness. Those assertions join the kit only when the
+Phase-0 spike un-defers the read-generation fence — v1 bindings ride
+admit-on-absent + the version-CAS and claim no fence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from typing import Protocol, runtime_checkable
+from uuid import UUID, uuid4
+
+import pytest
+
+import ccs.adapters.substrate as substrate_module
+from ccs.adapters.substrate import (
+    CasConflict,
+    CasUnknown,
+    CasWriteResult,
+    CasWritten,
+    CoordinatedSubstrate,
+    ReconcileDecision,
+    ReconcileVerdict,
+    ReconcilingSubstrate,
+    SubstrateCoordinatorSession,
+)
+from ccs.core.exceptions import CasVersionConflict, StaleView
+from ccs.core.substrate import (
+    CapabilityDescriptor,
+    Tier,
+    retention_is_empty_for,
+)
+
+# The wording a non-native tier must never carry: enforcement / CAS / rollback /
+# duplicate-effect claims. Matched case-insensitively, so the guarantee text must
+# express its disclaimers without these trigger words.
+_FORBIDDEN_ENFORCEMENT_WORDS = ("enforce", "cas", "rollback", "dedup")
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _fresh_ref(prefix: str = "conformance") -> str:
+    """A unique artifact ref, so sequential scenarios on ONE coordinator never
+    collide on shared per-artifact state."""
+    return f"{prefix}/{uuid4().hex}.bin"
+
+
+# ===========================================================================
+# The in-memory fake substrate (default arm) — defined HERE, never imported
+# from the tests package, so the kit is self-contained.
+# ===========================================================================
+
+
+def _fake_descriptor(arm: str) -> CapabilityDescriptor:
+    return CapabilityDescriptor(
+        tier=Tier.NATIVE_CAS,
+        version_source="fake row-version" if arm == "row" else "fake object ETag",
+        least_privilege="in-memory conformance fake",
+        consistency_note="fake single-primary",
+    )
+
+
+class InMemoryStore:
+    """The shared substrate state (one row / one object per ref), shared by every
+    binding view — distinct agents, one underlying artifact."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, tuple[bytes, str]] = {}
+        self._counter = 0
+
+    def set(self, ref: str, data: bytes) -> str:
+        self._counter += 1
+        token = f"tok-{self._counter}"
+        self._data[ref] = (bytes(data), token)
+        return token
+
+    def get(self, ref: str) -> tuple[bytes, str] | None:
+        return self._data.get(ref)
+
+
+class ConformanceSubstrate:
+    """A per-agent binding view over the shared store, implementing the
+    reconciling-substrate surface with realistic token-identity logic.
+
+    Supports two test seams: :meth:`script_unknown` (force an UNKNOWN write, so
+    the abort-after-partial-visibility reconciliation is reachable) and
+    :meth:`schedule_peer_write` (a peer write that lands right after this view's
+    atomic read — used by the split-comparand control, which OVERRIDES ``read``).
+    """
+
+    #: The body never reaches the coordinator (never-ship-a-store).
+    SENDS_CONTENT_TO_COORDINATOR: bool = False
+
+    def __init__(self, store: InMemoryStore, arm: str = "object") -> None:
+        self._store = store
+        self._arm = arm
+        self._descriptor = _fake_descriptor(arm)
+        self.cas_calls: list[tuple[str, str, bytes]] = []
+        self._script: tuple[str, bool] | None = None
+        self._scheduled_peer: bytes | None = None
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def coordinator_commit_content(self) -> None:
+        return None
+
+    def script_unknown(self, *, landed: bool) -> None:
+        """Next ``cas_write`` returns ``CasUnknown``; ``landed`` applies the write."""
+        self._script = ("unknown", landed)
+
+    def schedule_peer_write(self, data: bytes) -> None:
+        """A peer write that lands immediately AFTER this view's atomic read — so
+        this (conforming) view's token is the PRE-peer token and a later CAS
+        under it conflicts. The split control overrides ``read`` to capture the
+        POST-peer token instead."""
+        self._scheduled_peer = bytes(data)
+
+    def read(self, artifact_ref: str) -> tuple[bytes, str]:
+        entry = self._store.get(artifact_ref)
+        if entry is None:
+            raise KeyError(artifact_ref)
+        # Atomic pair captured BEFORE any scheduled peer write lands.
+        pair = entry
+        if self._scheduled_peer is not None:
+            self._store.set(artifact_ref, self._scheduled_peer)
+            self._scheduled_peer = None
+        return pair
+
+    def cas_write(self, artifact_ref: str, *, expected_token: str, new_bytes: bytes) -> CasWriteResult:
+        self.cas_calls.append((artifact_ref, expected_token, bytes(new_bytes)))
+        script, self._script = self._script, None
+        if script is not None:
+            _kind, landed = script
+            if landed:
+                self._store.set(artifact_ref, bytes(new_bytes))
+            return CasUnknown()
+        entry = self._store.get(artifact_ref)
+        if entry is None or entry[1] != expected_token:
+            return CasConflict()
+        return CasWritten(token=self._store.set(artifact_ref, bytes(new_bytes)))
+
+    def reconcile_after_unknown(
+        self, artifact_ref: str, *, expected_token: str, intended_hash: str
+    ) -> ReconcileDecision:
+        entry = self._store.get(artifact_ref)
+        if entry is None:
+            return ReconcileDecision(ReconcileVerdict.HOLD, None, None)
+        observed_bytes, observed_token = entry
+        if observed_token == expected_token:
+            return ReconcileDecision(ReconcileVerdict.RE_DRIVE, observed_bytes, observed_token)
+        if _sha256(observed_bytes) == intended_hash:
+            return ReconcileDecision(ReconcileVerdict.CONVERGE, observed_bytes, observed_token)
+        verdict = ReconcileVerdict.CONFLICT if self._arm == "object" else ReconcileVerdict.RE_DERIVE
+        return ReconcileDecision(verdict, observed_bytes, observed_token)
+
+
+class SplitComparandSubstrate(ConformanceSubstrate):
+    """The PR-#107 lost-update bug: ``(bytes, token)`` from TWO reads.
+
+    ``read`` returns the bytes from read A but the token from a LATER read B, with
+    a peer write landing between the two sub-reads. The returned token vouches for
+    bytes it never described, so a subsequent CAS under it PASSES and silently
+    loses the peer's write — the exact bug a version-CAS / ``NoLostUpdate`` check
+    does not catch. The kit MUST reject this binding.
+    """
+
+    def read(self, artifact_ref: str) -> tuple[bytes, str]:
+        entry = self._store.get(artifact_ref)
+        if entry is None:
+            raise KeyError(artifact_ref)
+        bytes_a = entry[0]  # read A: bytes
+        if self._scheduled_peer is not None:  # a peer writes BETWEEN the two reads
+            self._store.set(artifact_ref, self._scheduled_peer)
+            self._scheduled_peer = None
+        fresh = self._store.get(artifact_ref)
+        token_b = fresh[1] if fresh is not None else entry[1]  # read B: token only
+        return bytes_a, token_b  # SPLIT: stale bytes, fresh token
+
+
+class LwwSubstrate:
+    """A detect-only substrate model: NO atomic compare-and-set — every write is
+    last-write-wins. Used by the forced detect-only arm to demonstrate a SILENT
+    lost update (the tier catches a sequential stale-read→write but cannot prevent
+    a concurrent race)."""
+
+    def __init__(self, store: InMemoryStore) -> None:
+        self._store = store
+        self._descriptor = CapabilityDescriptor(
+            tier=Tier.DETECT_ONLY,
+            version_source=None,
+            least_privilege="in-memory detect-only fake",
+            consistency_note="last-write-wins; no atomic CAS",
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def read(self, artifact_ref: str) -> tuple[bytes, str]:
+        entry = self._store.get(artifact_ref)
+        if entry is None:
+            raise KeyError(artifact_ref)
+        return entry
+
+    def cas_write(self, artifact_ref: str, *, expected_token: str, new_bytes: bytes) -> CasWriteResult:
+        # No atomic CAS: expected_token is ignored, the write always lands.
+        del expected_token
+        return CasWritten(token=self._store.set(artifact_ref, bytes(new_bytes)))
+
+
+# ===========================================================================
+# The binding seam — the ONE abstraction every arm (fake + real) plugs into.
+# ===========================================================================
+
+
+@runtime_checkable
+class ConformanceBinding(Protocol):
+    """What a conformance run needs from a binding: a descriptor, a way to seed
+    and non-coordinated-write the shared artifact, and a factory for fresh binding
+    views over it. The in-memory fake and the real PG/S3 bindings both satisfy it.
+    """
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor: ...
+
+    def seed(self, ref: str, data: bytes) -> None: ...
+
+    def foreign_write(self, ref: str, data: bytes) -> None: ...
+
+    def make_view(self) -> ReconcilingSubstrate: ...
+
+
+class InMemoryBinding:
+    """A :class:`ConformanceBinding` backed by the in-memory fake substrate."""
+
+    def __init__(self, arm: str = "object") -> None:
+        self._store = InMemoryStore()
+        self._arm = arm
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return _fake_descriptor(self._arm)
+
+    def seed(self, ref: str, data: bytes) -> None:
+        self._store.set(ref, data)
+
+    def foreign_write(self, ref: str, data: bytes) -> None:
+        # A non-coordinated (fixed-stale) writer moves the substrate WITHOUT
+        # telling the coordinator — the racing-writer the substrate CAS arbitrates.
+        self._store.set(ref, data)
+
+    def make_view(self) -> ConformanceSubstrate:
+        return ConformanceSubstrate(self._store, self._arm)
+
+
+# ===========================================================================
+# Native-CAS scenarios — substrate-agnostic (fake AND real_substrate).
+# ===========================================================================
+
+
+def assert_native_cas_descriptor(descriptor: CapabilityDescriptor) -> None:
+    """The declared tier is native-CAS with the honest timeout-asterisk wording."""
+    assert descriptor.tier is Tier.NATIVE_CAS
+    assert descriptor.version_source, "native-CAS must name its version source"
+    text = descriptor.guarantee_text
+    assert "enforces no-lost-update on the version-CAS axis only" in text
+    assert "token-identity reconciliation" in text
+    assert "single-host" in text
+
+
+def assert_racing_writers_one_winner(
+    binding: ConformanceBinding, make_session: "SessionFactory"
+) -> None:
+    """(i) The SUBSTRATE CAS arbitrates: a non-coordinated writer moves the
+    substrate; the loser gets the uniform typed retryable conflict. This is the
+    guarantee a bare CAS already gives (it is NOT the coordinator's add)."""
+    ref = _fresh_ref()
+    binding.seed(ref, b"v1")
+    agent = CoordinatedSubstrate(binding.make_view(), make_session())
+    _bytes, tok = agent.read(ref)
+
+    # A concurrent (non-coordinated) writer moves the substrate — the coordinator
+    # is NOT told, so the pre-read stays clean and the substrate CAS is the arbiter.
+    binding.foreign_write(ref, b"v2-foreign")
+
+    with pytest.raises(CasVersionConflict):
+        agent.commit(ref, expected_token=tok, new_bytes=b"vA")
+    # The foreign write is the one winner; the loser's bytes never landed.
+    assert binding.make_view().read(ref)[0] == b"v2-foreign"
+
+
+def assert_invalidation_before_act(
+    binding: ConformanceBinding, make_session: "SessionFactory"
+) -> None:
+    """(ii) The COORDINATOR layer denies a peer-invalidated act with ``StaleView``
+    BEFORE the substrate CAS. The deny being ``StaleView`` (not the substrate's
+    ``CasVersionConflict``) is the proof the coordinator layer is load-bearing —
+    the case a bare CAS never surfaces."""
+    ref = _fresh_ref()
+    binding.seed(ref, b"v1")
+    view_a = binding.make_view()
+    agent_a = CoordinatedSubstrate(view_a, make_session())
+    agent_b = CoordinatedSubstrate(binding.make_view(), make_session())
+
+    _ab, a_tok = agent_a.read(ref)
+    _bb, b_tok = agent_b.read(ref)
+    agent_b.commit(ref, expected_token=b_tok, new_bytes=b"v2")  # B wins; A invalidated
+
+    with pytest.raises(StaleView):
+        agent_a.commit(ref, expected_token=a_tok, new_bytes=b"vA")
+    # Deny-before-act: the substrate write was never attempted (fake-observable).
+    if hasattr(view_a, "cas_calls"):
+        assert view_a.cas_calls == []
+
+
+def assert_never_ship_a_store_wire(
+    binding: ConformanceBinding, make_session: "SessionFactory"
+) -> None:
+    """(a) Binding behavior: the commit path threads ``content=None`` and the wire
+    payload carries the fixed-width ``content_hash`` but NO content."""
+    view = binding.make_view()
+    assert getattr(view, "SENDS_CONTENT_TO_COORDINATOR", None) is False
+    assert view.coordinator_commit_content() is None
+
+    ref = _fresh_ref()
+    binding.seed(ref, b"v1")
+    captured: list[dict] = []
+    real_post = substrate_module._coordinator_post
+
+    def spy(endpoint, path, payload):  # noqa: ANN001, ANN202
+        if path == "/hooks/post-edit-cas":
+            captured.append(dict(payload))
+        return real_post(endpoint, path, payload)
+
+    substrate_module._coordinator_post = spy
+    try:
+        agent = CoordinatedSubstrate(view, make_session())
+        _bytes, tok = agent.read(ref)
+        agent.commit(ref, expected_token=tok, new_bytes=b"v2")
+    finally:
+        substrate_module._coordinator_post = real_post
+
+    assert captured, "a commit must POST /hooks/post-edit-cas"
+    for payload in captured:
+        assert "content" not in payload, "bytes are NEVER sent to the coordinator"
+        assert isinstance(payload.get("content_hash"), str)
+
+
+def run_native_cas_conformance(
+    binding: ConformanceBinding, make_session: "SessionFactory"
+) -> None:
+    """The substrate-agnostic native-CAS arm — run against the fake AND real
+    substrates. (i) proves the bare CAS; (ii) proves the coordinator's
+    invalidation-before-act; (a) pins never-ship-a-store on the wire."""
+    assert_native_cas_descriptor(binding.descriptor)
+    assert_racing_writers_one_winner(binding, make_session)
+    assert_invalidation_before_act(binding, make_session)
+    assert_never_ship_a_store_wire(binding, make_session)
+
+
+# ===========================================================================
+# Fake-driven scenarios — abort reconciliation + the negative controls.
+# ===========================================================================
+
+
+def assert_abort_after_partial_visibility(
+    binding: ConformanceBinding, make_session: "SessionFactory"
+) -> None:
+    """A commit whose substrate write LANDED but whose ack was aborted mid-commit
+    must reconcile by token-identity (CONVERGE), never assume nothing landed."""
+    ref = _fresh_ref()
+    binding.seed(ref, b"v1")
+    view = binding.make_view()
+    if not hasattr(view, "script_unknown"):
+        pytest.skip("abort-after-partial-visibility needs a scriptable substrate")
+
+    agent = CoordinatedSubstrate(view, make_session())
+    _bytes, tok = agent.read(ref)
+    view.script_unknown(landed=True)  # the write lands; the ack aborts mid-commit
+
+    result = agent.commit(ref, expected_token=tok, new_bytes=b"v2")
+    assert result.converged is True, "an aborted-but-landed write must reconcile, not re-drive"
+    assert result.summary == "converged"  # never "landed" — attribution disclaimed
+    assert binding.make_view().read(ref)[0] == b"v2"  # the landed write is adopted, not lost
+
+
+def assert_rejects_split_comparand(store_arm: str = "object") -> None:
+    """The PR-#107 negative control (MANDATORY): a CONFORMING view passes the
+    read-pair-consistency check; a SPLIT view silently loses the peer's write.
+
+    A conforming view captures ``(bytes, token)`` atomically, so a peer write that
+    lands after the read leaves its CAS-comparand STALE → the later CAS conflicts →
+    the peer's write survives. A split view captures the token from a later read,
+    so its CAS PASSES on a token that never described its bytes → the peer's write
+    is silently lost. This function ASSERTS "the peer's write survives"; it PASSES
+    for the conforming view and RAISES ``AssertionError`` for the split view (the
+    test wraps the split call in ``pytest.raises(AssertionError)``).
+    """
+    _run_split_control(ConformanceSubstrate, store_arm)
+
+
+def assert_split_view_is_rejected(store_arm: str = "object") -> None:
+    """Confirm the split view fails the control (helper for the MUST-FAIL test)."""
+    with pytest.raises(AssertionError):
+        _run_split_control(SplitComparandSubstrate, store_arm)
+
+
+def _run_split_control(view_cls: type[ConformanceSubstrate], arm: str) -> None:
+    ref = _fresh_ref()
+    store = InMemoryStore()
+    store.set(ref, b"base")
+    view = view_cls(store, arm)
+    view.schedule_peer_write(b"peer-change")
+
+    _bytes, token = view.read(ref)
+    result = view.cas_write(ref, expected_token=token, new_bytes=b"derived-from-stale")
+
+    final = store.get(ref)[0]
+    assert final == b"peer-change" and isinstance(result, CasConflict), (
+        "a split comparand silently lost the peer's write (PR-#107): the CAS "
+        "passed on a token that vouched for bytes it never described"
+    )
+
+
+def assert_detect_only_silent_lost_update() -> None:
+    """The forced detect-only arm: force the interleave and prove the lost update
+    ACTUALLY occurred and was SILENT (no raise) — "not prevented" demonstrated,
+    not merely unobserved. Also pins the descriptor's honest (non-enforcement)
+    tier text."""
+    ref = _fresh_ref()
+    store = InMemoryStore()
+    store.set(ref, b"v1")
+    sub = LwwSubstrate(store)
+
+    _bytes, tok = sub.read(ref)  # two writers both read v1
+    # Forced interleave: a peer write lands, then the racing writer writes under
+    # the SAME (now stale) token. A detect-only substrate has no atomic CAS, so
+    # BOTH land — the peer's write is silently lost.
+    peer_result = sub.cas_write(ref, expected_token=tok, new_bytes=b"peer")
+    racer_result = sub.cas_write(ref, expected_token=tok, new_bytes=b"racer")
+
+    assert isinstance(peer_result, CasWritten) and isinstance(racer_result, CasWritten)
+    assert store.get(ref)[0] == b"racer", "the racer silently overwrote the peer (a race not prevented)"
+    # The descriptor's skip-with-reason: detection wording, never enforcement.
+    text = sub.descriptor.guarantee_text.lower()
+    assert "catches a sequential stale-read" in text
+    assert "cannot prevent a concurrent race" in text
+    for word in _FORBIDDEN_ENFORCEMENT_WORDS:
+        assert word not in text, f"detect-only text must not contain {word!r}"
+
+
+def assert_forward_only_honest() -> None:
+    """The forward-only arm (descriptor-level, pre-network): effect-ordering-only
+    text with NO enforcement/CAS/rollback/dedup wording, and the no-version_source
+    validation pinned. No binding ships for this tier in v1."""
+    descriptor = CapabilityDescriptor(
+        tier=Tier.FORWARD_ONLY,
+        version_source=None,
+        least_privilege="an action-backend credential",
+        consistency_note="the effect is forward-only",
+    )
+    text = descriptor.guarantee_text.lower()
+    assert "effect ordering only" in text
+    assert "freshness" in text
+    assert "deny-before-act" in text
+    for word in _FORBIDDEN_ENFORCEMENT_WORDS:
+        assert word not in text, f"forward-only text must not contain {word!r}"
+    # A forward-only descriptor declaring a version_source is rejected: an action
+    # mints no token to compare.
+    with pytest.raises(ValueError, match="version_source"):
+        CapabilityDescriptor(tier=Tier.FORWARD_ONLY, version_source="etag")
+
+
+# ===========================================================================
+# never-ship-a-store — the coordinator RETENTION backstop (b).
+# ===========================================================================
+
+
+def _dump_retention_rows(db_path) -> list[dict]:
+    """Dump the coordinator's ``artifact_versions`` table (data-in for the
+    ``retention_is_empty_for`` predicate). Any row is a content-proportional
+    shadow the floor forbids for a binding's artifacts."""
+    con = sqlite3.connect(str(db_path))
+    try:
+        rows = con.execute("SELECT artifact_id, version FROM artifact_versions").fetchall()
+    finally:
+        con.close()
+    return [{"artifact_id": UUID(hex=aid), "version": version} for aid, version in rows]
+
+
+def assert_coordinator_retention_empty(tmp_path) -> None:
+    """(b) Coordinator backstop, WITH ``retain_versions=True`` (else it false-greens
+    exactly when it matters): the binding's hash-only registration leg leaves the
+    ``artifact_versions`` table EMPTY, while a content-bearing register does NOT —
+    proving the zero-rows result is a real property, not a retention-off vacuum.
+
+    Note: the row-count probe cannot see a hypothetical NEW content-proportional
+    store OUTSIDE ``artifact_versions`` — that is the core ``never_ship_a_store``
+    predicate's job (Unit 1) plus the per-binding review checklist.
+    """
+    from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+    from ccs.core.types import Artifact
+
+    db_path = tmp_path / "state.db"
+    with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
+        # The binding registers via the hash-only resolve_or_register path — never
+        # register_artifact(artifact, content), which lands a v1 body under retention.
+        binding_id = reg.resolve_or_register("byo/row", "a" * 64)
+        rows = _dump_retention_rows(db_path)
+        assert retention_is_empty_for(rows, [binding_id]), (
+            "the binding's hash-only registration must leave artifact_versions empty"
+        )
+
+        # Teeth: a content-bearing register DOES capture a body row under the same
+        # retention — so the zero-rows result above cannot be a vacuous pass.
+        bearing = Artifact(id=uuid4(), name="content-bearing", version=1, content_hash="b" * 64)
+        reg.register_artifact(bearing, content="a body")
+        rows_after = _dump_retention_rows(db_path)
+        assert not retention_is_empty_for(rows_after, [bearing.id]), (
+            "retention must be ACTIVE — a content-bearing register must leave a row"
+        )
+
+
+# ===========================================================================
+# Session harness — a factory that mints agent identities over ONE coordinator.
+# ===========================================================================
+
+
+@runtime_checkable
+class SessionFactory(Protocol):
+    """Mint a fresh :class:`SubstrateCoordinatorSession` (a new agent identity) on
+    ONE coordinator root. Two calls are two agents sharing one artifact."""
+
+    def __call__(self) -> SubstrateCoordinatorSession: ...
+
+
+class CoordinatorHarness:
+    """Owns the coordinator lifecycle for a conformance run: each call mints a new
+    agent identity on ONE root; :meth:`close` tears the coordinator down."""
+
+    def __init__(self, root, config) -> None:
+        from pathlib import Path
+
+        self._root = Path(root)
+        self._config = config
+
+    def __call__(self) -> SubstrateCoordinatorSession:
+        return SubstrateCoordinatorSession(self._root, managed=("**",), config=self._config)
+
+    def close(self) -> None:
+        from ccs.adapters.claude_code.lifecycle import stop_coordinator
+
+        stop_coordinator(self._root)
+
+
+# ---------------------------------------------------------------------------
+# real_substrate note (MinIO): the racing-writers + invalidation assertions ALSO
+# run against real Postgres AND real S3 when the `real_substrate` marker is
+# selected and credentials are present (CCS_TEST_PG_DSN / CCS_REAL_S3_BUCKET) —
+# wired in test_tier_honesty.py. Moto/LocalStack are excluded (they serialize →
+# concurrency false-greens). For a local S3-compatible fixture, PIN MinIO to its
+# FINAL release tag/digest (upstream archived read-only 2026-04-25 — API drift is
+# impossible, but so are CVE fixes; never expose it) — its conditional-write
+# semantics are adequate (real 412s, atomic, wildcard If-None-Match) EXCEPT it
+# documents no 409 ConditionalRequestConflict path, so the 409-retry branch is
+# stub-tested locally and integration-verified against real AWS only. Do NOT stand
+# up MinIO here — this note is the record; the env-gated tests do the rest.
+# ---------------------------------------------------------------------------

--- a/tests/conformance/substrate_conformance.py
+++ b/tests/conformance/substrate_conformance.py
@@ -101,6 +101,9 @@ class InMemoryStore:
     def __init__(self) -> None:
         self._data: dict[str, tuple[bytes, str]] = {}
         self._counter = 0
+        #: Substrate-read count — a split (bytes, token) read shows up as >1 per
+        #: view.read(), which the read-pair-atomicity control asserts against.
+        self.read_count = 0
 
     def set(self, ref: str, data: bytes) -> str:
         self._counter += 1
@@ -109,6 +112,7 @@ class InMemoryStore:
         return token
 
     def get(self, ref: str) -> tuple[bytes, str] | None:
+        self.read_count += 1
         return self._data.get(ref)
 
 
@@ -288,6 +292,19 @@ class InMemoryBinding:
     def make_view(self) -> ConformanceSubstrate:
         return ConformanceSubstrate(self._store, self._arm)
 
+    def substrate_read_count(self) -> int:
+        """Total substrate reads so far — lets the read-pair-atomicity control
+        assert that one ``view.read()`` fetches ``(bytes, token)`` in ONE read."""
+        return self._store.read_count
+
+
+class _SplitReadBinding(InMemoryBinding):
+    """A ConformanceBinding whose view fetches ``(bytes, token)`` in TWO substrate
+    reads — the read-pair-atomicity control MUST reject it (teeth certification)."""
+
+    def make_view(self) -> SplitComparandSubstrate:
+        return SplitComparandSubstrate(self._store, self._arm)
+
 
 # ===========================================================================
 # Native-CAS scenarios — substrate-agnostic (fake AND real_substrate).
@@ -382,16 +399,52 @@ def assert_never_ship_a_store_wire(
         assert isinstance(payload.get("content_hash"), str)
 
 
+def assert_read_pair_is_atomic(binding: ConformanceBinding, make_session: "SessionFactory") -> None:
+    """Read-pair atomicity: one ``view.read()`` fetches ``(bytes, token)`` in a
+    SINGLE substrate read (the PR-#107 control, now certified for shipped bindings).
+
+    A split read — bytes from read A, token from a LATER read B — is the PR-#107
+    lost update: the token vouches for bytes it never described, so a CAS under it
+    passes on a stale comparand and silently loses a concurrent peer. A binding
+    that issues exactly one substrate read for the pair CANNOT split. The count is
+    read from ``substrate_read_count`` when the binding instruments it (the fake,
+    always; a real binding when its driver is wrapped); it skips otherwise rather
+    than false-green."""
+    del make_session  # a bare-substrate property; no coordinator needed
+    read_count = getattr(binding, "substrate_read_count", None)
+    if read_count is None:
+        return  # binding does not instrument substrate reads — cannot certify here
+    ref = _fresh_ref()
+    binding.seed(ref, b"base")
+    view = binding.make_view()
+    before = read_count()
+    view.read(ref)
+    delta = read_count() - before
+    assert delta == 1, (
+        f"read-pair split: view.read() issued {delta} substrate reads, not 1 — a "
+        "(bytes, token) pair read non-atomically can silently lose a peer (PR-#107)"
+    )
+
+
+def assert_read_pair_split_binding_is_rejected() -> None:
+    """Confirm the read-pair-atomicity control has TEETH: a split-read binding
+    (two substrate reads per pair) fails it (helper for the MUST-FAIL test)."""
+    with pytest.raises(AssertionError):
+        assert_read_pair_is_atomic(_SplitReadBinding("object"), None)  # type: ignore[arg-type]
+
+
 def run_native_cas_conformance(
     binding: ConformanceBinding, make_session: "SessionFactory"
 ) -> None:
     """The substrate-agnostic native-CAS arm — run against the fake AND real
     substrates. (i) proves the bare CAS; (ii) proves the coordinator's
-    invalidation-before-act; (a) pins never-ship-a-store on the wire."""
+    invalidation-before-act; (a) pins never-ship-a-store on the wire; and the
+    read-pair-atomicity control certifies the SHIPPED read is not split."""
     assert_native_cas_descriptor(binding.descriptor)
     assert_racing_writers_one_winner(binding, make_session)
     assert_invalidation_before_act(binding, make_session)
     assert_never_ship_a_store_wire(binding, make_session)
+    assert_read_pair_is_atomic(binding, make_session)
 
 
 # ===========================================================================

--- a/tests/conformance/test_tier_honesty.py
+++ b/tests/conformance/test_tier_honesty.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Drive the tier-honesty conformance kit over BOTH v1 descriptors (a row-shaped
+and an object-shaped native-CAS binding) plus the mandatory negative controls.
+
+The default run uses the in-memory fake substrate (real coordinator subprocess,
+fake bytes+token store) so the coordinator-mediated value — invalidation before
+act, the never-ship-a-store commit path — is exercised without credentials. The
+``real_substrate``-marked tests re-run the substrate-agnostic native-CAS arm
+against a REAL Postgres and a REAL S3 (skip unless ``CCS_TEST_PG_DSN`` /
+``CCS_REAL_S3_BUCKET`` are set); they are deselected from the default ``pytest -q``
+run by the ``real_substrate`` marker.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from ccs.adapters.claude_code.lifecycle import LifecycleConfig
+from tests.conformance.substrate_conformance import (
+    CoordinatorHarness,
+    InMemoryBinding,
+    assert_abort_after_partial_visibility,
+    assert_coordinator_retention_empty,
+    assert_detect_only_silent_lost_update,
+    assert_forward_only_honest,
+    assert_rejects_split_comparand,
+    assert_split_view_is_rejected,
+    run_native_cas_conformance,
+)
+
+
+@pytest.fixture
+def fast_cfg() -> LifecycleConfig:
+    """Coordinator config tuned for fast tests (no idle shutdown)."""
+    return LifecycleConfig(
+        idle_shutdown_sec=0,
+        sweep_interval_sec=0.1,
+        notice_evict_max_age_sec=1.0,
+        port_file_retry_attempts=20,
+        port_file_retry_interval_sec=0.05,
+        connect_retry_attempts=10,
+        connect_retry_interval_sec=0.05,
+    )
+
+
+@pytest.fixture
+def harness(tmp_path, fast_cfg: LifecycleConfig):
+    """A coordinator harness: mints agent identities on ONE root, torn down after."""
+    handle = CoordinatorHarness(tmp_path, fast_cfg)
+    try:
+        yield handle
+    finally:
+        handle.close()
+
+
+# ===========================================================================
+# Default arm — the in-memory fake over BOTH v1 descriptors (row + object).
+# ===========================================================================
+
+
+@pytest.mark.parametrize("arm", ["row", "object"])
+def test_native_cas_conformance_fake(arm: str, harness: CoordinatorHarness) -> None:
+    """Each v1 native-CAS descriptor passes: (i) the bare CAS arbitrates one
+    winner, (ii) a peer commit denies the other's act before the substrate CAS,
+    and the commit path never ships a store."""
+    run_native_cas_conformance(InMemoryBinding(arm), harness)
+
+
+def test_abort_after_partial_visibility_reconciles(harness: CoordinatorHarness) -> None:
+    """A commit whose write LANDED but whose ack aborted reconciles by
+    token-identity (CONVERGE) — Unit-5 Case 3 verified end-to-end."""
+    assert_abort_after_partial_visibility(InMemoryBinding("object"), harness)
+
+
+# ===========================================================================
+# Negative controls — the kit must REJECT an overclaiming binding.
+# ===========================================================================
+
+
+def test_split_comparand_conforming_view_passes() -> None:
+    """A conforming (single-read) view passes the read-pair-consistency control."""
+    assert_rejects_split_comparand("object")
+
+
+def test_split_comparand_must_fail() -> None:
+    """MANDATORY: a deliberately-split (bytes from read A, token from read B) view
+    FAILS the kit — the PR-#107 lost update a version-CAS / NoLostUpdate check
+    does not catch."""
+    assert_split_view_is_rejected("object")
+
+
+def test_detect_only_forced_silent_lost_update() -> None:
+    """A detect-only substrate under a forced interleave silently loses an update
+    (no raise), and its descriptor text is detection-only, never enforcement."""
+    assert_detect_only_silent_lost_update()
+
+
+def test_forward_only_tier_honest() -> None:
+    """The forward-only tier is effect-ordering-only (no enforcement/CAS/rollback/
+    dedup wording) and forbids a version_source — a pre-network descriptor arm."""
+    assert_forward_only_honest()
+
+
+# ===========================================================================
+# never-ship-a-store — the coordinator RETENTION backstop (retain_versions=True).
+# ===========================================================================
+
+
+def test_never_ship_a_store_retention_backstop(tmp_path) -> None:
+    """With retention ENABLED, the binding's hash-only registration leaves
+    ``artifact_versions`` empty, while a content-bearing register does not (teeth)."""
+    assert_coordinator_retention_empty(tmp_path)
+
+
+# ===========================================================================
+# real_substrate arm — the SAME native-CAS conformance against real backends.
+# Deselected by default (the `real_substrate` marker); skip unless credentialed.
+# ===========================================================================
+
+
+_IT_PG_TABLE = "coherence_conformance_it"
+
+
+class _PgConformanceBinding:
+    """A ConformanceBinding over a real Postgres table (one row per ref)."""
+
+    def __init__(self, dsn: str, table: str) -> None:
+        self._dsn = dsn
+        self._table = table
+
+    @property
+    def descriptor(self):  # noqa: ANN201 - CoherentRow's shipped descriptor
+        from ccs.adapters.coherent_row import CoherentRow
+
+        return CoherentRow(table=self._table, dsn=self._dsn).descriptor
+
+    def seed(self, ref: str, data: bytes) -> None:
+        import psycopg  # noqa: PLC0415
+
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                f'INSERT INTO "{self._table}" (id, value) VALUES (%s, %s) '
+                "ON CONFLICT (id) DO UPDATE SET value = EXCLUDED.value",
+                (ref, data),
+            )
+            conn.commit()
+
+    def foreign_write(self, ref: str, data: bytes) -> None:
+        import psycopg  # noqa: PLC0415
+
+        # A non-coordinated writer moves the row version (the trigger bumps it).
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(f'UPDATE "{self._table}" SET value = %s WHERE id = %s', (data, ref))
+            conn.commit()
+
+    def make_view(self):  # noqa: ANN201
+        from ccs.adapters.coherent_row import CoherentRow
+
+        return CoherentRow(table=self._table, dsn=self._dsn)
+
+
+@pytest.fixture
+def real_pg():
+    """Provision a real Postgres table + version trigger; yield ``(dsn, table)``."""
+    dsn = os.environ.get("CCS_TEST_PG_DSN")
+    if not dsn:
+        pytest.skip("set CCS_TEST_PG_DSN (owner DSN) to run the real Postgres conformance arm")
+    import psycopg  # noqa: PLC0415
+
+    from ccs.adapters.coherent_row import provisioning_sql
+
+    ddl = provisioning_sql(_IT_PG_TABLE)
+    with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute(f'DROP TABLE IF EXISTS "{_IT_PG_TABLE}" CASCADE')
+        cur.execute(
+            f'CREATE TABLE "{_IT_PG_TABLE}" '
+            "(id text PRIMARY KEY, value bytea NOT NULL, version int NOT NULL DEFAULT 0)"
+        )
+        cur.execute(ddl.trigger_function)
+        cur.execute(ddl.trigger_bindings)
+        conn.commit()
+    try:
+        yield dsn, _IT_PG_TABLE
+    finally:
+        with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute(f'DROP TABLE IF EXISTS "{_IT_PG_TABLE}" CASCADE')
+            conn.commit()
+
+
+@pytest.mark.real_substrate
+def test_real_postgres_native_cas_conformance(real_pg, harness: CoordinatorHarness) -> None:
+    dsn, table = real_pg
+    run_native_cas_conformance(_PgConformanceBinding(dsn, table), harness)
+
+
+class _S3ConformanceBinding:
+    """A ConformanceBinding over a real S3 bucket (one object per ref)."""
+
+    def __init__(self, bucket: str, region: str | None) -> None:
+        self._bucket = bucket
+        self._region = region
+
+    @property
+    def descriptor(self):  # noqa: ANN201
+        return self.make_view().descriptor
+
+    def _object(self):  # noqa: ANN202
+        from ccs.adapters.coherent_object import CoherentObject
+
+        return CoherentObject(self._bucket, region=self._region)
+
+    def seed(self, ref: str, data: bytes) -> None:
+        from ccs.adapters.coherent_object import CREATE_IF_ABSENT
+
+        self._object().cas_write(ref, expected_token=CREATE_IF_ABSENT, new_bytes=data)
+
+    def foreign_write(self, ref: str, data: bytes) -> None:
+        # A non-coordinated conditional put moves the object's ETag.
+        obj = self._object()
+        _bytes, token = obj.read(ref)
+        obj.cas_write(ref, expected_token=token, new_bytes=data)
+
+    def make_view(self):  # noqa: ANN201
+        return self._object()
+
+
+@pytest.fixture
+def real_s3():
+    """Yield a real S3 bucket + region, or skip if uncredentialed."""
+    bucket = os.environ.get("CCS_REAL_S3_BUCKET")
+    if not bucket:
+        pytest.skip("set CCS_REAL_S3_BUCKET (a real, non-Moto bucket) to run the real S3 arm")
+    pytest.importorskip("boto3")
+    return bucket, os.environ.get("CCS_REAL_S3_REGION")
+
+
+@pytest.mark.real_substrate
+def test_real_s3_native_cas_conformance(real_s3, harness: CoordinatorHarness) -> None:
+    bucket, region = real_s3
+    run_native_cas_conformance(_S3ConformanceBinding(bucket, region), harness)

--- a/tests/conformance/test_tier_honesty.py
+++ b/tests/conformance/test_tier_honesty.py
@@ -27,6 +27,7 @@ from tests.conformance.substrate_conformance import (
     assert_coordinator_retention_empty,
     assert_detect_only_silent_lost_update,
     assert_forward_only_honest,
+    assert_read_pair_split_binding_is_rejected,
     assert_rejects_split_comparand,
     assert_split_view_is_rejected,
     run_native_cas_conformance,
@@ -91,6 +92,13 @@ def test_split_comparand_must_fail() -> None:
     FAILS the kit — the PR-#107 lost update a version-CAS / NoLostUpdate check
     does not catch."""
     assert_split_view_is_rejected("object")
+
+
+def test_read_pair_atomicity_control_rejects_split_binding() -> None:
+    """MANDATORY teeth: the read-pair-atomicity control (now part of every
+    native-CAS run) fails a split-read binding — a (bytes, token) pair fetched in
+    two substrate reads, not one."""
+    assert_read_pair_split_binding_is_rejected()
 
 
 def test_detect_only_forced_silent_lost_update() -> None:

--- a/tests/test_coherent_object_demo.py
+++ b/tests/test_coherent_object_demo.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Smoke test for the CoherentObject cross-agent demo (examples/coherent_object).
+
+Runs the demo in both modes and asserts the honest contract holds (exit 0), so
+the demo cannot silently rot: with the binding the stale act is denied before the
+object is touched and A recovers; with --baseline the un-coordinated agent acts on
+a stale cache (the failure the binding catches).
+"""
+
+from __future__ import annotations
+
+
+def test_coherent_object_demo_exits_zero() -> None:
+    from examples.coherent_object.main import main
+
+    assert main([]) == 0
+
+
+def test_coherent_object_demo_baseline_exits_zero() -> None:
+    from examples.coherent_object.main import main
+
+    assert main(["--baseline"]) == 0

--- a/tests/test_coherent_row_demo.py
+++ b/tests/test_coherent_row_demo.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Smoke test for the CoherentRow cross-agent demo (examples/coherent_row).
+
+Runs the demo in both modes and asserts the honest contract holds (exit 0), so
+the demo cannot silently rot: with the binding the stale act is denied before the
+row is touched and A recovers; with --baseline the un-coordinated agent acts on a
+stale cache (the failure the binding catches).
+"""
+
+from __future__ import annotations
+
+
+def test_coherent_row_demo_exits_zero() -> None:
+    from examples.coherent_row.main import main
+
+    assert main([]) == 0
+
+
+def test_coherent_row_demo_baseline_exits_zero() -> None:
+    from examples.coherent_row.main import main
+
+    assert main(["--baseline"]) == 0

--- a/tests/test_substrate_contract.py
+++ b/tests/test_substrate_contract.py
@@ -26,11 +26,8 @@ from uuid import uuid4
 import pytest
 
 from ccs.adapters.substrate import (
-    CasConflict,
-    CasUnknown,
     CasWritten,
     CoherenceSubstrate,
-    TwoPartCommitMixin,
 )
 from ccs.core.substrate import (
     CapabilityDescriptor,
@@ -239,6 +236,36 @@ def test_unrecognized_value_type_fails_closed():
     assert never_ship_a_store(state) is False
 
 
+def test_unbounded_collection_rejected_as_content_proportional():
+    # A body encoded as a list of byte-value ints is content-proportional even
+    # though every element is an allowed scalar.
+    state = {**metadata_only_state(), "payload": list(range(256)) * 40}
+
+    assert never_ship_a_store(state) is False
+    assert any("collection" in v for v in never_ship_violations(state))
+
+
+def test_small_collection_of_scalars_allowed():
+    # A handful of tokens/ids is legitimate coherence metadata.
+    state = {**metadata_only_state(), "peers": ["agent-a", "agent-b", "agent-c"]}
+
+    assert never_ship_a_store(state) is True
+
+
+def test_arbitrary_precision_integer_rejected():
+    # A body packed into one big integer (int.from_bytes) is a content shadow.
+    state = {**metadata_only_state(), "blob": int.from_bytes(b"x" * 5000, "big")}
+
+    assert never_ship_a_store(state) is False
+    assert any("integer" in v for v in never_ship_violations(state))
+
+
+def test_ordinary_version_integer_allowed():
+    state = {**metadata_only_state(), "version": 42, "tick": 1_000_000}
+
+    assert never_ship_a_store(state) is True
+
+
 # ---------------------------------------------------------------------------
 # never_ship_a_store: retention-rows leg
 # ---------------------------------------------------------------------------
@@ -331,58 +358,11 @@ def test_read_returns_bytes_and_token_from_one_read():
 
 
 # ---------------------------------------------------------------------------
-# Two-part-commit mixin: ordering seam
+# The two-part-commit ordering (substrate CAS first, coordinator bump second) is
+# no longer a standalone mixin — it lives in CoordinatedSubstrate, and its
+# ordering guarantees (a conflict/unknown never reaches the coordinator) are
+# covered end-to-end in tests/adapters/test_substrate_cross_agent.py.
 # ---------------------------------------------------------------------------
-
-
-class RecordingBinding(TwoPartCommitMixin):
-    """Stub binding recording the order of the two commit legs."""
-
-    def __init__(self, outcome: object) -> None:
-        self.outcome = outcome
-        self.calls: list[str] = []
-
-    def cas_write(self, artifact_ref: str, *, expected_token: str, new_bytes: bytes):
-        self.calls.append("substrate_cas")
-        return self.outcome
-
-    def _bump_coordinator(self, artifact_ref: str, *, written: CasWritten) -> None:
-        self.calls.append("coordinator_bump")
-
-
-def test_win_runs_substrate_cas_before_coordinator_bump():
-    binding = RecordingBinding(CasWritten(token="token-2"))
-
-    outcome = binding.commit_two_part("ref", expected_token="token-1", new_bytes=b"new")
-
-    assert binding.calls == ["substrate_cas", "coordinator_bump"]
-    assert outcome == CasWritten(token="token-2")
-
-
-def test_conflict_never_reaches_the_coordinator():
-    binding = RecordingBinding(CasConflict())
-
-    outcome = binding.commit_two_part("ref", expected_token="token-1", new_bytes=b"new")
-
-    assert binding.calls == ["substrate_cas"]
-    assert isinstance(outcome, CasConflict)
-
-
-def test_unknown_outcome_never_bumps_the_coordinator():
-    binding = RecordingBinding(CasUnknown())
-
-    outcome = binding.commit_two_part("ref", expected_token="token-1", new_bytes=b"new")
-
-    assert binding.calls == ["substrate_cas"]
-    assert isinstance(outcome, CasUnknown)
-
-
-def test_mixin_seam_hooks_are_not_wired_by_default():
-    class BareBinding(TwoPartCommitMixin):
-        pass
-
-    with pytest.raises(NotImplementedError):
-        BareBinding().commit_two_part("ref", expected_token="t", new_bytes=b"n")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_substrate_contract.py
+++ b/tests/test_substrate_contract.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Contract tests for the BYO-substrate capability descriptor and I/O Protocol.
+
+Covers the four Unit-1 surfaces:
+
+- ``Tier`` + ``CapabilityDescriptor`` construction validation and the
+  tier-derived guarantee text (the honesty floor: a weaker tier must never
+  present as enforcement).
+- ``never_ship_a_store`` — the data-in predicate rejecting any
+  content-proportional material in extracted coordinator-side state.
+- The retention-leg helper: the retention table must hold ZERO rows for a
+  binding's artifacts, regardless of which leg (registration or commit)
+  produced them.
+- The ``CoherenceSubstrate`` runtime-checkable Protocol and the two-part-commit
+  ordering seam (substrate CAS first; coordinator bump only on a WIN).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from ccs.adapters.substrate import (
+    CasConflict,
+    CasUnknown,
+    CasWritten,
+    CoherenceSubstrate,
+    TwoPartCommitMixin,
+)
+from ccs.core.substrate import (
+    CapabilityDescriptor,
+    Tier,
+    never_ship_a_store,
+    never_ship_violations,
+    retained_rows_for,
+    retention_is_empty_for,
+)
+from ccs.hardening.architecture import run_architecture_checks
+
+SHA256_HEX = hashlib.sha256(b"canonical bytes").hexdigest()
+
+# The wording a non-native tier must never carry: enforcement/CAS/rollback/
+# duplicate-effect claims. Checked as case-insensitive substrings, so the
+# guarantee text has to express its disclaimers without these trigger words.
+FORBIDDEN_ENFORCEMENT_WORDS = ("enforce", "cas", "rollback", "dedup")
+
+
+def make_descriptor(tier: Tier, **overrides: object) -> CapabilityDescriptor:
+    """Arrange helper: a valid descriptor for any tier."""
+    defaults: dict[str, object] = {
+        Tier.NATIVE_CAS: {"version_source": "trigger-managed version column"},
+        Tier.DETECT_ONLY: {"version_source": None},
+        Tier.FORWARD_ONLY: {"version_source": None},
+    }[tier]
+    kwargs = {
+        "least_privilege": "read+conditional-write on the bound target",
+        "consistency_note": "read-after-write consistent per key",
+        **defaults,
+        **overrides,
+    }
+    return CapabilityDescriptor(tier=tier, **kwargs)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Guarantee text: happy paths per tier
+# ---------------------------------------------------------------------------
+
+
+def test_native_cas_guarantee_text_carries_timeout_asterisk():
+    text = make_descriptor(Tier.NATIVE_CAS).guarantee_text
+
+    assert "enforces no-lost-update on the version-CAS axis only" in text
+    assert "coordinator-timeout after a durable substrate write" in text
+    assert "token-identity reconciliation" in text
+    assert "single-host" in text
+
+
+def test_detect_only_guarantee_text_is_detection_wording():
+    text = make_descriptor(Tier.DETECT_ONLY).guarantee_text
+
+    assert "catches a sequential stale-read" in text
+    assert "cannot prevent a concurrent race" in text
+
+
+def test_detect_only_guarantee_text_never_claims_enforcement():
+    lowered = make_descriptor(Tier.DETECT_ONLY).guarantee_text.lower()
+
+    for word in FORBIDDEN_ENFORCEMENT_WORDS:
+        assert word not in lowered, f"detect-only text must not contain {word!r}"
+
+
+def test_forward_only_guarantee_text_is_effect_ordering_only():
+    text = make_descriptor(Tier.FORWARD_ONLY).guarantee_text
+
+    assert "effect ordering only" in text.lower()
+    assert "freshness" in text
+    assert "deny-before-act" in text
+
+
+def test_forward_only_guarantee_text_never_claims_enforcement():
+    lowered = make_descriptor(Tier.FORWARD_ONLY).guarantee_text.lower()
+
+    for word in FORBIDDEN_ENFORCEMENT_WORDS:
+        assert word not in lowered, f"forward-only text must not contain {word!r}"
+
+
+def test_guarantee_text_is_distinct_per_tier():
+    texts = {make_descriptor(tier).guarantee_text for tier in Tier}
+
+    assert len(texts) == len(list(Tier))
+
+
+# ---------------------------------------------------------------------------
+# Descriptor validation: error paths
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_tier_string_rejected_at_construction():
+    with pytest.raises(ValueError):
+        CapabilityDescriptor(tier="native_cas")  # type: ignore[arg-type]
+
+
+def test_unknown_tier_value_rejected_by_enum():
+    with pytest.raises(ValueError):
+        Tier("bogus_tier")
+
+
+def test_missing_tier_rejected_at_construction():
+    with pytest.raises(TypeError):
+        CapabilityDescriptor()  # type: ignore[call-arg]
+
+
+def test_forward_only_with_version_source_rejected():
+    with pytest.raises(ValueError, match="version_source"):
+        make_descriptor(Tier.FORWARD_ONLY, version_source="etag")
+
+
+def test_native_cas_without_version_source_rejected():
+    with pytest.raises(ValueError, match="version_source"):
+        make_descriptor(Tier.NATIVE_CAS, version_source=None)
+
+
+def test_detect_only_version_source_is_optional():
+    with_source = make_descriptor(Tier.DETECT_ONLY, version_source="client shadow")
+    without_source = make_descriptor(Tier.DETECT_ONLY, version_source=None)
+
+    assert with_source.version_source == "client shadow"
+    assert without_source.version_source is None
+
+
+def test_descriptor_is_frozen():
+    descriptor = make_descriptor(Tier.NATIVE_CAS)
+
+    with pytest.raises(AttributeError):
+        descriptor.tier = Tier.DETECT_ONLY  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# never_ship_a_store: payload-shape leg
+# ---------------------------------------------------------------------------
+
+
+def metadata_only_state() -> dict[str, object]:
+    """A coordinator-side state extract carrying ONLY coherence metadata."""
+    return {
+        "artifact_id": uuid4(),
+        "version": 7,
+        "content_hash": SHA256_HEX,
+        "token": 'W/"etag-0xabc123"',
+    }
+
+
+def test_metadata_only_state_passes():
+    assert never_ship_a_store(metadata_only_state()) is True
+    assert never_ship_violations(metadata_only_state()) == ()
+
+
+@pytest.mark.parametrize(
+    "field", ["content", "body", "compressed_body", "diff", "sample"]
+)
+def test_content_proportional_field_rejected(field):
+    state = {**metadata_only_state(), field: "even a short value is content"}
+
+    assert never_ship_a_store(state) is False
+    assert any(field in violation for violation in never_ship_violations(state))
+
+
+def test_content_field_set_to_none_is_allowed():
+    # content=None is the shipped content-free coordinator shape: the field
+    # naming content with NO value is exactly "no content stored".
+    state = {**metadata_only_state(), "content": None}
+
+    assert never_ship_a_store(state) is True
+
+
+def test_raw_bytes_rejected_under_any_field_name():
+    state = {**metadata_only_state(), "note": b"raw bytes are content"}
+
+    assert never_ship_a_store(state) is False
+
+
+def test_oversized_text_rejected_as_content_proportional():
+    state = {**metadata_only_state(), "annotation": "x" * 300}
+
+    assert never_ship_a_store(state) is False
+
+
+def test_content_hash_must_be_fixed_width():
+    truncated = {**metadata_only_state(), "content_hash": "abc123"}
+    inflated = {**metadata_only_state(), "content_hash": "a" * 4096}
+
+    assert never_ship_a_store(truncated) is False
+    assert never_ship_a_store(inflated) is False
+
+
+def test_content_hash_none_is_allowed():
+    # A never-written artifact legitimately has no fingerprint yet.
+    state = {**metadata_only_state(), "content_hash": None}
+
+    assert never_ship_a_store(state) is True
+
+
+def test_nested_rows_are_walked():
+    clean = {"rows": [metadata_only_state(), metadata_only_state()]}
+    leaking = {"rows": [metadata_only_state(), {**metadata_only_state(), "body": "shadow"}]}
+
+    assert never_ship_a_store(clean) is True
+    assert never_ship_a_store(leaking) is False
+
+
+def test_unrecognized_value_type_fails_closed():
+    state = {**metadata_only_state(), "opaque": object()}
+
+    assert never_ship_a_store(state) is False
+
+
+# ---------------------------------------------------------------------------
+# never_ship_a_store: retention-rows leg
+# ---------------------------------------------------------------------------
+
+
+def test_zero_retained_rows_passes():
+    binding_ids = {uuid4(), uuid4()}
+
+    assert retention_is_empty_for([], binding_ids) is True
+    assert retained_rows_for([], binding_ids) == ()
+
+
+def test_rows_for_other_artifacts_do_not_fail_the_binding():
+    binding_ids = {uuid4()}
+    foreign_row = {"artifact_id": uuid4(), "version": 1, "content": "not ours"}
+
+    assert retention_is_empty_for([foreign_row], binding_ids) is True
+
+
+def test_registration_leg_row_fails_the_check():
+    # The registration leg seeds a version-1 body under retention; the check
+    # takes rows regardless of which leg produced them.
+    artifact_id = uuid4()
+    row = {"artifact_id": artifact_id, "version": 1, "content": "seeded body"}
+
+    assert retention_is_empty_for([row], {artifact_id}) is False
+    assert retained_rows_for([row], {artifact_id}) == (row,)
+
+
+def test_commit_leg_row_fails_the_check():
+    artifact_id = uuid4()
+    row = {"artifact_id": artifact_id, "version": 5, "content": "captured body"}
+
+    assert retention_is_empty_for([row], {artifact_id}) is False
+
+
+def test_retained_row_fails_even_without_a_body_column():
+    # ANY retained row for the binding's artifacts is a violation: the floor is
+    # zero rows, not zero bytes-per-row.
+    artifact_id = uuid4()
+    row = {"artifact_id": artifact_id, "version": 2}
+
+    assert retention_is_empty_for([row], {artifact_id}) is False
+
+
+# ---------------------------------------------------------------------------
+# CoherenceSubstrate Protocol: structural conformance
+# ---------------------------------------------------------------------------
+
+
+class ConformingSubstrate:
+    """Minimal stub satisfying the bytes-I/O contract."""
+
+    descriptor = CapabilityDescriptor(
+        tier=Tier.NATIVE_CAS,
+        version_source="stub token",
+        least_privilege="stub",
+        consistency_note="stub",
+    )
+
+    def read(self, artifact_ref: str) -> tuple[bytes, str]:
+        return b"payload", "token-1"
+
+    def cas_write(self, artifact_ref: str, *, expected_token: str, new_bytes: bytes):
+        return CasWritten(token="token-2")
+
+
+class ReadOnlyStub:
+    """Missing ``cas_write`` — must NOT satisfy the Protocol."""
+
+    descriptor = ConformingSubstrate.descriptor
+
+    def read(self, artifact_ref: str) -> tuple[bytes, str]:
+        return b"payload", "token-1"
+
+
+def test_conforming_stub_satisfies_protocol():
+    assert isinstance(ConformingSubstrate(), CoherenceSubstrate)
+
+
+def test_non_conforming_stub_rejected_by_protocol():
+    assert not isinstance(ReadOnlyStub(), CoherenceSubstrate)
+
+
+def test_read_returns_bytes_and_token_from_one_read():
+    data, token = ConformingSubstrate().read("artifact-ref")
+
+    assert isinstance(data, bytes)
+    assert isinstance(token, str)
+
+
+# ---------------------------------------------------------------------------
+# Two-part-commit mixin: ordering seam
+# ---------------------------------------------------------------------------
+
+
+class RecordingBinding(TwoPartCommitMixin):
+    """Stub binding recording the order of the two commit legs."""
+
+    def __init__(self, outcome: object) -> None:
+        self.outcome = outcome
+        self.calls: list[str] = []
+
+    def cas_write(self, artifact_ref: str, *, expected_token: str, new_bytes: bytes):
+        self.calls.append("substrate_cas")
+        return self.outcome
+
+    def _bump_coordinator(self, artifact_ref: str, *, written: CasWritten) -> None:
+        self.calls.append("coordinator_bump")
+
+
+def test_win_runs_substrate_cas_before_coordinator_bump():
+    binding = RecordingBinding(CasWritten(token="token-2"))
+
+    outcome = binding.commit_two_part("ref", expected_token="token-1", new_bytes=b"new")
+
+    assert binding.calls == ["substrate_cas", "coordinator_bump"]
+    assert outcome == CasWritten(token="token-2")
+
+
+def test_conflict_never_reaches_the_coordinator():
+    binding = RecordingBinding(CasConflict())
+
+    outcome = binding.commit_two_part("ref", expected_token="token-1", new_bytes=b"new")
+
+    assert binding.calls == ["substrate_cas"]
+    assert isinstance(outcome, CasConflict)
+
+
+def test_unknown_outcome_never_bumps_the_coordinator():
+    binding = RecordingBinding(CasUnknown())
+
+    outcome = binding.commit_two_part("ref", expected_token="token-1", new_bytes=b"new")
+
+    assert binding.calls == ["substrate_cas"]
+    assert isinstance(outcome, CasUnknown)
+
+
+def test_mixin_seam_hooks_are_not_wired_by_default():
+    class BareBinding(TwoPartCommitMixin):
+        pass
+
+    with pytest.raises(NotImplementedError):
+        BareBinding().commit_two_part("ref", expected_token="t", new_bytes=b"n")
+
+
+# ---------------------------------------------------------------------------
+# Integration: layer boundaries stay green
+# ---------------------------------------------------------------------------
+
+
+def test_descriptor_and_tier_reexported_from_core():
+    import ccs.core as core
+
+    assert core.CapabilityDescriptor is CapabilityDescriptor
+    assert core.Tier is Tier
+    assert "CapabilityDescriptor" in core.__all__
+    assert "Tier" in core.__all__
+
+
+def test_architecture_boundaries_stay_green():
+    # Descriptor/predicates in core, Protocol in adapters: the 4-layer checker
+    # must stay green (core imports nothing above core).
+    src_root = Path(__file__).resolve().parents[1] / "src"
+
+    report = run_architecture_checks(src_root)
+
+    assert report.ok, (report.boundary_violations, report.cycles)

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "boto3" },
     { name = "crewai" },
     { name = "httpx" },
     { name = "jinja2" },
@@ -28,9 +29,16 @@ all = [
     { name = "openai-agents" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
+    { name = "psycopg", extra = ["binary"] },
 ]
 benchmark = [
     { name = "langchain-core" },
+]
+coherent-object = [
+    { name = "boto3" },
+]
+coherent-row = [
+    { name = "psycopg", extra = ["binary"] },
 ]
 crewai = [
     { name = "crewai" },
@@ -72,9 +80,10 @@ otel = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-coherence", extras = ["benchmark", "crewai", "diagnose", "langgraph", "langsmith", "mcp", "mistral", "openai-agents", "otel"], marker = "extra == 'all'" },
+    { name = "agent-coherence", extras = ["benchmark", "coherent-object", "coherent-row", "crewai", "diagnose", "langgraph", "langsmith", "mcp", "mistral", "openai-agents", "otel"], marker = "extra == 'all'" },
     { name = "agent-coherence", extras = ["langgraph"], marker = "extra == 'diagnose'" },
     { name = "agent-coherence", extras = ["openai"], marker = "extra == 'openai-agents'" },
+    { name = "boto3", marker = "extra == 'coherent-object'", specifier = ">=1.34" },
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=0.80" },
     { name = "httpx", marker = "extra == 'openai'", specifier = ">=0.27" },
     { name = "jinja2", marker = "extra == 'diagnose'", specifier = ">=3.1" },
@@ -88,11 +97,12 @@ requires-dist = [
     { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.17,<0.18" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.0" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'coherent-row'", specifier = ">=3.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
 ]
-provides-extras = ["dev", "langgraph", "crewai", "otel", "langsmith", "benchmark", "diagnose", "openai", "openai-agents", "mistral", "mcp", "all"]
+provides-extras = ["dev", "langgraph", "crewai", "otel", "langsmith", "benchmark", "diagnose", "openai", "openai-agents", "mistral", "mcp", "coherent-row", "coherent-object", "all"]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -344,6 +354,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/54/79/875f9558179573d40a9cc743038ac2bf67dfb79cecb1e8b5d70e88c94c3d/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:046ad6db88edb3c5ece4369af997938fb1c19d6a699b9c1b27b0db432faae4c4", size = 273791, upload-time = "2025-09-25T19:50:39.913Z" },
     { url = "https://files.pythonhosted.org/packages/bc/fe/975adb8c216174bf70fc17535f75e85ac06ed5252ea077be10d9cff5ce24/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dcd58e2b3a908b5ecc9b9df2f0085592506ac2d5110786018ee5e160f28e0911", size = 270746, upload-time = "2025-09-25T19:50:43.306Z" },
     { url = "https://files.pythonhosted.org/packages/e4/f8/972c96f5a2b6c4b3deca57009d93e946bbdbe2241dca9806d502f29dd3ee/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6b8f520b61e8781efee73cba14e3e8c9556ccfb375623f4f97429544734545b4", size = 273375, upload-time = "2025-09-25T19:50:45.43Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/2c/e9a853d4ca66f7ce1bf820674bcd9e6dd1934c27a4c545c67d3b69338d9b/boto3-1.43.49.tar.gz", hash = "sha256:e58e0704805f720b94e40a56588eadd6da05d3693bde78b573116b11ae56710f", size = 112755, upload-time = "2026-07-15T19:32:17.777Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/08/73efb432f9da880deb91eded8ed41d23f03ec7ac47af9b8ecf884f276876/boto3-1.43.49-py3-none-any.whl", hash = "sha256:2b31ab1a0eb1cee01d0363b8ee5e68b45dff2c8f99e7b53aca11c9f7b591a794", size = 140033, upload-time = "2026-07-15T19:32:16.483Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/2c/da2832f435371cd6c95b64325f981b3babe71e4aa4a71798b00ce2073100/botocore-1.43.49.tar.gz", hash = "sha256:7de02863c95b8008b1400c92a1a00996f25ad38944c07f7b620949f8798d1fdf", size = 15708260, upload-time = "2026-07-15T19:32:08.14Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/21/29bf66d513bca978c9506060c44eaf6df3210bd7773bf94beaed1ce56d18/botocore-1.43.49-py3-none-any.whl", hash = "sha256:16b6838ac2fbbab85fb265c1f2e37906527aca07f461b1d293d3f8ab82f992dc", size = 15393460, upload-time = "2026-07-15T19:32:05.355Z" },
 ]
 
 [[package]]
@@ -1223,6 +1261,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -2476,6 +2523,75 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
 name = "pybase64"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3253,6 +3369,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3405,6 +3533,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds **BYO substrate** — coherence over a store the builder already runs, so the coordinator holds only metadata (a version + a fixed-width content fingerprint + an opaque substrate token), never bytes. Two v1 native-CAS bindings ship:

- **`CoherentRow`** — one Postgres row, CAS on a trigger-owned version column.
- **`CoherentObject`** — one S3 object, CAS on the object ETag (`If-Match` / `If-None-Match`).

Both plug into the shipped coordinator over its existing `/hooks/pre-read` + `/hooks/post-edit-cas` routes — **no coordinator file is modified and no route is added**. The value over a bare substrate CAS: a peer's commit invalidates a cached read *before* the next act (pull invalidation, surfaced as the uniform typed `StaleView`), with the same typed-conflict vocabulary over a row or an object.

## What's included

- **Capability contract** (`core/substrate.py`, `adapters/substrate.py`): a `Tier` vocabulary (`native_cas` / `detect_only` / `forward_only`) with a `CapabilityDescriptor` whose guarantee wording is *derived from the tier*, so a weaker binding can never present itself as enforcement. Plus the **never-ship-a-store floor** — a data-in predicate that fails closed on raw bytes, content-named fields, oversized text, unbounded collections/integers, and unrecognized types.
- **Coherence Manifest** (`adapters/substrate_manifest.py`): declarative wiring of artifact → substrate with **allowlist-of-forms credential references** (never a literal secret), **resolved-address SSRF deny** (metadata / link-local / CGNAT hard-denied; RFC-1918 behind an explicit opt-in; injected DNS resolver for hermetic tests), and **TLS-required** for routable targets.
- **Two-part commit**: substrate CAS first, coordinator bump second (coordinator-first is unreachable and test-forbidden). A substrate/coordinator UNKNOWN is reconciled by **token identity** — never a blind re-drive, never a stranded converged bump.
- **Demos** (`examples/coherent_row`, `examples/coherent_object`) with an in-memory substrate stand-in + real coordinator, and a **descriptor-parametrized conformance kit** with tier-honesty and read-pair-atomicity controls.
- **Docs**: README "BYO substrate" section + guide API reference (tiers, least-privilege, honest scope).

## Honest scope (v1)

- **Single-host.** Cross-host coordination is out of scope.
- **The read-generation fence is NOT wired and NOT claimed.** v1 OCC writers ride admit-on-absent + version-CAS, stated plainly.
- Attribution of a converged write is disclaimed — the success surface says "converged", never "landed".
- `native-CAS` prevents a lost update on the version axis; `detect-only` catches only a sequential stale-read→write; `forward-only` (action backends) offers decision-input freshness only.

## Security

- Credential **references** only; a literal secret in a manifest is refused, and the loader logs host + posture, never the credential.
- SSRF deny runs on the **resolved** address(es), with mapped/compat IPv6 unwrapped. The Postgres DSN is decomposed with a libpq-faithful parser (both keyword and URI grammars); **every** `host`/`hostaddr` candidate is checked (the union), the most-restrictive `sslmode` wins, and a `service=` DSN (target resolved from an unreadable `pg_service.conf`) is refused — so a duplicate query key, a comma-list gap, or an unclassifiable target cannot smuggle a denied host or downgrade TLS.
- Adversarial re-review against **real libpq** drove several rounds of parser hardening. Documented residuals (parity with the S3 path): the connect-time DNS-rebind window for bare-hostname targets, and the `PGHOST`/`PGHOSTADDR`/`PGSERVICE` environment variables no DSN-text parser can see — an operator relying on egress control should pin host/hostaddr in the manifest.

## Test plan

- [x] `pytest -q` green except two **pre-existing** `test_claude_code_e2e.py` subprocess tests that resolve console scripts from a worktree `.venv` that doesn't exist here — environmental, unrelated to this diff, green in a normal checkout / CI.
- [x] Contract, manifest (incl. SSRF-bypass regressions), both bindings, cross-agent divergence, and conformance suites green.
- [x] Both demos exit 0 (and exit non-zero under `--baseline`).
- [x] `ruff` + architecture boundary check clean.
- [x] never-ship-a-store: no test sends content to the coordinator; the wire payload carries `content_hash` only.

## Post-deploy monitoring & validation

- **Real-substrate conformance** (`-m real_substrate`) is opt-in and requires credentials + a real Postgres/S3 (Moto/LocalStack serialize and false-green concurrency) — run before relying on a binding against a specific backend.
- Watch for `SubstrateTargetDenied` / `SubstrateInsecureTransport` at manifest load — these are the fail-closed egress guards firing; a surprise here means a misconfigured target, not a library bug.
- `ViewWedged` at read/commit means the substrate moved out of band of the coordinator (a crash between the two commit legs, or a non-coordinated writer) — recover via `reacquire()`.
- The bindings are lazily-imported optional extras (`agent-coherence[coherent-row]`, `[coherent-object]`); the adapters package stays importable without the drivers.
