### PR TITLE
fix(mcp-registry): correct namespace casing to io.github.Cohexa-ai

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,7 +1,7 @@
 # Publishes server.json to the Official MCP Registry (registry.modelcontextprotocol.io).
 #
 # Auth is GitHub OIDC rather than `mcp-publisher login github`. OIDC proves THIS
-# repository's identity, which is what grants the `io.github.cohexa-ai/*`
+# repository's identity, which is what grants the `io.github.Cohexa-ai/*`
 # namespace. The device flow cannot: it authenticates a user through the
 # registry's GitHub App, which has no visibility into org membership, so it only
 # ever grants the personal namespace — regardless of org role or membership

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Alpha — APIs may change before `v1.0`.
 
 ### Fixed
 
+- **MCP Registry namespace casing — `server.json` and the PyPI ownership tag.**
+  Both used `io.github.cohexa-ai/…`, but the registry derives the namespace from
+  GitHub's canonical organization name and grants `io.github.Cohexa-ai/*`, so
+  publishing was rejected with a 403. Both now read
+  `io.github.Cohexa-ai/stale-write-guard-fs`. The `mcp-name:` tag is matched
+  case-sensitively against the README of the *published* PyPI package, so the
+  corrected tag only takes effect for releases from this one onward.
+
 - **Guide examples table: two broken commands.** `examples.divergent_memory`
   and `examples.shared_knowledge_base` ship `demo.py`, not `main.py`; the
   documented `python -m examples.<name>.main` commands failed. Corrected to

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Two agents share an artifact — a `plan.md`, a store key, a `memory.json`. One 
 [![Discussions](https://img.shields.io/github/discussions/Cohexa-ai/agent-coherence)](https://github.com/Cohexa-ai/agent-coherence/discussions)
 
 <!-- MCP Registry — PyPI ownership tag for the stale-write-guard-fs server -->
-`mcp-name: io.github.cohexa-ai/stale-write-guard-fs`
+`mcp-name: io.github.Cohexa-ai/stale-write-guard-fs`
 
 ```bash
 # Requires Python 3.11+

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.cohexa-ai/stale-write-guard-fs",
+  "name": "io.github.Cohexa-ai/stale-write-guard-fs",
   "title": "Agent Coherence — Stale Write Guard (FS)",
   "description": "Coherence guard for shared files: denies stale writes so agents don't silently overwrite each other.",
   "repository": {


### PR DESCRIPTION
## Summary
Publishing to the Official MCP Registry failed with a 403 ([run](https://github.com/Cohexa-ai/agent-coherence/actions/runs/29680615891)):

```
You have permission to publish: io.github.Cohexa-ai/*     <- granted (canonical org casing)
Attempting to publish:          io.github.cohexa-ai/...   <- our manifest (lowercase)
```

OIDC auth **worked** — this was purely a case mismatch. The registry builds the grant as `fmt.Sprintf("io.github.%s/*", claims.RepositoryOwner)` (`github_oidc.go`) and never lowercases it, so it always uses GitHub's canonical org name `Cohexa-ai`.

## Why both files had to change
The registry matches the PyPI ownership tag with a literal `"mcp-name: " + serverName` comparison (`internal/validators/registries/mcpname.go`) — **no case folding**. Changing only `server.json` would have swapped the 403 for a *PyPI ownership validation failed* error.

- `server.json` → `io.github.Cohexa-ai/stale-write-guard-fs`
- `README.md` `mcp-name:` tag → same value
- `publish-mcp.yml` comment → accuracy
- `CHANGELOG.md` → Unreleased/Fixed entry (the 0.12.0 entry is left alone; it accurately records what that release shipped)

## ⚠️ Takes effect only from the next release
The `mcp-name:` tag is baked into **published** package metadata, and the validator fetches it for the version in `server.json`. The currently published 0.12.0 README still carries the lowercase tag, so the registry publish will only succeed once a release is cut **from this change onward** — at which point `publish-mcp.yml` fires automatically on `release: published`.

## Test plan
- [ ] CI green (manifest/docs/comment only; no src or test impact)
- [ ] Next release: `publish-mcp-registry` runs on `release: published` and publishes successfully
- [ ] Verify: `curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.Cohexa-ai/stale-write-guard-fs"`