### PR TITLE
feat(coordinator): SB-10 compaction-aware re-grounding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,44 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
 
+      # Which Node backend does this gate prove parity against?
+      #
+      # Pinning `main` unconditionally makes a PAIRED cross-repo change
+      # unverifiable before merge: the sibling Node half sits on its own
+      # plugin branch, so every fixture the pair adds fails here until a
+      # plugin release promotes dev to main — long after review. The pair is
+      # then merged on a maintainer's local run, which is the one place the
+      # parity contract must not be taken on trust.
+      #
+      # So: on a pull request, if the plugin repo carries a branch with the
+      # SAME name as this PR's head (the convention for a paired change),
+      # build that. Otherwise `main`, which is the historical behaviour and
+      # the behaviour of every push build — `github.head_ref` is empty off
+      # the pull_request event. An absent or unreachable sibling degrades to
+      # `main` rather than failing the job.
+      #
+      # `head_ref` is attacker-controlled on a fork PR, so it reaches the
+      # script through the environment and is never interpolated into it.
+      - name: Resolve plugin ref
+        id: plugin_ref
+        env:
+          SIBLING_REF: ${{ github.head_ref }}
+        run: |
+          remote=https://github.com/Cohexa-ai/agent-coherence-plugin.git
+          ref=main
+          if [ -n "$SIBLING_REF" ] &&
+             git ls-remote --exit-code --heads "$remote" "$SIBLING_REF" \
+               >/dev/null 2>&1; then
+            ref="$SIBLING_REF"
+          fi
+          # Record the SHA too: the sibling branch can move without a commit
+          # here, so the ref name alone does not identify what was proven.
+          sha=$(git ls-remote "$remote" "refs/heads/$ref" | cut -f1)
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "Node backend: agent-coherence-plugin@$ref ($sha)"
+          echo "Parity proven against \`agent-coherence-plugin@$ref\` \`$sha\`." \
+            >> "$GITHUB_STEP_SUMMARY"
+
       # Check out the plugin repo INSIDE the workspace so actions/checkout
       # accepts the path (it rejects paths outside $GITHUB_WORKSPACE). The
       # harness's resolve_node_dist_path() picks up the explicit env var below
@@ -188,7 +226,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           repository: Cohexa-ai/agent-coherence-plugin
-          ref: main
+          ref: ${{ steps.plugin_ref.outputs.ref }}
           path: _plugin_checkout
 
       - name: Build Node coordinator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,19 +189,20 @@ jobs:
       # then merged on a maintainer's local run, which is the one place the
       # parity contract must not be taken on trust.
       #
-      # So: on a pull request, if the plugin repo carries a branch with the
-      # SAME name as this PR's head (the convention for a paired change),
-      # build that. Otherwise `main`, which is the historical behaviour and
-      # the behaviour of every push build — `github.head_ref` is empty off
-      # the pull_request event. An absent or unreachable sibling degrades to
-      # `main` rather than failing the job.
+      # So: build the plugin branch whose name matches the branch under
+      # test — the PR's head branch on pull_request (`head_ref`), the pushed
+      # branch on push (`ref_name`, so a push to `dev` pairs with the
+      # plugin's `dev` and a push to `main` with its `main`) — and fall back
+      # to `main` when no same-named plugin branch exists (tags fall back
+      # too: no plugin branch is named `v*`). An absent or unreachable
+      # sibling degrades to `main` rather than failing the job.
       #
       # `head_ref` is attacker-controlled on a fork PR, so it reaches the
       # script through the environment and is never interpolated into it.
       - name: Resolve plugin ref
         id: plugin_ref
         env:
-          SIBLING_REF: ${{ github.head_ref }}
+          SIBLING_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           remote=https://github.com/Cohexa-ai/agent-coherence-plugin.git
           ref=main

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1824,10 +1824,20 @@ def _handle_pre_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
         # SB-10 U4 (KTD6): the deferred re-grounding seam sits AFTER the
         # deny decision inside work() — a strict deny returns untouched and
         # keeps the flag pending — and AFTER the notice drain above, so
-        # notices render before the re-grounding block.
-        return _deliver_pending_reground(coordinator, session_id, body, result)
+        # notices render before the re-grounding block. The abort token
+        # rides along so a timed-out request never consumes the
+        # compact-pending flag.
+        return _deliver_pending_reground(
+            coordinator, session_id, body, result, abort=abort
+        )
 
-    _run_or_degrade(req, coordinator, work_with_notice_surfacing)
+    # A6: pre-read never threaded an abort into work() — its SHARED
+    # re-grants are idempotent, so a late one is harmless. The token is
+    # introduced here solely for the re-grounding delivery, whose pop is
+    # NOT idempotent: a zombie that outlives the degraded response must not
+    # claim the flag out from under the next live admit.
+    abort = threading.Event()
+    _run_or_degrade(req, coordinator, work_with_notice_surfacing, abort=abort)
 
 
 def _handle_pre_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
@@ -1984,7 +1994,11 @@ def _handle_pre_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
         # SB-10 U4 (KTD6): allow-attach seam — after every deny decision
         # inside work(); notices are already merged into the result's
         # additionalContext, so the re-grounding block always lands last.
-        return _deliver_pending_reground(coordinator, session_id, body, work())
+        # The abort token rides along so a timed-out request never
+        # consumes the compact-pending flag.
+        return _deliver_pending_reground(
+            coordinator, session_id, body, work(), abort=abort
+        )
 
     # AC-05: pre-edit's wire contract is {ok: bool}, not {status: ...}.
     # On watchdog timeout, return the ok-shape degraded envelope so a
@@ -2739,10 +2753,20 @@ def _handle_pre_bash(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
 
     def work_with_reground() -> dict:
         # SB-10 U4 (KTD6): allow-attach seam — after the strict-deny
-        # decision inside work(); notices/stale prose render first.
-        return _deliver_pending_reground(coordinator, session_id, body, work())
+        # decision inside work(); notices/stale prose render first. The
+        # abort token rides along so a timed-out request never consumes
+        # the compact-pending flag.
+        return _deliver_pending_reground(
+            coordinator, session_id, body, work(), abort=abort
+        )
 
-    _run_or_degrade(req, coordinator, work_with_reground)
+    # A6: pre-bash never threaded an abort into work() — its SHARED
+    # re-grants are idempotent. The token is introduced here solely for the
+    # re-grounding delivery, whose pop is NOT idempotent: a zombie that
+    # outlives the degraded response must not claim the flag out from under
+    # the next live admit.
+    abort = threading.Event()
+    _run_or_degrade(req, coordinator, work_with_reground, abort=abort)
 
 
 def _handle_pre_grep(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
@@ -2889,10 +2913,20 @@ def _handle_pre_grep(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
 
     def work_with_reground() -> dict:
         # SB-10 U4 (KTD6): allow-attach seam — after the strict-deny
-        # decision inside work(); notices/stale prose render first.
-        return _deliver_pending_reground(coordinator, session_id, body, work())
+        # decision inside work(); notices/stale prose render first. The
+        # abort token rides along so a timed-out request never consumes
+        # the compact-pending flag.
+        return _deliver_pending_reground(
+            coordinator, session_id, body, work(), abort=abort
+        )
 
-    _run_or_degrade(req, coordinator, work_with_reground)
+    # A6: pre-grep never threaded an abort into work() — its SHARED
+    # re-grants are idempotent. The token is introduced here solely for the
+    # re-grounding delivery, whose pop is NOT idempotent: a zombie that
+    # outlives the degraded response must not claim the flag out from under
+    # the next live admit.
+    abort = threading.Event()
+    _run_or_degrade(req, coordinator, work_with_reground, abort=abort)
 
 
 # ----------------------------------------------------------------------
@@ -4850,7 +4884,11 @@ def _reground_qualifies(result: dict) -> bool:
 
 
 def _claim_reground_context(
-    coordinator: CoordinatorHTTPServer, session_id: str, body: dict
+    coordinator: CoordinatorHTTPServer,
+    session_id: str,
+    body: dict,
+    *,
+    abort: threading.Event | None = None,
 ) -> str | None:
     """SB-10 U4: atomically claim the session's pending re-grounding
     delivery and rebuild its prose.
@@ -4858,10 +4896,13 @@ def _claim_reground_context(
     Returns the payload text when THIS call wins the claim; ``None`` when
     the request carries a subagent identity (R8: a parent request carries
     NO agent_id field on the wire — a request presenting one must neither
-    consume nor attach), when no flag is pending, when a concurrent admit
-    won the pop (R2's at-most-once hangs on ``consume_compact_pending``'s
-    locked test-and-clear), or when the rebuild came back empty (state
-    drained since the compact event — nothing left worth re-grounding).
+    consume nor attach), when the caller's watchdog ``abort`` is already
+    set (a doomed request must not consume the flag — the abort check runs
+    BEFORE the pop so the delivery survives for the next live admit), when
+    no flag is pending, when a concurrent admit won the pop (R2's
+    at-most-once hangs on ``consume_compact_pending``'s locked
+    test-and-clear), or when the rebuild came back empty (state drained
+    since the compact event — nothing left worth re-grounding).
 
     KTD2 rebuild-at-delivery: the prose is rebuilt from registry truth via
     ``_build_session_start_context`` at the moment of attach, so the
@@ -4876,10 +4917,12 @@ def _claim_reground_context(
     forfeited (R2 permits at-most-once → zero) rather than propagated."""
     if has_subagent_id_field(body):
         return None
+    if abort is not None and abort.is_set():
+        return None
     if not coordinator.consume_compact_pending(session_id):
         return None
     try:
-        text, _ = _build_session_start_context(coordinator, session_id)
+        text, _ = _build_session_start_context(coordinator, session_id, abort=abort)
         return text
     except Exception:  # advisory delivery must never break the admit it rides
         logger.exception(
@@ -4892,17 +4935,30 @@ def _claim_reground_context(
 
 def _attach_reground(result: dict, text: str) -> dict:
     """SB-10 U4: merge the claimed re-grounding prose into a qualifying
-    admit response. An existing allow envelope keeps its text and gets the
-    block appended AFTER it (notices and stale warnings render first —
-    KTD6 ordering); a bare admit body is promoted to an allow envelope.
-    The deferred path rides the PreToolUse allow wrapper — never the
-    SessionStart ``hookSpecificOutput`` shape."""
+    admit response. An existing envelope keeps its text AND its existing
+    permission decision, and gets the block appended AFTER it (notices and
+    stale warnings render first — KTD6 ordering); a bare admit body gains
+    a CONTEXT-ONLY PreToolUse envelope. The deferred path rides the
+    PreToolUse shape — never the SessionStart ``hookSpecificOutput``
+    shape."""
     hso = result.get("hookSpecificOutput")
     if hso is None:
+        # WHY context-only rather than emit_allow: re-grounding is
+        # advisory (KD3), and an advisory payload must NEVER widen a
+        # permission decision. A bare body here is the untracked
+        # fast-path admit — a tool call Claude Code would ordinarily
+        # prompt the user about. Stamping permissionDecision "allow" on
+        # it just to carry prose auto-approved that call once per
+        # compaction, purely as a side effect of delivery.
+        # Empirical basis: a PreToolUse hookSpecificOutput carrying only
+        # hookEventName + additionalContext IS rendered to the model —
+        # A/B capture against the installed Claude Code CLI 2.1.233 on
+        # 2026-08-25 showed the marker-primed model quoting the injected
+        # line verbatim with and without permissionDecision. The allow
+        # bought nothing the context-only envelope does not already give.
         return {
             **result,
-            "hookSpecificOutput": _payloads.emit_allow(
-                source="deferred_reground_attach",
+            "hookSpecificOutput": _payloads.emit_pretooluse_context(
                 additional_context=text,
             ),
         }
@@ -4924,9 +4980,36 @@ def _fast_path_json(
     """SB-10 U4 (KTD6): shared exit for the four hoisted fast paths. The
     advisory peek keeps no-flag traffic registry-free with the exact
     pre-SB-10 response bytes; a pending flag routes through the deferred
-    re-ground attach, which claims it atomically at the allow seam."""
+    re-ground attach, which claims it atomically at the allow seam.
+
+    The delivery rebuild walks the registry, so it runs under the same
+    handler-side watchdog as the tracked seams (a slow/contended rebuild
+    must not hang the hook past its budget). On timeout the response is
+    the bare ``base`` — byte-identical to the no-flag fast path — and the
+    abort token (A6 pattern, set by ``run_with_watchdog`` on timeout)
+    stops the zombie delivery from consuming the flag or landing a
+    payload nobody will read; a zombie that already won the pop forfeits
+    the delivery (R2 permits at-most-once → zero)."""
     if coordinator.has_compact_pending(session_id):
-        base = _deliver_pending_reground(coordinator, session_id, body, base)
+        abort = threading.Event()
+
+        def deliver() -> dict:
+            return _deliver_pending_reground(
+                coordinator, session_id, body, base, abort=abort
+            )
+
+        try:
+            base = coordinator.run_with_watchdog(deliver, abort=abort)
+        except FuturesTimeout:
+            # KTD-G item 3 mirror of _run_or_degrade: surface the
+            # degradation via the /status counter, then fall through to
+            # the bare fast-path body.
+            coordinator.increment_watchdog_timeout()
+            logger.warning(
+                "deferred re-grounding delivery timed out after %ss; "
+                "degrading to the bare fast-path response",
+                HANDLER_TIMEOUT_SEC,
+            )
     req._json(200, base)
 
 
@@ -4935,15 +5018,22 @@ def _deliver_pending_reground(
     session_id: str,
     body: dict,
     result: dict,
+    *,
+    abort: threading.Event | None = None,
 ) -> dict:
     """SB-10 U4 (KTD6): the allow-attach seam shared by the four admit
     surfaces (pre-read, pre-edit, pre-bash, pre-grep). Runs AFTER any deny
     decision: a non-qualifying result is returned untouched — the same
     object, so deny bodies stay byte-identical — and only then does the
-    atomic pop race; exactly one concurrent qualifying admit attaches."""
+    atomic pop race; exactly one concurrent qualifying admit attaches.
+
+    ``abort`` is the caller's per-request watchdog token (A6 pattern):
+    threaded into the claim so a timed-out request neither consumes the
+    flag (checked before the pop) nor holds the registry walk hostage
+    (the rebuild aborts at the registry lock)."""
     if not _reground_qualifies(result):
         return result
-    text = _claim_reground_context(coordinator, session_id, body)
+    text = _claim_reground_context(coordinator, session_id, body, abort=abort)
     if text is None:
         return result
     return _attach_reground(result, text)

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1125,6 +1125,18 @@ class CoordinatorHTTPServer:
         with self._compact_pending_lock:
             return self._compact_pending.pop(session_id, None) is not None
 
+    def has_compact_pending(self, session_id: str) -> bool:
+        """SB-10 U4 (KTD6): NON-consuming advisory peek at the flag — the
+        cheap process-local dict lookup the admit handlers hoist above
+        their untracked fast-path exits, so no-flag traffic keeps today's
+        exact response bytes and never touches the registry. Advisory
+        only: the answer can go stale the instant the lock is released;
+        the authoritative at-most-once decision stays with the locked
+        test-and-clear in :meth:`consume_compact_pending` at the
+        allow-attach seam."""
+        with self._compact_pending_lock:
+            return session_id in self._compact_pending
+
     def expire_compact_pending(self, session_id: str) -> None:
         """SB-10 (KTD5): drop an unconsumed flag without delivering. Wired
         to the parent Stop by the deferred-delivery unit (R2: the flag's
@@ -1515,9 +1527,17 @@ def _handle_pre_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
         return
 
     # Tracked-policy gate: untracked paths fast-path to {fresh} without
-    # touching SQLite (R8 false-positive budget protection).
+    # touching SQLite (R8 false-positive budget protection). SB-10 U4
+    # (KTD6): the advisory compact-pending peek — a process-local dict
+    # lookup, never a registry touch — is hoisted above this exit so a
+    # pending re-grounding payload still reaches an untracked admit; with
+    # no flag pending, response bytes and the no-registry behavior are
+    # exactly today's.
     if not coordinator.policy.is_tracked(path):
-        req._json(200, {"status": "fresh"})
+        fast: dict[str, Any] = {"status": "fresh"}
+        if coordinator.has_compact_pending(session_id):
+            fast = _deliver_pending_reground(coordinator, session_id, body, fast)
+        req._json(200, fast)
         return
 
     agent_id = coordinator.register_session(session_id, read_subagent_id(body))
@@ -1795,14 +1815,18 @@ def _handle_pre_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
                 # Spread work()'s payload so additive fresh-path keys
                 # (Unit 6 ``version``) survive the notice attachment —
                 # rebuilding a literal dict here drops them.
-                return {
+                result = {
                     **result,
                     "hookSpecificOutput": _payloads.emit_allow(
                         source="pre_read_fresh_with_notice",
                         additional_context=notice_text,
                     ),
                 }
-        return result
+        # SB-10 U4 (KTD6): the deferred re-grounding seam sits AFTER the
+        # deny decision inside work() — a strict deny returns untouched and
+        # keeps the flag pending — and AFTER the notice drain above, so
+        # notices render before the re-grounding block.
+        return _deliver_pending_reground(coordinator, session_id, body, result)
 
     _run_or_degrade(req, coordinator, work_with_notice_surfacing)
 
@@ -1823,8 +1847,13 @@ def _handle_pre_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
         msg = "missing or empty path" if path_err in ("path is empty", "path must be a string") else path_err
         req._json(400, {"error": msg})
         return
+    # SB-10 U4 (KTD6): advisory peek hoisted above the untracked exit —
+    # see the pre-read twin for the no-flag byte/behavior guarantee.
     if not coordinator.policy.is_tracked(path):
-        req._json(200, {"ok": True})
+        fast: dict[str, Any] = {"ok": True}
+        if coordinator.has_compact_pending(session_id):
+            fast = _deliver_pending_reground(coordinator, session_id, body, fast)
+        req._json(200, fast)
         return
 
     agent_id = coordinator.register_session(session_id, read_subagent_id(body))
@@ -1955,6 +1984,12 @@ def _handle_pre_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
             }
         return {"ok": True}
 
+    def work_with_reground() -> dict:
+        # SB-10 U4 (KTD6): allow-attach seam — after every deny decision
+        # inside work(); notices are already merged into the result's
+        # additionalContext, so the re-grounding block always lands last.
+        return _deliver_pending_reground(coordinator, session_id, body, work())
+
     # AC-05: pre-edit's wire contract is {ok: bool}, not {status: ...}.
     # On watchdog timeout, return the ok-shape degraded envelope so a
     # client doing result.get("ok") sees True rather than None.
@@ -1962,7 +1997,7 @@ def _handle_pre_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
     # registry lock instead of granting a phantom EXCLUSIVE (and silently
     # invalidating peers) the agent never saw.
     abort = threading.Event()
-    _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE, abort=abort)
+    _run_or_degrade(req, coordinator, work_with_reground, degraded_response=_OK_DEGRADED_RESPONSE, abort=abort)
 
 
 def _handle_post_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
@@ -2265,6 +2300,16 @@ def _handle_session_stop(req: _RequestProtocol, coordinator: CoordinatorHTTPServ
         req._json(200, {"ok": True, "released_artifacts": []})
         return
 
+    # SB-10 U4 (R2): the deferred re-grounding flag lives at most one
+    # parent turn. A PARENT Stop — the wire carries NO agent_id field;
+    # SubagentStop always carries one (SB-25) — ends that turn, so an
+    # undelivered flag expires here instead of leaking into a later turn.
+    # A SubagentStop (or a malformed subagent id, which also presents the
+    # field and returned above) leaves the flag untouched: the parent turn
+    # is still in flight and its next admit may yet deliver.
+    if not has_subagent_id_field(body):
+        coordinator.expire_compact_pending(session_id)
+
     agent_id = coordinator.register_session(session_id, subagent_id)
     now = monotonic_seconds()
 
@@ -2560,9 +2605,14 @@ def _handle_pre_bash(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
 
     # Detect tracked paths the command would read. is_tracked is the
     # policy gate — handler never touches SQLite for an untracked workspace.
+    # SB-10 U4 (KTD6): advisory peek hoisted above the zero-tracked-reads
+    # exit — see the pre-read twin for the no-flag byte/behavior guarantee.
     tracked_paths = detect_tracked_paths(command, coordinator.policy.is_tracked)
     if not tracked_paths:
-        req._json(200, {"status": "fresh"})
+        fast: dict[str, Any] = {"status": "fresh"}
+        if coordinator.has_compact_pending(session_id):
+            fast = _deliver_pending_reground(coordinator, session_id, body, fast)
+        req._json(200, fast)
         return
 
     agent_id = coordinator.register_session(session_id, read_subagent_id(body))
@@ -2693,7 +2743,12 @@ def _handle_pre_bash(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
             resp["status"] = "fresh"
         return resp
 
-    _run_or_degrade(req, coordinator, work)
+    def work_with_reground() -> dict:
+        # SB-10 U4 (KTD6): allow-attach seam — after the strict-deny
+        # decision inside work(); notices/stale prose render first.
+        return _deliver_pending_reground(coordinator, session_id, body, work())
+
+    _run_or_degrade(req, coordinator, work_with_reground)
 
 
 def _handle_pre_grep(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
@@ -2728,9 +2783,14 @@ def _handle_pre_grep(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
             return
 
     # Find registry-known tracked artifacts under the search root.
+    # SB-10 U4 (KTD6): advisory peek hoisted above the zero-tracked-
+    # artifacts exit so a pending payload still reaches this admit.
     tracked_paths = coordinator.registry.artifact_names_under_prefix(search_root)
     if not tracked_paths:
-        req._json(200, {"status": "fresh"})
+        fast: dict[str, Any] = {"status": "fresh"}
+        if coordinator.has_compact_pending(session_id):
+            fast = _deliver_pending_reground(coordinator, session_id, body, fast)
+        req._json(200, fast)
         return
 
     agent_id = coordinator.register_session(session_id, read_subagent_id(body))
@@ -2836,7 +2896,12 @@ def _handle_pre_grep(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
             resp["status"] = "fresh"
         return resp
 
-    _run_or_degrade(req, coordinator, work)
+    def work_with_reground() -> dict:
+        # SB-10 U4 (KTD6): allow-attach seam — after the strict-deny
+        # decision inside work(); notices/stale prose render first.
+        return _deliver_pending_reground(coordinator, session_id, body, work())
+
+    _run_or_degrade(req, coordinator, work_with_reground)
 
 
 # ----------------------------------------------------------------------
@@ -4765,6 +4830,108 @@ def _build_session_start_context(
         )
     rendered.append(_payloads.SESSION_START_CLOSING_LINE)
     return "\n".join(rendered), workspace_has_state
+
+
+def _reground_qualifies(result: dict) -> bool:
+    """SB-10 U4 (R8): does this admit response qualify to carry — and
+    therefore consume — the deferred re-grounding payload?
+
+    The payload attaches ONLY to allow envelopes. A response already
+    carrying a ``hookSpecificOutput`` qualifies iff its decision is
+    ``allow`` — a strict-mode deny must stay byte-identical (KTD-P) and
+    must NOT consume: the flag survives for the next qualifying admit
+    (AE3). An envelope-less response qualifies iff it is an admit body —
+    ``{ok: true}`` (pre-edit) or ``{status: "fresh"}`` (pre-read /
+    pre-bash / pre-grep). A service-refusal body (``{ok: false, ...}``)
+    is neither a deny envelope nor an admit: no attach, no consume."""
+    hso = result.get("hookSpecificOutput")
+    if hso is not None:
+        return hso.get("permissionDecision") == "allow"
+    return result.get("ok") is True or result.get("status") == "fresh"
+
+
+def _claim_reground_context(
+    coordinator: CoordinatorHTTPServer, session_id: str, body: dict
+) -> str | None:
+    """SB-10 U4: atomically claim the session's pending re-grounding
+    delivery and rebuild its prose.
+
+    Returns the payload text when THIS call wins the claim; ``None`` when
+    the request carries a subagent identity (R8: a parent request carries
+    NO agent_id field on the wire — a request presenting one must neither
+    consume nor attach), when no flag is pending, when a concurrent admit
+    won the pop (R2's at-most-once hangs on ``consume_compact_pending``'s
+    locked test-and-clear), or when the rebuild came back empty (state
+    drained since the compact event — nothing left worth re-grounding).
+
+    KTD2 rebuild-at-delivery: the prose is rebuilt from registry truth via
+    ``_build_session_start_context`` at the moment of attach, so the
+    deferred payload says what a fresh /hooks/session-start would say NOW
+    — never a snapshot cached at compact time. The session-scoped build
+    covers the parent agent plus every registered subagent, and carries
+    the R5 verbatim cap, so the delivery budget matches the direct path.
+
+    Failure containment: re-grounding is advisory (KD3). A rebuild error
+    after a won claim must not turn an otherwise-successful admit into an
+    internal-error body, so the build is guarded and the delivery is
+    forfeited (R2 permits at-most-once → zero) rather than propagated."""
+    if has_subagent_id_field(body):
+        return None
+    if not coordinator.consume_compact_pending(session_id):
+        return None
+    try:
+        text, _ = _build_session_start_context(coordinator, session_id)
+        return text
+    except Exception:  # advisory delivery must never break the admit it rides
+        logger.exception(
+            "deferred re-grounding rebuild failed for session %s; "
+            "delivery forfeited",
+            session_id,
+        )
+        return None
+
+
+def _attach_reground(result: dict, text: str) -> dict:
+    """SB-10 U4: merge the claimed re-grounding prose into a qualifying
+    admit response. An existing allow envelope keeps its text and gets the
+    block appended AFTER it (notices and stale warnings render first —
+    KTD6 ordering); a bare admit body is promoted to an allow envelope.
+    The deferred path rides the PreToolUse allow wrapper — never the
+    SessionStart ``hookSpecificOutput`` shape."""
+    hso = result.get("hookSpecificOutput")
+    if hso is None:
+        return {
+            **result,
+            "hookSpecificOutput": _payloads.emit_allow(
+                source="deferred_reground_attach",
+                additional_context=text,
+            ),
+        }
+    existing = hso.get("additionalContext")
+    merged = dict(hso)
+    merged["additionalContext"] = (
+        text if existing is None else existing + "\n\n" + text
+    )
+    return {**result, "hookSpecificOutput": merged}
+
+
+def _deliver_pending_reground(
+    coordinator: CoordinatorHTTPServer,
+    session_id: str,
+    body: dict,
+    result: dict,
+) -> dict:
+    """SB-10 U4 (KTD6): the allow-attach seam shared by the four admit
+    surfaces (pre-read, pre-edit, pre-bash, pre-grep). Runs AFTER any deny
+    decision: a non-qualifying result is returned untouched — the same
+    object, so deny bodies stay byte-identical — and only then does the
+    atomic pop race; exactly one concurrent qualifying admit attaches."""
+    if not _reground_qualifies(result):
+        return result
+    text = _claim_reground_context(coordinator, session_id, body)
+    if text is None:
+        return result
+    return _attach_reground(result, text)
 
 
 def _last_writer_for(coordinator: CoordinatorHTTPServer, artifact_id: UUID) -> str | None:

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -13,6 +13,7 @@ shared-secret Bearer auth + Host-header check (KTD-12):
 - ``POST /hooks/post-edit-cas`` — OCC commit (Unit 6); version-checked CAS,
   NO pre-edit acquire (the OCC writer stays S/I); fail-closed degrade
 - ``POST /hooks/session-stop``  — KTD-11 release on end-of-turn
+- ``POST /hooks/session-start`` — SB-10 post-compaction re-grounding payload
 - ``POST /policy/track``        — Unit 6 CLI hot-add to tracked.yaml
 - ``POST /policy/untrack``      — Unit 6 CLI hot-add to ignored.yaml
 - ``GET  /status``              — Unit 6 status CLI
@@ -543,6 +544,7 @@ class CoordinatorHTTPServer:
             "post_edit_total": 0,
             "post_edit_cas_total": 0,
             "session_stop_total": 0,
+            "session_start_total": 0,
             "pre_bash_total": 0,
             "pre_grep_total": 0,
             "policy_track_total": 0,
@@ -623,6 +625,17 @@ class CoordinatorHTTPServer:
         # own state map.
         self._stale_warned_pairs: set[tuple[UUID, UUID]] = set()
         self._stale_warned_pairs_lock = threading.Lock()
+
+        # SB-10 U2 (KTD5): compact-pending flags, keyed by session_id. Set by
+        # /hooks/session-start when it emitted a non-empty re-grounding
+        # payload; consumed by the next qualifying PreToolUse allow (deferred
+        # delivery, wired in a later unit) and expired on parent Stop.
+        # PROCESS-LOCAL on purpose — a restarted coordinator loses the flag,
+        # an accepted degradation (the restart is a bigger re-grounding event
+        # than a compaction). Value is the monotonic mark time so the
+        # deferred-delivery unit can reason about flag age if it needs to.
+        self._compact_pending: dict[str, float] = {}
+        self._compact_pending_lock = threading.Lock()
 
         # Wire storage + coordinator service.
         db_path = self.coordinator_root / ".coherence" / "state.db"
@@ -853,6 +866,35 @@ class CoordinatorHTTPServer:
         with self._agent_names_lock:
             return self._agent_names.get(agent_id)
 
+    def agents_for_session(self, session_id: str) -> list[tuple[UUID, str | None]]:
+        """SB-10 U2: the session's coherence agents as ``(agent_id,
+        subagent_name)`` pairs — the parent first (``subagent_name=None``,
+        derivable via uuid5 WITHOUT prior registration), then registered
+        subagents sorted by agent name (KTD8 group order).
+
+        Enumeration is a prefix scan of the in-memory ``_agent_names`` map
+        using the deterministic SB-25 naming scheme
+        (``claude-session-<sid>:subagent-<name>``) — neither registry has a
+        session→subagents accessor, and the adapter-owned map is the SB-25
+        source of truth for registration. Session ids are fixed-shape UUIDs
+        (A3 validation), so one session's prefix can never be a prefix of
+        another's. Restart-empty maps are an accepted degradation (KTD5):
+        subagents re-enter on their next hook call."""
+        subagent_prefix = f"claude-session-{session_id}:subagent-"
+        with self._agent_names_lock:
+            subagents = [
+                (agent_id, name[len(subagent_prefix):])
+                for agent_id, name in self._agent_names.items()
+                if name.startswith(subagent_prefix)
+            ]
+        # Same-prefix names sort identically by full name or by suffix; the
+        # suffix is what the Subagent group prefix renders.
+        subagents.sort(key=lambda pair: pair[1])
+        parent: list[tuple[UUID, str | None]] = [
+            (session_to_agent_id(session_id), None)
+        ]
+        return parent + subagents
+
     def increment_endpoint_counter(self, name: str) -> None:
         """KTD-J (Unit 8): bump a per-endpoint counter. Names match the
         keys in ``_endpoint_counters`` (e.g., ``pre_read_total``). Unknown
@@ -1064,6 +1106,31 @@ class CoordinatorHTTPServer:
                 self._stale_warned_pairs.remove(pair)
                 return True
             return False
+
+    def mark_compact_pending(self, session_id: str) -> None:
+        """SB-10 (KTD5): flag the session for deferred re-grounding delivery.
+        Set only by /hooks/session-start after it built a NON-empty payload —
+        an empty session must leave the deferred path unarmed (R5).
+        Idempotent: a second compaction before delivery simply re-stamps."""
+        with self._compact_pending_lock:
+            self._compact_pending[session_id] = time.monotonic()
+
+    def consume_compact_pending(self, session_id: str) -> bool:
+        """SB-10 (KTD5): ATOMIC test-and-clear of the compact-pending flag.
+
+        The deferred-delivery unit's at-most-once contract (R2) hangs on
+        this primitive: two concurrent qualifying admits must never both
+        see True, so the check and the clear happen under one lock hold —
+        a separate has/clear pair would reopen the TOCTOU window."""
+        with self._compact_pending_lock:
+            return self._compact_pending.pop(session_id, None) is not None
+
+    def expire_compact_pending(self, session_id: str) -> None:
+        """SB-10 (KTD5): drop an unconsumed flag without delivering. Wired
+        to the parent Stop by the deferred-delivery unit (R2: the flag's
+        lifetime ends at turn end; coordinator restart clears implicitly)."""
+        with self._compact_pending_lock:
+            self._compact_pending.pop(session_id, None)
 
     def run_with_watchdog(
         self, fn: Callable[[], Any], abort: threading.Event | None = None
@@ -2262,6 +2329,91 @@ def _handle_session_stop(req: _RequestProtocol, coordinator: CoordinatorHTTPServ
     # aborts before revoking a grant the registry handed to the next session.
     abort = threading.Event()
     _run_or_degrade(req, coordinator, work, degraded_response=_OK_DEGRADED_RESPONSE, abort=abort)
+
+
+def _handle_session_start(
+    req: _RequestProtocol, coordinator: CoordinatorHTTPServer
+) -> None:
+    """POST /hooks/session-start — SB-10 U2 post-compaction re-grounding.
+
+    Returns the re-grounding ``additionalContext`` payload for a compacted
+    session and arms the process-local compact-pending flag for deferred
+    delivery on the next qualifying admit (consumption is wired in a later
+    unit). The ``source == "compact"`` gate lives client-side (U3, the
+    hook-client ladder): this endpoint trusts its caller and treats every
+    request as a compact event (R1).
+
+    Shape notes:
+    - Empty session → literal ``{}`` and NO flag (R5): the deferred path
+      must stay unarmed when there is nothing to deliver.
+    - Optional ``agent_id`` resolves per SB-25 like the read paths, but the
+      payload and the flag are SESSION-scoped either way — the parent agent
+      id is derivable without prior registration, and the payload always
+      covers the parent plus every registered subagent.
+    - No heartbeat and no observation recording: the endpoint is read-only
+      toward the registry (R6 — its own snapshot must never count as the
+      session "seeing" bytes; KTD-2 liveness resumes with the session's
+      next admit).
+    """
+    body = req._read_json()
+    if body is None:
+        return
+    session_id = body.get("session_id")
+    sid_err = validate_session_id(session_id)
+    if sid_err:
+        req._json(400, {"error": sid_err[1]})
+        return
+    subagent_id = read_subagent_id(body)
+
+    # R8 breadcrumb precondition: sample seen-ness BEFORE registration
+    # erases it — registration below makes this session "seen" for every
+    # later request, which is exactly what keeps the breadcrumb a
+    # once-per-rotation signal rather than log spam.
+    never_seen = coordinator.agent_name_for(session_to_agent_id(session_id)) is None
+    coordinator.register_session(session_id)
+    if subagent_id is not None:
+        coordinator.register_session(session_id, subagent_id)
+
+    abort = threading.Event()
+
+    def work() -> dict:
+        text, workspace_has_state = _build_session_start_context(
+            coordinator, session_id, abort=abort
+        )
+        if never_seen and workspace_has_state:
+            # R8: a compact event for a session this coordinator never saw,
+            # while the workspace demonstrably holds coordination state,
+            # is the signature of a silent session-id rotation (or a
+            # coordinator restart) — debug-level so it is an observable,
+            # not an alarm.
+            logger.debug(
+                "session-start for never-seen session %s while the workspace "
+                "holds coordination state — possible session-id rotation or "
+                "coordinator restart (SB-10 R8)",
+                session_id,
+            )
+        if text is None:
+            return {}
+        # Non-empty payload → arm deferred delivery (KTD5). Ordering matters:
+        # the flag is set only AFTER a successful build, so a degraded or
+        # failed request leaves the deferred path unarmed.
+        coordinator.mark_compact_pending(session_id)
+        return {
+            "hookSpecificOutput": _payloads.emit_session_start(
+                additional_context=text
+            )
+        }
+
+    # A6 pattern: abort threads into the builder's abort_guard so a
+    # watchdog-timed-out request fails closed at the registry lock instead
+    # of arming the flag after the client already saw the degraded `{}`.
+    _run_or_degrade(
+        req,
+        coordinator,
+        work,
+        degraded_response=_SESSION_START_DEGRADED_RESPONSE,
+        abort=abort,
+    )
 
 
 def _handle_policy_track(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) -> None:
@@ -4154,6 +4306,11 @@ _ROUTES: dict[tuple[str, str], Callable] = {
     # EXCLUSIVE acquire (the OCC writer stays S/I).
     ("POST", "/hooks/post-edit-cas"): _handle_post_edit_cas,
     ("POST", "/hooks/session-stop"): _handle_session_stop,
+    # SB-10 U2 — post-compaction re-grounding. Registered HERE so it rides
+    # the central verify_bearer + verify_host seam (KTD7: no operator
+    # header, no parallel router). Read-only toward the registry; stays out
+    # of _MIGRATION_REJECTED_ROUTES because it initiates no writes.
+    ("POST", "/hooks/session-start"): _handle_session_start,
     # v0.1.1 KTD-N — H4 mitigation: catch model routing-around-via-Bash/Grep
     # to bypass the Read-only stale-read warning. Per the v0.2 Phase 0
     # falsifiability experiment, the model retries Read 2-5 times then
@@ -4230,6 +4387,7 @@ _ENDPOINT_COUNTER_NAMES: dict[tuple[str, str], str] = {
     ("POST", "/hooks/post-edit"): "post_edit_total",
     ("POST", "/hooks/post-edit-cas"): "post_edit_cas_total",
     ("POST", "/hooks/session-stop"): "session_stop_total",
+    ("POST", "/hooks/session-start"): "session_start_total",
     ("POST", "/hooks/pre-bash"): "pre_bash_total",
     ("POST", "/hooks/pre-grep"): "pre_grep_total",
     ("POST", "/policy/track"): "policy_track_total",
@@ -4276,6 +4434,15 @@ pass ``OK_DEGRADED_RESPONSE`` instead so the client doesn't see ``None`` from
 _OK_DEGRADED_RESPONSE: dict = {"ok": True, "degraded": True}
 """AC-05: degraded envelope for {ok: bool}-shape endpoints (pre-edit,
 post-edit, session-stop). Pairs with ``_DEFAULT_DEGRADED_RESPONSE``."""
+
+_SESSION_START_DEGRADED_RESPONSE: dict = {}
+"""SB-10 U2 (KTD7): degrade envelope for ``/hooks/session-start`` — the
+empty payload. Re-grounding is advisory (KD3): a watchdog timeout must look
+exactly like "nothing to say", never block, and never claim state it could
+not read. The compact-pending flag is armed INSIDE the timed work only
+after a successful non-empty build (with the A6 abort threaded into the
+builder's ``abort_guard``), so a degraded response also means the deferred
+path stays unarmed."""
 
 _OCC_DEGRADED_RESPONSE: dict = {
     "ok": False,
@@ -4406,6 +4573,14 @@ def _iso_utc(unix_ts: float) -> str:
 #: well under 4KB before any stale-read prepend).
 _PREEMPTION_PROSE_VERBATIM_CAP = 3
 
+#: SB-10 U2 (R5) — same cap pattern for the post-compaction re-grounding
+#: payload: at most this many artifact lines render verbatim; the rest
+#: coalesce into one overflow line pointing at the status surface. Keeps the
+#: payload constant-size regardless of how many artifacts a session touched,
+#: comfortably under Claude Code's 10KB additionalContext ceiling even when
+#: the preemption-notice block (its own cap above) is prepended.
+_SESSION_START_ARTIFACT_VERBATIM_CAP = 3
+
 
 def _build_preemption_text(
     coordinator: CoordinatorHTTPServer,
@@ -4463,6 +4638,133 @@ def _build_preemption_text(
         "local-only until you re-acquire and commit."
     )
     return "\n".join(lines)
+
+
+def _build_session_start_context(
+    coordinator: CoordinatorHTTPServer,
+    session_id: str,
+    *,
+    abort: threading.Event | None = None,
+) -> tuple[str | None, bool]:
+    """SB-10 U2: render the post-compaction re-grounding prose for a session.
+
+    Returns ``(additional_context, workspace_has_state)`` where the context is
+    ``None`` when the session holds no coordination state (R5's no-op arm) and
+    ``workspace_has_state`` feeds the R8 breadcrumb decision in the handler.
+
+    KTD2: the payload is rebuilt from registry truth on EVERY delivery, from
+    ONE consistent read pass — the whole registry walk happens under a single
+    ``abort_guard`` hold (a plain re-entrant lock acquire for the inner read
+    calls), so a peer commit cannot tear the view between the snapshot and
+    the per-row last-observed / last-writer reads. The pass is read-only:
+    R6 forbids this endpoint from recording observations, and the pending
+    preemption notices are PEEKED, never popped — consumption ownership
+    stays with the admit-endpoint drains.
+
+    Rendering (KTD8, byte-mirrored by the Node coordinator):
+    - header first; the existing preemption-notice prose (if any) next;
+      then artifact lines — the parent agent's first, then each registered
+      subagent's under a ``Subagent {name}:`` prefix, groups sorted by name,
+      artifacts sorted by path within a group;
+    - a held E/M/S row renders the event-anchored grant line with the
+      CURRENT version; any other row (INVALID) renders the stale line only
+      when the version advanced past a RECORDED last-observed value and the
+      last writer is not this very agent (R7: never-observed admits, own
+      edits are exempt — KTD4's second layer — and no 0-sentinel compares);
+    - at most ``_SESSION_START_ARTIFACT_VERBATIM_CAP`` artifact lines render
+      verbatim, the rest coalesce into the overflow line (R5);
+    - the self-qualifying closing line is always last. No timestamps.
+    """
+    # Agent enumeration takes only the agent-names lock; done BEFORE the
+    # registry lock so the two locks never nest in names→registry order.
+    agents = coordinator.agents_for_session(session_id)
+
+    with coordinator.registry.abort_guard(abort):
+        artifact_by_id, state_by_artifact = coordinator.registry.status_snapshot()
+        workspace_has_state = bool(artifact_by_id)
+        # KTD8: artifacts sorted by path (ASCII-lexicographic — identical to
+        # the Node backend's default string sort for the path charset).
+        sorted_artifacts = sorted(
+            artifact_by_id.items(), key=lambda item: item[1]["name"]
+        )
+        notices: list[tuple[UUID, UUID, float]] = []
+        groups: list[tuple[str | None, list[str]]] = []
+        for agent_id, subagent_name in agents:
+            lines: list[str] = []
+            for artifact_id, meta in sorted_artifacts:
+                pending = coordinator.registry.peek_preemption_notice(
+                    agent_id, artifact_id
+                )
+                if pending is not None:
+                    notices.append((artifact_id, pending[0], pending[1]))
+                state = state_by_artifact.get(artifact_id, {}).get(agent_id)
+                if state is None:
+                    continue
+                path = meta["name"]
+                current = meta["version"]
+                if state is not MESIState.INVALID:
+                    lines.append(
+                        _payloads.SESSION_START_GRANT_LINE_TEMPLATE.format(
+                            state=state.name, path=path, version=current
+                        )
+                    )
+                    continue
+                last = coordinator.registry.last_observed_version_for(
+                    artifact_id, agent_id
+                )
+                stale = (
+                    last is not None
+                    and current > last
+                    and coordinator.registry.last_writer_for(artifact_id)
+                    != agent_id
+                )
+                if stale:
+                    lines.append(
+                        _payloads.SESSION_START_STALE_LINE_TEMPLATE.format(
+                            path=path, current=current, last=last
+                        )
+                    )
+                else:
+                    lines.append(
+                        _payloads.SESSION_START_TOUCHED_LINE_TEMPLATE.format(
+                            path=path, current=current
+                        )
+                    )
+            if lines:
+                groups.append((subagent_name, lines))
+        if not groups and not notices:
+            return None, workspace_has_state
+        # Rendered inside the guard: _build_preemption_text re-reads artifact
+        # names from the registry, and those reads belong to the same
+        # consistent pass as the snapshot the notices came from.
+        notice_text = (
+            _build_preemption_text(coordinator, notices) if notices else None
+        )
+
+    rendered: list[str] = [_payloads.SESSION_START_HEADER]
+    if notice_text is not None:
+        rendered.append(notice_text)
+    total_lines = sum(len(lines) for _, lines in groups)
+    budget = _SESSION_START_ARTIFACT_VERBATIM_CAP
+    for subagent_name, lines in groups:
+        if budget <= 0:
+            break
+        take = lines[:budget]
+        if subagent_name is not None:
+            rendered.append(
+                _payloads.SESSION_START_SUBAGENT_PREFIX_TEMPLATE.format(
+                    name=subagent_name
+                )
+            )
+        rendered.extend(take)
+        budget -= len(take)
+    overflow = total_lines - _SESSION_START_ARTIFACT_VERBATIM_CAP
+    if overflow > 0:
+        rendered.append(
+            _payloads.SESSION_START_OVERFLOW_LINE_TEMPLATE.format(count=overflow)
+        )
+    rendered.append(_payloads.SESSION_START_CLOSING_LINE)
+    return "\n".join(rendered), workspace_has_state
 
 
 def _last_writer_for(coordinator: CoordinatorHTTPServer, artifact_id: UUID) -> str | None:

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -626,15 +626,14 @@ class CoordinatorHTTPServer:
         self._stale_warned_pairs: set[tuple[UUID, UUID]] = set()
         self._stale_warned_pairs_lock = threading.Lock()
 
-        # SB-10 U2 (KTD5): compact-pending flags, keyed by session_id. Set by
+        # SB-10 (KTD5): compact-pending flags, keyed by session_id. Set by
         # /hooks/session-start when it emitted a non-empty re-grounding
-        # payload; consumed by the next qualifying PreToolUse allow (deferred
-        # delivery, wired in a later unit) and expired on parent Stop.
+        # payload; consumed by the next qualifying parent allow via
+        # _deliver_pending_reground (SB-10 U4) and expired on parent Stop.
         # PROCESS-LOCAL on purpose — a restarted coordinator loses the flag,
         # an accepted degradation (the restart is a bigger re-grounding event
-        # than a compaction). Value is the monotonic mark time so the
-        # deferred-delivery unit can reason about flag age if it needs to.
-        self._compact_pending: dict[str, float] = {}
+        # than a compaction).
+        self._compact_pending: set[str] = set()
         self._compact_pending_lock = threading.Lock()
 
         # Wire storage + coordinator service.
@@ -1111,9 +1110,9 @@ class CoordinatorHTTPServer:
         """SB-10 (KTD5): flag the session for deferred re-grounding delivery.
         Set only by /hooks/session-start after it built a NON-empty payload —
         an empty session must leave the deferred path unarmed (R5).
-        Idempotent: a second compaction before delivery simply re-stamps."""
+        Idempotent: a second compaction before delivery simply re-marks."""
         with self._compact_pending_lock:
-            self._compact_pending[session_id] = time.monotonic()
+            self._compact_pending.add(session_id)
 
     def consume_compact_pending(self, session_id: str) -> bool:
         """SB-10 (KTD5): ATOMIC test-and-clear of the compact-pending flag.
@@ -1123,7 +1122,10 @@ class CoordinatorHTTPServer:
         see True, so the check and the clear happen under one lock hold —
         a separate has/clear pair would reopen the TOCTOU window."""
         with self._compact_pending_lock:
-            return self._compact_pending.pop(session_id, None) is not None
+            if session_id in self._compact_pending:
+                self._compact_pending.remove(session_id)
+                return True
+            return False
 
     def has_compact_pending(self, session_id: str) -> bool:
         """SB-10 U4 (KTD6): NON-consuming advisory peek at the flag — the
@@ -1142,7 +1144,7 @@ class CoordinatorHTTPServer:
         to the parent Stop by the deferred-delivery unit (R2: the flag's
         lifetime ends at turn end; coordinator restart clears implicitly)."""
         with self._compact_pending_lock:
-            self._compact_pending.pop(session_id, None)
+            self._compact_pending.discard(session_id)
 
     def run_with_watchdog(
         self, fn: Callable[[], Any], abort: threading.Event | None = None
@@ -1534,10 +1536,7 @@ def _handle_pre_read(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
     # no flag pending, response bytes and the no-registry behavior are
     # exactly today's.
     if not coordinator.policy.is_tracked(path):
-        fast: dict[str, Any] = {"status": "fresh"}
-        if coordinator.has_compact_pending(session_id):
-            fast = _deliver_pending_reground(coordinator, session_id, body, fast)
-        req._json(200, fast)
+        _fast_path_json(req, coordinator, session_id, body, {"status": "fresh"})
         return
 
     agent_id = coordinator.register_session(session_id, read_subagent_id(body))
@@ -1850,10 +1849,7 @@ def _handle_pre_edit(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
     # SB-10 U4 (KTD6): advisory peek hoisted above the untracked exit —
     # see the pre-read twin for the no-flag byte/behavior guarantee.
     if not coordinator.policy.is_tracked(path):
-        fast: dict[str, Any] = {"ok": True}
-        if coordinator.has_compact_pending(session_id):
-            fast = _deliver_pending_reground(coordinator, session_id, body, fast)
-        req._json(200, fast)
+        _fast_path_json(req, coordinator, session_id, body, {"ok": True})
         return
 
     agent_id = coordinator.register_session(session_id, read_subagent_id(body))
@@ -2383,8 +2379,9 @@ def _handle_session_start(
 
     Returns the re-grounding ``additionalContext`` payload for a compacted
     session and arms the process-local compact-pending flag for deferred
-    delivery on the next qualifying admit (consumption is wired in a later
-    unit). The ``source == "compact"`` gate lives client-side (U3, the
+    delivery on the next qualifying admit (consumed by
+    ``_deliver_pending_reground`` at the allow-attach seam, SB-10 U4).
+    The ``source == "compact"`` gate lives client-side (U3, the
     hook-client ladder): this endpoint trusts its caller and treats every
     request as a compact event (R1).
 
@@ -2609,10 +2606,7 @@ def _handle_pre_bash(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
     # exit — see the pre-read twin for the no-flag byte/behavior guarantee.
     tracked_paths = detect_tracked_paths(command, coordinator.policy.is_tracked)
     if not tracked_paths:
-        fast: dict[str, Any] = {"status": "fresh"}
-        if coordinator.has_compact_pending(session_id):
-            fast = _deliver_pending_reground(coordinator, session_id, body, fast)
-        req._json(200, fast)
+        _fast_path_json(req, coordinator, session_id, body, {"status": "fresh"})
         return
 
     agent_id = coordinator.register_session(session_id, read_subagent_id(body))
@@ -2787,10 +2781,7 @@ def _handle_pre_grep(req: _RequestProtocol, coordinator: CoordinatorHTTPServer) 
     # artifacts exit so a pending payload still reaches this admit.
     tracked_paths = coordinator.registry.artifact_names_under_prefix(search_root)
     if not tracked_paths:
-        fast: dict[str, Any] = {"status": "fresh"}
-        if coordinator.has_compact_pending(session_id):
-            fast = _deliver_pending_reground(coordinator, session_id, body, fast)
-        req._json(200, fast)
+        _fast_path_json(req, coordinator, session_id, body, {"status": "fresh"})
         return
 
     agent_id = coordinator.register_session(session_id, read_subagent_id(body))
@@ -4754,17 +4745,24 @@ def _build_session_start_context(
         )
         notices: list[tuple[UUID, UUID, float]] = []
         groups: list[tuple[str | None, list[str]]] = []
+        # last_writer depends only on the artifact; cache it across agents so
+        # the loop stays O(pairs-with-state) single SELECTs, not O(A x P).
+        last_writer_cache: dict[UUID, UUID | None] = {}
         for agent_id, subagent_name in agents:
             lines: list[str] = []
             for artifact_id, meta in sorted_artifacts:
+                state = state_by_artifact.get(artifact_id, {}).get(agent_id)
+                if state is None:
+                    # A pending notice implies the victim held a grant, so its
+                    # state row exists (rows are never deleted; preemption
+                    # transitions them to INVALID) -- stateless pairs cannot
+                    # carry a notice and are skipped before any per-pair SQL.
+                    continue
                 pending = coordinator.registry.peek_preemption_notice(
                     agent_id, artifact_id
                 )
                 if pending is not None:
                     notices.append((artifact_id, pending[0], pending[1]))
-                state = state_by_artifact.get(artifact_id, {}).get(agent_id)
-                if state is None:
-                    continue
                 path = meta["name"]
                 current = meta["version"]
                 if state is not MESIState.INVALID:
@@ -4777,12 +4775,13 @@ def _build_session_start_context(
                 last = coordinator.registry.last_observed_version_for(
                     artifact_id, agent_id
                 )
-                stale = (
-                    last is not None
-                    and current > last
-                    and coordinator.registry.last_writer_for(artifact_id)
-                    != agent_id
-                )
+                stale = last is not None and current > last
+                if stale:
+                    if artifact_id not in last_writer_cache:
+                        last_writer_cache[artifact_id] = (
+                            coordinator.registry.last_writer_for(artifact_id)
+                        )
+                    stale = last_writer_cache[artifact_id] != agent_id
                 if stale:
                     lines.append(
                         _payloads.SESSION_START_STALE_LINE_TEMPLATE.format(
@@ -4913,6 +4912,22 @@ def _attach_reground(result: dict, text: str) -> dict:
         text if existing is None else existing + "\n\n" + text
     )
     return {**result, "hookSpecificOutput": merged}
+
+
+def _fast_path_json(
+    req: _RequestProtocol,
+    coordinator: CoordinatorHTTPServer,
+    session_id: str,
+    body: dict,
+    base: dict,
+) -> None:
+    """SB-10 U4 (KTD6): shared exit for the four hoisted fast paths. The
+    advisory peek keeps no-flag traffic registry-free with the exact
+    pre-SB-10 response bytes; a pending flag routes through the deferred
+    re-ground attach, which claims it atomically at the allow seam."""
+    if coordinator.has_compact_pending(session_id):
+        base = _deliver_pending_reground(coordinator, session_id, body, base)
+    req._json(200, base)
 
 
 def _deliver_pending_reground(

--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -4770,7 +4770,15 @@ def _build_session_start_context(
     agents = coordinator.agents_for_session(session_id)
 
     with coordinator.registry.abort_guard(abort):
-        artifact_by_id, state_by_artifact = coordinator.registry.status_snapshot()
+        # Scoped to THIS session's agents (SB-10 review): the walk below can
+        # only render rows belonging to `agents`, this runs on a hook path
+        # twice per compaction, and nothing garbage-collects `agent_states` —
+        # so an unscoped read would pull the workspace's whole history through
+        # the registry lock only to discard it. The artifact half stays
+        # workspace-wide: R8's breadcrumb asks about the WORKSPACE.
+        artifact_by_id, state_by_artifact = coordinator.registry.status_snapshot(
+            agent_ids=[agent_id for agent_id, _ in agents]
+        )
         workspace_has_state = bool(artifact_by_id)
         # KTD8: artifacts sorted by path (ASCII-lexicographic — identical to
         # the Node backend's default string sort for the path charset).

--- a/src/ccs/adapters/claude_code/hook_payloads.py
+++ b/src/ccs/adapters/claude_code/hook_payloads.py
@@ -248,6 +248,16 @@ class PreToolUseHookOutput(TypedDict):
     permissionDecisionReason: NotRequired[str]
 
 
+class SessionStartHookOutput(TypedDict):
+    """SB-10 U2: ``hookSpecificOutput`` envelope for the SessionStart hook.
+
+    Unlike PreToolUse there is no permissionDecision — SessionStart cannot
+    gate anything (KD3: re-grounding is advisory, never blocking); the
+    envelope carries only the re-grounding prose."""
+    hookEventName: Literal["SessionStart"]
+    additionalContext: str
+
+
 class OkResponse(TypedDict):
     ok: Literal[True]
 
@@ -410,6 +420,76 @@ def build_collision_response(
         ),
         "ok": True,
         "collision": True,
+    }
+
+
+# ----------------------------------------------------------------------
+# SB-10 post-compaction re-grounding prose (KTD8)
+# ----------------------------------------------------------------------
+#
+# Byte-parity contract: the Node coordinator (plan U6) mirrors these exact
+# strings, and the protocol corpus byte-matches the rendered payload. NO
+# timestamps may appear in any of them (corpus normalization keys stay
+# untouched), and grant prose is EVENT-ANCHORED, not present-tense — a
+# turn-end Stop drain can release E/M before the attachment ever renders,
+# so "you hold" would emit a false claim. Any wording change must land in
+# both backends plus the corpus fixtures in the same change.
+
+
+SESSION_START_HEADER: str = "Post-compaction re-grounding (agent-coherence):"
+"""First line of every non-empty re-grounding payload."""
+
+SESSION_START_GRANT_LINE_TEMPLATE: str = (
+    "At compaction you held {state} on {path} (v{version}) — re-acquire "
+    "before writing."
+)
+"""R3 held-grant line. ``state`` is the full MESI state name
+(EXCLUSIVE/MODIFIED/SHARED); ``version`` is the CURRENT coordinated
+version from the snapshot, not the granted-at version."""
+
+SESSION_START_STALE_LINE_TEMPLATE: str = (
+    "{path} advanced to v{current} past your last-observed v{last} — "
+    "re-read before relying on it."
+)
+"""R4 stale-divergence line (KD1 shape B): both versions render so the
+model can judge how far behind its cached view is."""
+
+SESSION_START_TOUCHED_LINE_TEMPLATE: str = "{path} is at v{current}."
+"""R4 touched-but-current line — also the R7 admit rendering for
+never-observed rows and own-edit-exempt rows."""
+
+SESSION_START_OVERFLOW_LINE_TEMPLATE: str = (
+    "Plus {count} more — run agent-coherence-status for the full picture."
+)
+"""R5 overflow line, mirroring the ``_build_preemption_text`` cap pattern:
+at most 3 artifact lines render verbatim; the rest coalesce here."""
+
+SESSION_START_SUBAGENT_PREFIX_TEMPLATE: str = "Subagent {name}:"
+"""KTD8 grouping: the parent agent's lines render first (no prefix), then
+each registered subagent's lines under this prefix, groups sorted by
+agent name."""
+
+SESSION_START_CLOSING_LINE: str = (
+    "Versions are as of this re-grounding; a more recent read supersedes "
+    "this notice."
+)
+"""Self-qualifier, always the last line when any lines rendered — R2
+accepts one residual duplicate delivery, so the prose must read correctly
+when seen twice (a later read wins over a stale re-emission)."""
+
+
+def emit_session_start(*, additional_context: str) -> SessionStartHookOutput:
+    """Build the ``hookSpecificOutput`` envelope for a SessionStart response.
+
+    The first non-PreToolUse builder in this module — hookEventName is
+    hardcoded per envelope kind, matching the existing builders' style.
+    Deliberately NOT routed through :func:`emit_allow`: there is no
+    permissionDecision on SessionStart, and the KTD-U meta-test counts
+    ``emit_allow`` call sites as allow-path surface, which this is not.
+    """
+    return {
+        "hookEventName": "SessionStart",
+        "additionalContext": additional_context,
     }
 
 

--- a/src/ccs/adapters/claude_code/hook_payloads.py
+++ b/src/ccs/adapters/claude_code/hook_payloads.py
@@ -248,6 +248,23 @@ class PreToolUseHookOutput(TypedDict):
     permissionDecisionReason: NotRequired[str]
 
 
+class PreToolUseContextOutput(TypedDict):
+    """SB-10: context-only ``hookSpecificOutput`` envelope for a PreToolUse
+    response — advisory prose with NO permission decision.
+
+    Distinct from :class:`PreToolUseHookOutput` by the ABSENCE of
+    ``permissionDecision``: this envelope delivers text to the model
+    without touching the tool call's permission outcome, so Claude Code's
+    ordinary prompting still applies. Used by the SB-10 deferred
+    re-grounding attach, whose payload is advisory (KD3) and must never
+    widen a permission decision. Empirically the CLI renders
+    ``additionalContext`` on a PreToolUse envelope carrying no
+    ``permissionDecision`` (A/B capture against Claude Code CLI 2.1.233,
+    2026-08-25)."""
+    hookEventName: Literal["PreToolUse"]
+    additionalContext: str
+
+
 class SessionStartHookOutput(TypedDict):
     """SB-10 U2: ``hookSpecificOutput`` envelope for the SessionStart hook.
 
@@ -476,6 +493,30 @@ SESSION_START_CLOSING_LINE: str = (
 """Self-qualifier, always the last line when any lines rendered — R2
 accepts one residual duplicate delivery, so the prose must read correctly
 when seen twice (a later read wins over a stale re-emission)."""
+
+
+def emit_pretooluse_context(*, additional_context: str) -> PreToolUseContextOutput:
+    """Build a context-only ``hookSpecificOutput`` envelope for a PreToolUse
+    response: ``additionalContext`` prose and nothing else.
+
+    Deliberately NOT routed through :func:`emit_allow` — and deliberately
+    emitting no ``permissionDecision``. An advisory payload must never
+    widen a permission decision: promoting a bare admit body to
+    ``permissionDecision: "allow"`` just to carry prose would
+    short-circuit Claude Code's own permission prompting for that tool
+    call. The KTD-U meta-test counts ``emit_allow`` call sites as
+    allow-path surface, which this is not.
+
+    Empirical basis: a PreToolUse ``hookSpecificOutput`` with
+    ``hookEventName`` + ``additionalContext`` and no ``permissionDecision``
+    IS rendered to the model — A/B capture against the installed Claude
+    Code CLI 2.1.233 on 2026-08-25 (the marker-primed model quoted the
+    injected line verbatim in both arms).
+    """
+    return {
+        "hookEventName": "PreToolUse",
+        "additionalContext": additional_context,
+    }
 
 
 def emit_session_start(*, additional_context: str) -> SessionStartHookOutput:

--- a/src/ccs/cli/coherence_hook_client.py
+++ b/src/ccs/cli/coherence_hook_client.py
@@ -89,6 +89,8 @@ def build_parser() -> argparse.ArgumentParser:
             # v0.1.1 KTD-N — H4 mitigation: extended hook coverage.
             "pre-bash",
             "pre-grep",
+            # SB-10 U3: post-compaction re-grounding (SessionStart hook).
+            "session-start",
         ],
         help="Which coordinator endpoint to invoke. Maps 1:1 to the CC hook event.",
     )
@@ -201,6 +203,12 @@ def _main_inner(argv: Sequence[str] | None = None) -> int:
         elif args.subcommand == "pre-grep":
             payload = _build_pre_grep(cc_payload, root_path)
             response = _call(endpoint, "/hooks/pre-grep", payload)
+        elif args.subcommand == "session-start":
+            # SB-10 U3: CC's SessionStart event → post-compaction
+            # re-grounding. The builder gates on source == "compact", so
+            # startup/resume/clear never reach the coordinator.
+            payload = _build_session_start(cc_payload)
+            response = _call(endpoint, "/hooks/session-start", payload)
         else:  # pragma: no cover — argparse already validates
             _emit_empty()
             return 0
@@ -332,6 +340,24 @@ def _build_subagent_stop(cc: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(aid, str) or not _SUBAGENT_ID_RE.fullmatch(aid):
         raise _SkipHook("agent_id missing or malformed for subagent-stop")
     return {"session_id": session_id, "agent_id": aid}
+
+
+def _build_session_start(cc: dict[str, Any]) -> dict[str, Any]:
+    """SB-10 U3: SessionStart → post-compaction re-grounding request.
+
+    Only the ``compact`` source qualifies: the coordinator endpoint trusts
+    its caller and treats EVERY request as a compact event (R1), so the
+    source gate lives HERE — ``startup``/``resume``/``clear`` (and an
+    absent source) must skip before any network call. SessionStart carries
+    no subagent identity, so the body is session-only: deliberately NOT
+    routed through ``_with_agent_id`` — the re-grounding payload is
+    session-scoped (it always covers the parent plus every registered
+    subagent), and a stray agent field must not narrow it.
+    """
+    if cc.get("source") != "compact":
+        raise _SkipHook("SessionStart source is not 'compact'")
+    session_id = _require_session_id(cc)
+    return {"session_id": session_id}
 
 
 def _build_pre_bash(cc: dict[str, Any]) -> dict[str, Any]:

--- a/src/ccs/coordinator/backend_contract.py
+++ b/src/ccs/coordinator/backend_contract.py
@@ -594,8 +594,8 @@ _MEMBER_CONTRACTS: tuple[MemberContract, ...] = (
         "status_snapshot",
         MemberClass.READ_ONLY,
         "sqlite_extended",
-        "Batch read of the artifact + state maps for the /status surface. "
-        "Non-mutating.",
+        "Batch read of the artifact + state maps for the /status surface, "
+        "optionally scoping the state half to named agents. Non-mutating.",
     ),
 )
 

--- a/src/ccs/coordinator/backend_contract.py
+++ b/src/ccs/coordinator/backend_contract.py
@@ -12,7 +12,7 @@ shipped. Nothing here connects to, reads from, or writes to any store.
 
 It follows the :mod:`ccs.coordinator.registry_protocol` precedent (a module that
 owns Protocols + shared types the two registries re-export). Where that module
-names the registry SURFACE (the 58-member ``RegistryBase`` + ``SqliteExtended``
+names the registry SURFACE (the 59-member ``RegistryBase`` + ``SqliteExtended``
 Protocols), this module names the CONTRACT that surface must satisfy for a
 backend to host the atomic boundary: which members participate in the
 single-writer atomic step (:data:`MEMBER_CLASSIFICATION`), what that atomic step
@@ -109,7 +109,7 @@ class MemberContract:
     rationale: str
 
 
-# The 58 members of RegistryBase (44 methods + 1 property) and SqliteExtended
+# The 59 members of RegistryBase (45 methods + 1 property) and SqliteExtended
 # (+13 methods), classified against the CoordinatorService call sites. The
 # ATOMIC_CLASS members are the ones the service touches INSIDE its atomic
 # mutation paths (``write`` / ``commit`` / ``commit_cas`` under ``abort_guard``;
@@ -400,6 +400,15 @@ _MEMBER_CONTRACTS: tuple[MemberContract, ...] = (
         "commit_cas / set_artifact_and_content.",
     ),
     MemberContract(
+        "last_observed_version_for",
+        MemberClass.READ_ONLY,
+        "base",
+        "Reads the artifact version whose bytes an agent last observed (the "
+        "SB-10 post-compaction staleness comparand). Non-mutating; the RECORD "
+        "side rides the atomic non-INVALID upserts (set_agent_state and the "
+        "commit_cas / commit_all WIN paths), which are already classified.",
+    ),
+    MemberContract(
         "get_artifact_and_generation",
         MemberClass.READ_ONLY,
         "base",
@@ -594,7 +603,7 @@ MEMBER_CLASSIFICATION: dict[str, MemberContract] = {
     contract.name: contract for contract in _MEMBER_CONTRACTS
 }
 """Every ``RegistryBase`` + ``SqliteExtended`` member → its :class:`MemberContract`
-(R8). Keyed by member name. The key set must equal the 58-member Protocol surface
+(R8). Keyed by member name. The key set must equal the 59-member Protocol surface
 exactly — :mod:`tests.test_backend_contract` fails if ``registry_protocol.py``
 gains or loses a member without a matching update here (bidirectional drift
 guard). Includes the ``coordinator_epoch`` property (property-omission teeth)."""

--- a/src/ccs/coordinator/registry.py
+++ b/src/ccs/coordinator/registry.py
@@ -94,6 +94,16 @@ class ArtifactRecord:
     # (resets to 0 per construction in-memory).
     owner_generation: int = 0
     read_generation_by_agent: dict[UUID, int] = field(default_factory=dict)
+    # SB-10 (compaction re-emission, R6/R7): the artifact version whose BYTES
+    # an agent last observed, recorded atomically with every non-INVALID grant
+    # transition (set_agent_state) and advanced by the commit WIN paths
+    # (commit_cas / commit_all / the pessimistic service.commit's MODIFIED
+    # upsert). An ABSENT key means never-observed (surfaced as None, never a
+    # 0-sentinel); a transition to INVALID deliberately preserves the prior
+    # value -- it is the durable comparand the post-compaction stale flag is
+    # computed from. Mirrors the sqlite agent_states.last_observed_version
+    # column (nullable INTEGER, schema v6).
+    last_observed_version_by_agent: dict[UUID, int] = field(default_factory=dict)
 
 
 class ArtifactRegistry:
@@ -331,6 +341,14 @@ class ArtifactRegistry:
         not the fence, arbitrates)."""
         return self._records[artifact_id].read_generation_by_agent.get(agent_id)
 
+    def last_observed_version_for(self, artifact_id: UUID, agent_id: UUID) -> int | None:
+        """Return the artifact version whose bytes this agent last observed
+        (SB-10 R6/R7: recorded atomically with every non-INVALID grant/commit
+        transition), or None when the pair was never observed — absence is an
+        absent key, never a 0-sentinel, and a transition to INVALID preserved
+        the prior recorded value. The post-compaction staleness comparand."""
+        return self._records[artifact_id].last_observed_version_by_agent.get(agent_id)
+
     def get_artifact_and_generation(
         self, artifact_id: UUID
     ) -> tuple[Artifact, int] | None:
@@ -513,6 +531,16 @@ class ArtifactRegistry:
             trigger in CLAIM_CAPTURE_TRIGGERS and state != MESIState.INVALID
         ):
             record.read_generation_by_agent[agent_id] = record.owner_generation
+
+        # SB-10 R6/R7: record the version whose bytes this agent now holds,
+        # GIL-atomic with the state write above (parity: the sqlite side writes
+        # it inside the same BEGIN IMMEDIATE as the upsert). Non-INVALID
+        # targets only -- a transition TO INVALID preserves the prior recorded
+        # value (the last version actually observed, the post-compaction
+        # staleness comparand) and a never-observed agent keeps no key (absent
+        # == None, never a 0-sentinel).
+        if state != MESIState.INVALID:
+            record.last_observed_version_by_agent[agent_id] = record.artifact.version
 
         if self._state_log is not None:
             self._seq += 1
@@ -707,6 +735,10 @@ class ArtifactRegistry:
         # clear the reclaim slot (mirror set_agent_state's non-M/E-from-non-M/E
         # path, which leaves both untouched).
         record.state_by_agent[agent_id] = MESIState.SHARED
+        # SB-10 R6/R7 (KTD4 first layer): the WIN advances the WRITER's
+        # last_observed_version to the version it just produced; the
+        # invalidated peers above keep their prior values.
+        record.last_observed_version_by_agent[agent_id] = next_version
 
         return updated, invalidated
 
@@ -849,6 +881,10 @@ class ArtifactRegistry:
                     # other per-record state the apply touches.
                     dict(record.version_history),
                     dict(record.version_captured_at),
+                    # SB-10: the apply advances the committer's observed-version
+                    # slot per member; a mid-apply raise must restore it with
+                    # the rest (sqlite's ROLLBACK undoes the column write).
+                    dict(record.last_observed_version_by_agent),
                 )
                 for _art, record, *_rest in staged
             ]
@@ -869,10 +905,14 @@ class ArtifactRegistry:
                     if member_invalidated:
                         invalidated[art_id] = member_invalidated
                     record.state_by_agent[agent_id] = MESIState.SHARED
+                    # SB-10 R6/R7 (KTD4 first layer): each member's WIN advances
+                    # the WRITER's observed version to that member's
+                    # next_version; invalidated peers keep theirs.
+                    record.last_observed_version_by_agent[agent_id] = next_version
                     versions[art_id] = next_version
             except Exception:
                 # Total apply: restore every mutated record, roll back the logs.
-                for (rec, art_obj, content, state_by, granted, last_w, ver_hist, ver_at) in snapshots:
+                for (rec, art_obj, content, state_by, granted, last_w, ver_hist, ver_at, observed) in snapshots:
                     rec.artifact = art_obj
                     rec.content = content
                     rec.state_by_agent = state_by
@@ -880,6 +920,7 @@ class ArtifactRegistry:
                     rec.last_writer = last_w
                     rec.version_history = ver_hist
                     rec.version_captured_at = ver_at
+                    rec.last_observed_version_by_agent = observed
                 self._seq -= emitted_here
                 raise
 

--- a/src/ccs/coordinator/registry_protocol.py
+++ b/src/ccs/coordinator/registry_protocol.py
@@ -527,6 +527,8 @@ class SqliteExtended(RegistryBase, Protocol):
 
     def status_snapshot(
         self,
+        *,
+        agent_ids: Iterable[UUID] | None = None,
     ) -> tuple[
         dict[UUID, dict[str, Any]],
         dict[UUID, dict[UUID, MESIState]],

--- a/src/ccs/coordinator/registry_protocol.py
+++ b/src/ccs/coordinator/registry_protocol.py
@@ -343,6 +343,15 @@ class RegistryBase(Protocol):
     def last_heartbeat_tick(self, agent_id: UUID) -> int | None:
         ...
 
+    def last_observed_version_for(self, artifact_id: UUID, agent_id: UUID) -> int | None:
+        """Return the artifact version whose bytes this agent last observed
+        (SB-10: recorded atomically with every non-INVALID grant/commit upsert),
+        or None when the pair was never observed. Absence semantics are part of
+        the contract: never a 0-sentinel, and a transition to INVALID preserves
+        the prior recorded value — this is the durable comparand the
+        post-compaction stale flag is computed from."""
+        ...
+
     def list_checkpoints(self) -> list[CheckpointRecord]:
         """Return every checkpoint header, ordered by ``(created_at,
         checkpoint_id)`` (deterministic for the CLI ``list`` verb)."""

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -188,10 +188,12 @@ table, no index, and deliberately NOT joined to any GC/retention exemption
 seam). The step also carries the ``_V5_USER_VERSION`` literal conversion —
 the same trap as the v5 bump: ``_migrate_v4_to_v5`` stamped the constant while
 it was the final chain step; it now stamps the intermediate literal 5 and the
-chained ``_migrate_v5_to_v6`` lands the column + the v6 stamp. The column is
-Python-lineage only; the Node ledger's own ``agent_states`` ALTER
-(``deadline_tick``, below) stays the foreign fingerprint and NEITHER runtime
-may add the other's column.
+chained ``_migrate_v5_to_v6`` lands the column + the v6 stamp. The column NAME
+is not a lineage discriminator and must never be used as one: the Node ledger's
+paired v4 adds an ``agent_states.last_observed_version`` of its own, so BOTH
+ledgers carry it. The disjoint load-bearing fingerprint is
+``agent_states.deadline_tick`` (Node-only, below — this repo must never add
+that column), backed by the ``registry_meta.schema_runtime`` stamp.
 
 **CROSS-RUNTIME LEDGER DIVERGENCE (security).** The sibling Node coordinator
 (agent-coherence-plugin) shares the SAME ``state.db`` path but keeps its OWN
@@ -901,10 +903,12 @@ class SqliteArtifactRegistry:
 
         The v6 bump (``agent_states.last_observed_version``, SB-10) adds NO
         probe by review (KTD9): it is a column on an existing table, and the
-        two ledgers' ``agent_states`` fingerprints stay disjoint — probe 2's
-        ``deadline_tick`` marker remains Node-only (this repo must never add
-        that column) and ``last_observed_version`` is Python-only, so probe 2
-        neither misses a Node db nor false-positives on a Python v6 one.
+        Node ledger's paired v4 adds a column of the SAME name — so
+        ``last_observed_version`` is COMMON to both ledgers and must never be
+        probed as a lineage discriminator. What stays disjoint is probe 2's
+        ``deadline_tick`` marker, which remains Node-only (this repo must never
+        add that column), so probe 2 still neither misses a Node db nor
+        false-positives on a Python v6 one.
 
         ``user_version == 1`` is deliberately NOT blocked: the Node ledger's
         v1 is a byte-for-byte mirror of this repo's v1 schema, so the two are
@@ -1477,16 +1481,19 @@ class SqliteArtifactRegistry:
         txn, sees the winner already at >= v6, and no-ops.
 
         NODE-LEDGER COORDINATION (KTD9 review): the sibling Node coordinator's
-        ledger still tops out at ``user_version=3`` and its
-        ``rejectForeignLedgerDb`` refuses any Python-lineage db on markers every
-        Python v2+ db carries (the ``schema_runtime='python'`` stamp, the
-        ``artifact_versions`` table, ``artifacts.owner_generation``) BEFORE the
-        integer 6 is interpreted against the Node ledger. The reverse direction
-        stays covered by the ``deadline_tick`` structural probe (``>= 3``) plus
-        the ``schema_runtime='node'`` stamp — this step adds
-        ``last_observed_version``, never ``deadline_tick``, so the two ledgers'
-        ``agent_states`` fingerprints remain disjoint and adding only a column
-        obliges NO new probe in ``_reject_foreign_ledger_db``.
+        ledger tops out at ``user_version=4``, and its paired v4 adds an
+        ``agent_states.last_observed_version`` of its own — the column this step
+        lands is therefore COMMON to both ledgers and must never be read as a
+        lineage discriminator. Its ``rejectForeignLedgerDb`` refuses any
+        Python-lineage db on markers every Python v2+ db carries (the
+        ``schema_runtime='python'`` stamp, the ``artifact_versions`` table,
+        ``artifacts.owner_generation``) BEFORE the integer 6 is interpreted
+        against the Node ledger. The reverse direction stays covered by the
+        ``deadline_tick`` structural probe (``>= 3``) plus the
+        ``schema_runtime='node'`` stamp — this step adds
+        ``last_observed_version``, never ``deadline_tick``, so the LOAD-BEARING
+        ``agent_states`` fingerprint remains disjoint and adding only a shared
+        column obliges NO new probe in ``_reject_foreign_ledger_db``.
         """
         c = self._conn
         c.execute("BEGIN IMMEDIATE")

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -57,6 +57,7 @@ Schema (KTD-3, applied via ``PRAGMA user_version`` on init):
     last_reclaim_tick INTEGER,
     PRIMARY KEY (artifact_id, agent_id)
   );
+  CREATE INDEX idx_agent_states_agent ON agent_states(agent_id);
   CREATE TABLE heartbeats (
     agent_id   TEXT PRIMARY KEY,
     last_tick  INTEGER NOT NULL
@@ -138,7 +139,7 @@ CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
 """Reuses the same schema version as in-memory registry (state_log emissions
 are interchangeable from a downstream consumer's perspective)."""
 
-SCHEMA_USER_VERSION = 6
+SCHEMA_USER_VERSION = 7
 """Schema version stamped via ``PRAGMA user_version`` on init.
 
 **v1 -> v2** (plan item N v1) added the durable ``artifact_versions`` table and
@@ -244,6 +245,15 @@ final step it correctly guarded/stamped the constant, but with the constant at
 6 that would stamp a v4-origin db ``user_version=6`` WITHOUT the v6 column —
 the chained v5->v6 loser-guard then no-ops and the write-free rehydrate never
 adds it. Only the FINAL step in the chain may stamp the constant."""
+
+_V6_USER_VERSION = 6
+"""``_migrate_v5_to_v6``'s guard/stamp literal: it adds the
+``agent_states.last_observed_version`` column and advances to v6 — NO LONGER
+the final step once v7 (the ``agent_states(agent_id)`` index) landed. A
+literal for the same reason as ``_V4_USER_VERSION``/``_V5_USER_VERSION``:
+stamping the constant would mark a v5-origin db ``user_version=7`` WITHOUT
+the index, and the chained v6->v7 loser-guard would no-op (the re-stamp
+trap, third arming)."""
 
 _DB_FILE_MODE = 0o600
 """state.db (and its -wal/-shm sidecars) must be owner-read/write only.
@@ -719,7 +729,7 @@ class SqliteArtifactRegistry:
         - ``user_version == 4`` → ``_migrate_v4_to_v5`` then ``_migrate_v5_to_v6``.
         - ``user_version == 5`` → ``_migrate_v5_to_v6``: an existing v5 db gains
           the ``agent_states.last_observed_version`` column.
-        - ``user_version == 6`` (SCHEMA_USER_VERSION) → ``_rehydrate_meta``: the
+        - ``user_version == 7`` (SCHEMA_USER_VERSION) → ``_rehydrate_meta``: the
           WRITE-FREE open path (no ALTER, no IF-NOT-EXISTS) — the prerequisite for
           read-only mode.
         - anything else → :class:`SchemaVersionError` (no destructive advice).
@@ -744,6 +754,7 @@ class SqliteArtifactRegistry:
                 self._migrate_v3_to_v4(instance_id)
                 self._migrate_v4_to_v5(instance_id)
                 self._migrate_v5_to_v6(instance_id)
+                self._migrate_v6_to_v7(instance_id)
             elif current == 2:
                 # 2 → 3 → 4 → 5 → 6: session_pins, session_meta + index,
                 # checkpoints, last_observed_version.
@@ -751,6 +762,7 @@ class SqliteArtifactRegistry:
                 self._migrate_v3_to_v4(instance_id)
                 self._migrate_v4_to_v5(instance_id)
                 self._migrate_v5_to_v6(instance_id)
+                self._migrate_v6_to_v7(instance_id)
             elif current == _V3_USER_VERSION:
                 # An existing v3 db (session_pins, NO session_meta — earlier
                 # commits of that branch stamped it) → add session_meta + index,
@@ -760,16 +772,23 @@ class SqliteArtifactRegistry:
                 self._migrate_v3_to_v4(instance_id)
                 self._migrate_v4_to_v5(instance_id)
                 self._migrate_v5_to_v6(instance_id)
+                self._migrate_v6_to_v7(instance_id)
             elif current == _V4_USER_VERSION:
                 # An existing v4 db → the workspace-checkpoint tables (v5), then
                 # the last_observed_version column (v6).
                 self._migrate_v4_to_v5(instance_id)
                 self._migrate_v5_to_v6(instance_id)
+                self._migrate_v6_to_v7(instance_id)
             elif current == _V5_USER_VERSION:
-                # An existing v5 db → add agent_states.last_observed_version (v6).
+                # An existing v5 db → last_observed_version (v6), then the
+                # agent_id index (v7).
                 self._migrate_v5_to_v6(instance_id)
+                self._migrate_v6_to_v7(instance_id)
+            elif current == _V6_USER_VERSION:
+                # An existing v6 db (SB-10-era) → index agent_states(agent_id).
+                self._migrate_v6_to_v7(instance_id)
             elif current == SCHEMA_USER_VERSION:
-                # Existing v6 database — rehydrate; NO writes on this path (the
+                # Existing v7 database — rehydrate; NO writes on this path (the
                 # prerequisite for read-only open mode).
                 self._rehydrate_meta(instance_id)
             else:
@@ -1036,6 +1055,9 @@ class SqliteArtifactRegistry:
                     FOREIGN KEY (artifact_id) REFERENCES artifacts(id) ON DELETE CASCADE
                 )
                 """
+            )
+            c.execute(
+                "CREATE INDEX idx_agent_states_agent ON agent_states(agent_id)"
             )
             c.execute(
                 """
@@ -1456,8 +1478,10 @@ class SqliteArtifactRegistry:
     def _migrate_v5_to_v6(self, instance_id: str | None) -> None:
         """Migrate a v5 db to v6 in ONE atomic transaction (SB-10, R6/R7 /
         KTD9): add the nullable ``agent_states.last_observed_version`` column,
-        then stamp ``user_version=6``. Caller holds lock. The FINAL step of the
-        chain, so it stamps ``SCHEMA_USER_VERSION``.
+        then stamp ``user_version=6``. Caller holds lock. Guards and stamps
+        the ``_V6_USER_VERSION`` literal — v7 (the agent_states(agent_id)
+        index) made this a chained step, so stamping the constant would
+        re-arm the re-stamp trap this module's docstrings catalogue.
 
         Column-only and additive — it creates no table and no index, so there
         is no shim to subsume and no content/mode posture change (the column
@@ -1498,7 +1522,7 @@ class SqliteArtifactRegistry:
         c = self._conn
         c.execute("BEGIN IMMEDIATE")
         try:
-            if c.execute("PRAGMA user_version").fetchone()[0] >= SCHEMA_USER_VERSION:
+            if c.execute("PRAGMA user_version").fetchone()[0] >= _V6_USER_VERSION:
                 # A racing winner already advanced to v6 — nothing to do.
                 c.execute("COMMIT")
                 self._rehydrate_meta(instance_id)
@@ -1507,6 +1531,63 @@ class SqliteArtifactRegistry:
                 c.execute(
                     "ALTER TABLE agent_states ADD COLUMN last_observed_version INTEGER"
                 )
+            c.execute(f"PRAGMA user_version = {_V6_USER_VERSION}")
+            c.execute("COMMIT")
+        except BaseException:
+            try:
+                c.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
+        # Load meta from the now-migrated db (write-free).
+        self._rehydrate_meta(instance_id)
+
+    def _migrate_v6_to_v7(self, instance_id: str | None) -> None:
+        """Migrate a v6 db to v7 in ONE atomic transaction (SB-10 perf
+        follow-up): index ``agent_states(agent_id)``, then stamp
+        ``user_version=7``. Caller holds lock. The FINAL step of the chain,
+        so it stamps ``SCHEMA_USER_VERSION``.
+
+        WHY: the post-compaction session-start builder reads ``agent_states``
+        scoped by ``agent_id IN (...)`` (``status_snapshot(agent_ids=...)``),
+        but the table is keyed ``(artifact_id, agent_id)`` and nothing indexed
+        ``agent_id`` alone — the predicate still walked every page of a table
+        nothing garbage-collects, on a hook path, twice per compaction, under
+        this registry's lock. Measured on a 500k-row ledger with a four-agent
+        session: 61ms -> 1.5ms (SCAN -> SEARCH), a gain that grows with
+        accumulated agents — the dimension that grows forever. The write tax
+        is a single-row upsert moving p50 ~24us -> ~40us.
+
+        Index-only and additive: no table, no column, no content. ``CREATE
+        INDEX IF NOT EXISTS`` is itself the half-migrated-db guard (a crash
+        after the CREATE but before the stamp leaves a v6-stamped db whose
+        re-migrate no-ops the CREATE), same atomicity discipline as every
+        other step: ONE ``BEGIN IMMEDIATE`` wrapping CREATE + stamp,
+        ``except BaseException`` ROLLBACK.
+
+        NODE-LEDGER COORDINATION (KTD9): the sibling Node coordinator's v5
+        lands the SAME index name — the pair moves together because the
+        cross-runtime schema guard treats a one-sided ``user_version`` bump
+        as a foreign ledger. An index carries no lineage signal (the guards
+        probe columns, tables, and the ``schema_runtime`` stamp, never index
+        names), so neither direction needs a new probe.
+
+        Concurrent-loser path: both processes can read ``user_version == 6``
+        pre-lock and both land here; they serialize on ``BEGIN IMMEDIATE``,
+        and the loser re-reads the version inside its txn and no-ops.
+        """
+        c = self._conn
+        c.execute("BEGIN IMMEDIATE")
+        try:
+            if c.execute("PRAGMA user_version").fetchone()[0] >= SCHEMA_USER_VERSION:
+                # A racing winner already advanced to v7 — nothing to do.
+                c.execute("COMMIT")
+                self._rehydrate_meta(instance_id)
+                return
+            c.execute(
+                "CREATE INDEX IF NOT EXISTS idx_agent_states_agent "
+                "ON agent_states(agent_id)"
+            )
             c.execute(f"PRAGMA user_version = {SCHEMA_USER_VERSION}")
             c.execute("COMMIT")
         except BaseException:

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -2837,15 +2837,29 @@ class SqliteArtifactRegistry:
                         (artifact_id.hex,),
                     )
 
-                # Upsert agent state.
+                # Upsert agent state. SB-10 R6/R7 rides the same statement: the
+                # ``last_observed_version`` operand was SELECTed above in this
+                # txn; non-INVALID targets record it (the version whose bytes
+                # this agent now holds -- the post-compaction staleness
+                # comparand), a transition TO INVALID preserves the prior
+                # recorded value via the CASE guard, and a never-observed row
+                # keeps NULL (never a 0-sentinel).
+                observe = state != MESIState.INVALID
                 if prior_row is None:
                     self._conn.execute(
                         """
                         INSERT INTO agent_states (artifact_id, agent_id, state, granted_at_tick,
-                                                  last_reclaim_trigger, last_reclaim_tick)
-                        VALUES (?, ?, ?, ?, NULL, NULL)
+                                                  last_reclaim_trigger, last_reclaim_tick,
+                                                  last_observed_version)
+                        VALUES (?, ?, ?, ?, NULL, NULL, ?)
                         """,
-                        (artifact_id.hex, agent_id.hex, state.name, granted_at_tick),
+                        (
+                            artifact_id.hex,
+                            agent_id.hex,
+                            state.name,
+                            granted_at_tick,
+                            version if observe else None,
+                        ),
                     )
                 else:
                     if clear_reclaim:
@@ -2853,19 +2867,37 @@ class SqliteArtifactRegistry:
                             """
                             UPDATE agent_states
                             SET state = ?, granted_at_tick = ?, last_reclaim_trigger = NULL,
-                                last_reclaim_tick = NULL
+                                last_reclaim_tick = NULL,
+                                last_observed_version =
+                                    CASE WHEN ? THEN ? ELSE last_observed_version END
                             WHERE artifact_id = ? AND agent_id = ?
                             """,
-                            (state.name, granted_at_tick, artifact_id.hex, agent_id.hex),
+                            (
+                                state.name,
+                                granted_at_tick,
+                                1 if observe else 0,
+                                version,
+                                artifact_id.hex,
+                                agent_id.hex,
+                            ),
                         )
                     else:
                         self._conn.execute(
                             """
                             UPDATE agent_states
-                            SET state = ?, granted_at_tick = ?
+                            SET state = ?, granted_at_tick = ?,
+                                last_observed_version =
+                                    CASE WHEN ? THEN ? ELSE last_observed_version END
                             WHERE artifact_id = ? AND agent_id = ?
                             """,
-                            (state.name, granted_at_tick, artifact_id.hex, agent_id.hex),
+                            (
+                                state.name,
+                                granted_at_tick,
+                                1 if observe else 0,
+                                version,
+                                artifact_id.hex,
+                                agent_id.hex,
+                            ),
                         )
 
                 # Read-generation fence: capture the current ownership epoch into
@@ -2883,20 +2915,6 @@ class SqliteArtifactRegistry:
                         "(SELECT owner_generation FROM artifacts WHERE id = ?) "
                         "WHERE artifact_id = ? AND agent_id = ?",
                         (artifact_id.hex, artifact_id.hex, agent_id.hex),
-                    )
-
-                # SB-10 R6/R7: record the version whose bytes this agent now
-                # holds, atomic with the upsert in this BEGIN IMMEDIATE (the
-                # ``version`` operand was SELECTed above in this same txn).
-                # Non-INVALID targets only -- a transition TO INVALID preserves
-                # the prior recorded value (the last version actually observed,
-                # the post-compaction staleness comparand) and a never-observed
-                # row keeps NULL (never a 0-sentinel).
-                if state != MESIState.INVALID:
-                    self._conn.execute(
-                        "UPDATE agent_states SET last_observed_version = ? "
-                        "WHERE artifact_id = ? AND agent_id = ?",
-                        (version, artifact_id.hex, agent_id.hex),
                     )
 
                 # Mutation-then-log: emit state_log BEFORE commit. If the callback

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -2725,6 +2725,8 @@ class SqliteArtifactRegistry:
 
     def status_snapshot(
         self,
+        *,
+        agent_ids: Iterable[UUID] | None = None,
     ) -> tuple[
         dict[UUID, dict[str, Any]],
         dict[UUID, dict[UUID, MESIState]],
@@ -2742,9 +2744,32 @@ class SqliteArtifactRegistry:
         per-artifact loop that issued ``2 * N`` separate SELECTs
         (``get_artifact`` + ``get_state_map`` for each id) — eliminates
         the N+1 hot path in ``_handle_status``.
+
+        ``agent_ids`` narrows the SECOND query to those agents (SB-10
+        review). ``/status`` renders every holder and passes nothing, keeping
+        the whole-ledger view; the session-start builder can only render its
+        own session's parent + subagents, and it runs on a hook path twice
+        per compaction — under this same lock — so it scopes. Nothing
+        garbage-collects ``agent_states``, which makes the unscoped read grow
+        with the workspace's entire coordination history. An EMPTY iterable
+        means no agents, never all of them: the artifact half is still read,
+        so the workspace-level emptiness signal is unaffected either way.
+
+        The predicate is NOT index-backed: ``agent_states`` is keyed
+        ``(artifact_id, agent_id)`` and nothing indexes ``agent_id`` alone,
+        so SQLite walks the table either way (``EXPLAIN QUERY PLAN`` reports
+        ``SCAN`` for both forms). What the scope removes is the per-row cost
+        — a ``UUID(hex=...)`` and a ``MESIState`` lookup for every row the
+        caller would then discard. Measured on a 500k-row table with a
+        four-agent session: 2804ms unscoped, 174ms scoped. An index on
+        ``agent_id`` would turn the remaining constant into a bound, but it
+        needs a migration in BOTH backends (a one-sided ``user_version`` bump
+        trips the cross-runtime schema guard), so it is deliberately not done
+        here.
         """
         artifact_by_id: dict[UUID, dict[str, Any]] = {}
         state_by_artifact: dict[UUID, dict[UUID, MESIState]] = {}
+        scoped_hexes = None if agent_ids is None else [a.hex for a in agent_ids]
         with self._lock:
             for row in self._conn.execute(
                 "SELECT id, name, version FROM artifacts"
@@ -2752,9 +2777,20 @@ class SqliteArtifactRegistry:
                 aid = UUID(hex=row[0])
                 artifact_by_id[aid] = {"name": row[1], "version": row[2]}
                 state_by_artifact[aid] = {}
-            for row in self._conn.execute(
-                "SELECT artifact_id, agent_id, state FROM agent_states"
-            ).fetchall():
+            if scoped_hexes is None:
+                state_rows = self._conn.execute(
+                    "SELECT artifact_id, agent_id, state FROM agent_states"
+                ).fetchall()
+            elif scoped_hexes:
+                placeholders = ", ".join("?" * len(scoped_hexes))
+                state_rows = self._conn.execute(
+                    "SELECT artifact_id, agent_id, state FROM agent_states "
+                    f"WHERE agent_id IN ({placeholders})",
+                    scoped_hexes,
+                ).fetchall()
+            else:
+                state_rows = []
+            for row in state_rows:
                 aid = UUID(hex=row[0])
                 gid = UUID(hex=row[1])
                 # Only artifacts present in artifact_by_id get state rows.

--- a/src/ccs/coordinator/sqlite_registry.py
+++ b/src/ccs/coordinator/sqlite_registry.py
@@ -138,7 +138,7 @@ CCS_STATE_LOG_SCHEMA_VERSION = "ccs.state_log.v2"
 """Reuses the same schema version as in-memory registry (state_log emissions
 are interchangeable from a downstream consumer's perspective)."""
 
-SCHEMA_USER_VERSION = 5
+SCHEMA_USER_VERSION = 6
 """Schema version stamped via ``PRAGMA user_version`` on init.
 
 **v1 -> v2** (plan item N v1) added the durable ``artifact_versions`` table and
@@ -176,6 +176,22 @@ conversion: ``_migrate_v3_to_v4`` previously guarded AND stamped with the
 v3-origin db stamp user_version=5 WITHOUT the v5 DDL — exactly the state the
 structural probes refuse. It now stamps the intermediate literal 4 and the
 chained ``_migrate_v4_to_v5`` lands the v5 DDL + the v5 stamp.
+
+**v5 -> v6** (SB-10 / compaction re-emission, R6/R7, KTD3/KTD9) adds the
+nullable ``agent_states.last_observed_version`` column — the durable
+per-(agent, artifact) record of the artifact version whose BYTES that agent
+last observed (written atomically with every non-INVALID state upsert and the
+commit WIN paths; a transition to INVALID preserves the prior value and a
+never-observed row stays NULL, never a 0-sentinel). It is the comparand the
+post-compaction stale flag is computed from. Column-only and additive (no new
+table, no index, and deliberately NOT joined to any GC/retention exemption
+seam). The step also carries the ``_V5_USER_VERSION`` literal conversion —
+the same trap as the v5 bump: ``_migrate_v4_to_v5`` stamped the constant while
+it was the final chain step; it now stamps the intermediate literal 5 and the
+chained ``_migrate_v5_to_v6`` lands the column + the v6 stamp. The column is
+Python-lineage only; the Node ledger's own ``agent_states`` ALTER
+(``deadline_tick``, below) stays the foreign fingerprint and NEITHER runtime
+may add the other's column.
 
 **CROSS-RUNTIME LEDGER DIVERGENCE (security).** The sibling Node coordinator
 (agent-coherence-plugin) shares the SAME ``state.db`` path but keeps its OWN
@@ -215,6 +231,17 @@ was 4), so the v5 bump alone would have made a v3-origin db skip the v4->v5
 step's loser-guard and get stamped 5 without the v5 DDL. Every intermediate
 migration must pin its own stamp as a literal; only the FINAL step in the chain
 may stamp the constant."""
+
+_V5_USER_VERSION = 5
+"""The intermediate v5 stamp ``_migrate_v4_to_v5`` writes (the
+workspace-checkpoint tables + name index), before the chained
+``_migrate_v5_to_v6`` step adds ``agent_states.last_observed_version`` and
+advances to ``SCHEMA_USER_VERSION``. A literal for the same reason as the
+earlier intermediates (the re-stamp trap): while ``_migrate_v4_to_v5`` was the
+final step it correctly guarded/stamped the constant, but with the constant at
+6 that would stamp a v4-origin db ``user_version=6`` WITHOUT the v6 column —
+the chained v5->v6 loser-guard then no-ops and the write-free rehydrate never
+adds it. Only the FINAL step in the chain may stamp the constant."""
 
 _DB_FILE_MODE = 0o600
 """state.db (and its -wal/-shm sidecars) must be owner-read/write only.
@@ -667,26 +694,30 @@ class SqliteArtifactRegistry:
 
         - ``user_version == 0`` (brand-new file) → ``_apply_v2_schema``: the
           COMPLETE current schema (v2 tables + ``session_pins`` + ``session_meta``
-          + the workspace-checkpoint tables + the indexes) in one atomic
-          transaction (no shim ever runs on a fresh db).
+          + the workspace-checkpoint tables + the v6 ``last_observed_version``
+          column + the indexes) in one atomic transaction (no shim ever runs on a
+          fresh db).
         - ``user_version == 1`` (any wild v1 variant) → ``_migrate_v1_to_v2`` then
           ``_migrate_v2_to_v3`` then ``_migrate_v3_to_v4`` then
-          ``_migrate_v4_to_v5``: idempotently subsumes BOTH additive shims (fence
-          columns + epoch seed, and ``pending_notices``), adds
-          ``artifact_versions`` (v2), ``session_pins`` (v3), ``session_meta`` +
-          the artifact index (v4), then the workspace-checkpoint tables (v5). The
-          wild v1 population is a 2x2 matrix ({±fence columns} x
+          ``_migrate_v4_to_v5`` then ``_migrate_v5_to_v6``: idempotently subsumes
+          BOTH additive shims (fence columns + epoch seed, and
+          ``pending_notices``), adds ``artifact_versions`` (v2), ``session_pins``
+          (v3), ``session_meta`` + the artifact index (v4), the
+          workspace-checkpoint tables (v5), then the ``last_observed_version``
+          column (v6). The wild v1 population is a 2x2 matrix ({±fence columns} x
           {±pending_notices}) because both shims shipped with no version bump;
           ``IF NOT EXISTS`` guards make each piece apply only when missing.
-        - ``user_version == 2`` → the chained ``2 -> 3 -> 4 -> 5`` steps.
-        - ``user_version == 3`` → ``_migrate_v3_to_v4`` then ``_migrate_v4_to_v5``:
-          an existing v3 db (``session_pins`` present, ``session_meta`` ABSENT —
+        - ``user_version == 2`` → the chained ``2 -> 3 -> 4 -> 5 -> 6`` steps.
+        - ``user_version == 3`` → the chained ``3 -> 4 -> 5 -> 6`` steps: an
+          existing v3 db (``session_pins`` present, ``session_meta`` ABSENT —
           earlier commits of that branch stamped it) gains ``session_meta`` + the
-          index, then the workspace-checkpoint tables. Without the v3 branch such
-          a db would open write-free and crash on the first session op.
-        - ``user_version == 4`` → ``_migrate_v4_to_v5``: an existing v4 db gains
-          the workspace-checkpoint tables.
-        - ``user_version == 5`` (SCHEMA_USER_VERSION) → ``_rehydrate_meta``: the
+          index, then the workspace-checkpoint tables, then the v6 column.
+          Without the v3 branch such a db would open write-free and crash on the
+          first session op.
+        - ``user_version == 4`` → ``_migrate_v4_to_v5`` then ``_migrate_v5_to_v6``.
+        - ``user_version == 5`` → ``_migrate_v5_to_v6``: an existing v5 db gains
+          the ``agent_states.last_observed_version`` column.
+        - ``user_version == 6`` (SCHEMA_USER_VERSION) → ``_rehydrate_meta``: the
           WRITE-FREE open path (no ALTER, no IF-NOT-EXISTS) — the prerequisite for
           read-only mode.
         - anything else → :class:`SchemaVersionError` (no destructive advice).
@@ -704,30 +735,39 @@ class SqliteArtifactRegistry:
             if current == 0:
                 self._apply_v2_schema(instance_id)
             elif current == 1:
-                # v1 → v2 → v3 → v4 → v5: each step is its own atomic BEGIN
+                # v1 → v2 → v3 → v4 → v5 → v6: each step is its own atomic BEGIN
                 # IMMEDIATE and rehydrates meta; the chain lands the full schema.
                 self._migrate_v1_to_v2(instance_id)
                 self._migrate_v2_to_v3(instance_id)
                 self._migrate_v3_to_v4(instance_id)
                 self._migrate_v4_to_v5(instance_id)
+                self._migrate_v5_to_v6(instance_id)
             elif current == 2:
-                # 2 → 3 → 4 → 5: session_pins, session_meta + index, checkpoints.
+                # 2 → 3 → 4 → 5 → 6: session_pins, session_meta + index,
+                # checkpoints, last_observed_version.
                 self._migrate_v2_to_v3(instance_id)
                 self._migrate_v3_to_v4(instance_id)
                 self._migrate_v4_to_v5(instance_id)
+                self._migrate_v5_to_v6(instance_id)
             elif current == _V3_USER_VERSION:
                 # An existing v3 db (session_pins, NO session_meta — earlier
                 # commits of that branch stamped it) → add session_meta + index,
-                # then chain to v5. WITHOUT the v3 branch such a db would open
+                # then chain to v6. WITHOUT the v3 branch such a db would open
                 # write-free and crash on the first session op with 'no such
                 # table: session_meta'.
                 self._migrate_v3_to_v4(instance_id)
                 self._migrate_v4_to_v5(instance_id)
+                self._migrate_v5_to_v6(instance_id)
             elif current == _V4_USER_VERSION:
-                # An existing v4 db → add the workspace-checkpoint tables (v5).
+                # An existing v4 db → the workspace-checkpoint tables (v5), then
+                # the last_observed_version column (v6).
                 self._migrate_v4_to_v5(instance_id)
+                self._migrate_v5_to_v6(instance_id)
+            elif current == _V5_USER_VERSION:
+                # An existing v5 db → add agent_states.last_observed_version (v6).
+                self._migrate_v5_to_v6(instance_id)
             elif current == SCHEMA_USER_VERSION:
-                # Existing v5 database — rehydrate; NO writes on this path (the
+                # Existing v6 database — rehydrate; NO writes on this path (the
                 # prerequisite for read-only open mode).
                 self._rehydrate_meta(instance_id)
             else:
@@ -859,6 +899,13 @@ class SqliteArtifactRegistry:
            refusal is the honest response. Literal ``5`` — pins Python-v5
            semantics.
 
+        The v6 bump (``agent_states.last_observed_version``, SB-10) adds NO
+        probe by review (KTD9): it is a column on an existing table, and the
+        two ledgers' ``agent_states`` fingerprints stay disjoint — probe 2's
+        ``deadline_tick`` marker remains Node-only (this repo must never add
+        that column) and ``last_observed_version`` is Python-only, so probe 2
+        neither misses a Node db nor false-positives on a Python v6 one.
+
         ``user_version == 1`` is deliberately NOT blocked: the Node ledger's
         v1 is a byte-for-byte mirror of this repo's v1 schema, so the two are
         indistinguishable by design — the normal v1->v2 migration proceeds
@@ -921,7 +968,8 @@ class SqliteArtifactRegistry:
     def _apply_v2_schema(self, instance_id: str | None) -> None:
         """Create the COMPLETE current schema (v2 tables + the v3 ``session_pins``
         table + the v4 ``session_meta`` table/index + the v5 workspace-checkpoint
-        tables) + seed registry_meta, stamping ``user_version=SCHEMA_USER_VERSION``.
+        tables + the v6 ``agent_states.last_observed_version`` column) + seed
+        registry_meta, stamping ``user_version=SCHEMA_USER_VERSION``.
         Caller holds lock. (The method keeps its historical ``_apply_v2_schema``
         name; a fresh db is always built at the latest schema directly so no
         migration shim ever runs against it.)
@@ -970,15 +1018,16 @@ class SqliteArtifactRegistry:
             c.execute(
                 """
                 CREATE TABLE agent_states (
-                    artifact_id          TEXT NOT NULL,
-                    agent_id             TEXT NOT NULL,
-                    state                TEXT NOT NULL,
-                    transient_state      TEXT,
-                    transient_tick       INTEGER,
-                    granted_at_tick      INTEGER,
-                    last_reclaim_trigger TEXT,
-                    last_reclaim_tick    INTEGER,
-                    read_generation      INTEGER,
+                    artifact_id           TEXT NOT NULL,
+                    agent_id              TEXT NOT NULL,
+                    state                 TEXT NOT NULL,
+                    transient_state       TEXT,
+                    transient_tick        INTEGER,
+                    granted_at_tick       INTEGER,
+                    last_reclaim_trigger  TEXT,
+                    last_reclaim_tick     INTEGER,
+                    read_generation       INTEGER,
+                    last_observed_version INTEGER,
                     PRIMARY KEY (artifact_id, agent_id),
                     FOREIGN KEY (artifact_id) REFERENCES artifacts(id) ON DELETE CASCADE
                 )
@@ -1316,10 +1365,20 @@ class SqliteArtifactRegistry:
         self._rehydrate_meta(instance_id)
 
     def _migrate_v4_to_v5(self, instance_id: str | None) -> None:
-        """Migrate a v4 db to v5 in ONE atomic transaction (WV plan Unit 2 / R1,
-        R9): add the ``workspace_checkpoints`` + ``workspace_checkpoint_members``
-        tables and the name index, then stamp ``user_version=5``. Caller holds
-        lock. The FINAL step of the chain, so it stamps ``SCHEMA_USER_VERSION``.
+        """Migrate a v4 db to the INTERMEDIATE v5 in ONE atomic transaction (WV
+        plan Unit 2 / R1, R9): add the ``workspace_checkpoints`` +
+        ``workspace_checkpoint_members`` tables and the name index, then stamp
+        ``user_version=5``. Caller holds lock. Chained to ``_migrate_v5_to_v6``
+        by the open dispatcher (a v4 db steps 4 -> 5 -> 6).
+
+        Guard + stamp use the ``_V5_USER_VERSION`` LITERAL, not the constant
+        (the recurring re-stamp trap, third occurrence): while this was the
+        final chain step it guarded and stamped ``SCHEMA_USER_VERSION``, which
+        was correct at 5 — but once the constant moved to 6, a v4-origin db
+        running this step would have been stamped 6 WITHOUT the v6 column (and
+        the chained v5->v6 step's loser-guard would then see >= 6 and no-op).
+        Intermediate migrations pin their own stamp; only the final chain step
+        stamps the constant.
 
         Additive-only — it touches NO existing table, so there is no shim to
         subsume and no content/mode posture change (the new tables hold
@@ -1336,7 +1395,8 @@ class SqliteArtifactRegistry:
         Concurrent-loser path: two processes can both read ``user_version == 4``
         (a bare pre-lock read) and both land here; they serialize on the ``BEGIN
         IMMEDIATE`` write lock. The loser re-reads ``user_version`` INSIDE its
-        txn, sees the winner already at >= v5, and no-ops.
+        txn, sees the winner already at >= v5, and no-ops (the chained v5->v6
+        step runs next regardless).
 
         NODE-LEDGER COORDINATION (checked at authoring, 2026-08-08, against the
         local agent-coherence-plugin checkout): the sibling Node coordinator's
@@ -1357,8 +1417,9 @@ class SqliteArtifactRegistry:
         c = self._conn
         c.execute("BEGIN IMMEDIATE")
         try:
-            if c.execute("PRAGMA user_version").fetchone()[0] >= SCHEMA_USER_VERSION:
-                # A racing winner already advanced to v5 — nothing to do.
+            if c.execute("PRAGMA user_version").fetchone()[0] >= _V5_USER_VERSION:
+                # A racing winner already advanced to >= v5 — nothing to do here
+                # (the chained v5->v6 step runs next regardless).
                 c.execute("COMMIT")
                 self._rehydrate_meta(instance_id)
                 return
@@ -1377,6 +1438,68 @@ class SqliteArtifactRegistry:
                     "CREATE INDEX", "CREATE INDEX IF NOT EXISTS", 1
                 )
             )
+            c.execute(f"PRAGMA user_version = {_V5_USER_VERSION}")
+            c.execute("COMMIT")
+        except BaseException:
+            try:
+                c.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
+        # Load meta from the now-migrated db (write-free).
+        self._rehydrate_meta(instance_id)
+
+    def _migrate_v5_to_v6(self, instance_id: str | None) -> None:
+        """Migrate a v5 db to v6 in ONE atomic transaction (SB-10, R6/R7 /
+        KTD9): add the nullable ``agent_states.last_observed_version`` column,
+        then stamp ``user_version=6``. Caller holds lock. The FINAL step of the
+        chain, so it stamps ``SCHEMA_USER_VERSION``.
+
+        Column-only and additive — it creates no table and no index, so there
+        is no shim to subsume and no content/mode posture change (the column
+        holds a version INTEGER, never content bytes). Nullable on purpose: a
+        pre-v6 grant observed no version under the new comparand, and NULL (not
+        a 0-sentinel) is the absence the accessor surfaces as ``None``. Same
+        atomicity discipline as every other migration (the
+        sqlite-schema-init-non-atomic-leaves-unbootable-db learning): ONE
+        explicit ``BEGIN IMMEDIATE`` wrapping the ALTER + the ``PRAGMA
+        user_version`` stamp, individual ``execute()`` calls (never
+        ``executescript``), ``except BaseException`` ROLLBACK so a SIGKILL
+        mid-migration leaves the v5 db intact for a clean re-migrate, and a
+        ``_has_column`` guard for the half-migrated-db case (column added by a
+        prior crashed migration whose stamp never committed — ALTER TABLE has
+        no IF NOT EXISTS, so the probe is the guard, mirroring
+        ``_migrate_v1_to_v2``'s fence-column idiom).
+
+        Concurrent-loser path: two processes can both read ``user_version == 5``
+        (a bare pre-lock read) and both land here; they serialize on the ``BEGIN
+        IMMEDIATE`` write lock. The loser re-reads ``user_version`` INSIDE its
+        txn, sees the winner already at >= v6, and no-ops.
+
+        NODE-LEDGER COORDINATION (KTD9 review): the sibling Node coordinator's
+        ledger still tops out at ``user_version=3`` and its
+        ``rejectForeignLedgerDb`` refuses any Python-lineage db on markers every
+        Python v2+ db carries (the ``schema_runtime='python'`` stamp, the
+        ``artifact_versions`` table, ``artifacts.owner_generation``) BEFORE the
+        integer 6 is interpreted against the Node ledger. The reverse direction
+        stays covered by the ``deadline_tick`` structural probe (``>= 3``) plus
+        the ``schema_runtime='node'`` stamp — this step adds
+        ``last_observed_version``, never ``deadline_tick``, so the two ledgers'
+        ``agent_states`` fingerprints remain disjoint and adding only a column
+        obliges NO new probe in ``_reject_foreign_ledger_db``.
+        """
+        c = self._conn
+        c.execute("BEGIN IMMEDIATE")
+        try:
+            if c.execute("PRAGMA user_version").fetchone()[0] >= SCHEMA_USER_VERSION:
+                # A racing winner already advanced to v6 — nothing to do.
+                c.execute("COMMIT")
+                self._rehydrate_meta(instance_id)
+                return
+            if not self._has_column("agent_states", "last_observed_version"):
+                c.execute(
+                    "ALTER TABLE agent_states ADD COLUMN last_observed_version INTEGER"
+                )
             c.execute(f"PRAGMA user_version = {SCHEMA_USER_VERSION}")
             c.execute("COMMIT")
         except BaseException:
@@ -1833,6 +1956,20 @@ class SqliteArtifactRegistry:
         with self._lock:
             row = self._conn.execute(
                 "SELECT read_generation FROM agent_states "
+                "WHERE artifact_id = ? AND agent_id = ?",
+                (artifact_id.hex, agent_id.hex),
+            ).fetchone()
+            return row[0] if row is not None else None
+
+    def last_observed_version_for(self, artifact_id: UUID, agent_id: UUID) -> int | None:
+        """Return the artifact version whose bytes this agent last observed
+        (SB-10 R6/R7: recorded atomically with every non-INVALID grant/commit
+        upsert), or None when the pair was never observed — absence is NULL,
+        never a 0-sentinel, and a transition to INVALID preserved the prior
+        recorded value. The post-compaction staleness comparand."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT last_observed_version FROM agent_states "
                 "WHERE artifact_id = ? AND agent_id = ?",
                 (artifact_id.hex, agent_id.hex),
             ).fetchone()
@@ -2748,6 +2885,20 @@ class SqliteArtifactRegistry:
                         (artifact_id.hex, artifact_id.hex, agent_id.hex),
                     )
 
+                # SB-10 R6/R7: record the version whose bytes this agent now
+                # holds, atomic with the upsert in this BEGIN IMMEDIATE (the
+                # ``version`` operand was SELECTed above in this same txn).
+                # Non-INVALID targets only -- a transition TO INVALID preserves
+                # the prior recorded value (the last version actually observed,
+                # the post-compaction staleness comparand) and a never-observed
+                # row keeps NULL (never a 0-sentinel).
+                if state != MESIState.INVALID:
+                    self._conn.execute(
+                        "UPDATE agent_states SET last_observed_version = ? "
+                        "WHERE artifact_id = ? AND agent_id = ?",
+                        (version, artifact_id.hex, agent_id.hex),
+                    )
+
                 # Mutation-then-log: emit state_log BEFORE commit. If the callback
                 # raises, ROLLBACK undoes the agent_states change AND we decrement
                 # _seq so gap detection stays consistent.
@@ -3298,14 +3449,19 @@ class SqliteArtifactRegistry:
                 committer_from = (
                     MESIState[committer_row[0]] if committer_row else MESIState.INVALID
                 )
+                # SB-10 R6/R7 (KTD4 first layer): the WIN advances the WRITER's
+                # last_observed_version to next_version atomically in this txn
+                # — it produced (and therefore observed) the new version's
+                # bytes. Peers going INVALID above keep their prior value.
                 if committer_row is None:
                     self._conn.execute(
                         """
                         INSERT INTO agent_states (artifact_id, agent_id, state, granted_at_tick,
-                                                  last_reclaim_trigger, last_reclaim_tick)
-                        VALUES (?, ?, ?, NULL, NULL, NULL)
+                                                  last_reclaim_trigger, last_reclaim_tick,
+                                                  last_observed_version)
+                        VALUES (?, ?, ?, NULL, NULL, NULL, ?)
                         """,
-                        (artifact_id.hex, agent_id.hex, MESIState.SHARED.name),
+                        (artifact_id.hex, agent_id.hex, MESIState.SHARED.name, next_version),
                     )
                 else:
                     # Preserve granted_at_tick (None for an S/I committer); the
@@ -3315,10 +3471,11 @@ class SqliteArtifactRegistry:
                     self._conn.execute(
                         """
                         UPDATE agent_states
-                        SET state = ?, granted_at_tick = ?
+                        SET state = ?, granted_at_tick = ?, last_observed_version = ?
                         WHERE artifact_id = ? AND agent_id = ?
                         """,
-                        (MESIState.SHARED.name, prior_granted_at, artifact_id.hex, agent_id.hex),
+                        (MESIState.SHARED.name, prior_granted_at, next_version,
+                         artifact_id.hex, agent_id.hex),
                     )
                 seq_incremented_count += self._emit_state_log(
                     artifact_id=artifact_id,
@@ -3485,17 +3642,23 @@ class SqliteArtifactRegistry:
                     committer_from = (
                         MESIState[committer_row[0]] if committer_row else MESIState.INVALID
                     )
+                    # SB-10 R6/R7 (KTD4 first layer): each member's WIN advances
+                    # the WRITER's last_observed_version to that member's
+                    # next_version in this same txn; invalidated peers keep theirs.
                     if committer_row is None:
                         self._conn.execute(
                             "INSERT INTO agent_states (artifact_id, agent_id, state, granted_at_tick, "
-                            "last_reclaim_trigger, last_reclaim_tick) VALUES (?, ?, ?, NULL, NULL, NULL)",
-                            (art_id.hex, agent_id.hex, MESIState.SHARED.name),
+                            "last_reclaim_trigger, last_reclaim_tick, last_observed_version) "
+                            "VALUES (?, ?, ?, NULL, NULL, NULL, ?)",
+                            (art_id.hex, agent_id.hex, MESIState.SHARED.name, next_version),
                         )
                     else:
                         self._conn.execute(
-                            "UPDATE agent_states SET state = ?, granted_at_tick = ? "
+                            "UPDATE agent_states SET state = ?, granted_at_tick = ?, "
+                            "last_observed_version = ? "
                             "WHERE artifact_id = ? AND agent_id = ?",
-                            (MESIState.SHARED.name, committer_row[1], art_id.hex, agent_id.hex),
+                            (MESIState.SHARED.name, committer_row[1], next_version,
+                             art_id.hex, agent_id.hex),
                         )
                     seq_incremented_count += self._emit_state_log(
                         artifact_id=art_id, agent_id=agent_id, from_state=committer_from,

--- a/tests/coordinator/test_last_observed_version.py
+++ b/tests/coordinator/test_last_observed_version.py
@@ -119,6 +119,7 @@ def _revert_to_v5_shape(db_path: Path) -> None:
     ``last_observed_version`` ABSENT, stamped ``user_version=5`` (what a pre-SB-10
     build produced). DROP COLUMN needs sqlite >= 3.35 (2021) — every supported
     interpreter's bundled sqlite clears that."""
+    _revert_to_v6_shape(db_path)
     conn = sqlite3.connect(str(db_path))
     try:
         conn.execute("ALTER TABLE agent_states DROP COLUMN last_observed_version")
@@ -140,6 +141,32 @@ def _revert_to_v4_shape(db_path: Path) -> None:
         conn.execute("DROP INDEX IF EXISTS idx_workspace_checkpoints_name")
         conn.execute("PRAGMA user_version = 4")
         conn.commit()
+    finally:
+        conn.close()
+
+
+def _revert_to_v6_shape(db_path: Path) -> None:
+    """Mutate a current (v7) db on disk back to the v6 shape: the
+    ``idx_agent_states_agent`` index ABSENT, stamped ``user_version=6`` (what
+    an SB-10-era build produced before the index migration)."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("DROP INDEX IF EXISTS idx_agent_states_agent")
+        conn.execute("PRAGMA user_version = 6")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _indexes(db_path: Path) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%'"
+            ).fetchall()
+        }
     finally:
         conn.close()
 
@@ -176,8 +203,8 @@ def test_fresh_v6_init_has_column(db_path: Path) -> None:
     """A fresh db is created at v6 directly: ``last_observed_version`` inline in
     the ``agent_states`` DDL, ``user_version=6`` — no migration shim ever runs."""
     with SqliteArtifactRegistry(db_path) as reg:
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 6
-    assert SCHEMA_USER_VERSION == 6
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
+    assert SCHEMA_USER_VERSION == 7
     cols = {row[1] for row in _agent_states_shape(db_path)}
     assert "last_observed_version" in cols
 
@@ -194,7 +221,7 @@ def test_v5_db_upgrades_to_v6_and_prior_rows_read_null(db_path: Path) -> None:
     assert _user_version(db_path) == 5
 
     with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 6
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
         # Pre-migration data intact.
         got = reg.get_artifact(art.id)
         assert got is not None and got.version == 1 and got.content_hash == "h"
@@ -218,7 +245,7 @@ def test_upgraded_and_fresh_agent_states_shapes_identical(
         pass
     _revert_to_v5_shape(upgraded)
     with SqliteArtifactRegistry(upgraded) as reg:
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 6
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
     assert _agent_states_shape(upgraded) == _agent_states_shape(fresh)
 
 
@@ -226,12 +253,13 @@ def test_v4_to_v5_to_v6_walk_lands_v6_column_at_v6_stamp(db_path: Path) -> None:
     """THE RE-STAMP TRAP REGRESSION (KTD9). A v4-origin db must walk 4 -> 5 -> 6
     and end with the v5 DDL AND the v6 column present AT the v6 stamp.
 
-    If ``_migrate_v4_to_v5`` still guarded/stamped ``SCHEMA_USER_VERSION`` (the
-    correct shape while the constant was 5), a v4-origin db would be stamped 6
-    by the v4->v5 step WITHOUT the v6 column, and the chained v5->v6 step's
-    loser-guard would see >= 6 and no-op — the write-free rehydrate then never
-    adds the column and the first recording UPDATE fails. This test fails if
-    the ``_V5_USER_VERSION`` literal conversion is ever reverted."""
+    Two literal conversions are load-bearing, one per constant bump. If
+    ``_migrate_v4_to_v5`` still stamped ``SCHEMA_USER_VERSION``, a v4-origin
+    db would be stamped past v6 WITHOUT the column; if ``_migrate_v5_to_v6``
+    still stamped the constant (correct while it was 6), a v5-origin db would
+    be stamped 7 WITHOUT the index and the chained v6->v7 loser-guard would
+    no-op. This test fails if EITHER the ``_V5_USER_VERSION`` or the
+    ``_V6_USER_VERSION`` literal conversion is ever reverted."""
     with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
         art = _register(reg)
     _revert_to_v4_shape(db_path)
@@ -240,7 +268,7 @@ def test_v4_to_v5_to_v6_walk_lands_v6_column_at_v6_stamp(db_path: Path) -> None:
 
     agent = uuid4()
     with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 6
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
         # The intermediate v5 surface landed too (the chain did not skip a step).
         tables = {
             r[0]
@@ -248,6 +276,13 @@ def test_v4_to_v5_to_v6_walk_lands_v6_column_at_v6_stamp(db_path: Path) -> None:
                 "SELECT name FROM sqlite_master WHERE type='table'"
             ).fetchall()
         }
+        idx = {
+            r[0]
+            for r in reg._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+            ).fetchall()
+        }
+        assert "idx_agent_states_agent" in idx
         assert "workspace_checkpoints" in tables
         assert "workspace_checkpoint_members" in tables
         # The column is USABLE, not just present: a grant records through it.
@@ -309,7 +344,7 @@ def test_sigkill_mid_v5_to_v6_migration_leaves_bootable_v5(
 
     # A clean reopen completes the migration (idempotent), data intact.
     with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 6
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
         got = reg.get_artifact(art.id)
         assert got is not None and got.content_hash == "h"
         assert reg.last_observed_version_for(art.id, uuid4()) is None
@@ -336,7 +371,7 @@ def test_genuine_v6_db_reopens_fine_both_paths(db_path: Path) -> None:
     with SqliteArtifactRegistry(db_path) as reg:
         _register(reg)
     with SqliteArtifactRegistry(db_path) as rw:
-        assert rw._conn.execute("PRAGMA user_version").fetchone()[0] == 6
+        assert rw._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
     with SqliteArtifactRegistry(db_path, read_only=True) as ro:
         assert ro.instance_id
 
@@ -474,3 +509,49 @@ def test_parity_service_commit_advances_writer(registry) -> None:
     assert reg.last_observed_version_for(art.id, writer) == 2
     assert reg.get_agent_state(art.id, peer) is MESIState.INVALID
     assert reg.last_observed_version_for(art.id, peer) == 1
+
+# ---------------------------------------------------------------------------
+# Migration v7 — the agent_states(agent_id) index (SB-10 perf follow-up)
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_v7_init_has_agent_states_agent_index(db_path: Path) -> None:
+    """A fresh db is created at v7 directly: the ``idx_agent_states_agent``
+    index inline in the fresh DDL, ``user_version=7`` — no migration shim."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 7
+    assert "idx_agent_states_agent" in _indexes(db_path)
+
+
+def test_v6_db_upgrades_to_v7_and_gains_the_index(db_path: Path) -> None:
+    """A v6 db (SB-10-era: column present, index absent) migrates on open:
+    index created, stamped v7, pre-migration data intact."""
+    agent = uuid4()
+    with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
+        art = _register(reg)
+        reg.set_agent_state(art.id, agent, MESIState.SHARED, trigger="fetch", tick=1)
+    _revert_to_v6_shape(db_path)
+    assert _user_version(db_path) == 6
+    assert "idx_agent_states_agent" not in _indexes(db_path)
+
+    with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 7
+        assert reg.get_agent_state(art.id, agent) is MESIState.SHARED
+        assert reg.last_observed_version_for(art.id, agent) == 1
+    assert "idx_agent_states_agent" in _indexes(db_path)
+
+
+def test_upgraded_and_fresh_index_sets_identical(tmp_path: Path) -> None:
+    """A v6->v7-migrated db and a fresh-v7 db expose the same idx_* set — the
+    migration creates exactly what the fresh DDL declares."""
+    fresh = tmp_path / "fresh.db"
+    upgraded = tmp_path / "upgraded.db"
+    with SqliteArtifactRegistry(fresh):
+        pass
+    with SqliteArtifactRegistry(upgraded):
+        pass
+    _revert_to_v6_shape(upgraded)
+    with SqliteArtifactRegistry(upgraded):
+        pass
+    assert _indexes(upgraded) == _indexes(fresh)
+

--- a/tests/coordinator/test_last_observed_version.py
+++ b/tests/coordinator/test_last_observed_version.py
@@ -1,0 +1,476 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Registry v6 — the ``last_observed_version`` comparand (SB-10, R6/R7, KTD3/KTD9).
+
+SB-10 plan (docs/plans/2026-08-24-1750-feat-sb10-compaction-reemission-plan.md),
+durable-comparand unit. After a Claude Code compaction a session must re-learn
+which cached tracked-artifact views are stale; the comparand is the artifact
+version whose BYTES an agent last observed, recorded per (agent, artifact)
+atomically with every non-INVALID ``agent_states`` upsert. Covers, per the
+unit's test scenarios:
+
+- migration: a fresh db lands v6 with the ``agent_states.last_observed_version``
+  column; a v5 db upgrades (pre-v6 grants read NULL — never a 0-sentinel);
+  upgraded and fresh ``agent_states`` shapes are IDENTICAL;
+- **the v4 -> 5 -> 6 walk regression** (the re-stamp trap, KTD9): with the
+  constant at 6, ``_migrate_v4_to_v5`` must guard/stamp the intermediate
+  ``_V5_USER_VERSION`` literal — stamping the constant would mark a v4-origin
+  db ``user_version=6`` WITHOUT the column, and the chained v5->v6 step's
+  loser-guard would no-op. The walk test fails if the literal is ever reverted;
+- a SIGKILL-simulation mid v5->v6 (ALTER executed, raise before the in-txn
+  stamp) leaves a bootable v5 that a clean reopen re-migrates;
+- the foreign-ledger guard still refuses a Node-fingerprint db
+  (``agent_states.deadline_tick`` at ``user_version>=3``) and does NOT
+  false-positive on a genuine Python v6;
+- recording semantics on BOTH registries (the parametrized arms are the parity
+  run): S/E/M upserts record the artifact's current version; a transition to
+  INVALID preserves the prior recorded value; a never-observed pair stays
+  NULL/absent (accessor returns None);
+- the commit paths advance the WRITER's recorded value to the NEW version in
+  the same transaction (``commit_cas`` / ``commit_all`` / the pessimistic
+  ``service.commit``), while invalidated peers keep their pre-commit value.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Iterator
+from uuid import uuid4
+
+import pytest
+
+from ccs.coordinator.registry import ArtifactRegistry
+from ccs.coordinator.sqlite_registry import (
+    SCHEMA_USER_VERSION,
+    CrossRuntimeSchemaError,
+    SqliteArtifactRegistry,
+)
+from ccs.core.states import MESIState
+from ccs.core.types import Artifact, CommitAllEntry, ConflictDetail, MultiCommitResult
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "state.db"
+
+
+# Both-arms fixture: every recording scenario runs against the in-memory AND
+# the sqlite registry — the parametrization IS the parity harness for this
+# surface (the test_fencing.py precedent for per-agent bookkeeping).
+@pytest.fixture(params=["in_memory", "sqlite"])
+def registry(
+    request: pytest.FixtureRequest, tmp_path: Path
+) -> "Iterator[ArtifactRegistry | SqliteArtifactRegistry]":
+    if request.param == "in_memory":
+        yield ArtifactRegistry()
+    else:
+        reg = SqliteArtifactRegistry(tmp_path / "parity-arm.db")
+        yield reg
+        reg.close()
+
+
+def _register(reg) -> Artifact:
+    art = Artifact(id=uuid4(), name="plan.md", version=1, content_hash="h")
+    reg.register_artifact(art, content="seed-body")
+    return art
+
+
+# ---------------------------------------------------------------------------
+# Raw-db helpers (probes + shape reverts; plain sqlite3, never the registry)
+# ---------------------------------------------------------------------------
+
+
+def _user_version(db_path: Path) -> int:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute("PRAGMA user_version").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _tables(db_path: Path) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+
+
+def _agent_states_shape(db_path: Path) -> list[tuple]:
+    """Full ``PRAGMA table_info(agent_states)`` rows — (cid, name, type,
+    notnull, dflt_value, pk) — so the fresh-vs-upgraded comparison pins the
+    column ORDER and declared types, not just the name set."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute("PRAGMA table_info(agent_states)").fetchall()
+    finally:
+        conn.close()
+
+
+def _revert_to_v5_shape(db_path: Path) -> None:
+    """Mutate a current (v6) db on disk back to the v5 shape:
+    ``last_observed_version`` ABSENT, stamped ``user_version=5`` (what a pre-SB-10
+    build produced). DROP COLUMN needs sqlite >= 3.35 (2021) — every supported
+    interpreter's bundled sqlite clears that."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("ALTER TABLE agent_states DROP COLUMN last_observed_version")
+        conn.execute("PRAGMA user_version = 5")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _revert_to_v4_shape(db_path: Path) -> None:
+    """Mutate a current (v6) db on disk back to the v4 shape (the re-stamp
+    trap's migration origin): v6 column + v5 workspace tables ABSENT, stamped
+    ``user_version=4``."""
+    _revert_to_v5_shape(db_path)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("DROP TABLE IF EXISTS workspace_checkpoint_members")
+        conn.execute("DROP TABLE IF EXISTS workspace_checkpoints")
+        conn.execute("DROP INDEX IF EXISTS idx_workspace_checkpoints_name")
+        conn.execute("PRAGMA user_version = 4")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _forge_node_v3_db(db_path: Path) -> None:
+    """Forge a sibling-Node-ledger v3 db: the shared v1 DDL + the Node ledger's
+    v3 marker (``agent_states.deadline_tick``) + ``user_version=3``. Compact
+    mirror of the fuller forge in ``tests/test_sqlite_registry.py``."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "CREATE TABLE artifacts (id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE, "
+            "version INTEGER NOT NULL, content_hash TEXT NOT NULL, size_tokens INTEGER, "
+            "last_writer_id TEXT, updated_at REAL NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE agent_states (artifact_id TEXT NOT NULL, agent_id TEXT NOT NULL, "
+            "state TEXT NOT NULL, PRIMARY KEY (artifact_id, agent_id))"
+        )
+        conn.execute("CREATE TABLE registry_meta (key TEXT PRIMARY KEY, value TEXT)")
+        conn.execute("ALTER TABLE agent_states ADD COLUMN deadline_tick INTEGER")
+        conn.execute("PRAGMA user_version = 3")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Migration — fresh init, v5 upgrade, the re-stamp trap, crash atomicity
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_v6_init_has_column(db_path: Path) -> None:
+    """A fresh db is created at v6 directly: ``last_observed_version`` inline in
+    the ``agent_states`` DDL, ``user_version=6`` — no migration shim ever runs."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 6
+    assert SCHEMA_USER_VERSION == 6
+    cols = {row[1] for row in _agent_states_shape(db_path)}
+    assert "last_observed_version" in cols
+
+
+def test_v5_db_upgrades_to_v6_and_prior_rows_read_null(db_path: Path) -> None:
+    """A v5 db migrates on open; a grant recorded BEFORE v6 existed has no
+    observation on file, so the accessor reports None (never a 0-sentinel) and
+    the pre-migration data survives untouched."""
+    agent = uuid4()
+    with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
+        art = _register(reg)
+        reg.set_agent_state(art.id, agent, MESIState.EXCLUSIVE, trigger="write", tick=1)
+    _revert_to_v5_shape(db_path)
+    assert _user_version(db_path) == 5
+
+    with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 6
+        # Pre-migration data intact.
+        got = reg.get_artifact(art.id)
+        assert got is not None and got.version == 1 and got.content_hash == "h"
+        assert reg.get_agent_state(art.id, agent) is MESIState.EXCLUSIVE
+        assert reg.get_content_at_version(art.id, 1) == "seed-body"
+        # The pre-v6 grant was never observed under the new comparand: NULL.
+        assert reg.last_observed_version_for(art.id, agent) is None
+
+
+def test_upgraded_and_fresh_agent_states_shapes_identical(
+    tmp_path: Path,
+) -> None:
+    """A v5->v6-migrated ``agent_states`` and a fresh-v6 one are byte-identical
+    per ``PRAGMA table_info`` (names, order, types) — the ALTER appends the
+    column exactly where the fresh DDL declares it."""
+    fresh = tmp_path / "fresh.db"
+    upgraded = tmp_path / "upgraded.db"
+    with SqliteArtifactRegistry(fresh):
+        pass
+    with SqliteArtifactRegistry(upgraded):
+        pass
+    _revert_to_v5_shape(upgraded)
+    with SqliteArtifactRegistry(upgraded) as reg:
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 6
+    assert _agent_states_shape(upgraded) == _agent_states_shape(fresh)
+
+
+def test_v4_to_v5_to_v6_walk_lands_v6_column_at_v6_stamp(db_path: Path) -> None:
+    """THE RE-STAMP TRAP REGRESSION (KTD9). A v4-origin db must walk 4 -> 5 -> 6
+    and end with the v5 DDL AND the v6 column present AT the v6 stamp.
+
+    If ``_migrate_v4_to_v5`` still guarded/stamped ``SCHEMA_USER_VERSION`` (the
+    correct shape while the constant was 5), a v4-origin db would be stamped 6
+    by the v4->v5 step WITHOUT the v6 column, and the chained v5->v6 step's
+    loser-guard would see >= 6 and no-op — the write-free rehydrate then never
+    adds the column and the first recording UPDATE fails. This test fails if
+    the ``_V5_USER_VERSION`` literal conversion is ever reverted."""
+    with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
+        art = _register(reg)
+    _revert_to_v4_shape(db_path)
+    assert _user_version(db_path) == 4
+    assert "workspace_checkpoints" not in _tables(db_path)
+
+    agent = uuid4()
+    with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 6
+        # The intermediate v5 surface landed too (the chain did not skip a step).
+        tables = {
+            r[0]
+            for r in reg._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert "workspace_checkpoints" in tables
+        assert "workspace_checkpoint_members" in tables
+        # The column is USABLE, not just present: a grant records through it.
+        reg.set_agent_state(art.id, agent, MESIState.SHARED, trigger="fetch", tick=1)
+        assert reg.last_observed_version_for(art.id, agent) == 1
+    # And the migrated db re-opens write-free at v6 (the trap's failure mode
+    # surfaced on the SECOND open).
+    with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
+        assert reg.last_observed_version_for(art.id, agent) == 1
+
+
+def test_sigkill_mid_v5_to_v6_migration_leaves_bootable_v5(
+    db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Single-transaction proof: crash the migration AFTER its ALTER executed
+    but BEFORE the in-txn stamp lands. The rollback must discard the ALTER (one
+    ``BEGIN IMMEDIATE`` wraps DDL + stamp), leaving a bootable v5 db that a
+    clean reopen re-migrates without erroring on a duplicate column."""
+    with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
+        art = _register(reg)
+    _revert_to_v5_shape(db_path)
+
+    real_connect = sqlite3.connect
+    opened: list[sqlite3.Connection] = []
+
+    class _CrashBeforeStamp:
+        """Connection proxy that simulates a SIGKILL at the v6 stamp: the ALTER
+        before it has executed inside the open BEGIN IMMEDIATE."""
+
+        def __init__(self, conn: sqlite3.Connection) -> None:
+            object.__setattr__(self, "_conn", conn)
+
+        def execute(self, sql: str, *args: object) -> object:
+            if sql.strip().startswith("PRAGMA user_version = 6"):
+                raise sqlite3.OperationalError("simulated SIGKILL before the v6 stamp")
+            return self._conn.execute(sql, *args)
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._conn, name)
+
+    def crashing_connect(*args: object, **kwargs: object) -> _CrashBeforeStamp:
+        conn = real_connect(*args, **kwargs)  # type: ignore[arg-type]
+        opened.append(conn)
+        return _CrashBeforeStamp(conn)
+
+    with monkeypatch.context() as mp:
+        mp.setattr(
+            "ccs.coordinator.sqlite_registry.sqlite3.connect", crashing_connect
+        )
+        with pytest.raises(sqlite3.OperationalError, match="simulated SIGKILL"):
+            SqliteArtifactRegistry(db_path)
+    for conn in opened:
+        conn.close()
+
+    # Pre-state bootable and UNCHANGED: still v5, and the ALTER that ran before
+    # the crash did NOT survive (it was inside the rolled-back txn).
+    assert _user_version(db_path) == 5
+    assert "last_observed_version" not in {r[1] for r in _agent_states_shape(db_path)}
+
+    # A clean reopen completes the migration (idempotent), data intact.
+    with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
+        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 6
+        got = reg.get_artifact(art.id)
+        assert got is not None and got.content_hash == "h"
+        assert reg.last_observed_version_for(art.id, uuid4()) is None
+
+
+# ---------------------------------------------------------------------------
+# Foreign-lineage refusal (probes intact; no false positive on Python v6)
+# ---------------------------------------------------------------------------
+
+
+def test_node_v3_db_still_refused(db_path: Path) -> None:
+    """The Node-ledger marker (``agent_states.deadline_tick`` at
+    ``user_version>=3``) still refuses after the v6 bump — KTD9 obliged NO new
+    probe, and the existing chain was not rearranged."""
+    _forge_node_v3_db(db_path)
+    with pytest.raises(CrossRuntimeSchemaError):
+        SqliteArtifactRegistry(db_path)
+    assert _user_version(db_path) == 3  # untouched
+
+
+def test_genuine_v6_db_reopens_fine_both_paths(db_path: Path) -> None:
+    """No false positive: a Python v6 db (which carries ``last_observed_version``,
+    never ``deadline_tick``) passes the guard on the writer AND read-only paths."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        _register(reg)
+    with SqliteArtifactRegistry(db_path) as rw:
+        assert rw._conn.execute("PRAGMA user_version").fetchone()[0] == 6
+    with SqliteArtifactRegistry(db_path, read_only=True) as ro:
+        assert ro.instance_id
+
+
+# ---------------------------------------------------------------------------
+# Recording semantics — BOTH registries (the parametrized arms are the parity run)
+# ---------------------------------------------------------------------------
+
+
+def test_parity_grant_records_current_version(registry) -> None:
+    reg = registry
+    art = _register(reg)
+    a, b, c = uuid4(), uuid4(), uuid4()
+    reg.set_agent_state(art.id, a, MESIState.SHARED, trigger="fetch", tick=1)
+    assert reg.last_observed_version_for(art.id, a) == 1
+    reg.set_agent_state(art.id, b, MESIState.EXCLUSIVE, trigger="write", tick=2)
+    assert reg.last_observed_version_for(art.id, b) == 1
+    reg.set_agent_state(art.id, b, MESIState.MODIFIED, trigger="write", tick=3)
+    assert reg.last_observed_version_for(art.id, b) == 1
+    # A never-observed pair stays absent — None, never a 0-sentinel.
+    assert reg.last_observed_version_for(art.id, c) is None
+
+
+def test_parity_invalid_transition_preserves_prior_value(registry) -> None:
+    """R7: INVALID never overwrites the comparand — the stored value is the last
+    version whose bytes the agent actually saw, exactly what the stale flag
+    compares against after a compaction."""
+    reg = registry
+    art = _register(reg)
+    a, b = uuid4(), uuid4()
+    reg.set_agent_state(art.id, a, MESIState.EXCLUSIVE, trigger="write", tick=1)
+    reg.set_agent_state(art.id, a, MESIState.INVALID, trigger="reclaim_heartbeat", tick=9)
+    assert reg.last_observed_version_for(art.id, a) == 1
+    # The non-reclaim invalidation leg preserves too.
+    reg.set_agent_state(art.id, b, MESIState.SHARED, trigger="fetch", tick=10)
+    reg.set_agent_state(art.id, b, MESIState.INVALID, trigger="peer_invalidation", tick=11)
+    assert reg.last_observed_version_for(art.id, b) == 1
+
+
+def test_parity_invalid_on_fresh_pair_records_nothing(registry) -> None:
+    """An INVALID upsert on a never-observed pair must not mint a value (the
+    row/entry may exist for other bookkeeping; the comparand stays NULL)."""
+    reg = registry
+    art = _register(reg)
+    a = uuid4()
+    reg.set_agent_state(art.id, a, MESIState.INVALID, trigger="peer_invalidation", tick=1)
+    assert reg.last_observed_version_for(art.id, a) is None
+
+
+def test_parity_refetch_after_version_move_records_new_version(registry) -> None:
+    reg = registry
+    art = _register(reg)
+    a, writer = uuid4(), uuid4()
+    reg.set_agent_state(art.id, a, MESIState.SHARED, trigger="fetch", tick=1)
+    assert reg.last_observed_version_for(art.id, a) == 1
+    res = reg.commit_cas(art.id, writer, expected_version=1, content_hash="h2")
+    assert not isinstance(res, ConflictDetail)  # WIN -> version 2
+    # The invalidated reader still shows the version it last SAW ...
+    assert reg.last_observed_version_for(art.id, a) == 1
+    # ... until it re-fetches the new bytes.
+    reg.set_agent_state(art.id, a, MESIState.SHARED, trigger="fetch", tick=2)
+    assert reg.last_observed_version_for(art.id, a) == 2
+
+
+def test_parity_commit_cas_advances_writer_same_transaction(registry) -> None:
+    """KTD4 first layer: the WIN that bumps the version also advances the
+    committing agent's comparand to the NEW version — atomically (sqlite: the
+    same BEGIN IMMEDIATE; in-memory: the same GIL-atomic apply)."""
+    reg = registry
+    art = _register(reg)
+    writer, peer = uuid4(), uuid4()
+    reg.set_agent_state(art.id, writer, MESIState.SHARED, trigger="fetch", tick=1)
+    reg.set_agent_state(art.id, peer, MESIState.SHARED, trigger="fetch", tick=1)
+    res = reg.commit_cas(art.id, writer, expected_version=1, content_hash="h2")
+    assert not isinstance(res, ConflictDetail)
+    assert reg.get_artifact(art.id).version == 2
+    assert reg.last_observed_version_for(art.id, writer) == 2
+    # The invalidated peer keeps its pre-commit observation.
+    assert reg.get_agent_state(art.id, peer) is MESIState.INVALID
+    assert reg.last_observed_version_for(art.id, peer) == 1
+
+
+def test_parity_commit_cas_fresh_writer_records_new_version(registry) -> None:
+    """An OCC writer with NO prior row (never fetched) ends SHARED at the new
+    version it just produced — the INSERT leg of the committer upsert records
+    too, not only the UPDATE leg."""
+    reg = registry
+    art = _register(reg)
+    writer = uuid4()
+    res = reg.commit_cas(art.id, writer, expected_version=1, content_hash="h2")
+    assert not isinstance(res, ConflictDetail)
+    assert reg.last_observed_version_for(art.id, writer) == 2
+
+
+def test_parity_commit_all_advances_writer_per_member(registry) -> None:
+    reg = registry
+    art_a = Artifact(id=uuid4(), name="a.md", version=1, content_hash="ha")
+    art_b = Artifact(id=uuid4(), name="b.md", version=1, content_hash="hb")
+    reg.register_artifact(art_a, content="A")
+    reg.register_artifact(art_b, content="B")
+    writer, peer = uuid4(), uuid4()
+    reg.set_agent_state(art_b.id, peer, MESIState.SHARED, trigger="fetch", tick=1)
+    res = reg.commit_all(
+        writer,
+        {
+            art_a.id: CommitAllEntry(expected_version=1, content_hash="ha2"),
+            art_b.id: CommitAllEntry(expected_version=1, content_hash="hb2"),
+        },
+        tick=2,
+    )
+    assert isinstance(res, MultiCommitResult)
+    assert reg.last_observed_version_for(art_a.id, writer) == 2
+    assert reg.last_observed_version_for(art_b.id, writer) == 2
+    # The invalidated peer keeps its pre-commit observation on its member.
+    assert reg.last_observed_version_for(art_b.id, peer) == 1
+
+
+def test_parity_service_commit_advances_writer(registry) -> None:
+    """The pessimistic commit path (M/E holder via ``service.commit``): the
+    version bump and the committer's MODIFIED upsert land the NEW version in the
+    comparand, while the invalidated peer keeps the version it last saw."""
+    from ccs.coordinator.service import CoordinatorService
+
+    reg = registry
+    art = _register(reg)
+    service = CoordinatorService(reg)
+    writer, peer = uuid4(), uuid4()
+    reg.set_agent_state(art.id, peer, MESIState.SHARED, trigger="fetch", tick=1)
+    service.write(agent_id=writer, artifact_id=art.id, issued_at_tick=2)
+    assert reg.last_observed_version_for(art.id, writer) == 1  # acquire at v1
+    service.commit(
+        agent_id=writer, artifact_id=art.id, content="new-body", issued_at_tick=3
+    )
+    assert reg.get_artifact(art.id).version == 2
+    assert reg.last_observed_version_for(art.id, writer) == 2
+    assert reg.get_agent_state(art.id, peer) is MESIState.INVALID
+    assert reg.last_observed_version_for(art.id, peer) == 1

--- a/tests/coordinator/test_workspace_checkpoints.py
+++ b/tests/coordinator/test_workspace_checkpoints.py
@@ -6,8 +6,9 @@
 WV plan Unit 2 (docs/plans/2026-08-08-001-feat-workspace-versioning-e2e-plan.md).
 Covers, per the unit's test scenarios:
 
-- fresh v5 init lands the complete schema (both checkpoint tables + the name
-  index) at ``user_version=5``;
+- fresh init lands the complete schema (both checkpoint tables + the name
+  index) at the current stamp (v5 at authoring; SB-10 later chained v6, so the
+  stamp asserts use ``SCHEMA_USER_VERSION``);
 - **the v3 -> 4 -> 5 walk regression** (the migration trap): ``_migrate_v3_to_v4``
   used to guard AND stamp with the ``SCHEMA_USER_VERSION`` constant, so bumping
   the constant to 5 would have stamped a v3-origin db ``user_version=5`` WITHOUT
@@ -104,14 +105,15 @@ def _indexes(db_path: Path) -> set[str]:
 
 
 def _revert_to_v4_shape(db_path: Path) -> None:
-    """Mutate a current (v5) db on disk back to the v4 shape: workspace tables
-    + name index ABSENT, stamped ``user_version=4`` (what a pre-WV build
-    produced)."""
+    """Mutate a current db on disk back to the v4 shape: workspace tables +
+    name index AND the v6 ``last_observed_version`` column (SB-10) ABSENT,
+    stamped ``user_version=4`` (what a pre-WV build produced)."""
     conn = sqlite3.connect(str(db_path))
     try:
         conn.execute("DROP TABLE IF EXISTS workspace_checkpoint_members")
         conn.execute("DROP TABLE IF EXISTS workspace_checkpoints")
         conn.execute("DROP INDEX IF EXISTS idx_workspace_checkpoints_name")
+        conn.execute("ALTER TABLE agent_states DROP COLUMN last_observed_version")
         conn.execute("PRAGMA user_version = 4")
         conn.commit()
     finally:
@@ -217,11 +219,15 @@ def _members() -> list[CheckpointMember]:
 
 
 def test_fresh_v5_init_complete(db_path: Path) -> None:
-    """A fresh db is created at v5 directly: both workspace-checkpoint tables +
-    the name index present, ``user_version=5`` — no migration shim ever runs."""
+    """A fresh db carries the complete v5 checkpoint surface directly: both
+    workspace-checkpoint tables + the name index present — no migration shim
+    ever runs. (The fresh stamp is the CURRENT schema version; SB-10 later
+    chained v6 on top, so it is asserted via the constant, not a literal 5.)"""
     with SqliteArtifactRegistry(db_path) as reg:
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 5
-    assert SCHEMA_USER_VERSION == 5
+        assert (
+            reg._conn.execute("PRAGMA user_version").fetchone()[0]
+            == SCHEMA_USER_VERSION
+        )
     tables = _tables(db_path)
     assert "workspace_checkpoints" in tables
     assert "workspace_checkpoint_members" in tables
@@ -249,9 +255,13 @@ def test_v3_to_v4_to_v5_walk_lands_v5_ddl_at_v5_stamp(db_path: Path) -> None:
     assert "workspace_checkpoints" not in _tables(db_path)
 
     with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
-        # The v5 stamp AND the v5 DDL, together — the trap produced the stamp
-        # without the DDL.
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 5
+        # The current stamp AND the v5 DDL, together — the trap produced the
+        # stamp without the DDL. (SB-10 chained v6 on top, so the walk now ends
+        # at SCHEMA_USER_VERSION; the v5 DDL must still be present there.)
+        assert (
+            reg._conn.execute("PRAGMA user_version").fetchone()[0]
+            == SCHEMA_USER_VERSION
+        )
         tables = {
             r[0]
             for r in reg._conn.execute(
@@ -286,7 +296,10 @@ def test_v4_to_v5_preserves_existing_data(db_path: Path) -> None:
     assert _user_version(db_path) == 4
 
     with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 5
+        assert (
+            reg._conn.execute("PRAGMA user_version").fetchone()[0]
+            == SCHEMA_USER_VERSION
+        )
         # Pre-migration data intact.
         got = reg.get_artifact(art.id)
         assert got is not None and got.version == 1 and got.content_hash == "h1"
@@ -353,7 +366,10 @@ def test_sigkill_mid_v4_to_v5_migration_leaves_bootable_pre_state(
     # A clean reopen completes the migration (idempotent, no
     # "table already exists"), with the pre-migration data intact.
     with SqliteArtifactRegistry(db_path, retain_versions=True) as reg:
-        assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == 5
+        assert (
+            reg._conn.execute("PRAGMA user_version").fetchone()[0]
+            == SCHEMA_USER_VERSION
+        )
         got = reg.get_artifact(art.id)
         assert got is not None and got.content_hash == "h1"
         reg.create_checkpoint(_checkpoint(), [])
@@ -376,7 +392,12 @@ def test_v5_stamp_without_checkpoint_tables_is_refused(db_path: Path) -> None:
     try:
         conn.execute("DROP TABLE IF EXISTS workspace_checkpoint_members")
         conn.execute("DROP TABLE IF EXISTS workspace_checkpoints")
-        conn.commit()  # user_version stays 5
+        # A fresh db is stamped at the CURRENT version (v6 since SB-10); forge
+        # the exact v5-era trap state the probe pins: v5 stamp, no checkpoint
+        # tables, and no v6 column (a pre-v6 build never had it).
+        conn.execute("ALTER TABLE agent_states DROP COLUMN last_observed_version")
+        conn.execute("PRAGMA user_version = 5")
+        conn.commit()
     finally:
         conn.close()
 

--- a/tests/integration/test_strict_mode.py
+++ b/tests/integration/test_strict_mode.py
@@ -640,10 +640,13 @@ ALLOW_EMISSION_SOURCES: list[str] = [
     "pre_bash_stale_warn",           # coordinator_server._handle_pre_bash
     "pre_grep_stale_warn",           # coordinator_server._handle_pre_grep
     "watchdog_degraded_read",        # coordinator_server._DEFAULT_DEGRADED_RESPONSE (A7)
-    # coordinator_server._attach_reground — the SB-10 U4 deferred
-    # re-grounding attach shared by all four admit surfaces (pre-read,
-    # pre-edit, pre-bash, pre-grep, tracked seams + untracked fast paths).
-    "deferred_reground_attach",
+    # NOT listed: coordinator_server._attach_reground. The SB-10 deferred
+    # re-grounding attach no longer emits an allow — a bare admit body now
+    # gains a CONTEXT-ONLY PreToolUse envelope (hookEventName +
+    # additionalContext, no permissionDecision) via
+    # hook_payloads.emit_pretooluse_context, because an advisory payload
+    # must never widen a permission decision. No emit_allow call site, so
+    # no entry here.
 ]
 
 

--- a/tests/integration/test_strict_mode.py
+++ b/tests/integration/test_strict_mode.py
@@ -529,6 +529,100 @@ def test_strict_deny_reason_byte_stable_across_retries(strict_client: _Client) -
 
 
 # ----------------------------------------------------------------------
+# SB-10 U4 (AE3): deferred re-grounding must never touch strict-deny bodies
+# ----------------------------------------------------------------------
+
+
+def test_strict_deny_with_pending_reground_flag_byte_identical_and_flag_survives(
+    strict_coordinator, strict_client: _Client,
+) -> None:
+    """AE3 first half (KTD-P preservation): a strict-mode deny issued while
+    the session's compact-pending flag is armed carries a deny envelope
+    byte-identical to the no-flag baseline — the deferred re-grounding
+    payload attaches ONLY to allow envelopes (R8) — and the deny neither
+    consumes nor expires the flag (only a qualifying admit consumes, R2).
+
+    Written FIRST per the unit's execution note: this test passes against
+    the pre-U4 coordinator (no admit consumes the flag today) and must stay
+    green throughout the deferred-injection implementation."""
+    _setup_stale(strict_client, "CLAUDE.md")
+    # Baseline deny envelope with NO flag armed.
+    status, baseline = strict_client.post(
+        "/hooks/pre-read",
+        {"session_id": _sid("A"), "path": "CLAUDE.md", "content_hash": _hash("v1")},
+    )
+    assert status == 200
+    assert baseline["hookSpecificOutput"]["permissionDecision"] == "deny"
+    # Arm the deferred-delivery flag, then retry the same denied read.
+    strict_coordinator.mark_compact_pending(_sid("A"))
+    status, with_flag = strict_client.post(
+        "/hooks/pre-read",
+        {"session_id": _sid("A"), "path": "CLAUDE.md", "content_hash": _hash("v1")},
+    )
+    assert status == 200
+    # The deny envelope is byte-stable (KTD-P) AND untouched by the pending
+    # flag — no re-grounding prose may ride a deny.
+    assert with_flag["hookSpecificOutput"] == baseline["hookSpecificOutput"]
+    assert set(with_flag.keys()) == set(baseline.keys())
+    # Flag still pending: the deny consumed nothing (asserted via the
+    # test-and-clear primitive, which also cleans up the armed flag).
+    assert strict_coordinator.consume_compact_pending(_sid("A")) is True
+
+
+def test_strict_deny_then_allowed_warn_read_orders_notices_before_reground(
+    strict_coordinator, strict_client: _Client,
+) -> None:
+    """AE3 second half: after a strict deny left the flag pending, the NEXT
+    qualifying admit — a warn-mode stale re-read that also drains a pending
+    preemption notice — delivers everything in one additionalContext, in
+    the order notices → stale warning → re-grounding block."""
+    # Stale strict artifact FIRST — its fresh pre-reads would otherwise
+    # drain the preemption notice staged below (fresh-path notice surfacing).
+    _setup_stale(strict_client, "CLAUDE.md")
+    # Session A holds EXCLUSIVE on the warn-mode path; B preempts (recording
+    # a notice for A) and commits, leaving A INVALID on docs/plans/x.md.
+    strict_client.post(
+        "/hooks/pre-read",
+        {"session_id": _sid("A"), "path": "docs/plans/x.md", "content_hash": _hash("v1")},
+    )
+    strict_client.post(
+        "/hooks/pre-edit", {"session_id": _sid("A"), "path": "docs/plans/x.md"},
+    )
+    strict_client.post(
+        "/hooks/pre-edit", {"session_id": _sid("B"), "path": "docs/plans/x.md"},
+    )
+    strict_client.post(
+        "/hooks/post-edit",
+        {"session_id": _sid("B"), "path": "docs/plans/x.md",
+         "content_hash": _hash("v2"), "success": True},
+    )
+    # Strict deny for A on CLAUDE.md with the flag armed: flag must survive
+    # the deny (no consume) so the next qualifying admit can deliver.
+    strict_coordinator.mark_compact_pending(_sid("A"))
+    status, denied = strict_client.post(
+        "/hooks/pre-read",
+        {"session_id": _sid("A"), "path": "CLAUDE.md", "content_hash": _hash("v1")},
+    )
+    assert status == 200
+    assert denied["hookSpecificOutput"]["permissionDecision"] == "deny"
+    # Follow-up ALLOWED warn-mode re-read: notice + stale warning + re-ground.
+    status, body = strict_client.post(
+        "/hooks/pre-read",
+        {"session_id": _sid("A"), "path": "docs/plans/x.md", "content_hash": _hash("v1")},
+    )
+    assert status == 200
+    out = body["hookSpecificOutput"]
+    assert out["permissionDecision"] == "allow"
+    text = out["additionalContext"]
+    notice_at = text.index("Coordinator notice")
+    stale_at = text.index("Stale read")
+    reground_at = text.index("Post-compaction re-grounding (agent-coherence):")
+    assert notice_at < stale_at < reground_at
+    # Delivered exactly once: the flag is gone.
+    assert strict_coordinator.consume_compact_pending(_sid("A")) is False
+
+
+# ----------------------------------------------------------------------
 # KTD-U structural invariant: emit_allow refuses terminal-denial conversion
 # ----------------------------------------------------------------------
 
@@ -546,6 +640,10 @@ ALLOW_EMISSION_SOURCES: list[str] = [
     "pre_bash_stale_warn",           # coordinator_server._handle_pre_bash
     "pre_grep_stale_warn",           # coordinator_server._handle_pre_grep
     "watchdog_degraded_read",        # coordinator_server._DEFAULT_DEGRADED_RESPONSE (A7)
+    # coordinator_server._attach_reground — the SB-10 U4 deferred
+    # re-grounding attach shared by all four admit surfaces (pre-read,
+    # pre-edit, pre-bash, pre-grep, tracked seams + untracked fast paths).
+    "deferred_reground_attach",
 ]
 
 

--- a/tests/protocol_corpus/fixtures/session_start/01-session-start-grant-and-stale-lines.json
+++ b/tests/protocol_corpus/fixtures/session_start/01-session-start-grant-and-stale-lines.json
@@ -1,0 +1,75 @@
+{
+  "name": "session-start-grant-and-stale-lines",
+  "description": "SB-10 U2/U6 canonical /hooks/session-start payload. Session A pre-reads two tracked files (SHARED grants record last-observed v1); peer B pre-edits + post-edits docs/alpha.md to v2, invalidating A. A's session-start renders the full SessionStart wrapper: header, the R4 stale-divergence line for docs/alpha.md (current v2 past recorded last-observed v1, writer is B not A), the R3 event-anchored grant line for the still-SHARED docs/beta.md at the CURRENT version, and the self-qualifying closing line. Artifact lines sort by path (KTD8). No timestamps anywhere in the payload — the whole additionalContext byte-matches across backends with no normalization sentinels needed.",
+  "setup": {
+    "tracked": [
+      "docs/alpha.md",
+      "docs/beta.md"
+    ],
+    "files": {
+      "docs/alpha.md": "# Alpha\nv1 content\n",
+      "docs/beta.md": "# Beta\nv1 content\n"
+    },
+    "preflight_requests": [
+      {
+        "method": "POST",
+        "path": "/hooks/pre-read",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+          "path": "docs/alpha.md"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/pre-read",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+          "path": "docs/beta.md"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/pre-edit",
+        "body": {
+          "session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+          "path": "docs/alpha.md"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/post-edit",
+        "body": {
+          "session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+          "path": "docs/alpha.md",
+          "content_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+          "success": true
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/pre-read",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+          "path": "docs/beta.md"
+        }
+      }
+    ]
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/session-start",
+    "body": {
+      "session_id": "aaaaaaaa-0000-4000-8000-000000000001"
+    }
+  },
+  "expected": {
+    "status": 200,
+    "body": {
+      "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": "Post-compaction re-grounding (agent-coherence):\ndocs/alpha.md advanced to v2 past your last-observed v1 — re-read before relying on it.\nAt compaction you held SHARED on docs/beta.md (v1) — re-acquire before writing.\nVersions are as of this re-grounding; a more recent read supersedes this notice."
+      }
+    }
+  },
+  "_comment": "The final preflight (A's fresh re-read of docs/beta.md, response discarded) drains A's pending preemption notices so the session-start payload contains ONLY the byte-mirrored SESSION_START templates. This sidesteps two pre-existing cross-backend notice asymmetries that predate SB-10 and are masked elsewhere by warn_mode/14's ignore_keys: (a) the Node registry records a notice for EVERY invalidated peer including SHARED victims (registry.ts acquireExclusive) while Python records only for M∪E victims (_peers_in_me_excluding), and (b) the notice prose itself differs byte-wise between _build_preemption_text and preemptionNoticeText. The stale line proves U1/U5 last-observed recording end-to-end: pre-read grant records v1, B's commit advances to v2 while preserving A's recorded value across the INVALID transition."
+}

--- a/tests/protocol_corpus/fixtures/session_start/02-session-start-cap-overflow.json
+++ b/tests/protocol_corpus/fixtures/session_start/02-session-start-cap-overflow.json
@@ -1,0 +1,78 @@
+{
+  "name": "session-start-cap-overflow",
+  "description": "SB-10 R5 verbatim cap: session A pre-reads five tracked artifacts (five SHARED grants). The session-start payload renders exactly SESSION_START_ARTIFACT_VERBATIM_CAP (3) grant lines verbatim in path-sorted order, then coalesces the remaining two into the single overflow line pointing at the status surface, then the closing line. Pins that the cap and the overflow arithmetic are identical across backends.",
+  "setup": {
+    "tracked": [
+      "docs/a.md",
+      "docs/b.md",
+      "docs/c.md",
+      "docs/d.md",
+      "docs/e.md"
+    ],
+    "files": {
+      "docs/a.md": "a v1\n",
+      "docs/b.md": "b v1\n",
+      "docs/c.md": "c v1\n",
+      "docs/d.md": "d v1\n",
+      "docs/e.md": "e v1\n"
+    },
+    "preflight_requests": [
+      {
+        "method": "POST",
+        "path": "/hooks/pre-read",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+          "path": "docs/a.md"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/pre-read",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+          "path": "docs/b.md"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/pre-read",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+          "path": "docs/c.md"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/pre-read",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+          "path": "docs/d.md"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/pre-read",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+          "path": "docs/e.md"
+        }
+      }
+    ]
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/session-start",
+    "body": {
+      "session_id": "aaaaaaaa-0000-4000-8000-000000000001"
+    }
+  },
+  "expected": {
+    "status": 200,
+    "body": {
+      "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": "Post-compaction re-grounding (agent-coherence):\nAt compaction you held SHARED on docs/a.md (v1) — re-acquire before writing.\nAt compaction you held SHARED on docs/b.md (v1) — re-acquire before writing.\nAt compaction you held SHARED on docs/c.md (v1) — re-acquire before writing.\nPlus 2 more — run agent-coherence-status for the full picture.\nVersions are as of this re-grounding; a more recent read supersedes this notice."
+      }
+    }
+  }
+}

--- a/tests/protocol_corpus/fixtures/session_start/03-session-start-empty-session-noop.json
+++ b/tests/protocol_corpus/fixtures/session_start/03-session-start-empty-session-noop.json
@@ -1,0 +1,23 @@
+{
+  "name": "session-start-empty-session-noop",
+  "description": "SB-10 R5 no-op arm: a session-start for a session with no coordination state (nothing ever read or edited in the workspace) answers the literal empty object {} on both backends — no SessionStart envelope, no additionalContext. The tracked policy file exists but no artifact was ever observed, so the registry snapshot is empty. The deferred-delivery flag also stays unarmed on this path (pinned behaviorally by fixtures 04/05, which require an armed flag to attach).",
+  "setup": {
+    "tracked": [
+      "docs/alpha.md"
+    ],
+    "files": {
+      "docs/alpha.md": "# Alpha\nv1 content\n"
+    }
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/session-start",
+    "body": {
+      "session_id": "aaaaaaaa-0000-4000-8000-000000000001"
+    }
+  },
+  "expected": {
+    "status": 200,
+    "body": {}
+  }
+}

--- a/tests/protocol_corpus/fixtures/session_start/04-deferred-reground-attaches-to-tracked-stale-allow.json
+++ b/tests/protocol_corpus/fixtures/session_start/04-deferred-reground-attaches-to-tracked-stale-allow.json
@@ -1,0 +1,90 @@
+{
+  "name": "deferred-reground-attaches-to-tracked-stale-allow",
+  "description": "SB-10 U4/U8 deferred-injection carriage on a TRACKED admit. Preflight: A pre-reads docs/notes.md (SHARED, last-observed v1); peer B pre-edits + commits v2 (invalidates A); A pre-reads docs/aux.md (notice drain, see _comment); A's session-start builds a non-empty payload and arms the compact-pending flag. The test request is A's next pre-read — a warn-mode stale allow — and the deferred re-grounding block rides that envelope: additionalContext is the stale-read warning, then a blank line, then the re-ground block (KTD6 ordering: existing prose first, re-ground last). KTD2 rebuild-at-delivery is visible in the bytes: the block is rebuilt AFTER the stale path re-granted SHARED, so it renders the R3 grant line for docs/notes.md at the CURRENT v2 — not the stale line the session-start preflight rendered when the flag was armed.",
+  "setup": {
+    "tracked": [
+      "docs/aux.md",
+      "docs/notes.md"
+    ],
+    "files": {
+      "docs/aux.md": "# Aux\nv1 content\n",
+      "docs/notes.md": "# Notes\nv1 content\n"
+    },
+    "preflight_requests": [
+      {
+        "method": "POST",
+        "path": "/hooks/pre-read",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+          "path": "docs/notes.md"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/pre-edit",
+        "body": {
+          "session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+          "path": "docs/notes.md"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/post-edit",
+        "body": {
+          "session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+          "path": "docs/notes.md",
+          "content_hash": "2222222222222222222222222222222222222222222222222222222222222222",
+          "success": true
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/pre-read",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+          "path": "docs/aux.md"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/session-start",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001"
+        }
+      }
+    ]
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-read",
+    "body": {
+      "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+      "path": "docs/notes.md"
+    }
+  },
+  "ignore_keys": [
+    "last_writer_at_unix_ts",
+    "warning_generated_at_unix_ts"
+  ],
+  "expected": {
+    "status": 200,
+    "body": {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow",
+        "additionalContext": "⚠ Stale read [warning emitted <TS>]: docs/notes.md was updated by session bbbbbbbb at <TS>. Current version is v2; you previously saw v1. Your worktree's content matches the last-recorded hash; the divergence is purely about version-tracking metadata. Consider re-reading docs/notes.md before acting on stale assumptions.\n\nPost-compaction re-grounding (agent-coherence):\nAt compaction you held SHARED on docs/aux.md (v1) — re-acquire before writing.\nAt compaction you held SHARED on docs/notes.md (v2) — re-acquire before writing.\nVersions are as of this re-grounding; a more recent read supersedes this notice."
+      },
+      "status": "stale",
+      "summary": {
+        "path": "docs/notes.md",
+        "current_version": 2,
+        "prior_version_seen_by_session": 1,
+        "last_writer_session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+        "last_writer_at_unix_ts": 0,
+        "warning_generated_at_unix_ts": 0,
+        "hash_differs": false
+      }
+    }
+  },
+  "_comment": "additionalContext IS byte-asserted (unlike warn_mode/14): the stale-read warning prose is byte-mirrored across backends and its ISO timestamps are scrubbed in string position by the harness's existing _ISO_TS_RE rule; the re-ground block carries no timestamps at all. The docs/aux.md preflight (response discarded) drains A's pending preemption notices before the session-start arms the flag — the notice subsystem has two pre-existing cross-backend asymmetries (Node records notices for SHARED victims where Python is M∪E-only, and the notice prose bytes differ) that predate SB-10 and are masked elsewhere by warn_mode/14's ignore_keys; without the drain they would leak into this byte pin. The two summary unix-ts floats are ignored per the warn_mode/14 precedent; every other summary field is compared."
+}

--- a/tests/protocol_corpus/fixtures/session_start/05-deferred-reground-attaches-to-untracked-admit.json
+++ b/tests/protocol_corpus/fixtures/session_start/05-deferred-reground-attaches-to-untracked-admit.json
@@ -1,0 +1,49 @@
+{
+  "name": "deferred-reground-attaches-to-untracked-admit",
+  "description": "SB-10 U4/U8 untracked-admit carriage — a brand-new wire shape and this fixture is its only cross-backend pin. Preflight: A pre-reads tracked docs/notes.md (SHARED v1); A's session-start arms the compact-pending flag. The test request is A's pre-read of an UNTRACKED path: the coordinator's fast path answers {status: fresh} without touching the registry, but the hoisted compact-pending peek promotes it to a PreToolUse allow envelope carrying the re-ground block (source deferred_reground_attach). The whole body byte-matches across backends with no normalization sentinels — the re-ground block carries no timestamps.",
+  "setup": {
+    "tracked": [
+      "docs/notes.md"
+    ],
+    "files": {
+      "docs/notes.md": "# Notes\nv1 content\n"
+    },
+    "preflight_requests": [
+      {
+        "method": "POST",
+        "path": "/hooks/pre-read",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+          "path": "docs/notes.md"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/session-start",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001"
+        }
+      }
+    ]
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-read",
+    "body": {
+      "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+      "path": "scratch/tmp.md"
+    }
+  },
+  "expected": {
+    "status": 200,
+    "body": {
+      "status": "fresh",
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow",
+        "additionalContext": "Post-compaction re-grounding (agent-coherence):\nAt compaction you held SHARED on docs/notes.md (v1) — re-acquire before writing.\nVersions are as of this re-grounding; a more recent read supersedes this notice."
+      }
+    }
+  },
+  "_comment": "The bare untracked fast path stays {status: fresh} with NO hookSpecificOutput when no flag pends (pinned by warn_mode/01); this fixture pins the flag-pending promotion. KTD2: the block is rebuilt at attach from registry truth — A still holds SHARED at v1, so the R3 grant line renders v1."
+}

--- a/tests/protocol_corpus/fixtures/session_start/05-deferred-reground-attaches-to-untracked-admit.json
+++ b/tests/protocol_corpus/fixtures/session_start/05-deferred-reground-attaches-to-untracked-admit.json
@@ -1,6 +1,6 @@
 {
   "name": "deferred-reground-attaches-to-untracked-admit",
-  "description": "SB-10 U4/U8 untracked-admit carriage — a brand-new wire shape and this fixture is its only cross-backend pin. Preflight: A pre-reads tracked docs/notes.md (SHARED v1); A's session-start arms the compact-pending flag. The test request is A's pre-read of an UNTRACKED path: the coordinator's fast path answers {status: fresh} without touching the registry, but the hoisted compact-pending peek promotes it to a PreToolUse allow envelope carrying the re-ground block (source deferred_reground_attach). The whole body byte-matches across backends with no normalization sentinels — the re-ground block carries no timestamps.",
+  "description": "SB-10 U4/U8 untracked-admit carriage — a brand-new wire shape and this fixture is its only cross-backend pin. Preflight: A pre-reads tracked docs/notes.md (SHARED v1); A's session-start arms the compact-pending flag. The test request is A's pre-read of an UNTRACKED path: the coordinator's fast path answers {status: fresh} without touching the registry, and the hoisted compact-pending peek attaches a CONTEXT-ONLY PreToolUse envelope carrying the re-ground block. The envelope has exactly two keys — hookEventName and additionalContext — and NO permissionDecision: re-grounding is advisory (KD3) and must never widen a permission decision, so a bare untracked admit that Claude Code would ordinarily prompt about is not auto-approved as a side effect of delivery. The whole body byte-matches across backends with no normalization sentinels — the re-ground block carries no timestamps.",
   "setup": {
     "tracked": [
       "docs/notes.md"
@@ -40,10 +40,9 @@
       "status": "fresh",
       "hookSpecificOutput": {
         "hookEventName": "PreToolUse",
-        "permissionDecision": "allow",
         "additionalContext": "Post-compaction re-grounding (agent-coherence):\nAt compaction you held SHARED on docs/notes.md (v1) — re-acquire before writing.\nVersions are as of this re-grounding; a more recent read supersedes this notice."
       }
     }
   },
-  "_comment": "The bare untracked fast path stays {status: fresh} with NO hookSpecificOutput when no flag pends (pinned by warn_mode/01); this fixture pins the flag-pending promotion. KTD2: the block is rebuilt at attach from registry truth — A still holds SHARED at v1, so the R3 grant line renders v1."
+  "_comment": "The bare untracked fast path stays {status: fresh} with NO hookSpecificOutput when no flag pends (pinned by warn_mode/01); this fixture pins the flag-pending promotion. KTD2: the block is rebuilt at attach from registry truth — A still holds SHARED at v1, so the R3 grant line renders v1. PERMISSION CONTAINMENT: the harness compares exact normalized dicts, so the ABSENCE of permissionDecision under hookSpecificOutput is asserted, not merely unmentioned — a backend that went back to minting an allow envelope here would produce a three-key hookSpecificOutput and fail this fixture's body compare on the extra key, on BOTH backends. Before 2026-08-25 this fixture did expect permissionDecision 'allow'; that expectation was the bug (an advisory payload short-circuiting Claude Code's permission prompt once per compaction) and was corrected alongside the backends. Context-only delivery is empirically sufficient: an A/B capture against Claude Code CLI 2.1.233 showed additionalContext with no permissionDecision is rendered to the model, identically to the allow-stamped control arm. The sibling fixture 04 is the OTHER branch — there the envelope pre-exists (a warn-mode stale allow) and the merge path must leave its permissionDecision untouched."
 }

--- a/tests/protocol_corpus/fixtures/session_start/06-strict-deny-does-not-carry-reground.json
+++ b/tests/protocol_corpus/fixtures/session_start/06-strict-deny-does-not-carry-reground.json
@@ -1,0 +1,85 @@
+{
+  "name": "strict-deny-does-not-carry-reground",
+  "description": "SB-10 U4/U8 non-carriage on deny (AE3/KTD-P): with the compact-pending flag armed, a strict-mode stale-read deny must stay byte-identical to the flagless deny — no additionalContext key appears, and the flag is neither consumed nor attached. Setup mirrors strict_mode/01 exactly (A and B read v1, B commits v2 invalidating A), plus one extra preflight: A's session-start builds a non-empty payload (A is INVALID with recorded last-observed v1 behind current v2) and arms the flag. The test request is A's stale re-read on the strict artifact — the deny body below is byte-for-byte the strict_mode/01 expected body.",
+  "setup": {
+    "tracked": [
+      "CLAUDE.md"
+    ],
+    "strict_mode": [
+      "CLAUDE.md"
+    ],
+    "files": {
+      "CLAUDE.md": "# Project rules\nv1 content\n"
+    },
+    "preflight_requests": [
+      {
+        "method": "POST",
+        "path": "/hooks/pre-read",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+          "path": "CLAUDE.md",
+          "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/pre-read",
+        "body": {
+          "session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+          "path": "CLAUDE.md",
+          "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/pre-edit",
+        "body": {
+          "session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+          "path": "CLAUDE.md"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/post-edit",
+        "body": {
+          "session_id": "bbbbbbbb-0000-4000-8000-000000000002",
+          "path": "CLAUDE.md",
+          "content_hash": "ad0f2f1b1e8d8c5a8c2e6f4b0d3a7b5e9c8f1e2d3a4b5c6d7e8f9a0b1c2d3e4f",
+          "success": true
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/hooks/session-start",
+        "body": {
+          "session_id": "aaaaaaaa-0000-4000-8000-000000000001"
+        }
+      }
+    ]
+  },
+  "request": {
+    "method": "POST",
+    "path": "/hooks/pre-read",
+    "body": {
+      "session_id": "aaaaaaaa-0000-4000-8000-000000000001",
+      "path": "CLAUDE.md",
+      "content_hash": "fd34c2c2ce75b1f7c8df6ff05bd1ff8b9be3a25e8bb1d76b1d3a5a78f47db59c"
+    }
+  },
+  "ignore_keys": [
+    "summary"
+  ],
+  "expected": {
+    "status": 200,
+    "body": {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": "Stale read denied: CLAUDE.md was updated by session bbbbbbbb at <TS>. Re-read CLAUDE.md via the Read tool before proceeding. This denial is structural (v0.2 strict mode); retrying the same operation will produce the same denial."
+      },
+      "status": "stale",
+      "summary": "<IGNORED>"
+    }
+  },
+  "_comment": "The corpus compares exact normalized dicts, so the absence of additionalContext under hookSpecificOutput IS asserted — a backend that let the deferred payload ride (or consume on) a deny would fail this fixture. summary is ignored per the strict_mode/01 precedent (its unix-ts floats vary per run); the deny reason text and shape are the byte contract."
+}

--- a/tests/protocol_corpus/fixtures/warn_mode/09-status-default-tier-node-backend.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/09-status-default-tier-node-backend.json
@@ -20,13 +20,13 @@
       "counts": "<IGNORED>",
       "coordinator_uptime_seconds": "<UPTIME>",
       "policy_summary": "<IGNORED>",
-      "schema_version": 4,
+      "schema_version": 5,
       "sessions": "<IGNORED>",
       "status": "ok",
       "tracked_artifacts": "<IGNORED>",
       "version": "<IGNORED>"
     }
   },
-  "_comment": "Cross-backend /status shape parity is a stretch goal tracked as AC-08 follow-up. v0.2 broad-beta launch ships with the divergence documented here in the corpus, the AC-09 README note, and the configuration.md operator guide. v0.3 should converge the shapes when the multi-target converter layer lands. schema_version tracks the Node SQLite registry schema: bumped 3→4 by SB-10 U5 (plugin migration v4, agent_states.last_observed_version).",
+  "_comment": "Cross-backend /status shape parity is a stretch goal tracked as AC-08 follow-up. v0.2 broad-beta launch ships with the divergence documented here in the corpus, the AC-09 README note, and the configuration.md operator guide. v0.3 should converge the shapes when the multi-target converter layer lands. schema_version tracks the Node SQLite registry schema: bumped 3→4 by SB-10 U5 (plugin migration v4, agent_states.last_observed_version), then 4→5 by the SB-10 perf follow-up (plugin migration v5, the agent_states(agent_id) index paired with Python v7).",
   "backends": ["node"]
 }

--- a/tests/protocol_corpus/fixtures/warn_mode/09-status-default-tier-node-backend.json
+++ b/tests/protocol_corpus/fixtures/warn_mode/09-status-default-tier-node-backend.json
@@ -20,13 +20,13 @@
       "counts": "<IGNORED>",
       "coordinator_uptime_seconds": "<UPTIME>",
       "policy_summary": "<IGNORED>",
-      "schema_version": 3,
+      "schema_version": 4,
       "sessions": "<IGNORED>",
       "status": "ok",
       "tracked_artifacts": "<IGNORED>",
       "version": "<IGNORED>"
     }
   },
-  "_comment": "Cross-backend /status shape parity is a stretch goal tracked as AC-08 follow-up. v0.2 broad-beta launch ships with the divergence documented here in the corpus, the AC-09 README note, and the configuration.md operator guide. v0.3 should converge the shapes when the multi-target converter layer lands.",
+  "_comment": "Cross-backend /status shape parity is a stretch goal tracked as AC-08 follow-up. v0.2 broad-beta launch ships with the divergence documented here in the corpus, the AC-09 README note, and the configuration.md operator guide. v0.3 should converge the shapes when the multi-target converter layer lands. schema_version tracks the Node SQLite registry schema: bumped 3→4 by SB-10 U5 (plugin migration v4, agent_states.last_observed_version).",
   "backends": ["node"]
 }

--- a/tests/protocol_corpus/test_session_start_corpus.py
+++ b/tests/protocol_corpus/test_session_start_corpus.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Cross-implementation SB-10 session-start / deferred re-grounding corpus.
+
+Byte wire-parity for the ``/hooks/session-start`` endpoint (SB-10 U2/U6) and
+the deferred-injection allow envelopes (SB-10 U4/U8) across the Python and
+Node coordinators. Fixtures live in ``fixtures/session_start/`` and follow
+the warn/strict corpus schema — ``preflight_requests`` drives the multi-step
+"A reads → B commits → A session-start → A admits" setups.
+
+The SB-10 prose templates (``SESSION_START_*`` in ``hook_payloads``) carry NO
+timestamps by design, so the payloads byte-match without touching the
+harness's fixed normalization key lists. The stale-read warning prose that
+the deferred block appends onto is also byte-mirrored; only its in-string
+ISO timestamps go through the existing ``_ISO_TS_RE`` scrub.
+
+Marked ``protocol_corpus`` — opt-in via ``pytest -m protocol_corpus``. Skipped
+in default runs (see ``pyproject.toml`` ``addopts``)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.protocol_corpus.harness import (
+    BACKEND_NODE,
+    Fixture,
+    load_fixtures,
+    normalize_response,
+    resolve_node_dist_path,
+    run_scenario,
+)
+
+pytestmark = pytest.mark.protocol_corpus
+
+
+def _all_session_start_fixtures() -> list[Fixture]:
+    """Loaded once at collection so parametrize ids stay stable."""
+    return load_fixtures("session_start")
+
+
+def _parametrize_rows() -> list[tuple[Fixture, str]]:
+    rows: list[tuple[Fixture, str]] = []
+    for fixture in _all_session_start_fixtures():
+        for backend in fixture.backends:
+            rows.append((fixture, backend))
+    return rows
+
+
+def _row_id(row: tuple[Fixture, str]) -> str:
+    fixture, backend = row
+    return f"{fixture.name}[{backend}]"
+
+
+_ROWS = _parametrize_rows()
+_NODE_DIST_PATH = resolve_node_dist_path()
+
+
+@pytest.mark.parametrize("row", _ROWS, ids=[_row_id(r) for r in _ROWS] if _ROWS else None)
+def test_session_start_fixture_response_matches_expected(
+    row: tuple[Fixture, str],
+    tmp_path: Path,
+) -> None:
+    fixture, backend = row
+    if backend == BACKEND_NODE and _NODE_DIST_PATH is None:
+        pytest.xfail(
+            "Node coordinator dist not resolvable. Build the plugin checkout "
+            "(npm ci && npm run build) or set AGENT_COHERENCE_PLUGIN_DIST_PATH."
+        )
+
+    actual_status, actual_body = run_scenario(
+        fixture=fixture,
+        backend_id=backend,
+        workspace=tmp_path,
+        node_dist_path=_NODE_DIST_PATH,
+    )
+
+    expected_status = fixture.expected["status"]
+    expected_body = normalize_response(
+        fixture.expected["body"],
+        ignore_keys=fixture.ignore_keys,
+        optional_keys=fixture.optional_keys,
+    )
+
+    assert actual_status == expected_status, (
+        f"{fixture.name}[{backend}]: status mismatch — "
+        f"expected {expected_status}, got {actual_status}\n"
+        f"body={actual_body!r}"
+    )
+    assert actual_body == expected_body, (
+        f"{fixture.name}[{backend}]: body mismatch\n"
+        f"expected={expected_body!r}\nactual=  {actual_body!r}"
+    )
+
+
+def test_collection_loaded_session_start_fixtures() -> None:
+    """Self-test: the six SB-10 fixtures are present so parametrize doesn't
+    silently no-op. Catches the failure mode where the fixtures directory
+    is empty or path-resolution is wrong."""
+    fixtures = _all_session_start_fixtures()
+    assert len(fixtures) >= 6, (
+        f"Expected ≥6 session-start fixtures, found {len(fixtures)}. "
+        f"Add coverage in tests/protocol_corpus/fixtures/session_start/."
+    )

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -8,7 +8,7 @@ frozen dataclasses, string constants) formalizing what a networked registry
 backend must provide to re-home the coordinator's atomic boundary. These tests
 are the DRIFT GUARDS the plan calls for:
 
-- the member-classification map covers EXACTLY the 58 ``RegistryBase`` +
+- the member-classification map covers EXACTLY the 59 ``RegistryBase`` +
   ``SqliteExtended`` members — no more, no fewer — so a Protocol member added or
   removed in ``registry_protocol.py`` without a matching contract update FAILS
   CI (bidirectional guard);
@@ -19,7 +19,7 @@ are the DRIFT GUARDS the plan calls for:
 - a classification value outside the enum is unrepresentable (typed);
 - the tier enum has exactly ``TIER_1`` and ``TIER_2``.
 
-The expected 58-member set is FROZEN here (imported from the parity test's own
+The expected 59-member set is FROZEN here (imported from the parity test's own
 frozen name-sets), NOT derived from the Protocol at runtime — so a silent
 Protocol edit cannot move the goalposts this test guards (the same discipline
 ``tests/test_registry_protocol_parity.py`` uses).
@@ -42,8 +42,8 @@ from ccs.coordinator.backend_contract import (
     Tier,
 )
 
-# The 58-member expected surface, imported from the parity test's FROZEN
-# name-sets (44 base methods + 13 extended methods + 1 base property). Reusing
+# The 59-member expected surface, imported from the parity test's FROZEN
+# name-sets (45 base methods + 13 extended methods + 1 base property). Reusing
 # those frozensets means this contract and the Protocol parity share ONE
 # source of truth for the surface: if either the parity test or the Protocol
 # changes the surface, the two drift guards fire together.
@@ -62,20 +62,21 @@ EXPECTED_MEMBERS = BASE_METHODS | EXTENDED_ONLY_METHODS | BASE_PROPERTIES
 
 
 def test_member_map_covers_exactly_the_protocol_surface() -> None:
-    """The classification map keys equal the 58-member Protocol surface EXACTLY
+    """The classification map keys equal the 59-member Protocol surface EXACTLY
     — no more, no fewer. A member added to (or removed from) ``registry_protocol.py``
     without a matching contract update fails HERE (bidirectional drift guard)."""
     assert set(MEMBER_CLASSIFICATION) == EXPECTED_MEMBERS
 
 
-def test_member_map_has_exactly_58_members() -> None:
-    """Pin the count explicitly: 44 base methods (SB-18 ``commit_all``, the
+def test_member_map_has_exactly_59_members() -> None:
+    """Pin the count explicitly: 45 base methods (SB-18 ``commit_all``, the
     WV Unit-2 checkpoint surface — 8 members — then the effect-gate pair read
-    ``get_artifact_and_generation`` added) + 13 extended methods + 1
-    base property = 58. Guards against a same-size add+remove that would slip
+    ``get_artifact_and_generation``, then the SB-10 comparand read
+    ``last_observed_version_for`` added) + 13 extended methods + 1
+    base property = 59. Guards against a same-size add+remove that would slip
     past the set-equality check on cardinality alone."""
-    assert len(MEMBER_CLASSIFICATION) == 58
-    assert len(EXPECTED_MEMBERS) == 58
+    assert len(MEMBER_CLASSIFICATION) == 59
+    assert len(EXPECTED_MEMBERS) == 59
 
 
 def test_coordinator_epoch_property_is_in_the_map() -> None:

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -3996,3 +3996,302 @@ def test_session_start_prose_constants_byte_pinned() -> None:
         "Versions are as of this re-grounding; a more recent read supersedes "
         "this notice."
     )
+
+
+# ======================================================================
+# SB-10 U4 — deferred re-grounding delivery on the next qualifying admit
+# ======================================================================
+#
+# R2: at-most-once per delivery path; the flag is consumed by the FIRST
+# qualifying PARENT admit and expires at parent Stop. R8: the payload
+# attaches ONLY to allow envelopes; a request carrying agent_id neither
+# consumes nor attaches. KTD6: the check rides the four admit surfaces
+# (pre-read, pre-edit, pre-bash, pre-grep), with the advisory flag peek
+# hoisted above the untracked fast-path exits.
+
+
+def _arm_reground(client: _Client, sid: str) -> str:
+    """Give the session coordination state (SHARED on CLAUDE.md), then arm
+    the deferred flag via the REAL /hooks/session-start endpoint (KTD5).
+    Returns the payload text the arming call rendered — KTD2's
+    rebuild-at-delivery means the deferred copy must byte-match it as long
+    as no state moves in between."""
+    client.post("/hooks/pre-read",
+                {"session_id": sid, "path": "CLAUDE.md", "content_hash": _hash("rg1")})
+    status, body = client.post("/hooks/session-start", {"session_id": sid})
+    assert status == 200
+    assert body != {}
+    return body["hookSpecificOutput"]["additionalContext"]
+
+
+def _reground_text_of(body: dict) -> str | None:
+    """The additionalContext of an admit response's allow envelope, or None."""
+    hso = body.get("hookSpecificOutput")
+    if hso is None:
+        return None
+    return hso.get("additionalContext")
+
+
+def test_deferred_reground_tracked_pre_read_delivers_exactly_once(
+    coordinator, client: _Client
+) -> None:
+    """Pending flag + tracked pre-read allow → the fresh admit carries the
+    re-grounding block (byte-identical to the session-start rendering —
+    KTD2 rebuild-at-delivery), and the following admit is clean."""
+    sid = _sid("dr-tracked")
+    armed_text = _arm_reground(client, sid)
+    status, body = client.post(
+        "/hooks/pre-read",
+        {"session_id": sid, "path": "CLAUDE.md", "content_hash": _hash("rg1")})
+    assert status == 200
+    assert body["status"] == "fresh"
+    out = body["hookSpecificOutput"]
+    assert out["permissionDecision"] == "allow"
+    assert out["additionalContext"] == armed_text
+    # Consumed: the very next admit is today's bare fresh shape.
+    status, body2 = client.post(
+        "/hooks/pre-read",
+        {"session_id": sid, "path": "CLAUDE.md", "content_hash": _hash("rg1")})
+    assert status == 200
+    assert body2 == {"status": "fresh", "version": 1}
+
+
+def test_deferred_reground_untracked_pre_read_delivers_then_bare(
+    coordinator, client: _Client
+) -> None:
+    """Pending flag + UNTRACKED pre-read → the payload still rides the new
+    allow envelope on the fast path; the next untracked call returns
+    today's bare body."""
+    sid = _sid("dr-untracked")
+    armed_text = _arm_reground(client, sid)
+    status, body = client.post(
+        "/hooks/pre-read", {"session_id": sid, "path": "notes.txt"})
+    assert status == 200
+    assert body["status"] == "fresh"
+    out = body["hookSpecificOutput"]
+    assert out["hookEventName"] == "PreToolUse"
+    assert out["permissionDecision"] == "allow"
+    assert out["additionalContext"] == armed_text
+    status, body2 = client.post(
+        "/hooks/pre-read", {"session_id": sid, "path": "notes.txt"})
+    assert status == 200
+    assert body2 == {"status": "fresh"}
+
+
+def test_untracked_pre_read_no_flag_byte_identical_and_registry_free(
+    coordinator, client: _Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No flag + untracked → byte-identical to today's fast-path response
+    AND zero registry access (the KTD6 advisory peek is a process-local
+    dict lookup). The registry is swapped for a proxy that explodes on ANY
+    attribute access; a touched registry would 500 the request."""
+    sid = _sid("dr-noflag")
+
+    class _ExplodingRegistry:
+        def __getattr__(self, name: str) -> Any:
+            raise AssertionError(f"registry touched on untracked fast path: {name}")
+
+    monkeypatch.setattr(coordinator, "registry", _ExplodingRegistry())
+    status, body = client.post(
+        "/hooks/pre-read", {"session_id": sid, "path": "notes.txt"})
+    assert status == 200
+    assert body == {"status": "fresh"}
+
+
+def test_deferred_reground_subagent_admit_neither_consumes_nor_attaches(
+    coordinator, client: _Client
+) -> None:
+    """R8: a request carrying agent_id (subagent identity) must neither
+    consume nor attach — the payload waits for the PARENT's next admit.
+    Covered on BOTH the untracked fast path (bare bytes preserved) and the
+    tracked seam (the subagent's own warn envelope carries no re-ground)."""
+    sid = _sid("dr-subagent")
+    _arm_reground(client, sid)
+    # Untracked subagent admit: today's bare fast-path bytes, flag intact.
+    status, body = client.post(
+        "/hooks/pre-read",
+        {"session_id": sid, "agent_id": "sub1", "path": "notes.txt"})
+    assert status == 200
+    assert body == {"status": "fresh"}
+    assert coordinator.has_compact_pending(sid) is True
+    # Tracked subagent admit: the subagent's first read of the existing
+    # artifact yields the ordinary warn-stale envelope — but never the
+    # re-grounding block, and the flag survives.
+    status, body2 = client.post(
+        "/hooks/pre-read",
+        {"session_id": sid, "agent_id": "sub1", "path": "CLAUDE.md",
+         "content_hash": _hash("rg1")})
+    assert status == 200
+    assert "Post-compaction re-grounding" not in (_reground_text_of(body2) or "")
+    assert coordinator.has_compact_pending(sid) is True
+    # The parent's next admit delivers (rebuilt from CURRENT registry truth
+    # per KTD2 — the subagent's grants above now render as their own group).
+    status, body3 = client.post(
+        "/hooks/pre-read",
+        {"session_id": sid, "path": "CLAUDE.md", "content_hash": _hash("rg1")})
+    assert status == 200
+    delivered = _reground_text_of(body3) or ""
+    assert delivered.startswith("Post-compaction re-grounding (agent-coherence):")
+    assert "Subagent sub1:" in delivered
+    assert coordinator.has_compact_pending(sid) is False
+
+
+def test_subagent_stop_keeps_flag_parent_stop_expires(
+    coordinator, client: _Client
+) -> None:
+    """R2 lifetime: SubagentStop (agent_id present) leaves the flag
+    untouched — the parent turn is still in flight; a parent Stop (no
+    agent_id) expires it, so the next admit is clean."""
+    sid = _sid("dr-stop")
+    _arm_reground(client, sid)
+    status, _ = client.post(
+        "/hooks/session-stop", {"session_id": sid, "agent_id": "sub1"})
+    assert status == 200
+    assert coordinator.has_compact_pending(sid) is True
+    status, _ = client.post("/hooks/session-stop", {"session_id": sid})
+    assert status == 200
+    assert coordinator.has_compact_pending(sid) is False
+    status, body = client.post(
+        "/hooks/pre-read",
+        {"session_id": sid, "path": "CLAUDE.md", "content_hash": _hash("rg1")})
+    assert status == 200
+    assert body == {"status": "fresh", "version": 1}
+
+
+def test_second_session_start_re_marks_idempotently_one_delivery(
+    coordinator, client: _Client
+) -> None:
+    """A second compaction before delivery re-stamps the same flag: still
+    exactly one delivery, and the admit after it is clean."""
+    sid = _sid("dr-remark")
+    _arm_reground(client, sid)
+    status, body = client.post("/hooks/session-start", {"session_id": sid})
+    assert status == 200
+    armed_text = body["hookSpecificOutput"]["additionalContext"]
+    status, first = client.post(
+        "/hooks/pre-read",
+        {"session_id": sid, "path": "CLAUDE.md", "content_hash": _hash("rg1")})
+    assert status == 200
+    assert _reground_text_of(first) == armed_text
+    status, second = client.post(
+        "/hooks/pre-read",
+        {"session_id": sid, "path": "CLAUDE.md", "content_hash": _hash("rg1")})
+    assert status == 200
+    assert second == {"status": "fresh", "version": 1}
+
+
+def test_deferred_reground_pre_edit_delivers(
+    coordinator, client: _Client
+) -> None:
+    """Pre-edit attach point: a pending flag rides the {ok: true} admit as
+    a new allow envelope; the next pre-edit is today's bare shape. KTD2
+    rebuild-at-delivery: this pre-edit acquires EXCLUSIVE BEFORE the attach
+    seam runs, so the delivered prose renders the CURRENT grant state —
+    EXCLUSIVE — not the SHARED snapshot the arming call saw."""
+    sid = _sid("dr-edit")
+    _arm_reground(client, sid)
+    status, body = client.post(
+        "/hooks/pre-edit", {"session_id": sid, "path": "CLAUDE.md"})
+    assert status == 200
+    assert body["ok"] is True
+    delivered = _reground_text_of(body) or ""
+    assert delivered.startswith("Post-compaction re-grounding (agent-coherence):")
+    assert (
+        "At compaction you held EXCLUSIVE on CLAUDE.md (v1) — re-acquire "
+        "before writing." in delivered
+    )
+    status, body2 = client.post(
+        "/hooks/pre-edit", {"session_id": sid, "path": "CLAUDE.md"})
+    assert status == 200
+    assert body2 == {"ok": True}
+
+
+def test_deferred_reground_pre_bash_delivers_untracked_and_tracked(
+    coordinator, client: _Client
+) -> None:
+    """Pre-bash attach point: delivery works from BOTH the zero-tracked-
+    paths fast path and the tracked work path."""
+    sid = _sid("dr-bash")
+    armed_text = _arm_reground(client, sid)
+    # Fast path: no tracked paths detected in the command.
+    status, body = client.post(
+        "/hooks/pre-bash", {"session_id": sid, "command": "echo hello"})
+    assert status == 200
+    assert body["status"] == "fresh"
+    assert _reground_text_of(body) == armed_text
+    status, bare = client.post(
+        "/hooks/pre-bash", {"session_id": sid, "command": "echo hello"})
+    assert status == 200
+    assert bare == {"status": "fresh"}
+    # Tracked path: session is fresh on CLAUDE.md; the flag re-armed.
+    coordinator.mark_compact_pending(sid)
+    status, body2 = client.post(
+        "/hooks/pre-bash", {"session_id": sid, "command": "cat CLAUDE.md"})
+    assert status == 200
+    assert body2["status"] == "fresh"
+    assert _reground_text_of(body2) == armed_text
+
+
+def test_deferred_reground_pre_grep_delivers_tracked_and_empty_root(
+    coordinator, client: _Client
+) -> None:
+    """Pre-grep attach point: delivery works from BOTH the tracked work
+    path (artifacts under the search root) and the zero-tracked-artifacts
+    fast path."""
+    sid = _sid("dr-grep")
+    armed_text = _arm_reground(client, sid)
+    status, body = client.post(
+        "/hooks/pre-grep", {"session_id": sid, "search_root": ""})
+    assert status == 200
+    assert body["status"] == "fresh"
+    assert _reground_text_of(body) == armed_text
+    # Fast path: a root with no registry-known artifacts.
+    coordinator.mark_compact_pending(sid)
+    status, body2 = client.post(
+        "/hooks/pre-grep", {"session_id": sid, "search_root": "src/empty"})
+    assert status == 200
+    assert body2["status"] == "fresh"
+    assert _reground_text_of(body2) == armed_text
+    status, bare = client.post(
+        "/hooks/pre-grep", {"session_id": sid, "search_root": "src/empty"})
+    assert status == 200
+    assert bare == {"status": "fresh"}
+
+
+def test_deferred_reground_concurrent_parent_admits_exactly_one_delivery(
+    coordinator, client: _Client
+) -> None:
+    """R2 at-most-once under contention: 6 concurrent qualifying parent
+    admits race one pending flag; EXACTLY ONE response carries the
+    re-grounding block (the atomic pop at the attach seam)."""
+    sid = _sid("dr-race")
+    _arm_reground(client, sid)
+    barrier = threading.Barrier(6)
+    results: list[dict] = []
+    results_lock = threading.Lock()
+
+    def admit(i: int) -> None:
+        barrier.wait()
+        # Distinct tracked paths so first-observation seeding never contends
+        # on one artifact row; every response is a qualifying fresh admit.
+        _, body = client.post(
+            "/hooks/pre-read",
+            {"session_id": sid, "path": f"docs/plans/p{i}.md",
+             "content_hash": _hash(f"p{i}")})
+        with results_lock:
+            results.append(body)
+
+    threads = [threading.Thread(target=admit, args=(i,)) for i in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    delivered = [
+        body for body in results
+        if "Post-compaction re-grounding" in (_reground_text_of(body) or "")
+    ]
+    assert len(delivered) == 1, (
+        f"expected exactly one re-grounding delivery, got {len(delivered)} "
+        f"of {len(results)} admits"
+    )
+    assert coordinator.has_compact_pending(sid) is False

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -3588,3 +3588,411 @@ def test_pre_read_pair_comes_from_the_classifying_snapshot(
         "the handler must derive the classification version AND the reported "
         f"generation from ONE pair-atomic read; saw {len(reads)}"
     )
+
+
+# ======================================================================
+# SB-10 U2 — POST /hooks/session-start: post-compaction re-grounding
+# ======================================================================
+#
+# Prose lines are byte-pinned here on purpose: the Node coordinator (U6)
+# mirrors these exact strings, and the protocol corpus byte-matches them.
+# Any wording change must land in BOTH backends plus the corpus fixtures.
+
+_SS_HEADER = "Post-compaction re-grounding (agent-coherence):"
+_SS_CLOSING = (
+    "Versions are as of this re-grounding; a more recent read supersedes "
+    "this notice."
+)
+
+
+def _session_start_text(body: dict) -> str:
+    """Unwrap the additionalContext from a session-start response body."""
+    return body["hookSpecificOutput"]["additionalContext"]
+
+
+def test_session_start_missing_authorization_returns_401(coordinator) -> None:
+    url = f"http://127.0.0.1:{coordinator.port}/hooks/session-start"
+    req = urlrequest.Request(url, data=b"{}", method="POST",
+                             headers={"Host": "127.0.0.1", "Content-Type": "application/json"})
+    try:
+        urlrequest.urlopen(req, timeout=5)
+        assert False, "expected 401"
+    except urlerror.HTTPError as e:
+        assert e.code == 401
+
+
+def test_session_start_bad_host_returns_403(client: _Client) -> None:
+    status, body = client.post(
+        "/hooks/session-start", {"session_id": _sid("ss-host")},
+        headers_override={"Host": "attacker.example.com"},
+    )
+    assert status == 403
+
+
+def test_session_start_malformed_session_id_returns_400(client: _Client) -> None:
+    status, body = client.post("/hooks/session-start", {"session_id": "not-a-uuid"})
+    assert status == 400
+
+
+def test_session_start_empty_session_returns_empty_and_no_flag(
+    coordinator, client: _Client
+) -> None:
+    """AE4 (R5): a session with no coordination state gets `{}` and no
+    compact-pending flag — the model sees nothing, the deferred path stays
+    unarmed."""
+    sid = _sid("ss-empty")
+    status, body = client.post("/hooks/session-start", {"session_id": sid})
+    assert status == 200
+    assert body == {}
+    assert coordinator.consume_compact_pending(sid) is False
+
+
+def test_session_start_counter_increments(coordinator, client: _Client) -> None:
+    before = coordinator.endpoint_counters_snapshot()["session_start_total"]
+    client.post("/hooks/session-start", {"session_id": _sid("ss-counter")})
+    after = coordinator.endpoint_counters_snapshot()["session_start_total"]
+    assert after == before + 1
+
+
+def test_session_start_peer_advanced_renders_stale_line(
+    coordinator, client: _Client
+) -> None:
+    """AE1 (R4/R7): A observed v1, peer B committed v2 → A's re-grounding
+    flags the divergence with BOTH versions. B's own grant lines must not
+    leak into A's payload."""
+    sid_a, sid_b = _sid("ss-ae1-a"), _sid("ss-ae1-b")
+    client.post("/hooks/pre-read",
+                {"session_id": sid_a, "path": "plan.md", "content_hash": _hash("v1")})
+    client.post("/hooks/pre-edit", {"session_id": sid_b, "path": "plan.md"})
+    client.post("/hooks/post-edit",
+                {"session_id": sid_b, "path": "plan.md",
+                 "content_hash": _hash("v2"), "success": True})
+
+    status, body = client.post("/hooks/session-start", {"session_id": sid_a})
+    assert status == 200
+    assert set(body.keys()) == {"hookSpecificOutput"}
+    hso = body["hookSpecificOutput"]
+    assert set(hso.keys()) == {"hookEventName", "additionalContext"}
+    assert hso["hookEventName"] == "SessionStart"
+    text = hso["additionalContext"]
+    lines = text.split("\n")
+    assert lines[0] == _SS_HEADER
+    assert lines[1] == (
+        "plan.md advanced to v2 past your last-observed v1 — re-read before "
+        "relying on it."
+    )
+    assert lines[-1] == _SS_CLOSING
+    # B's E/M grant belongs to B's session — never rendered for A.
+    assert "At compaction you held" not in text
+    # KTD8: no timestamps anywhere in the re-grounding prose (no notices in
+    # this scenario, so the whole payload must be timestamp-free).
+    assert "+00:00" not in text
+
+
+def test_session_start_own_last_writer_renders_non_stale_line(
+    coordinator, client: _Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AE2 (R7, KTD4 second layer): even when the version advanced past the
+    recorded last-observed value, a row whose artifact last_writer is the
+    requesting agent itself renders the plain version line, never the stale
+    flag."""
+    sid_a, sid_b = _sid("ss-ae2-a"), _sid("ss-ae2-b")
+    client.post("/hooks/pre-read",
+                {"session_id": sid_a, "path": "plan.md", "content_hash": _hash("v1")})
+    client.post("/hooks/pre-edit", {"session_id": sid_b, "path": "plan.md"})
+    client.post("/hooks/post-edit",
+                {"session_id": sid_b, "path": "plan.md",
+                 "content_hash": _hash("v2"), "success": True})
+    # Force the own-edit exemption arm: pretend A itself is the last writer
+    # (the natural flow advances the writer's own last_observed in the same
+    # transaction — KTD4's FIRST layer — so the second layer is only
+    # reachable via this seam).
+    own_agent = session_to_agent_id(sid_a)
+    monkeypatch.setattr(coordinator.registry, "last_writer_for", lambda aid: own_agent)
+
+    status, body = client.post("/hooks/session-start", {"session_id": sid_a})
+    assert status == 200
+    text = _session_start_text(body)
+    assert "plan.md is at v2." in text
+    assert "advanced to" not in text
+
+
+def test_session_start_null_last_observed_renders_non_stale(
+    coordinator, client: _Client
+) -> None:
+    """R7: a never-observed row (NULL last_observed) is admitted, never
+    flagged — no 0-sentinel comparison may sneak in."""
+    sid_a, sid_b = _sid("ss-null-a"), _sid("ss-null-b")
+    # B seeds the artifact and advances it to v2.
+    client.post("/hooks/pre-read",
+                {"session_id": sid_b, "path": "plan.md", "content_hash": _hash("v1")})
+    client.post("/hooks/pre-edit", {"session_id": sid_b, "path": "plan.md"})
+    client.post("/hooks/post-edit",
+                {"session_id": sid_b, "path": "plan.md",
+                 "content_hash": _hash("v2"), "success": True})
+    # A gets a state row WITHOUT ever observing bytes: an INVALID upsert on a
+    # fresh pair records nothing (U1 contract), leaving last_observed NULL.
+    artifact_id = coordinator.registry.lookup_artifact_id_by_name("plan.md")
+    assert artifact_id is not None
+    coordinator.registry.set_agent_state(
+        artifact_id, session_to_agent_id(sid_a), MESIState.INVALID,
+        trigger="peer_invalidation", tick=1,
+    )
+
+    status, body = client.post("/hooks/session-start", {"session_id": sid_a})
+    assert status == 200
+    text = _session_start_text(body)
+    assert "plan.md is at v2." in text
+    assert "advanced to" not in text
+
+
+def test_session_start_held_exclusive_renders_event_anchored_grant_line(
+    coordinator, client: _Client
+) -> None:
+    """R3 + KTD8: grant prose is event-anchored ("At compaction you held"),
+    never present-tense — a turn-end Stop drain may release E/M before the
+    attachment renders."""
+    sid = _sid("ss-grant")
+    client.post("/hooks/pre-edit", {"session_id": sid, "path": "plan.md"})
+
+    status, body = client.post("/hooks/session-start", {"session_id": sid})
+    assert status == 200
+    text = _session_start_text(body)
+    assert (
+        "At compaction you held EXCLUSIVE on plan.md (v1) — re-acquire "
+        "before writing."
+    ) in text
+
+
+def test_session_start_cap_renders_three_verbatim_plus_overflow_under_10kb(
+    coordinator, client: _Client
+) -> None:
+    """R5: 5 touched artifacts → 3 verbatim lines + a single "Plus 2 more"
+    overflow pointing at the status surface; total payload far below the
+    10KB additionalContext ceiling."""
+    sid = _sid("ss-cap")
+    paths = [f"docs/plans/{n}.md" for n in ("a", "b", "c", "d", "e")]
+    for p in paths:
+        client.post("/hooks/pre-read",
+                    {"session_id": sid, "path": p, "content_hash": _hash(p)})
+
+    status, body = client.post("/hooks/session-start", {"session_id": sid})
+    assert status == 200
+    text = _session_start_text(body)
+    for p in paths[:3]:
+        assert (
+            f"At compaction you held SHARED on {p} (v1) — re-acquire "
+            f"before writing."
+        ) in text
+    for p in paths[3:]:
+        assert p not in text
+    assert "Plus 2 more — run agent-coherence-status for the full picture." in text
+    assert len(text.encode("utf-8")) < 10_000
+
+
+def test_session_start_pending_notice_rendered_read_only(
+    coordinator, client: _Client
+) -> None:
+    """R3: pending preemption notices appear in the payload via the existing
+    preemption prose builder — AFTER the header, BEFORE grant lines — and the
+    queue is NOT drained: the next pre-read still surfaces (and consumes)
+    the same notice. Consumption ownership stays with the admit endpoints."""
+    sid = _sid("ss-notice")
+    client.post("/hooks/pre-read",
+                {"session_id": sid, "path": "AGENTS.md", "content_hash": _hash("n1")})
+    artifact_id = coordinator.registry.lookup_artifact_id_by_name("AGENTS.md")
+    assert artifact_id is not None
+    agent_id = session_to_agent_id(sid)
+    coordinator.registry.record_preemption_notice(
+        victim_agent_id=agent_id,
+        artifact_id=artifact_id,
+        preempter_agent_id=uuid.uuid4(),
+        preempted_at_unix_ts=1_700_000_000.0,
+    )
+
+    status, body = client.post("/hooks/session-start", {"session_id": sid})
+    assert status == 200
+    text = _session_start_text(body)
+    assert text.split("\n")[0] == _SS_HEADER
+    notice_at = text.index("⚠ Coordinator notice:")
+    grant_at = text.index("At compaction you held")
+    assert notice_at < grant_at
+    # Read-only proof: the queue still holds the notice for the admit drain.
+    status, body = client.post(
+        "/hooks/pre-read",
+        {"session_id": sid, "path": "AGENTS.md", "content_hash": _hash("n1")},
+    )
+    assert status == 200
+    assert "AGENTS.md" in body["hookSpecificOutput"]["additionalContext"]
+
+
+def test_session_start_subagent_grants_grouped_and_released_absent(
+    coordinator, client: _Client
+) -> None:
+    """R3 + KTD8: the parent's lines render first, then subagent groups
+    under a `Subagent {name}:` prefix. After the subagent stops (grants
+    released), its grant line disappears from the next payload."""
+    sid = _sid("ss-sub")
+    client.post("/hooks/pre-read",
+                {"session_id": sid, "path": "CLAUDE.md", "content_hash": _hash("c1")})
+    client.post("/hooks/pre-edit",
+                {"session_id": sid, "path": "plan.md", "agent_id": "worker-1"})
+
+    status, body = client.post("/hooks/session-start", {"session_id": sid})
+    assert status == 200
+    text = _session_start_text(body)
+    parent_at = text.index("At compaction you held SHARED on CLAUDE.md (v1)")
+    prefix_at = text.index("Subagent worker-1:")
+    sub_at = text.index("At compaction you held EXCLUSIVE on plan.md (v1)")
+    assert parent_at < prefix_at < sub_at
+
+    # Stop the subagent — its E grant is released (row goes INVALID).
+    client.post("/hooks/session-stop", {"session_id": sid, "agent_id": "worker-1"})
+    status, body = client.post("/hooks/session-start", {"session_id": sid})
+    assert status == 200
+    text = _session_start_text(body)
+    assert "At compaction you held EXCLUSIVE on plan.md" not in text
+    # The released row is still a touched row — rendered without a flag.
+    assert "Subagent worker-1:" in text
+    assert "plan.md is at v1." in text
+
+
+def test_session_start_two_identical_calls_byte_identical(
+    coordinator, client: _Client
+) -> None:
+    """KTD8 determinism: with no state movement between them, two calls
+    produce byte-identical additionalContext (no timestamps, stable sort)."""
+    sid_a, sid_b = _sid("ss-det-a"), _sid("ss-det-b")
+    client.post("/hooks/pre-read",
+                {"session_id": sid_a, "path": "CLAUDE.md", "content_hash": _hash("d1")})
+    client.post("/hooks/pre-edit", {"session_id": sid_b, "path": "plan.md"})
+    client.post("/hooks/post-edit",
+                {"session_id": sid_b, "path": "plan.md",
+                 "content_hash": _hash("d2"), "success": True})
+    client.post("/hooks/pre-read",
+                {"session_id": sid_a, "path": "docs/plans/x.md", "content_hash": _hash("d3")})
+
+    _, first = client.post("/hooks/session-start", {"session_id": sid_a})
+    _, second = client.post("/hooks/session-start", {"session_id": sid_a})
+    assert _session_start_text(first) == _session_start_text(second)
+
+
+def test_session_start_sets_flag_consume_is_test_and_clear(
+    coordinator, client: _Client
+) -> None:
+    """KTD5: a non-empty session-start marks compact-pending; the first
+    consume wins, the second sees nothing."""
+    sid = _sid("ss-flag")
+    client.post("/hooks/pre-read",
+                {"session_id": sid, "path": "CLAUDE.md", "content_hash": _hash("f1")})
+    status, body = client.post("/hooks/session-start", {"session_id": sid})
+    assert status == 200
+    assert body != {}
+    assert coordinator.consume_compact_pending(sid) is True
+    assert coordinator.consume_compact_pending(sid) is False
+
+
+def test_consume_compact_pending_race_exactly_one_winner(coordinator) -> None:
+    """KTD5: consume is an atomic test-and-clear — 8 racing consumers get
+    exactly one True (the deferred-delivery unit's TOCTOU safety)."""
+    sid = _sid("ss-race")
+    coordinator.mark_compact_pending(sid)
+    barrier = threading.Barrier(8)
+    results: list[bool] = []
+    results_lock = threading.Lock()
+
+    def racer() -> None:
+        barrier.wait()
+        got = coordinator.consume_compact_pending(sid)
+        with results_lock:
+            results.append(got)
+
+    threads = [threading.Thread(target=racer) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert sum(results) == 1
+
+
+def test_expire_compact_pending_clears_flag(coordinator) -> None:
+    """KTD5: expire drops an unconsumed flag (parent-Stop wiring lands in
+    the deferred-delivery unit; the primitive is pinned here)."""
+    sid = _sid("ss-expire")
+    coordinator.mark_compact_pending(sid)
+    coordinator.expire_compact_pending(sid)
+    assert coordinator.consume_compact_pending(sid) is False
+
+
+def test_session_start_degraded_returns_empty_and_no_flag(
+    coordinator, client: _Client
+) -> None:
+    """KTD7: a watchdog-degraded session-start answers `{}` — advisory
+    re-grounding must never block — and the compact-pending flag stays
+    unset (nothing to deliver later that was never built)."""
+    from concurrent.futures import TimeoutError as FuturesTimeout
+    from unittest.mock import patch
+
+    sid = _sid("ss-degraded")
+    client.post("/hooks/pre-read",
+                {"session_id": sid, "path": "CLAUDE.md", "content_hash": _hash("g1")})
+    with patch.object(coordinator, "run_with_watchdog", side_effect=FuturesTimeout()):
+        status, body = client.post("/hooks/session-start", {"session_id": sid})
+    assert status == 200
+    assert body == {}
+    assert coordinator.consume_compact_pending(sid) is False
+
+
+def test_session_start_breadcrumb_only_for_never_seen_with_state(
+    coordinator, client: _Client, caplog: pytest.LogCaptureFixture
+) -> None:
+    """R8: the debug breadcrumb fires exactly when a never-seen session
+    arrives while the workspace holds coordination state — converting a
+    silent session-id-rotation regression into an observable."""
+    import logging
+
+    caplog.set_level(logging.DEBUG, logger="ccs.adapters.claude_code.coordinator_server")
+
+    # (a) never-seen session + EMPTY workspace → no breadcrumb.
+    client.post("/hooks/session-start", {"session_id": _sid("ss-bc-empty")})
+    assert "never-seen session" not in caplog.text
+
+    # Seed workspace state with an unrelated session.
+    client.post("/hooks/pre-read",
+                {"session_id": _sid("ss-bc-other"), "path": "CLAUDE.md",
+                 "content_hash": _hash("b1")})
+
+    # (b) never-seen session + NONEMPTY workspace → breadcrumb.
+    caplog.clear()
+    client.post("/hooks/session-start", {"session_id": _sid("ss-bc-new")})
+    assert "never-seen session" in caplog.text
+
+    # (c) already-seen session + nonempty workspace → no breadcrumb.
+    caplog.clear()
+    client.post("/hooks/session-start", {"session_id": _sid("ss-bc-new")})
+    assert "never-seen session" not in caplog.text
+
+
+def test_session_start_prose_constants_byte_pinned() -> None:
+    """KTD8: the Node coordinator byte-matches these module-level constants;
+    a wording tweak here must ship in both backends + the corpus."""
+    from ccs.adapters.claude_code import hook_payloads as hp
+
+    assert hp.SESSION_START_HEADER == "Post-compaction re-grounding (agent-coherence):"
+    assert hp.SESSION_START_GRANT_LINE_TEMPLATE == (
+        "At compaction you held {state} on {path} (v{version}) — re-acquire "
+        "before writing."
+    )
+    assert hp.SESSION_START_STALE_LINE_TEMPLATE == (
+        "{path} advanced to v{current} past your last-observed v{last} — "
+        "re-read before relying on it."
+    )
+    assert hp.SESSION_START_TOUCHED_LINE_TEMPLATE == "{path} is at v{current}."
+    assert hp.SESSION_START_OVERFLOW_LINE_TEMPLATE == (
+        "Plus {count} more — run agent-coherence-status for the full picture."
+    )
+    assert hp.SESSION_START_SUBAGENT_PREFIX_TEMPLATE == "Subagent {name}:"
+    assert hp.SESSION_START_CLOSING_LINE == (
+        "Versions are as of this re-grounding; a more recent read supersedes "
+        "this notice."
+    )

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -3689,6 +3689,51 @@ def test_session_start_peer_advanced_renders_stale_line(
     assert "+00:00" not in text
 
 
+def test_session_start_scopes_the_state_read_to_this_sessions_agents(
+    coordinator, client: _Client, monkeypatch
+) -> None:
+    """SB-10 review: the builder must narrow ``status_snapshot`` to its own
+    session's agents.
+
+    No behavioural test can pin this — the walk looks each pair up per agent
+    (``state_by_artifact.get(artifact_id, {}).get(agent_id)``), so surplus
+    rows are unobservable and dropping the scope would render byte-identical
+    and ship green. Assert the ARGUMENT instead, or the whole point of the
+    fix — a hook path that stops reading the workspace's entire never-GC'd
+    ``agent_states`` ledger, twice per compaction, under the registry lock —
+    is revertible in silence."""
+    sid_a, sid_b = _sid("ss-scope-a"), _sid("ss-scope-b")
+    # A peer session's rows on the same artifact: present in the ledger,
+    # never in scope.
+    client.post("/hooks/pre-read",
+                {"session_id": sid_a, "path": "plan.md", "content_hash": _hash("v1")})
+    client.post("/hooks/pre-read",
+                {"session_id": sid_b, "path": "plan.md", "content_hash": _hash("v1")})
+
+    scopes: list[list[uuid.UUID] | None] = []
+    real = coordinator.registry.status_snapshot
+
+    def recording(*args, **kwargs):
+        scopes.append(
+            None if kwargs.get("agent_ids") is None else list(kwargs["agent_ids"])
+        )
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(coordinator.registry, "status_snapshot", recording)
+
+    status, _ = client.post("/hooks/session-start", {"session_id": sid_a})
+    assert status == 200
+    assert len(scopes) == 1, "the builder reads state exactly once"
+    expected = [agent_id for agent_id, _ in coordinator.agents_for_session(sid_a)]
+    assert scopes[0] == expected
+    peer_agent_ids = {
+        agent_id for agent_id, _ in coordinator.agents_for_session(sid_b)
+    }
+    assert not peer_agent_ids.intersection(scopes[0] or []), (
+        "a peer session's agent must never enter the scope"
+    )
+
+
 def test_session_start_own_last_writer_renders_non_stale_line(
     coordinator, client: _Client, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -4035,9 +4035,13 @@ def _reground_text_of(body: dict) -> str | None:
 def test_deferred_reground_tracked_pre_read_delivers_exactly_once(
     coordinator, client: _Client
 ) -> None:
-    """Pending flag + tracked pre-read allow → the fresh admit carries the
+    """Pending flag + tracked pre-read admit → the fresh admit carries the
     re-grounding block (byte-identical to the session-start rendering —
-    KTD2 rebuild-at-delivery), and the following admit is clean."""
+    KTD2 rebuild-at-delivery), and the following admit is clean.
+
+    This tracked fresh-no-notice admit has no envelope of its own, so the
+    attach mints the CONTEXT-ONLY shape: prose without a permission
+    decision (advisory payloads never widen one)."""
     sid = _sid("dr-tracked")
     armed_text = _arm_reground(client, sid)
     status, body = client.post(
@@ -4046,7 +4050,8 @@ def test_deferred_reground_tracked_pre_read_delivers_exactly_once(
     assert status == 200
     assert body["status"] == "fresh"
     out = body["hookSpecificOutput"]
-    assert out["permissionDecision"] == "allow"
+    assert out["hookEventName"] == "PreToolUse"
+    assert "permissionDecision" not in out
     assert out["additionalContext"] == armed_text
     # Consumed: the very next admit is today's bare fresh shape.
     status, body2 = client.post(
@@ -4059,9 +4064,10 @@ def test_deferred_reground_tracked_pre_read_delivers_exactly_once(
 def test_deferred_reground_untracked_pre_read_delivers_then_bare(
     coordinator, client: _Client
 ) -> None:
-    """Pending flag + UNTRACKED pre-read → the payload still rides the new
-    allow envelope on the fast path; the next untracked call returns
-    today's bare body."""
+    """Pending flag + UNTRACKED pre-read → the payload rides a CONTEXT-ONLY
+    PreToolUse envelope on the fast path (no permission decision — the
+    advisory delivery must not auto-approve an otherwise-promptable tool
+    call); the next untracked call returns today's bare body."""
     sid = _sid("dr-untracked")
     armed_text = _arm_reground(client, sid)
     status, body = client.post(
@@ -4070,12 +4076,72 @@ def test_deferred_reground_untracked_pre_read_delivers_then_bare(
     assert body["status"] == "fresh"
     out = body["hookSpecificOutput"]
     assert out["hookEventName"] == "PreToolUse"
-    assert out["permissionDecision"] == "allow"
+    assert "permissionDecision" not in out
     assert out["additionalContext"] == armed_text
     status, body2 = client.post(
         "/hooks/pre-read", {"session_id": sid, "path": "notes.txt"})
     assert status == 200
     assert body2 == {"status": "fresh"}
+
+
+def test_deferred_reground_untracked_admit_emits_no_permission_decision(
+    coordinator, client: _Client
+) -> None:
+    """Security pin (explicit absence): the deferred delivery must never
+    widen a permission decision. An untracked admit whose base body has no
+    envelope of its own gets prose ONLY — hookEventName + additionalContext
+    and NOTHING else. A ``permissionDecision: "allow"`` here would
+    short-circuit Claude Code's permission prompting for that tool call,
+    once per compaction, purely as a side effect of delivery.
+
+    Verified empirically (A/B capture, Claude Code CLI 2.1.233,
+    2026-08-25): the CLI renders additionalContext on a PreToolUse
+    envelope carrying no permissionDecision, so the allow was never
+    needed to get the prose in front of the model."""
+    sid = _sid("dr-no-decision")
+    armed_text = _arm_reground(client, sid)
+    status, body = client.post(
+        "/hooks/pre-read", {"session_id": sid, "path": "notes.txt"})
+    assert status == 200
+    out = body["hookSpecificOutput"]
+    assert "permissionDecision" not in out
+    assert "permissionDecisionReason" not in out
+    assert set(out) == {"hookEventName", "additionalContext"}
+    assert out["hookEventName"] == "PreToolUse"
+    # The advisory still lands — absence of the decision costs no prose.
+    assert out["additionalContext"] == armed_text
+    assert armed_text.startswith("Post-compaction re-grounding (agent-coherence):")
+
+
+def test_deferred_reground_merge_preserves_existing_permission_decision(
+    coordinator, client: _Client
+) -> None:
+    """The OTHER branch is untouched: when the base admit already carries
+    an envelope (here a warn-mode stale-read allow), the attach merges the
+    re-grounding block into it and the pre-existing permissionDecision
+    survives verbatim — the advisory neither widens nor narrows a decision
+    the admit already made. KTD6 ordering: the stale warning renders
+    first, the re-ground block after it."""
+    sid = _sid("dr-merge")
+    peer = _sid("dr-merge-peer")
+    # Session A first-reads plan.md (SHARED v1); peer commits v2 → A stale.
+    client.post("/hooks/pre-read",
+                {"session_id": sid, "path": "plan.md", "content_hash": _hash("m1")})
+    client.post("/hooks/pre-edit", {"session_id": peer, "path": "plan.md"})
+    client.post("/hooks/post-edit",
+                {"session_id": peer, "path": "plan.md",
+                 "content_hash": _hash("m2"), "success": True})
+    coordinator.mark_compact_pending(sid)
+    status, body = client.post(
+        "/hooks/pre-read",
+        {"session_id": sid, "path": "plan.md", "content_hash": _hash("m1")})
+    assert status == 200
+    out = body["hookSpecificOutput"]
+    assert out["permissionDecision"] == "allow"  # warn-mode decision preserved
+    text = out["additionalContext"]
+    assert text.index("Stale read") < text.index(
+        "Post-compaction re-grounding (agent-coherence):")
+    assert coordinator.has_compact_pending(sid) is False
 
 
 def test_untracked_pre_read_no_flag_byte_identical_and_registry_free(
@@ -4294,4 +4360,121 @@ def test_deferred_reground_concurrent_parent_admits_exactly_one_delivery(
         f"expected exactly one re-grounding delivery, got {len(delivered)} "
         f"of {len(results)} admits"
     )
+    assert coordinator.has_compact_pending(sid) is False
+
+
+def test_deferred_reground_rebuild_failure_forfeits_without_breaking_admit(
+    coordinator, client: _Client, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """KTD2 rebuild-at-delivery can fail AFTER the claim won the pop. The
+    guard in ``_claim_reground_context`` forfeits that delivery (R2 permits
+    at-most-once → zero) instead of turning an otherwise-successful admit
+    into an internal-error body: the admit answers its ordinary bare shape,
+    the flag stays consumed, and the forfeit is logged."""
+    import logging
+
+    import ccs.adapters.claude_code.coordinator_server as mod
+
+    caplog.set_level(logging.ERROR, logger=_CSRV)
+    sid = _sid("dr-rebuild-fail")
+
+    # Explode on the DELIVERY rebuild only — the arming session-start is
+    # call #1 and must succeed, or the flag would never be set at all.
+    real_build = mod._build_session_start_context
+    calls = {"n": 0}
+
+    def build_then_explode(coord, sid_arg, *, abort=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return real_build(coord, sid_arg, abort=abort)
+        raise RuntimeError("registry exploded mid-rebuild")
+
+    monkeypatch.setattr(mod, "_build_session_start_context", build_then_explode)
+    _arm_reground(client, sid)
+    assert calls["n"] == 1
+    caplog.clear()
+
+    status, body = client.post(
+        "/hooks/pre-read",
+        {"session_id": sid, "path": "CLAUDE.md", "content_hash": _hash("rg1")})
+    assert status == 200
+    # The admit is NOT broken: today's bare fresh shape, not the
+    # {ok: false, reason: "internal: ..."} body _run_or_degrade emits when
+    # work() raises.
+    assert body == {"status": "fresh", "version": 1}
+    assert calls["n"] == 2
+    # The claim won the pop before the rebuild raised, so the delivery is
+    # forfeited rather than re-queued.
+    assert coordinator.has_compact_pending(sid) is False
+    assert "delivery forfeited" in caplog.text
+
+    status, body2 = client.post(
+        "/hooks/pre-read",
+        {"session_id": sid, "path": "CLAUDE.md", "content_hash": _hash("rg1")})
+    assert status == 200
+    assert body2 == {"status": "fresh", "version": 1}
+
+
+def test_deferred_reground_fast_path_slow_rebuild_degrades_to_bare_base(
+    coordinator, client: _Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fast-path delivery rebuild walks the registry, so it runs under
+    the handler watchdog: a slow/contended rebuild must not hang the hook
+    past its budget. On timeout the response is the bare ``base`` —
+    byte-identical to the no-flag fast path — the request raises nothing,
+    and the degradation is observable via the /status counter."""
+    import ccs.adapters.claude_code.coordinator_server as mod
+
+    sid = _sid("dr-fast-slow")
+    _arm_reground(client, sid)
+
+    def slow_build(coord, sid_arg, *, abort=None):
+        time.sleep(1.0)
+        return ("never reaches the client", True)
+
+    monkeypatch.setattr(mod, "_build_session_start_context", slow_build)
+    monkeypatch.setattr(mod, "HANDLER_TIMEOUT_SEC", 0.1)
+
+    before = coordinator._watchdog_timeouts_total
+    started = time.monotonic()
+    status, body = client.post(
+        "/hooks/pre-read", {"session_id": sid, "path": "notes.txt"})
+    elapsed = time.monotonic() - started
+    assert status == 200
+    assert body == {"status": "fresh"}
+    assert elapsed < 0.8, (
+        f"fast-path delivery waited {elapsed:.2f}s on a 1.0s rebuild; the "
+        f"watchdog did not cut it"
+    )
+    assert coordinator._watchdog_timeouts_total == before + 1
+
+
+def test_deferred_reground_preset_abort_does_not_consume_flag(
+    coordinator, client: _Client
+) -> None:
+    """A6: the abort check runs BEFORE the pop, so a request already known
+    doomed leaves the flag pending — the delivery survives for the next
+    live admit instead of being burned by a response nobody will read."""
+    import ccs.adapters.claude_code.coordinator_server as mod
+
+    sid = _sid("dr-abort-preset")
+    armed_text = _arm_reground(client, sid)
+
+    doomed = threading.Event()
+    doomed.set()
+    base = {"status": "fresh"}
+    out = mod._deliver_pending_reground(
+        coordinator, sid, {"session_id": sid}, base, abort=doomed
+    )
+    # Same object back — the qualifying admit body stays byte-identical.
+    assert out is base
+    assert coordinator.has_compact_pending(sid) is True
+
+    # The next live admit still delivers.
+    status, body = client.post(
+        "/hooks/pre-read",
+        {"session_id": sid, "path": "CLAUDE.md", "content_hash": _hash("rg1")})
+    assert status == 200
+    assert _reground_text_of(body) == armed_text
     assert coordinator.has_compact_pending(sid) is False

--- a/tests/test_claude_code_hook_client.py
+++ b/tests/test_claude_code_hook_client.py
@@ -437,3 +437,242 @@ def test_pre_grep_empty_path_does_not_crash(
     # {"status": "fresh"}. We just need a parseable JSON response, not
     # specifically empty or non-empty.
     assert isinstance(response, dict)
+
+
+# ----------------------------------------------------------------------
+# session-start (SB-10 U3) — post-compaction re-grounding bridge
+#
+# The coordinator endpoint trusts its caller and treats EVERY request as a
+# compact event (R1), so the ``source == "compact"`` gate lives in the
+# hook-client builder. These tests pin both halves of that contract: a
+# compact SessionStart reaches /hooks/session-start and its response is
+# passed through verbatim; every other source (startup/resume/clear/absent)
+# never touches the network; and every failure mode stays fail-open ({}).
+# ----------------------------------------------------------------------
+
+
+def _fake_coherence_dir(workspace: Path, port: int) -> None:
+    """Fabricate .coherence/{server.pid,hook.secret} so resolve_endpoint
+    (pure file reads — no network) succeeds and the dispatch ladder is
+    reachable without spawning a real coordinator."""
+    coherence = workspace / ".coherence"
+    coherence.mkdir(exist_ok=True)
+    # Port-file format per lifecycle.read_port_from_file: line 1 pid, line 2 port.
+    (coherence / "server.pid").write_text(f"12345\n{port}\n")
+    (coherence / "hook.secret").write_text("test-secret")
+
+
+def test_session_start_compact_posts_and_passes_response_through(
+    live_coordinator, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """source:"compact" with coordination state → non-empty re-grounding
+    payload on stdout, byte-for-byte identical to what the coordinator
+    returns for a direct POST (the passthrough contract: the client must
+    not reshape, filter, or annotate the coordinator's response)."""
+    workspace, _ = live_coordinator
+    from ccs.cli import coherence_track
+    from ccs.cli._coherence_client import post, resolve_endpoint
+
+    (workspace / "docs").mkdir(parents=True, exist_ok=True)
+    (workspace / "docs" / "plan.md").write_text("plan v1")
+    coherence_track.main(["--root", str(workspace), "docs/plan.md"])
+    capsys.readouterr()  # drain track output
+
+    # Give the session coordination state: a pre-read on the tracked file
+    # grants this session's agent a MESI state, which is exactly what makes
+    # the session-start payload non-empty (R5's has-state arm).
+    session_id = _sid()
+    read_payload = {
+        "session_id": session_id,
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(workspace / "docs" / "plan.md")},
+    }
+    rc, _ = _drive("pre-read", read_payload, workspace, monkeypatch, capsys)
+    assert rc == 0
+
+    cc_payload = {
+        "session_id": session_id,
+        "hook_event_name": "SessionStart",
+        "source": "compact",
+    }
+    rc, out = _drive("session-start", cc_payload, workspace, monkeypatch, capsys)
+    assert rc == 0
+    response = json.loads(out)
+    hso = response.get("hookSpecificOutput")
+    assert hso is not None, (
+        f"compact session-start with a grant must return a re-grounding "
+        f"payload, got {response!r}"
+    )
+    assert hso["hookEventName"] == "SessionStart"
+    assert "docs/plan.md" in hso["additionalContext"]
+
+    # Verbatim passthrough: a direct POST with the translated body must
+    # yield the exact bytes the client printed (the build is read-only
+    # toward the registry — R6 — so back-to-back calls are stable).
+    endpoint = resolve_endpoint(workspace)
+    direct = post(endpoint, "/hooks/session-start", {"session_id": session_id})
+    assert out.strip() == json.dumps(direct)
+
+
+def test_session_start_non_compact_sources_never_hit_network(
+    live_coordinator, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """startup/resume/clear/absent → {} exit 0 with NO request made. A
+    live coordinator is running, so if the source gate ever regressed the
+    recorded-call list would be non-empty (and the response non-{})."""
+    workspace, _ = live_coordinator
+    calls: list[tuple[str, dict[str, Any]]] = []
+    real_post = coherence_hook_client.post
+
+    def recording_post(endpoint, path, body, **kwargs):
+        calls.append((path, body))
+        return real_post(endpoint, path, body, **kwargs)
+
+    monkeypatch.setattr(coherence_hook_client, "post", recording_post)
+    for source in ("startup", "resume", "clear", None):
+        cc_payload: dict[str, Any] = {"session_id": _sid()}
+        if source is not None:
+            cc_payload["source"] = source
+        rc, out = _drive("session-start", cc_payload, workspace, monkeypatch, capsys)
+        assert rc == 0, f"source={source!r}"
+        assert out.strip() == "{}", f"source={source!r} must skip, got {out!r}"
+    assert calls == [], f"non-compact sources must not reach the network: {calls}"
+
+
+def test_session_start_body_is_session_only(
+    git_workspace: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The translated body is exactly {"session_id": ...}: source is
+    stripped, and a stray agent_id is NOT forwarded (SessionStart carries
+    no subagent context — the re-grounding payload is session-scoped, so
+    the builder deliberately bypasses _with_agent_id). Also pins verbatim
+    passthrough of an arbitrary coordinator response."""
+    _fake_coherence_dir(git_workspace, port=65000)
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def canned_post(endpoint, path, body, **kwargs):
+        calls.append((path, body))
+        return {"ok": True}
+
+    monkeypatch.setattr(coherence_hook_client, "post", canned_post)
+    session_id = _sid()
+    cc_payload = {
+        "session_id": session_id,
+        "source": "compact",
+        "agent_id": "worker-1",  # never expected on SessionStart; must be dropped
+    }
+    rc, out = _drive("session-start", cc_payload, git_workspace, monkeypatch, capsys)
+    assert rc == 0
+    assert calls == [("/hooks/session-start", {"session_id": session_id})]
+    assert out.strip() == json.dumps({"ok": True})
+
+
+def test_session_start_missing_session_id_emits_empty(
+    git_workspace: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Compact source but no session_id → skip before any network call."""
+    _fake_coherence_dir(git_workspace, port=65000)
+    calls: list[str] = []
+    monkeypatch.setattr(
+        coherence_hook_client,
+        "post",
+        lambda endpoint, path, body, **kwargs: calls.append(path) or {},
+    )
+    rc, out = _drive("session-start", {"source": "compact"}, git_workspace,
+                     monkeypatch, capsys)
+    assert rc == 0
+    assert out.strip() == "{}"
+    assert calls == []
+
+
+def test_session_start_tty_stdin_emits_empty(
+    git_workspace: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Developer runs the subcommand manually (stdin is a TTY) → usage
+    hint on stderr, {} on stdout, exit 0 — never a blocking read."""
+    class _TtyStdin(io.StringIO):
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr("sys.stdin", _TtyStdin())
+    rc = coherence_hook_client.main(["session-start", "--root", str(git_workspace)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out.strip() == "{}"
+
+
+def test_session_start_empty_stdin_emits_empty(
+    git_workspace: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    rc = coherence_hook_client.main(["session-start", "--root", str(git_workspace)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out.strip() == "{}"
+
+
+def test_session_start_malformed_stdin_emits_empty(
+    git_workspace: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("sys.stdin", io.StringIO("not json at all"))
+    rc = coherence_hook_client.main(["session-start", "--root", str(git_workspace)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out.strip() == "{}"
+
+
+def test_session_start_no_coordinator_returns_empty(
+    git_workspace: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Compact event with no coordinator running → {} exit 0."""
+    cc_payload = {"session_id": _sid(), "source": "compact"}
+    rc, out = _drive("session-start", cc_payload, git_workspace, monkeypatch, capsys)
+    assert rc == 0
+    assert out.strip() == "{}"
+
+
+def test_session_start_unreachable_coordinator_returns_empty(
+    git_workspace: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Port file exists but nothing is listening (stale pid file after a
+    coordinator crash) → the POST raises CoordinatorUnavailable → {}."""
+    import socket
+
+    # Bind-then-close: the freed ephemeral port is near-certainly unbound,
+    # so the client's connect gets refused instead of talking to a stranger.
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        dead_port = probe.getsockname()[1]
+    _fake_coherence_dir(git_workspace, port=dead_port)
+
+    cc_payload = {"session_id": _sid(), "source": "compact"}
+    rc, out = _drive("session-start", cc_payload, git_workspace, monkeypatch, capsys)
+    assert rc == 0
+    assert out.strip() == "{}"
+
+
+def test_session_start_builder_exception_emits_empty(
+    git_workspace: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unexpected exception inside the builder (refactor regression)
+    must be swallowed by the dispatch ladder's catch-all → {} exit 0."""
+    _fake_coherence_dir(git_workspace, port=65000)
+    monkeypatch.setattr(
+        coherence_hook_client,
+        "_build_session_start",
+        lambda cc: (_ for _ in ()).throw(RuntimeError("builder regression")),
+    )
+    cc_payload = {"session_id": _sid(), "source": "compact"}
+    rc, out = _drive("session-start", cc_payload, git_workspace, monkeypatch, capsys)
+    assert rc == 0
+    assert out.strip() == "{}"

--- a/tests/test_registry_protocol_parity.py
+++ b/tests/test_registry_protocol_parity.py
@@ -11,7 +11,7 @@ module pins the WHOLE surface:
 
 - both registries are ``isinstance`` of :class:`RegistryBase`, and the SQLite one
   is additionally ``isinstance`` of :class:`SqliteExtended`;
-- the exact expected method names (43 base + 13 extended) are present + callable
+- the exact expected method names (45 base + 13 extended) are present + callable
   on each registry, and the base **property** members (e.g. ``coordinator_epoch``)
   are present as properties — the callable checks cannot see them, so they are
   pinned separately;
@@ -74,6 +74,7 @@ BASE_METHODS = frozenset(
         "granted_at_tick",
         "has_artifact",
         "last_heartbeat_tick",
+        "last_observed_version_for",
         "list_checkpoints",
         "record_heartbeat",
         "record_last_reclamation",

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -828,9 +828,16 @@ def test_fresh_db_has_fence_schema(db_path: Path) -> None:
         assert "workspace_checkpoint_members" in tables
         # The v6 observed-version comparand column (SB-10) is inline as well.
         assert "last_observed_version" in state_cols
-        # SB-10 bumped the schema to v6; a fresh db is created at v6.
+        # The v7 agent_id index (SB-10 perf follow-up) is inline as well.
+        indexes = {
+            r[0] for r in reg._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+            ).fetchall()
+        }
+        assert "idx_agent_states_agent" in indexes
+        # A fresh db is created directly at the current head.
         assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
-        assert SCHEMA_USER_VERSION == 6
+        assert SCHEMA_USER_VERSION == 7
 
 
 def test_pre_fence_db_upgrades_in_place_additively(db_path: Path) -> None:
@@ -2242,3 +2249,22 @@ def test_status_snapshot_scoped_to_no_agents_reads_no_state(db_path: Path) -> No
         artifact_by_id, state_by_artifact = reg.status_snapshot(agent_ids=[])
         assert set(artifact_by_id) == {art.id}
         assert state_by_artifact == {art.id: {}}
+
+
+def test_status_snapshot_scoped_query_is_index_backed(db_path: Path) -> None:
+    """SB-10 perf follow-up: the scoped state read must SEARCH via
+    ``idx_agent_states_agent``, never SCAN. Without the index the scope only
+    trims per-row materialization — the page walk over a table nothing
+    garbage-collects still runs on the hook path, and dropping the index in a
+    later migration would regress it silently (every query stays correct)."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        plan = " | ".join(
+            r[3]
+            for r in reg._conn.execute(
+                "EXPLAIN QUERY PLAN SELECT artifact_id, agent_id, state "
+                "FROM agent_states WHERE agent_id IN (?, ?)",
+                ("a" * 32, "b" * 32),
+            ).fetchall()
+        )
+    assert "idx_agent_states_agent" in plan, plan
+    assert "SCAN agent_states" not in plan, plan

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -2183,3 +2183,62 @@ class TestV3ToV4Migration:
                     "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
                     (table,),
                 ).fetchone() is not None, table
+
+
+# --------------------------------------------------------------------
+# status_snapshot agent scoping (SB-10 review)
+# --------------------------------------------------------------------
+
+
+def test_status_snapshot_unscoped_reads_every_agent(db_path: Path) -> None:
+    """The /status caller passes no scope and keeps the whole-ledger view."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        art = _make_artifact()
+        reg.register_artifact(art, content="")
+        a1, a2 = uuid4(), uuid4()
+        reg.set_agent_state(art.id, a1, MESIState.SHARED, tick=1)
+        reg.set_agent_state(art.id, a2, MESIState.EXCLUSIVE, tick=2)
+
+        artifact_by_id, state_by_artifact = reg.status_snapshot()
+        assert set(artifact_by_id) == {art.id}
+        assert state_by_artifact[art.id] == {
+            a1: MESIState.SHARED,
+            a2: MESIState.EXCLUSIVE,
+        }
+
+
+def test_status_snapshot_scoped_reads_only_the_named_agents(db_path: Path) -> None:
+    """SB-10 review: the session-start builder runs on a HOOK path, twice per
+    compaction, under the registry lock — and can only ever render its own
+    session's agents. Nothing garbage-collects ``agent_states``, so an
+    unscoped read would drag the workspace's entire coordination history
+    through that lock to discard all but a handful of rows."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        mine = _make_artifact(name="mine.md")
+        theirs = _make_artifact(name="theirs.md", content_hash="h2")
+        reg.register_artifact(mine, content="")
+        reg.register_artifact(theirs, content="")
+        ours, foreign = uuid4(), uuid4()
+        reg.set_agent_state(mine.id, ours, MESIState.SHARED, tick=1)
+        reg.set_agent_state(mine.id, foreign, MESIState.EXCLUSIVE, tick=2)
+        reg.set_agent_state(theirs.id, foreign, MESIState.SHARED, tick=3)
+
+        artifact_by_id, state_by_artifact = reg.status_snapshot(agent_ids=[ours])
+        # Artifact metadata stays workspace-wide on purpose: SB-10's R8
+        # breadcrumb asks whether the WORKSPACE holds state, not this session.
+        assert set(artifact_by_id) == {mine.id, theirs.id}
+        assert state_by_artifact[mine.id] == {ours: MESIState.SHARED}
+        assert state_by_artifact[theirs.id] == {}
+
+
+def test_status_snapshot_scoped_to_no_agents_reads_no_state(db_path: Path) -> None:
+    """An empty scope is 'no agents', never 'every agent' — the degenerate
+    case must not silently widen back to a full scan."""
+    with SqliteArtifactRegistry(db_path) as reg:
+        art = _make_artifact()
+        reg.register_artifact(art, content="")
+        reg.set_agent_state(art.id, uuid4(), MESIState.SHARED, tick=1)
+
+        artifact_by_id, state_by_artifact = reg.status_snapshot(agent_ids=[])
+        assert set(artifact_by_id) == {art.id}
+        assert state_by_artifact == {art.id: {}}

--- a/tests/test_sqlite_registry.py
+++ b/tests/test_sqlite_registry.py
@@ -826,9 +826,11 @@ def test_fresh_db_has_fence_schema(db_path: Path) -> None:
         # db too — the fresh apply always lands the COMPLETE current schema.
         assert "workspace_checkpoints" in tables
         assert "workspace_checkpoint_members" in tables
-        # WV Unit 2 bumped the schema to v5; a fresh db is created at v5.
+        # The v6 observed-version comparand column (SB-10) is inline as well.
+        assert "last_observed_version" in state_cols
+        # SB-10 bumped the schema to v6; a fresh db is created at v6.
         assert reg._conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_USER_VERSION
-        assert SCHEMA_USER_VERSION == 5
+        assert SCHEMA_USER_VERSION == 6
 
 
 def test_pre_fence_db_upgrades_in_place_additively(db_path: Path) -> None:


### PR DESCRIPTION
## Summary

Implements SB-10 compaction-aware re-grounding in the Python coordinator. After Claude Code compacts a session, the model is re-grounded in what it holds and what moved underneath it: held MESI grants (event-anchored to the compaction), the current coordinated version of every touched artifact, and a stale-divergence flag when a peer advanced one past this session's last-observed version.

Three pieces:

- **New durable state** — migration v5 to v6 adds a nullable `last_observed_version` column to `agent_states`, recorded inside the existing upsert transaction at every non-INVALID grant and advanced for the committer on commit. Never-observed rows stay NULL (never a 0-sentinel) and an INVALID transition preserves the prior value.
- **New endpoint** — `POST /hooks/session-start` builds the payload from one atomic registry pass: grants, touched-artifact versions, stale flags (never for a NULL comparand, never for the session's own last write), preemption notices rendered read-only, capped at 3 verbatim lines plus an overflow summary, closed by a self-qualifying line. Empty sessions emit `{}` and arm nothing.
- **Dual delivery** — the payload reaches the model at the next user turn and on resume via `additionalContext`; a live autonomous loop additionally receives it on its next tool admit through a process-local compact-pending flag claimed atomically at the allow seam of the four admit surfaces.

Delivery is at-most-once per path, expiring at parent turn end or coordinator restart. Only parent-identity requests consume or expire the flag; subagent admits leave it untouched. Strict-mode deny bodies stay byte-identical and never carry the block.

## Behaviour verified against the platform, not assumed

Two empirical captures against Claude Code 2.1.233 shaped the design:

1. Auto-compaction fires `PreCompact(trigger:auto)` then `SessionStart(source:compact)` then `PostCompact`, with a stable `session_id`. `SessionStart` `additionalContext` renders at the next user turn and on resume but never mid-autonomous-loop, and `PreCompact`/`PostCompact` output is discarded entirely — which is why the deferred tool-admit path exists at all.
2. A `PreToolUse` envelope carrying only `hookEventName` + `additionalContext` **is** rendered to the model. So the delivery seam emits a context-only envelope on a bare admit body rather than minting `permissionDecision: "allow"` — advisory prose must never widen a permission decision.

## Review round (79c36e2)

Reviewing the Node half turned up a defect with a twin here, and it was
this backend that had it worse.

`_build_session_start_context` called `status_snapshot()` — two unfiltered
full-table reads (`artifacts`, then `agent_states`) taken under the
registry-wide lock. That method predates SB-10; it was the `/status` N+1 fix,
and until this branch `/status` was its only caller. SB-10 put it on a hook
path, run twice per compaction, while the walk can only ever render rows for
the requesting session's parent and subagents — and nothing garbage-collects
`agent_states`.

`status_snapshot` now takes an optional `agent_ids` keyword that narrows the
state query. `/status` passes nothing and keeps the whole-ledger view. The
artifacts half stays workspace-wide on purpose: R8's breadcrumb asks whether
the *workspace* holds coordination state, not whether this session does.

| `agent_states` rows, four-agent session | Unscoped | Scoped |
|---|---|---|
| 500k, Python `status_snapshot` | 2804 ms | 174 ms |
| 500k, Node `allStateMaps` (sibling PR) | 990 ms | 94 ms |

Rendered bytes do not move — the walk looks each pair up per agent, so surplus
rows were never observable. That is also exactly why the scoping was silently
revertible: deleting the keyword left all 214 server tests and all 25
hook-client tests green. The call site now asserts the argument it passes,
mutation-checked by dropping the keyword.

The sibling PR carries two further fixes with no counterpart here, because
this backend was already correct on both: its preemption-notice builder
already sorts newest-first and reports the true pre-cap count, and its
`PreToolUseHookOutput` kept `permissionDecision` required with a separate
`PreToolUseContextOutput` for the advisory envelope. The Node port had widened
the shared type instead; that divergence is what surfaced the finding.

### The parity gate could not actually check this PR (98b4365)

Landing the two halves exposed a hole in the gate that is supposed to make
landing them safe. `protocol-corpus` built the Node backend from
`agent-coherence-plugin@main` unconditionally, so this branch's six
session-start fixtures and its `schema_version` 3→4 bump were asserted against
a Node backend that has none of SB-10: three fixtures 404 on a route that does
not exist there, two deferred-reground fixtures mismatched, one status fixture
reported `schema_version` 3. Six red, not one of them a defect. Merging the
sibling would not have cleared it either — #122 targets the plugin's `dev`,
the gate pinned `main`, and `main` trails `dev` by 39 commits. The pair would
have merged on the strength of a maintainer's local run.

On a pull request the gate now builds the plugin branch whose name matches
this PR's head — the convention for a paired change — and falls back to `main`
otherwise, which is what every push build still does. An absent, moved, or
unreachable sibling degrades to `main` rather than failing, so the gate is
never weaker than before. The resolved ref *and* its SHA go to the step
summary, since the sibling branch can move without a commit here.

## Testing

- Full suite: **3478 passed**, 10 skipped.
- Cross-backend wire parity: **61 protocol-corpus fixtures on both backends, proven in CI** — this PR's run built `agent-coherence-plugin@feat/sb10-compaction-reemission` at `68b8fd9` (the sibling PR's head) and reported `61 passed`. Before 98b4365 that number could only be produced on a maintainer's machine (six new ones cover the endpoint payload, cap overflow, empty no-op, tracked and untracked deferred envelopes, and the strict-deny non-carriage). A deliberate one-byte prose mutation in the Node build was confirmed to fail exactly the expected fixture.
- `tools/check_architecture.py` clean; ruff clean; the KTD-U allow-source meta-test passes with the retired source removed.

Pairs with the Node half in Cohexa-ai/agent-coherence-plugin#122; the two must land together for wire parity.

## Known residuals

- ~~`agent_states.agent_id` is not indexed~~ **Resolved (08daa17):** migration v6→v7 lands `idx_agent_states_agent`, paired with plugin migration v5. The scoped read is `SEARCH`-backed (61 ms → 1.5 ms at 500k rows in the high-agent regime), the plan is pinned by an `EXPLAIN QUERY PLAN` test in both backends, the third arming of the re-stamp trap is defused via the `_V6_USER_VERSION` literal conversion (walk test asserts the index at the v7 stamp), and both cross-runtime guards were re-proven against forged ledgers of the other runtime at its new version. The gate amendment also extends sibling resolution to push builds (`head_ref || ref_name`), so `dev` stays green after the pair merges.
- **Efficacy is unmeasured.** The captures prove delivery, not compliance — whether the model acts on the flag is untested, and the platform's own post-compaction injection competes in the same window.
- **Pre-ship re-capture wanted.** The hook surface drifted once already (`compaction_reason` to `trigger`) inside ten weeks; the harness should be re-run against the then-current CLI before release.
- Watchdog timeout during delivery may forfeit that compaction's block (at-most-once permits zero); the flag is process-local and lost on restart.
- The first compaction after upgrade cannot flag staleness — pre-existing rows have no comparand — and self-heals as sessions read.
- Coverage gaps and structural notes from review are recorded in the run artifacts rather than silently dropped: the delivery seam is a candidate for extraction from `coordinator_server.py`, and deferred attach is corpus-pinned only for pre-read.

## Post-Deploy Monitoring & Validation

- **Watch:** `session_start_total` and the watchdog-timeout counter on `/status`; a rising timeout count against session-start traffic means the payload walk is too slow for the workspace.
- **Log signals:** `delivery forfeited` (rebuild failed after the claim — advisory loss, admit unaffected) and the never-seen-session breadcrumb (would indicate `session_id` rotation, the silent-no-op failure mode).
- **Healthy:** admits unchanged in shape and latency when no flag is pending; untracked traffic makes no registry roundtrip.
- **Rollback trigger:** any change in strict-mode deny bytes, or a permission prompt disappearing after a compaction. Both are pinned by tests; either would mean a regression escaped.
- **Window/owner:** first week of dogfooding after merge, feature owner.



