### PR TITLE
fix(adapters): bind coordinator server without getfqdn DNS lookup

### DIFF
--- a/src/ccs/adapters/claude_code/coordinator_server.py
+++ b/src/ccs/adapters/claude_code/coordinator_server.py
@@ -1248,6 +1248,22 @@ class _ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
         self.handler_concurrency_overflows_total: int = 0
         self._overflow_counter_lock = threading.Lock()
 
+    def server_bind(self) -> None:
+        """Bind without the stdlib's reverse-DNS lookup.
+
+        Regression note: http.server.HTTPServer.server_bind calls
+        socket.getfqdn() to populate self.server_name, which blocks on
+        the host resolver — measured at 35 s on a macOS workstation
+        with a stalled resolver, blowing the coordinator spawn's 10 s
+        reachability window (_spawn_detached in cli/coherence_coordinator.py).
+        We bind 127.0.0.1 only, so the FQDN is purely cosmetic: bind at
+        the TCPServer layer and fill server_name/server_port from the
+        bound address ourselves. Never call socket.getfqdn here.
+        """
+        socketserver.TCPServer.server_bind(self)
+        self.server_name = self.server_address[0] or "localhost"
+        self.server_port = self.server_address[1]
+
     def process_request(self, request: Any, client_address: Any) -> None:
         """Override ThreadingMixIn.process_request to gate handler spawn
         on the concurrency semaphore. If at limit, send 503 directly

--- a/tests/test_claude_code_bind_validation.py
+++ b/tests/test_claude_code_bind_validation.py
@@ -271,3 +271,42 @@ def test_coordinator_routed_bind_constructs_with_insecure_ack(tmp_path, monkeypa
     except OSError:
         return  # address not assignable on this host — guard already passed
     server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Regression: degraded-DNS bind stall.
+#
+# stdlib http.server.HTTPServer.server_bind calls socket.getfqdn(), which
+# blocks on the host resolver — measured at 35 s on a macOS workstation with
+# a stalled resolver, blowing the coordinator spawn's 10 s reachability window
+# (_spawn_detached). The server binds loopback only, so the FQDN is cosmetic;
+# _ThreadingHTTPServer.server_bind must never touch socket.getfqdn.
+# ---------------------------------------------------------------------------
+
+
+def test_server_bind_never_calls_getfqdn(monkeypatch):
+    """Binding the coordinator's HTTP server must not perform reverse DNS."""
+    import http.server as _http_server
+    import socket as _socket
+
+    from ccs.adapters.claude_code.coordinator_server import _ThreadingHTTPServer
+
+    def _stalled_resolver(name: str = "") -> str:  # pragma: no cover - fail path
+        raise AssertionError(
+            "server_bind reached socket.getfqdn — this stalls coordinator "
+            "startup past the 10 s spawn window when host DNS is degraded"
+        )
+
+    monkeypatch.setattr(_socket, "getfqdn", _stalled_resolver)
+    monkeypatch.setattr(_http_server.socket, "getfqdn", _stalled_resolver)
+
+    server = _ThreadingHTTPServer(
+        ("127.0.0.1", 0),
+        _http_server.BaseHTTPRequestHandler,
+        concurrency_limit=4,
+    )
+    try:
+        assert server.server_name == "127.0.0.1"
+        assert server.server_port == server.server_address[1] > 0
+    finally:
+        server.server_close()


### PR DESCRIPTION
## Summary
- `http.server.HTTPServer.server_bind` calls `socket.getfqdn()`, which blocks on the host resolver — measured at 35 s on a macOS workstation with a stalled resolver. That blows the coordinator spawn's 10 s reachability window (`_spawn_detached`), failing startup for real users and the spawn/lifecycle tests.
- Override `server_bind` on `_ThreadingHTTPServer` to bind at the `socketserver.TCPServer` layer and fill `server_name`/`server_port` from the bound address. The server binds 127.0.0.1 only, so the FQDN was purely cosmetic.

## Test Plan
- [x] Regression test: `test_server_bind_never_calls_getfqdn` patches `socket.getfqdn` to raise and binds — any future path back to the resolver fails loudly
- [x] `test_e2e_subprocess_spawn_then_status`, `test_e2e_subprocess_idempotent_second_spawn`, `test_ten_process_race_one_binds_others_read_same_port` pass (3.17 s combined — spawn well inside the 10 s window)
- [x] Full sweep: `test_claude_code_coordinator_server.py` + `test_claude_code_lifecycle.py` + `test_claude_code_e2e.py` — 257 passed
- [x] Manual proof: with `getfqdn` patched to a 35 s stall, bind completes in 0.1 ms with zero resolver calls