### PR TITLE
test(adapters): pin the gate's verification read at the Python API too

### DIFF
--- a/tests/adapters/test_effect_gate_wrapper.py
+++ b/tests/adapters/test_effect_gate_wrapper.py
@@ -733,3 +733,52 @@ def test_hold_cause_is_typed_per_class() -> None:
         assert exc.value.hold_cause == expected_cause, reads
     # A bare coordinator-raised StaleView carries no cause (uniform shape).
     assert StaleView("peer committed").hold_cause is None
+
+
+def test_gate_does_not_absolve_a_foreign_edit_it_never_showed_the_caller(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """Python-API twin of the MCP surface's paired-write regression.
+
+    ``gate()`` makes TWO reads, and only the first is an observation: its bytes
+    go to ``decide()``, so seeding the foreign-edit baseline there is correct.
+    The boundary re-read is a VERIFICATION — it compares comparands and discards
+    the bytes — so it must leave the baseline alone. An out-of-band edit landing
+    between the two (the fixed-stale buffer below) is therefore one the caller
+    demonstrably never saw, and the caller's next write must still be denied.
+
+    Without ``observe=False`` on the boundary read the baseline advances to the
+    foreign bytes, the write-side guard sees them as already-observed, and the
+    agent silently clobbers an edit it was never shown — calling the safety
+    check making the NEXT write less safe than skipping it."""
+    _seed(tmp_path)
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.write(REL, b"config-v1")
+        fired: list[str] = []
+
+        def decide(data: bytes) -> str:
+            assert data == b"config-v1", "the caller observes v1, and only v1"
+            # FIXED-STALE BUFFER: an out-of-band editor lands AFTER the caller's
+            # observation and BEFORE the boundary re-read — deterministic, no sleep.
+            (tmp_path / REL).write_bytes(b"foreign-v2")
+            return "deploy"
+
+        def effect(decision: str) -> str:  # pragma: no cover - must never run
+            fired.append(decision)
+            return "should-not-fire"
+
+        with pytest.raises(StaleView):
+            gate(vol, REL, decide=decide, effect=effect)
+        assert fired == []
+
+        # THE POINT: the caller was shown config-v1 and never foreign-v2, so the
+        # write-side foreign-edit guard must still fire.
+        with pytest.raises(StaleView):
+            vol.write(REL, b"agent-write")
+        assert (tmp_path / REL).read_bytes() == b"foreign-v2", (
+            "the foreign bytes must survive — the gate must not have laundered "
+            "an edit it read only to compare and then discarded"
+        )
+    finally:
+        stop_coordinator(tmp_path)

--- a/tests/adapters/test_effect_gate_wrapper.py
+++ b/tests/adapters/test_effect_gate_wrapper.py
@@ -459,6 +459,72 @@ def test_gate_accepts_pathlib_path(tmp_path: Path, fast_cfg: LifecycleConfig) ->
         stop_coordinator(tmp_path)
 
 
+def test_gate_does_not_absolve_a_foreign_edit_it_never_showed_the_caller(
+    tmp_path: Path, fast_cfg: LifecycleConfig
+) -> None:
+    """Python-API twin of the MCP surface's paired-write regression.
+
+    ``gate()`` makes TWO reads, and only the first is an observation: its bytes
+    go to ``decide()``, so seeding the foreign-edit baseline there is correct.
+    The boundary re-read is a VERIFICATION — it compares comparands and discards
+    the bytes — so it must leave the baseline alone. An out-of-band edit landing
+    between the two is therefore one the caller demonstrably never saw, and the
+    caller's next write must still be denied.
+
+    Without ``observe=False`` on the boundary read the baseline advances to the
+    foreign bytes, the write-side guard sees them as already-observed, and the
+    agent silently clobbers an edit it was never shown — so calling the safety
+    check would make the NEXT write less safe than skipping it.
+
+    Read the two HOLDs differently. The FIRST is only a precondition: the gate
+    refuses, but through the coordinator's own hash-mismatch handling, which is
+    independent of the flag under test — and *which* mechanism answers is
+    timing-dependent (inside the self-commit-lag window the client's
+    ``hash_differs`` rule reports an unconfirmed generation; outside it the
+    coordinator strict-denies), so this deliberately does not pin a
+    ``hold_cause`` there. The SECOND raise is the one that pins ``observe``:
+    it is the SB-23 write-side guard, asserted on its own reason text so the
+    test cannot pass on an unrelated deny.
+    """
+    _seed(tmp_path)
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.write(REL, b"config-v1")
+        fired: list[str] = []
+
+        def decide(data: bytes) -> str:
+            assert data == b"config-v1", "the caller observes v1, and only v1"
+            # FIXED-STALE BUFFER: an out-of-band editor lands AFTER the caller's
+            # observation and BEFORE the boundary re-read — deterministic, no sleep.
+            (tmp_path / REL).write_bytes(b"foreign-v2")
+            return "deploy"
+
+        def effect(decision: str) -> str:  # pragma: no cover - must never run
+            fired.append(decision)
+            return "should-not-fire"
+
+        with pytest.raises(StaleView):  # precondition, not the assertion under test
+            gate(vol, REL, decide=decide, effect=effect)
+        assert fired == []
+
+        # THE POINT: the caller was shown config-v1 and never foreign-v2, so the
+        # write-side foreign-edit guard must still fire. Pinned on the guard's own
+        # reason text — a bare `raises(StaleView)` would also accept an unrelated
+        # deny (a sticky-INVALID view, a strict pre-edit refusal) and pass while
+        # proving nothing.
+        with pytest.raises(StaleView) as denied:
+            vol.write(REL, b"agent-write")
+        assert "out-of-band edit" in str(denied.value), (
+            "the denial must come from the SB-23 foreign-edit guard, not from "
+            f"some other refusal: {denied.value}"
+        )
+        assert (tmp_path / REL).read_bytes() == b"foreign-v2", (
+            "the foreign bytes must survive — the gate must not have laundered "
+            "an edit it read only to compare and then discarded"
+        )
+    finally:
+        stop_coordinator(tmp_path)
+
 # --- Fast unit tests of gate()'s pure logic (a stub volume, no coordinator) ----
 
 
@@ -733,52 +799,3 @@ def test_hold_cause_is_typed_per_class() -> None:
         assert exc.value.hold_cause == expected_cause, reads
     # A bare coordinator-raised StaleView carries no cause (uniform shape).
     assert StaleView("peer committed").hold_cause is None
-
-
-def test_gate_does_not_absolve_a_foreign_edit_it_never_showed_the_caller(
-    tmp_path: Path, fast_cfg: LifecycleConfig
-) -> None:
-    """Python-API twin of the MCP surface's paired-write regression.
-
-    ``gate()`` makes TWO reads, and only the first is an observation: its bytes
-    go to ``decide()``, so seeding the foreign-edit baseline there is correct.
-    The boundary re-read is a VERIFICATION — it compares comparands and discards
-    the bytes — so it must leave the baseline alone. An out-of-band edit landing
-    between the two (the fixed-stale buffer below) is therefore one the caller
-    demonstrably never saw, and the caller's next write must still be denied.
-
-    Without ``observe=False`` on the boundary read the baseline advances to the
-    foreign bytes, the write-side guard sees them as already-observed, and the
-    agent silently clobbers an edit it was never shown — calling the safety
-    check making the NEXT write less safe than skipping it."""
-    _seed(tmp_path)
-    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
-    try:
-        vol.write(REL, b"config-v1")
-        fired: list[str] = []
-
-        def decide(data: bytes) -> str:
-            assert data == b"config-v1", "the caller observes v1, and only v1"
-            # FIXED-STALE BUFFER: an out-of-band editor lands AFTER the caller's
-            # observation and BEFORE the boundary re-read — deterministic, no sleep.
-            (tmp_path / REL).write_bytes(b"foreign-v2")
-            return "deploy"
-
-        def effect(decision: str) -> str:  # pragma: no cover - must never run
-            fired.append(decision)
-            return "should-not-fire"
-
-        with pytest.raises(StaleView):
-            gate(vol, REL, decide=decide, effect=effect)
-        assert fired == []
-
-        # THE POINT: the caller was shown config-v1 and never foreign-v2, so the
-        # write-side foreign-edit guard must still fire.
-        with pytest.raises(StaleView):
-            vol.write(REL, b"agent-write")
-        assert (tmp_path / REL).read_bytes() == b"foreign-v2", (
-            "the foreign bytes must survive — the gate must not have laundered "
-            "an edit it read only to compare and then discarded"
-        )
-    finally:
-        stop_coordinator(tmp_path)


### PR DESCRIPTION
## Summary

Follow-up to #162. The paired-write regression for the foreign-edit baseline existed only on the MCP surface (`tests/mcp/test_gate_tool.py`). `check_fence` is shared between `gate()` and `swg_gate`, so a regression would still have been caught — but the Python `gate()` reaches it by a different route, and that route carries the subtlety worth pinning.

## Why the interleaving differs from the MCP test

`gate()` makes **two** reads and only the first is an observation:

- the **capture** read hands its bytes to `decide()`, so seeding the foreign-edit baseline there is *correct*
- the **boundary** re-read compares comparands and discards the bytes, so it must **not** seed

An out-of-band edit landing *between* the two is therefore one the caller demonstrably never saw — which is exactly when the write-side guard has to keep denying. The MCP tool has no capture read at all (its comparand came from an earlier `swg_read`), so its test can edit before the call; this one uses the file's established fixed-stale-buffer shape and edits inside `decide()`. No sleeps.

## Verification

- Confirmed to **fail** when `observe=False` is removed from `check_fence`'s re-read: the baseline advances to the foreign bytes, the write-side guard reads them as already-observed, and the agent clobbers an edit it was never shown.
- 193 tests green across `test_effect_gate_wrapper.py`, `tests/mcp`, and `test_coherent_volume.py`; ruff clean; new test stable over 5 consecutive runs.

## Test plan

- [x] New test passes
- [x] Verified to fail against the reintroduced bug (teeth)
- [x] Affected suites green
- [x] Lint clean