### PR TITLE
chore(deps): sync uv.lock with the conformance extra

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -40,6 +40,9 @@ coherent-object = [
 coherent-row = [
     { name = "psycopg", extra = ["binary"] },
 ]
+conformance = [
+    { name = "pytest" },
+]
 crewai = [
     { name = "crewai" },
 ]
@@ -98,11 +101,12 @@ requires-dist = [
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'coherent-row'", specifier = ">=3.1" },
+    { name = "pytest", marker = "extra == 'conformance'", specifier = ">=7.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
 ]
-provides-extras = ["dev", "langgraph", "crewai", "otel", "langsmith", "benchmark", "diagnose", "openai", "openai-agents", "mistral", "mcp", "coherent-row", "coherent-object", "all"]
+provides-extras = ["dev", "conformance", "langgraph", "crewai", "otel", "langsmith", "benchmark", "diagnose", "openai", "openai-agents", "mistral", "mcp", "coherent-row", "coherent-object", "all"]
 
 [[package]]
 name = "aiohappyeyeballs"


### PR DESCRIPTION
## Summary
- `pyproject.toml` declares a `conformance` optional extra (`conformance = ["pytest>=7.0"]`, added in a4492c5), but `uv.lock` was not regenerated at the time, so the lock file did not reflect it.
- Regenerated with `uv lock`. The diff is exactly the three expected entries: the `conformance` optional-dependency group, the `pytest` requires-dist entry with the `extra == 'conformance'` marker, and `provides-extras` gaining `conformance`. No package versions changed.

## Test Plan
- [x] Verified the diff contains only the conformance extra entries (no resolution changes)