### PR TITLE
test(spike): demonstrate the three-leg atomic boundary on postgres

### DIFF
--- a/tests/conformance/pg_spike_sql.py
+++ b/tests/conformance/pg_spike_sql.py
@@ -47,6 +47,7 @@ __all__ = [
     "READ_AGENT_STATES_SQL",
     "READ_ANCHOR_SQL",
     "READ_ARTIFACT_SQL",
+    "RESET_ROWS_SQL",
     "SPIKE_SCHEMA",
     "SpikeSql",
     "build_spike_sql",
@@ -334,3 +335,6 @@ READ_AGENT_STATES_SQL = (
 
 # (artifact)
 READ_ANCHOR_SQL = f"SELECT forced_writes FROM {SPIKE_SCHEMA}.anchor WHERE artifact = %s"
+
+# Per-attempt reset for the cross-process cases: rows only, schema untouched.
+RESET_ROWS_SQL = f"TRUNCATE {SPIKE_SCHEMA}.artifacts, {SPIKE_SCHEMA}.agent_states, {SPIKE_SCHEMA}.anchor"

--- a/tests/conformance/pg_spike_sql.py
+++ b/tests/conformance/pg_spike_sql.py
@@ -38,6 +38,7 @@ __all__ = [
     "GRANT_TRANSITION_SQL",
     "INSERT_ANCHOR_SQL",
     "INSERT_ARTIFACT_SQL",
+    "LOCK_AGENT_STATE_ROW_SQL",
     "LOCK_ARTIFACT_ROW_SQL",
     "MUTANT_ARBITRATE_SQL",
     "MUTANT_FN_NAME",
@@ -54,6 +55,7 @@ __all__ = [
     "RESET_ROWS_SQL",
     "SPIKE_SCHEMA",
     "SpikeSql",
+    "build_bump_transition_ddl",
     "build_mutant_arbitration_ddl",
     "build_spike_sql",
 ]
@@ -363,11 +365,13 @@ INSERT_ANCHOR_SQL = f"INSERT INTO {SPIKE_SCHEMA}.anchor (artifact) VALUES (%s)"
 
 # Fence-precondition scaffold: supersede outstanding read_generations by
 # bumping the artifact's owner_generation, as the shipped sweep/invalidate
-# would. Not a grant change, so it does not use the transition helper.
+# would. Routed through the SAME anchor lock chain as every other conflicting
+# transition (see build_bump_transition_ddl below): the shipped contract
+# serializes the generation-bumping sweep with the atomic mutations, and the
+# scaffold models that discipline so no test can accidentally rely on an
+# unserialized bump.
 # (artifact)
-BUMP_OWNER_GENERATION_SQL = (
-    f"UPDATE {SPIKE_SCHEMA}.artifacts SET owner_generation = owner_generation + 1 WHERE id = %s"
-)
+BUMP_OWNER_GENERATION_SQL = f"SELECT {SPIKE_SCHEMA}.spike_bump_owner_generation(%s)"
 
 # (artifact)
 READ_ARTIFACT_SQL = (
@@ -386,3 +390,46 @@ READ_ANCHOR_SQL = f"SELECT forced_writes FROM {SPIKE_SCHEMA}.anchor WHERE artifa
 
 # Per-attempt reset for the cross-process cases: rows only, schema untouched.
 RESET_ROWS_SQL = f"TRUNCATE {SPIKE_SCHEMA}.artifacts, {SPIKE_SCHEMA}.agent_states, {SPIKE_SCHEMA}.anchor"
+
+# Timeout-forcing scaffold: a raw row lock on one agent_states row that stays
+# deliberately OUTSIDE the anchor chain, so a victim arbitration call EXECUTES
+# its anchor bump and blocks only at the grant leg's FOR UPDATE — giving the
+# statement_timeout cancel a real intra-function write to roll back.
+# (artifact, agent)
+LOCK_AGENT_STATE_ROW_SQL = (
+    f"SELECT 1 FROM {SPIKE_SCHEMA}.agent_states WHERE artifact = %s AND agent = %s FOR UPDATE"
+)
+
+
+def build_bump_transition_ddl(schema: str = SPIKE_SCHEMA) -> str:
+    """The generation-bump scaffold as a function in the anchor lock chain.
+
+    Scaffolding, not the construction under test — but the shipped contract
+    requires the generation-bumping sweep serialized under the SAME lock as
+    the atomic mutations, so even seeding models the discipline a build must
+    honor. Applied by the fixture in the same provisioning transaction as the
+    other functions (R6's revoke/grant pairing included).
+    """
+    sch = _validate_identifier(schema)
+    sig = f"{sch}.spike_bump_owner_generation(text)"
+    return f"""\
+CREATE FUNCTION {sch}.spike_bump_owner_generation(p_artifact text)
+RETURNS void
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = {sch}, pg_temp
+AS $spike$
+BEGIN
+    UPDATE anchor SET forced_writes = forced_writes + 1
+        WHERE artifact = p_artifact;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'spike: no anchor row for artifact %', p_artifact;
+    END IF;
+    UPDATE artifacts SET owner_generation = owner_generation + 1
+        WHERE id = p_artifact;
+END;
+$spike$;
+
+REVOKE ALL ON FUNCTION {sig} FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION {sig} TO CURRENT_USER;"""

--- a/tests/conformance/pg_spike_sql.py
+++ b/tests/conformance/pg_spike_sql.py
@@ -64,7 +64,7 @@ _IDENTIFIER_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
 
 def _validate_identifier(name: str) -> str:
     """Refuse any identifier that could smuggle SQL into the emitted DDL."""
-    if not _IDENTIFIER_RE.match(name):
+    if not _IDENTIFIER_RE.fullmatch(name):
         raise ValueError(f"unsafe SQL identifier for the spike schema: {name!r}")
     return name
 

--- a/tests/conformance/pg_spike_sql.py
+++ b/tests/conformance/pg_spike_sql.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+from ccs.core.exceptions import STALE_READ_GENERATION_REASON, VERSION_MISMATCH_REASON
+
 __all__ = [
     "ARBITRATE_SQL",
     "BUMP_OWNER_GENERATION_SQL",
@@ -71,12 +73,21 @@ SPIKE_SCHEMA = _validate_identifier("ccs_spike")
 
 
 # Typed positional outcomes of the arbitration step (R3) — the shipped reason
-# vocabulary from the conformance kit / ConflictDetail, matched verbatim.
+# vocabulary. version_mismatch / stale_read_generation ALIAS the shipped
+# constants so "matched verbatim" holds by construction. "other_holder" is
+# pinned by tests/backend_conformance/kit.py:OTHER_HOLDER_REASON — importing
+# the kit would drag the coordinator stack into this module's import graph, so
+# it is mirrored here. win/corruption have no shipped reason constant
+# (corruption ships as a raised error, not a ConflictDetail reason).
 OUTCOME_WIN = "win"
-OUTCOME_VERSION_MISMATCH = "version_mismatch"
+OUTCOME_VERSION_MISMATCH = VERSION_MISMATCH_REASON
 OUTCOME_OTHER_HOLDER = "other_holder"
-OUTCOME_STALE_READ_GENERATION = "stale_read_generation"
+OUTCOME_STALE_READ_GENERATION = STALE_READ_GENERATION_REASON
 OUTCOME_CORRUPTION = "corruption"
+
+# The M/E holder predicate — ONE shared fragment for the real grant leg and
+# the naive control, so the two race arms always compare the same predicate.
+_HOLDER_STATES_SQL = "('MODIFIED', 'EXCLUSIVE')"
 
 
 @dataclass(frozen=True)
@@ -87,13 +98,12 @@ class SpikeSql:
     both functions AND performs the privilege REVOKE/GRANT in the SAME emitted
     block — the fixture must apply it inside one transaction (R6, the origin's
     RD-79 defensive floor: no window where the function exists PUBLIC-executable).
+    Deliberately no joined-script accessor: a single flattened script invites
+    applying the function DDL outside one transaction, reopening that window.
     """
 
     schema_ddl: str
     functions_ddl: str
-
-    def as_script(self) -> str:
-        return "\n\n".join([self.schema_ddl, self.functions_ddl])
 
 
 def build_spike_sql(schema: str = SPIKE_SCHEMA) -> SpikeSql:
@@ -201,7 +211,7 @@ def build_mutant_arbitration_ddl(schema: str = SPIKE_SCHEMA) -> str:
     )
 
 
-_GRANT_LEG_SQL = """\
+_GRANT_LEG_SQL = f"""\
 -- Leg 2: grant arbitration. This statement takes a FRESH snapshot: if the
     -- anchor UPDATE above waited out a peer's grant-transition commit, the
     -- rows read here are the peer's COMMITTED rows — the mechanism the naive
@@ -209,10 +219,10 @@ _GRANT_LEG_SQL = """\
     PERFORM 1 FROM agent_states s
         WHERE s.artifact = p_artifact
           AND s.agent <> p_agent
-          AND s.state IN ('MODIFIED', 'EXCLUSIVE')
+          AND s.state IN {_HOLDER_STATES_SQL}
         FOR UPDATE;
     IF FOUND THEN
-        outcome := 'other_holder'; current_version := v_version; RETURN;
+        outcome := '{OUTCOME_OTHER_HOLDER}'; current_version := v_version; RETURN;
     END IF;"""
 
 
@@ -261,10 +271,10 @@ BEGIN
     -- everything; behind is the ordinary conflict. Checked before the grant
     -- read, so corruption structurally outranks other_holder (KTD8).
     IF p_expected_version > v_version THEN
-        outcome := 'corruption'; current_version := v_version; RETURN;
+        outcome := '{OUTCOME_CORRUPTION}'; current_version := v_version; RETURN;
     END IF;
     IF p_expected_version < v_version THEN
-        outcome := 'version_mismatch'; current_version := v_version; RETURN;
+        outcome := '{OUTCOME_VERSION_MISMATCH}'; current_version := v_version; RETURN;
     END IF;
 
     {grant_leg}
@@ -278,7 +288,7 @@ BEGIN
         WHERE s.artifact = p_artifact AND s.agent = p_agent
         FOR UPDATE;
     IF v_read_generation IS NOT NULL AND v_read_generation < v_owner_generation THEN
-        outcome := 'stale_read_generation'; current_version := v_version; RETURN;
+        outcome := '{OUTCOME_STALE_READ_GENERATION}'; current_version := v_version; RETURN;
     END IF;
 
     -- WIN: payload, commit token, and the committer's grant land in the SAME
@@ -292,7 +302,7 @@ BEGIN
         VALUES (p_artifact, p_agent, 'MODIFIED', v_owner_generation)
         ON CONFLICT (artifact, agent) DO UPDATE
             SET state = excluded.state, read_generation = excluded.read_generation;
-    outcome := 'win'; current_version := v_version + 1;
+    outcome := '{OUTCOME_WIN}'; current_version := v_version + 1;
 END;
 $spike$;"""
 
@@ -331,7 +341,7 @@ UPDATE {SPIKE_SCHEMA}.artifacts a
        SELECT 1 FROM {SPIKE_SCHEMA}.agent_states s
         WHERE s.artifact = a.id
           AND s.agent <> %s
-          AND s.state IN ('MODIFIED', 'EXCLUSIVE'))"""
+          AND s.state IN {_HOLDER_STATES_SQL})"""
 
 # U2's forcing scaffold: take the artifact's row lock WITHOUT bumping the
 # version (no trigger mints versions in the spike schema), so a blocked naive

--- a/tests/conformance/pg_spike_sql.py
+++ b/tests/conformance/pg_spike_sql.py
@@ -37,6 +37,8 @@ __all__ = [
     "INSERT_ANCHOR_SQL",
     "INSERT_ARTIFACT_SQL",
     "LOCK_ARTIFACT_ROW_SQL",
+    "MUTANT_ARBITRATE_SQL",
+    "MUTANT_FN_NAME",
     "NAIVE_COMMIT_CAS_SQL",
     "OUTCOME_CORRUPTION",
     "OUTCOME_OTHER_HOLDER",
@@ -50,6 +52,7 @@ __all__ = [
     "RESET_ROWS_SQL",
     "SPIKE_SCHEMA",
     "SpikeSql",
+    "build_mutant_arbitration_ddl",
     "build_spike_sql",
 ]
 
@@ -138,7 +141,86 @@ CREATE TABLE {sch}.anchor (
 -- function owning all three legs, invoked as one SELECT. It runs INSIDE the
 -- invoking statement's transaction (plpgsql cannot commit); with an autocommit
 -- client the whole ladder is one self-contained transaction.
-CREATE FUNCTION {sch}.spike_commit_cas(
+{_arbitration_fn_ddl(sch, "spike_commit_cas", _GRANT_LEG_SQL)}
+
+-- The ONLY sanctioned way any test code changes a grant: the anchor
+-- forced-write and the agent_states upsert in ONE transaction, SAME lock
+-- order as the arbitration function (anchor first). KTD3's lock-chain
+-- discipline applies to scaffolding too — a grant written outside this chain
+-- would be invisible to a concurrently-arbitrating call and prove nothing.
+CREATE FUNCTION {sch}.spike_grant_transition(
+    p_artifact text,
+    p_agent text,
+    p_state text,
+    p_read_generation bigint
+)
+RETURNS void
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = {sch}, pg_temp
+AS $spike$
+BEGIN
+    UPDATE anchor SET forced_writes = forced_writes + 1
+        WHERE artifact = p_artifact;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'spike: no anchor row for artifact %', p_artifact;
+    END IF;
+    INSERT INTO agent_states (artifact, agent, state, read_generation)
+        VALUES (p_artifact, p_agent, p_state, p_read_generation)
+        ON CONFLICT (artifact, agent) DO UPDATE
+            SET state = excluded.state, read_generation = excluded.read_generation;
+END;
+$spike$;
+
+-- R6 (RD-79 defensive floor): revoke and re-grant in the SAME transaction as
+-- creation, throwaway schema or not. PUBLIC gets no EXECUTE window, ever.
+REVOKE ALL ON FUNCTION {arbitrate_sig} FROM PUBLIC;
+REVOKE ALL ON FUNCTION {transition_sig} FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION {arbitrate_sig} TO CURRENT_USER;
+GRANT EXECUTE ON FUNCTION {transition_sig} TO CURRENT_USER;"""
+
+    return SpikeSql(schema_ddl=schema_ddl, functions_ddl=functions_ddl)
+
+
+MUTANT_FN_NAME = "spike_commit_cas_mutant"
+
+
+def build_mutant_arbitration_ddl(schema: str = SPIKE_SCHEMA) -> str:
+    """The SAME arbitration function with the grant leg STRIPPED — the
+    Verification Contract's teeth check: the other_holder scenarios must flip
+    red under this mutant, or the spike cannot fail and proves nothing. Emitted
+    from the same template as the real function so the two can never drift."""
+    sch = _validate_identifier(schema)
+    mutant_leg = "-- MUTANT: the grant-arbitration leg is deliberately removed."
+    sig = f"{sch}.{MUTANT_FN_NAME}(text, text, bigint, text, text)"
+    return (
+        f"{_arbitration_fn_ddl(sch, MUTANT_FN_NAME, mutant_leg)}\n\n"
+        f"REVOKE ALL ON FUNCTION {sig} FROM PUBLIC;\n"
+        f"GRANT EXECUTE ON FUNCTION {sig} TO CURRENT_USER;"
+    )
+
+
+_GRANT_LEG_SQL = """\
+-- Leg 2: grant arbitration. This statement takes a FRESH snapshot: if the
+    -- anchor UPDATE above waited out a peer's grant-transition commit, the
+    -- rows read here are the peer's COMMITTED rows — the mechanism the naive
+    -- single-statement construction structurally lacks.
+    PERFORM 1 FROM agent_states s
+        WHERE s.artifact = p_artifact
+          AND s.agent <> p_agent
+          AND s.state IN ('MODIFIED', 'EXCLUSIVE')
+        FOR UPDATE;
+    IF FOUND THEN
+        outcome := 'other_holder'; current_version := v_version; RETURN;
+    END IF;"""
+
+
+def _arbitration_fn_ddl(sch: str, fn_name: str, grant_leg: str) -> str:
+    """One template for the real arbitration function and its teeth-check mutant."""
+    _validate_identifier(fn_name)
+    return f"""\
+CREATE FUNCTION {sch}.{fn_name}(
     p_artifact text,
     p_agent text,
     p_expected_version bigint,
@@ -185,18 +267,7 @@ BEGIN
         outcome := 'version_mismatch'; current_version := v_version; RETURN;
     END IF;
 
-    -- Leg 2: grant arbitration. This statement takes a FRESH snapshot: if the
-    -- anchor UPDATE above waited out a peer's grant-transition commit, the
-    -- rows read here are the peer's COMMITTED rows — the mechanism the naive
-    -- single-statement construction structurally lacks.
-    PERFORM 1 FROM agent_states s
-        WHERE s.artifact = p_artifact
-          AND s.agent <> p_agent
-          AND s.state IN ('MODIFIED', 'EXCLUSIVE')
-        FOR UPDATE;
-    IF FOUND THEN
-        outcome := 'other_holder'; current_version := v_version; RETURN;
-    END IF;
+    {grant_leg}
 
     -- Leg 3: read-generation fence. Contract verbatim: an ABSENT
     -- read_generation (no row, or NULL) is ADMITTED — version-CAS arbitrates;
@@ -223,46 +294,7 @@ BEGIN
             SET state = excluded.state, read_generation = excluded.read_generation;
     outcome := 'win'; current_version := v_version + 1;
 END;
-$spike$;
-
--- The ONLY sanctioned way any test code changes a grant: the anchor
--- forced-write and the agent_states upsert in ONE transaction, SAME lock
--- order as the arbitration function (anchor first). KTD3's lock-chain
--- discipline applies to scaffolding too — a grant written outside this chain
--- would be invisible to a concurrently-arbitrating call and prove nothing.
-CREATE FUNCTION {sch}.spike_grant_transition(
-    p_artifact text,
-    p_agent text,
-    p_state text,
-    p_read_generation bigint
-)
-RETURNS void
-LANGUAGE plpgsql
-VOLATILE
-SECURITY DEFINER
-SET search_path = {sch}, pg_temp
-AS $spike$
-BEGIN
-    UPDATE anchor SET forced_writes = forced_writes + 1
-        WHERE artifact = p_artifact;
-    IF NOT FOUND THEN
-        RAISE EXCEPTION 'spike: no anchor row for artifact %', p_artifact;
-    END IF;
-    INSERT INTO agent_states (artifact, agent, state, read_generation)
-        VALUES (p_artifact, p_agent, p_state, p_read_generation)
-        ON CONFLICT (artifact, agent) DO UPDATE
-            SET state = excluded.state, read_generation = excluded.read_generation;
-END;
-$spike$;
-
--- R6 (RD-79 defensive floor): revoke and re-grant in the SAME transaction as
--- creation, throwaway schema or not. PUBLIC gets no EXECUTE window, ever.
-REVOKE ALL ON FUNCTION {arbitrate_sig} FROM PUBLIC;
-REVOKE ALL ON FUNCTION {transition_sig} FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION {arbitrate_sig} TO CURRENT_USER;
-GRANT EXECUTE ON FUNCTION {transition_sig} TO CURRENT_USER;"""
-
-    return SpikeSql(schema_ddl=schema_ddl, functions_ddl=functions_ddl)
+$spike$;"""
 
 
 # --- client-side statements (positional %s params, order in the comment) -----
@@ -270,6 +302,12 @@ GRANT EXECUTE ON FUNCTION {transition_sig} TO CURRENT_USER;"""
 # (artifact, agent, expected_version, content_hash, commit_token)
 ARBITRATE_SQL = (
     f"SELECT outcome, current_version FROM {SPIKE_SCHEMA}.spike_commit_cas(%s, %s, %s, %s, %s)"
+)
+
+# Same signature against the teeth-check mutant (grant leg removed).
+# (artifact, agent, expected_version, content_hash, commit_token)
+MUTANT_ARBITRATE_SQL = (
+    f"SELECT outcome, current_version FROM {SPIKE_SCHEMA}.{MUTANT_FN_NAME}(%s, %s, %s, %s, %s)"
 )
 
 # (artifact, agent, state, read_generation)

--- a/tests/conformance/pg_spike_sql.py
+++ b/tests/conformance/pg_spike_sql.py
@@ -1,0 +1,336 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""SQL for the Postgres three-leg boundary spike — test tree ONLY, nothing ships.
+
+Research spike (plan ``docs/plans/2026-09-01-1824-test-pg-three-leg-spike-plan.md``,
+origin BRD §9): can Postgres at READ COMMITTED host the full three-leg deny —
+version-CAS, grant arbitration, read-generation fence — as ONE atomic step a
+client invokes as a single statement? The construction under test is a
+``SECURITY DEFINER`` plpgsql function plus an actually-WRITTEN per-artifact
+anchor row; the deliberately naive single-statement construction is emitted too,
+as the negative control that must lose the grant leg.
+
+The load-bearing mechanism: at READ COMMITTED every *statement* inside a
+VOLATILE plpgsql function takes a fresh snapshot, so the grant-leg read that
+runs after blocking on a peer's anchor-row lock sees the peer's committed
+grant — which the naive single statement structurally cannot, because its one
+snapshot predates the wait. The anchor-row write forces every grant transition
+into the same lock chain (including INSERTs of NEW agent_states rows, which no
+row lock on existing rows can see).
+
+Emission follows the ``provisioning_sql()`` frozen-dataclass style from
+``ccs.adapters.coherent_row``: constants + a validated-identifier build step,
+executed by the test fixture, never at package runtime. This module imports no
+driver, so collection never requires the ``coherent-row`` extra.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+__all__ = [
+    "ARBITRATE_SQL",
+    "BUMP_OWNER_GENERATION_SQL",
+    "GRANT_TRANSITION_SQL",
+    "INSERT_ANCHOR_SQL",
+    "INSERT_ARTIFACT_SQL",
+    "LOCK_ARTIFACT_ROW_SQL",
+    "NAIVE_COMMIT_CAS_SQL",
+    "OUTCOME_CORRUPTION",
+    "OUTCOME_OTHER_HOLDER",
+    "OUTCOME_STALE_READ_GENERATION",
+    "OUTCOME_VERSION_MISMATCH",
+    "OUTCOME_WIN",
+    "PAIR_READ_SQL",
+    "READ_AGENT_STATES_SQL",
+    "READ_ANCHOR_SQL",
+    "READ_ARTIFACT_SQL",
+    "SPIKE_SCHEMA",
+    "SpikeSql",
+    "build_spike_sql",
+]
+
+
+_IDENTIFIER_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+
+def _validate_identifier(name: str) -> str:
+    """Refuse any identifier that could smuggle SQL into the emitted DDL."""
+    if not _IDENTIFIER_RE.match(name):
+        raise ValueError(f"unsafe SQL identifier for the spike schema: {name!r}")
+    return name
+
+
+SPIKE_SCHEMA = _validate_identifier("ccs_spike")
+
+
+# Typed positional outcomes of the arbitration step (R3) — the shipped reason
+# vocabulary from the conformance kit / ConflictDetail, matched verbatim.
+OUTCOME_WIN = "win"
+OUTCOME_VERSION_MISMATCH = "version_mismatch"
+OUTCOME_OTHER_HOLDER = "other_holder"
+OUTCOME_STALE_READ_GENERATION = "stale_read_generation"
+OUTCOME_CORRUPTION = "corruption"
+
+
+@dataclass(frozen=True)
+class SpikeSql:
+    """The spike's one-time DDL, in apply order.
+
+    ``schema_ddl`` creates the schema + three tables. ``functions_ddl`` creates
+    both functions AND performs the privilege REVOKE/GRANT in the SAME emitted
+    block — the fixture must apply it inside one transaction (R6, the origin's
+    RD-79 defensive floor: no window where the function exists PUBLIC-executable).
+    """
+
+    schema_ddl: str
+    functions_ddl: str
+
+    def as_script(self) -> str:
+        return "\n\n".join([self.schema_ddl, self.functions_ddl])
+
+
+def build_spike_sql(schema: str = SPIKE_SCHEMA) -> SpikeSql:
+    """Emit the spike schema, arbitration function, and grant-transition helper."""
+    sch = _validate_identifier(schema)
+
+    schema_ddl = f"""\
+CREATE SCHEMA {sch};
+
+-- version + owner_generation are CO-LOCATED on one row (KTD3): the pair-read
+-- is a single-row SELECT, untearable by construction — splitting them would
+-- manufacture a torn-pair proof obligation the spike does not need.
+-- commit_token is present-but-unreconciled (R10): build-phase reconciliation
+-- would re-read it after an unknown-outcome driver error; the spike only
+-- proves the column travels in the same atomic step.
+CREATE TABLE {sch}.artifacts (
+    id               text PRIMARY KEY,
+    version          bigint NOT NULL,
+    owner_generation bigint NOT NULL DEFAULT 0,
+    content_hash     text,
+    commit_token     text
+);
+
+CREATE TABLE {sch}.agent_states (
+    artifact        text NOT NULL,
+    agent           text NOT NULL,
+    state           text NOT NULL,
+    read_generation bigint,
+    PRIMARY KEY (artifact, agent)
+);
+
+-- The forcing-write target: every arbitration call and every grant transition
+-- UPDATEs this artifact's anchor row FIRST, so they all serialize on one row
+-- lock regardless of which agent_states rows they touch (KTD3).
+CREATE TABLE {sch}.anchor (
+    artifact      text PRIMARY KEY,
+    forced_writes bigint NOT NULL DEFAULT 0
+);"""
+
+    arbitrate_sig = f"{sch}.spike_commit_cas(text, text, bigint, text, text)"
+    transition_sig = f"{sch}.spike_grant_transition(text, text, text, bigint)"
+
+    functions_ddl = f"""\
+-- The construction under test (KTD1): one SECURITY DEFINER VOLATILE plpgsql
+-- function owning all three legs, invoked as one SELECT. It runs INSIDE the
+-- invoking statement's transaction (plpgsql cannot commit); with an autocommit
+-- client the whole ladder is one self-contained transaction.
+CREATE FUNCTION {sch}.spike_commit_cas(
+    p_artifact text,
+    p_agent text,
+    p_expected_version bigint,
+    p_content_hash text,
+    p_commit_token text,
+    OUT outcome text,
+    OUT current_version bigint
+)
+RETURNS record
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = {sch}, pg_temp
+AS $spike$
+DECLARE
+    v_version bigint;
+    v_owner_generation bigint;
+    v_read_generation bigint;
+BEGIN
+    -- Lock chain first: force a write on this artifact's anchor row. Acquiring
+    -- it serializes this call against every concurrent grant transition —
+    -- including INSERTs of NEW agent_states rows that row locks on existing
+    -- rows cannot see. A DENIED call still commits this bump by design: the
+    -- no-mutation guarantee is scoped to artifacts + agent_states.
+    UPDATE anchor SET forced_writes = forced_writes + 1
+        WHERE artifact = p_artifact;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'spike: no anchor row for artifact %', p_artifact;
+    END IF;
+
+    -- Pair-read: version + owner_generation from ONE single-row read (KTD3).
+    -- STRICT: a missing artifact is a loud error, never a typed outcome.
+    SELECT a.version, a.owner_generation
+        INTO STRICT v_version, v_owner_generation
+        FROM artifacts a WHERE a.id = p_artifact;
+
+    -- Leg 1: version-CAS. Corruption (comparand AHEAD of stored) outranks
+    -- everything; behind is the ordinary conflict. Checked before the grant
+    -- read, so corruption structurally outranks other_holder (KTD8).
+    IF p_expected_version > v_version THEN
+        outcome := 'corruption'; current_version := v_version; RETURN;
+    END IF;
+    IF p_expected_version < v_version THEN
+        outcome := 'version_mismatch'; current_version := v_version; RETURN;
+    END IF;
+
+    -- Leg 2: grant arbitration. This statement takes a FRESH snapshot: if the
+    -- anchor UPDATE above waited out a peer's grant-transition commit, the
+    -- rows read here are the peer's COMMITTED rows — the mechanism the naive
+    -- single-statement construction structurally lacks.
+    PERFORM 1 FROM agent_states s
+        WHERE s.artifact = p_artifact
+          AND s.agent <> p_agent
+          AND s.state IN ('MODIFIED', 'EXCLUSIVE')
+        FOR UPDATE;
+    IF FOUND THEN
+        outcome := 'other_holder'; current_version := v_version; RETURN;
+    END IF;
+
+    -- Leg 3: read-generation fence. Contract verbatim: an ABSENT
+    -- read_generation (no row, or NULL) is ADMITTED — version-CAS arbitrates;
+    -- ONLY a PRESENT-and-superseded read_generation is rejected. Reachable
+    -- only with the version UNMOVED, which is the shipped precedence pin.
+    SELECT s.read_generation INTO v_read_generation
+        FROM agent_states s
+        WHERE s.artifact = p_artifact AND s.agent = p_agent
+        FOR UPDATE;
+    IF v_read_generation IS NOT NULL AND v_read_generation < v_owner_generation THEN
+        outcome := 'stale_read_generation'; current_version := v_version; RETURN;
+    END IF;
+
+    -- WIN: payload, commit token, and the committer's grant land in the SAME
+    -- transaction as the decision.
+    UPDATE artifacts
+        SET version = version + 1,
+            content_hash = p_content_hash,
+            commit_token = p_commit_token
+        WHERE id = p_artifact;
+    INSERT INTO agent_states (artifact, agent, state, read_generation)
+        VALUES (p_artifact, p_agent, 'MODIFIED', v_owner_generation)
+        ON CONFLICT (artifact, agent) DO UPDATE
+            SET state = excluded.state, read_generation = excluded.read_generation;
+    outcome := 'win'; current_version := v_version + 1;
+END;
+$spike$;
+
+-- The ONLY sanctioned way any test code changes a grant: the anchor
+-- forced-write and the agent_states upsert in ONE transaction, SAME lock
+-- order as the arbitration function (anchor first). KTD3's lock-chain
+-- discipline applies to scaffolding too — a grant written outside this chain
+-- would be invisible to a concurrently-arbitrating call and prove nothing.
+CREATE FUNCTION {sch}.spike_grant_transition(
+    p_artifact text,
+    p_agent text,
+    p_state text,
+    p_read_generation bigint
+)
+RETURNS void
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = {sch}, pg_temp
+AS $spike$
+BEGIN
+    UPDATE anchor SET forced_writes = forced_writes + 1
+        WHERE artifact = p_artifact;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'spike: no anchor row for artifact %', p_artifact;
+    END IF;
+    INSERT INTO agent_states (artifact, agent, state, read_generation)
+        VALUES (p_artifact, p_agent, p_state, p_read_generation)
+        ON CONFLICT (artifact, agent) DO UPDATE
+            SET state = excluded.state, read_generation = excluded.read_generation;
+END;
+$spike$;
+
+-- R6 (RD-79 defensive floor): revoke and re-grant in the SAME transaction as
+-- creation, throwaway schema or not. PUBLIC gets no EXECUTE window, ever.
+REVOKE ALL ON FUNCTION {arbitrate_sig} FROM PUBLIC;
+REVOKE ALL ON FUNCTION {transition_sig} FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION {arbitrate_sig} TO CURRENT_USER;
+GRANT EXECUTE ON FUNCTION {transition_sig} TO CURRENT_USER;"""
+
+    return SpikeSql(schema_ddl=schema_ddl, functions_ddl=functions_ddl)
+
+
+# --- client-side statements (positional %s params, order in the comment) -----
+
+# (artifact, agent, expected_version, content_hash, commit_token)
+ARBITRATE_SQL = (
+    f"SELECT outcome, current_version FROM {SPIKE_SCHEMA}.spike_commit_cas(%s, %s, %s, %s, %s)"
+)
+
+# (artifact, agent, state, read_generation)
+GRANT_TRANSITION_SQL = f"SELECT {SPIKE_SCHEMA}.spike_grant_transition(%s, %s, %s, %s)"
+
+# The pair-read accessor: BOTH halves from one single-row statement (KTD3).
+# (artifact)
+PAIR_READ_SQL = f"SELECT version, owner_generation FROM {SPIKE_SCHEMA}.artifacts WHERE id = %s"
+
+# The negative control (U2, §9.2's predicted loser): version-CAS and the grant
+# check assembled into ONE statement whose single snapshot predates any lock
+# wait — after blocking, the row re-check sees the peer's committed tuple but
+# the NOT EXISTS subquery keeps the stale statement snapshot.
+# (content_hash, commit_token, artifact, expected_version, agent)
+NAIVE_COMMIT_CAS_SQL = f"""\
+UPDATE {SPIKE_SCHEMA}.artifacts a
+   SET version = a.version + 1, content_hash = %s, commit_token = %s
+ WHERE a.id = %s
+   AND a.version = %s
+   AND NOT EXISTS (
+       SELECT 1 FROM {SPIKE_SCHEMA}.agent_states s
+        WHERE s.artifact = a.id
+          AND s.agent <> %s
+          AND s.state IN ('MODIFIED', 'EXCLUSIVE'))"""
+
+# U2's forcing scaffold: take the artifact's row lock WITHOUT bumping the
+# version (no trigger mints versions in the spike schema), so a blocked naive
+# statement still passes its version qual on the EvalPlanQual re-check.
+# (artifact)
+LOCK_ARTIFACT_ROW_SQL = (
+    f"UPDATE {SPIKE_SCHEMA}.artifacts SET content_hash = content_hash WHERE id = %s"
+)
+
+# --- seeding / inspection scaffolding (single-threaded, pre-barrier — KTD4) --
+
+# (id, version, owner_generation)
+INSERT_ARTIFACT_SQL = (
+    f"INSERT INTO {SPIKE_SCHEMA}.artifacts (id, version, owner_generation) VALUES (%s, %s, %s)"
+)
+
+# (artifact)
+INSERT_ANCHOR_SQL = f"INSERT INTO {SPIKE_SCHEMA}.anchor (artifact) VALUES (%s)"
+
+# Fence-precondition scaffold: supersede outstanding read_generations by
+# bumping the artifact's owner_generation, as the shipped sweep/invalidate
+# would. Not a grant change, so it does not use the transition helper.
+# (artifact)
+BUMP_OWNER_GENERATION_SQL = (
+    f"UPDATE {SPIKE_SCHEMA}.artifacts SET owner_generation = owner_generation + 1 WHERE id = %s"
+)
+
+# (artifact)
+READ_ARTIFACT_SQL = (
+    f"SELECT version, owner_generation, content_hash, commit_token "
+    f"FROM {SPIKE_SCHEMA}.artifacts WHERE id = %s"
+)
+
+# (artifact)
+READ_AGENT_STATES_SQL = (
+    f"SELECT agent, state, read_generation FROM {SPIKE_SCHEMA}.agent_states "
+    f"WHERE artifact = %s ORDER BY agent"
+)
+
+# (artifact)
+READ_ANCHOR_SQL = f"SELECT forced_writes FROM {SPIKE_SCHEMA}.anchor WHERE artifact = %s"

--- a/tests/conformance/test_pg_three_leg_spike.py
+++ b/tests/conformance/test_pg_three_leg_spike.py
@@ -23,7 +23,9 @@ never the driver message, which may embed the DSN password (the shipped
 from __future__ import annotations
 
 import os
+import threading
 import time
+import warnings
 
 import pytest
 
@@ -35,6 +37,7 @@ from tests.conformance.pg_spike_sql import (
     INSERT_ANCHOR_SQL,
     INSERT_ARTIFACT_SQL,
     LOCK_ARTIFACT_ROW_SQL,
+    MUTANT_ARBITRATE_SQL,
     NAIVE_COMMIT_CAS_SQL,
     OUTCOME_CORRUPTION,
     OUTCOME_OTHER_HOLDER,
@@ -47,6 +50,7 @@ from tests.conformance.pg_spike_sql import (
     READ_ARTIFACT_SQL,
     RESET_ROWS_SQL,
     SPIKE_SCHEMA,
+    build_mutant_arbitration_ddl,
     build_spike_sql,
 )
 
@@ -453,4 +457,442 @@ def test_naive_single_statement_loses_the_grant_leg(spike_pg) -> None:
         "INCONCLUSIVE (not a §9.2 refutation): the forced interleaving could not be "
         f"established in {_U2_ATTEMPTS} attempts ({'; '.join(inconclusive)}). Rerun the spike; "
         "do not escalate an unforced run to the C-3 pause."
+    )
+
+
+# --- U3: cross-process affirmative demonstration ----------------------------
+#
+# Two-phase contenders per the shipped pattern: barrier 1 (everyone running),
+# each contender pair-reads its comparands, barrier 2 (everyone holds the same
+# pre-race version), optional delay, then ONE arbitration call on its own
+# autocommit connection. Concurrent calls serialize on the anchor row lock;
+# the loser's pair-read after the wait takes a fresh statement snapshot and
+# sees the winner's committed bump — the mechanism under test, cross-process.
+
+_U3_APP_PREFIX = "ccs-spike-u3"
+
+
+class _LockWaitMonitor:
+    """KTD6's primary affirmative signal: a parent-side connection samples
+    pg_stat_activity during the race window; a contender backend seen with
+    ``wait_event_type='Lock'`` proves the block-then-fresh-read path fired.
+    Runs on an AUTOCOMMIT connection (backend-status views freeze at first
+    access inside a transaction)."""
+
+    def __init__(self, dsn: str, app_prefix: str = _U3_APP_PREFIX) -> None:
+        self._dsn = dsn
+        self._pattern = app_prefix + "%"
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self.observed = False
+
+    def __enter__(self) -> "_LockWaitMonitor":
+        conn = _connect(self._dsn, autocommit=True)
+
+        def _poll() -> None:
+            try:
+                while not self._stop.is_set():
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "SELECT count(*) FROM pg_stat_activity "
+                            "WHERE application_name LIKE %s AND wait_event_type = 'Lock'",
+                            (self._pattern,),
+                        )
+                        (count,) = cur.fetchone()
+                    if count:
+                        self.observed = True
+                        return
+                    time.sleep(0.005)
+            finally:
+                conn.close()
+
+        self._thread = threading.Thread(target=_poll, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self._stop.set()
+        assert self._thread is not None
+        self._thread.join(timeout=5.0)
+
+
+def _u3_arbitrate_contender(ctx, dsn: str, agent: str, payload: str, app_name: str) -> dict:
+    """Generic racing committer: pair-read the comparand pre-barrier-2, then
+    one arbitration SELECT on an autocommit connection (KTD2)."""
+    import psycopg  # noqa: PLC0415
+
+    conn = _contender_connect(dsn, autocommit=True, application_name=app_name)
+    try:
+        ctx.barrier_wait()  # phase 1: everyone is running
+        with conn.cursor() as cur:
+            cur.execute(PAIR_READ_SQL, (_ARTIFACT,))
+            read_version, _generation = cur.fetchone()
+        ctx.barrier_wait()  # phase 2: everyone holds the same pre-race state
+        ctx.delay()
+        started = time.monotonic()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(ARBITRATE_SQL, (_ARTIFACT, agent, read_version, payload, f"tok-{agent}"))
+                outcome, current = cur.fetchone()
+        except (psycopg.OperationalError, psycopg.InterfaceError) as exc:
+            # KTD5: the write MAY have landed server-side — classify, discard
+            # the connection, and let the parent's authoritative read settle it.
+            return {"agent": agent, "payload": payload, "outcome": "unknown", "error_type": type(exc).__name__}
+        return {
+            "agent": agent,
+            "payload": payload,
+            "outcome": outcome,
+            "current_version": current,
+            "read_version": read_version,
+            "elapsed": time.monotonic() - started,
+        }
+    finally:
+        conn.close()
+
+
+def _u3_grant_transition_contender(ctx, dsn: str, agent: str, state: str, read_generation: int | None) -> dict:
+    """Mid-race grant transition through the sanctioned anchor lock chain —
+    INSERTs a NEW agent_states row, the phantom no row lock can see."""
+    conn = _contender_connect(dsn, autocommit=True, application_name=f"{_U3_APP_PREFIX}-grant")
+    try:
+        ctx.barrier_wait()  # phase 1
+        ctx.barrier_wait()  # phase 2
+        with conn.cursor() as cur:
+            cur.execute(GRANT_TRANSITION_SQL, (_ARTIFACT, agent, state, read_generation))
+        return {"agent": agent, "outcome": "granted"}
+    finally:
+        conn.close()
+
+
+def _u3_grant_locker_contender(ctx, dsn: str) -> dict:
+    """Paired-contrast forcer: hold an UNCOMMITTED grant transition (anchor
+    lock + EXCLUSIVE upsert), observe the function-arm contender blocked on the
+    anchor, then commit mid-flight — the same commit-across-a-blocked-peer
+    shape as U2, at the construction's OWN serialization point."""
+    conn = _contender_connect(dsn, autocommit=False)
+    monitor = _contender_connect(dsn, autocommit=True)
+    try:
+        ctx.barrier_wait()  # phase 1
+        with conn.cursor() as cur:
+            cur.execute(GRANT_TRANSITION_SQL, (_ARTIFACT, _AGENT_A, "EXCLUSIVE", 0))  # uncommitted
+        ctx.barrier_wait()  # phase 2: the anchor lock is provably held before B fires
+        observed_blocked = _await_backend_blocked(monitor, f"{_U3_APP_PREFIX}-fn")
+        conn.commit()  # B unblocks HERE, mid-flight across this grant commit
+        return {"observed_blocked": observed_blocked}
+    finally:
+        monitor.close()
+        conn.close()
+
+
+def _u3_function_contender(ctx, dsn: str) -> dict:
+    """Paired-contrast function arm: fires the arbitration function while the
+    locker holds the anchor; blocks at the function's FIRST statement."""
+    import psycopg  # noqa: PLC0415
+
+    conn = _contender_connect(dsn, autocommit=True, application_name=f"{_U3_APP_PREFIX}-fn")
+    try:
+        ctx.barrier_wait()  # phase 1
+        ctx.barrier_wait()  # phase 2: the locker holds the anchor lock
+        try:
+            with conn.cursor() as cur:
+                cur.execute(ARBITRATE_SQL, (_ARTIFACT, _AGENT_B, 1, "fn-c", "fn-t"))
+                outcome, current = cur.fetchone()
+        except (psycopg.OperationalError, psycopg.InterfaceError) as exc:
+            return {"outcome": "unknown", "error_type": type(exc).__name__}
+        return {"outcome": outcome, "current_version": current}
+    finally:
+        conn.close()
+
+
+def _uncontended_baseline_sec(dsn: str) -> float:
+    """Median of a few solo arbitration calls on freshly seeded rows — the
+    comparison floor for the loser-elapsed fallback signal (KTD6)."""
+    samples = []
+    with _connect(dsn, autocommit=True) as conn:
+        for i in range(3):
+            _reset_rows(dsn)
+            started = time.monotonic()
+            _arbitrate(conn, agent=f"baseline-{i}", expected_version=1)
+            samples.append(time.monotonic() - started)
+    return sorted(samples)[1]
+
+
+def _signal_lock_wait_or_warn(observed: bool, results: list[dict], baseline_sec: float) -> None:
+    """R9: report the affirmative lock-wait signal, warn (never fail) when
+    unproven — barrier overlap alone is necessary but not sufficient."""
+    if observed:
+        return
+    slowest_loser = max((r["elapsed"] for r in results if r["outcome"] != OUTCOME_WIN and "elapsed" in r), default=0.0)
+    if slowest_loser > baseline_sec * 3 + 0.005:
+        return
+    warnings.warn(
+        RuntimeWarning(
+            "spike lock-wait path UNPROVEN this run: no contender backend was observed in a "
+            "Lock wait and loser elapsed times are indistinguishable from the uncontended "
+            "baseline. Barrier overlap proves process concurrency, not that the "
+            "block-then-fresh-read path fired. The forced-interleaving contrast test carries "
+            "the deterministic observation."
+        ),
+        stacklevel=2,
+    )
+
+
+def _race_committers(dsn: str, *, agents: list[str], delays: tuple[float, ...]) -> tuple[list[dict], bool]:
+    assert len(delays) == len(agents), "one delay per contender"
+    harness = ProcessRaceHarness(timeout_sec=60.0)
+    with _LockWaitMonitor(dsn) as monitor:
+        result = harness.race(
+            [
+                ContenderSpec(
+                    _u3_arbitrate_contender,
+                    args=(dsn, agent, f"payload-{agent}", f"{_U3_APP_PREFIX}-{i}"),
+                    delay_seconds=delays[i],
+                )
+                for i, agent in enumerate(agents)
+            ]
+        )
+    for outcome in result.outcomes:
+        if outcome.error is not None:
+            raise outcome.error
+    return [o.value for o in result.outcomes], monitor.observed
+
+
+def _assert_exactly_one_winner(dsn: str, results: list[dict], *, pre_version: int = 1) -> None:
+    """One winner, typed losses in the shipped precedence, and the parent's
+    authoritative read settles what landed — including any unknown-outcome
+    contender whose write may have landed after a driver error (KTD5)."""
+    with _connect(dsn, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(READ_ARTIFACT_SQL, (_ARTIFACT,))
+            version, _generation, content_hash, _token = cur.fetchone()
+    wins = [r for r in results if r["outcome"] == OUTCOME_WIN]
+    unknowns = [r for r in results if r["outcome"] == "unknown"]
+    losers = [r for r in results if r["outcome"] not in (OUTCOME_WIN, "unknown")]
+
+    assert version == pre_version + 1, f"exactly one write must land, got version {version}"
+    assert len(wins) <= 1, f"two winners is a lost update: {results}"
+    # Peer-committed ⇒ the version leg fires first (the shipped precedence
+    # pin): every typed loser must see version_mismatch, never other_holder
+    # against the winner's own MODIFIED grant.
+    assert all(r["outcome"] == OUTCOME_VERSION_MISMATCH for r in losers), results
+    if wins:
+        assert content_hash == wins[0]["payload"], "the winner's bytes did not survive — a loser left a trace"
+        assert wins[0]["current_version"] == pre_version + 1
+    else:
+        # No typed winner: only an unknown-outcome contender may own the landed
+        # write (the documented indeterminate case, settled authoritatively).
+        assert unknowns, f"version moved with no winner and no unknown: {results}"
+        assert content_hash in {u["payload"] for u in unknowns}, results
+
+
+def test_race_two_contenders_exactly_one_winner(spike_pg) -> None:
+    _reset_rows(spike_pg)
+    baseline = _uncontended_baseline_sec(spike_pg)
+    _reset_rows(spike_pg)
+    results, observed = _race_committers(spike_pg, agents=["r2-a", "r2-b"], delays=(0.0, 0.05))
+    _assert_exactly_one_winner(spike_pg, results)
+    _signal_lock_wait_or_warn(observed, results, baseline)
+
+
+def test_race_four_contenders_exactly_one_winner(spike_pg) -> None:
+    _reset_rows(spike_pg)
+    baseline = _uncontended_baseline_sec(spike_pg)
+    _reset_rows(spike_pg)
+    results, observed = _race_committers(
+        spike_pg, agents=["r4-a", "r4-b", "r4-c", "r4-d"], delays=(0.0, 0.02, 0.04, 0.06)
+    )
+    _assert_exactly_one_winner(spike_pg, results)
+    _signal_lock_wait_or_warn(observed, results, baseline)
+
+
+def test_race_zero_delay_exactly_one_winner(spike_pg) -> None:
+    """Delays are never load-bearing: every assertion holds at all-zero."""
+    _reset_rows(spike_pg)
+    baseline = _uncontended_baseline_sec(spike_pg)
+    _reset_rows(spike_pg)
+    results, observed = _race_committers(spike_pg, agents=["z-a", "z-b"], delays=(0.0, 0.0))
+    _assert_exactly_one_winner(spike_pg, results)
+    _signal_lock_wait_or_warn(observed, results, baseline)
+
+
+def test_race_fence_zombie_vs_fresh_peer(spike_pg) -> None:
+    """The fence cross-process: a reclaimed-generation committer races a fresh
+    peer. With the version unmoved the zombie sees stale_read_generation; once
+    the peer's commit moves it, version_mismatch — the shipped precedence pin."""
+    _reset_rows(spike_pg)
+    with _connect(spike_pg, autocommit=True) as conn:
+        _grant(conn, "zombie", "INVALID", 0)  # captured generation 0 at its acquire
+        with conn.cursor() as cur:
+            cur.execute(BUMP_OWNER_GENERATION_SQL, (_ARTIFACT,))  # the reclaim supersedes it
+
+    results, _observed = _race_committers(spike_pg, agents=["zombie", "fresh"], delays=(0.0, 0.0))
+    zombie, fresh = results[0], results[1]
+
+    # The fresh peer has NO read_generation — admit-on-absent, cross-process:
+    # it must never be fenced. It wins unless the zombie somehow won first,
+    # and the zombie can never win at a superseded generation.
+    assert zombie["outcome"] in (OUTCOME_STALE_READ_GENERATION, OUTCOME_VERSION_MISMATCH), results
+    assert fresh["outcome"] == OUTCOME_WIN, results
+    # Reason correlates with whether the version had moved at arbitration time:
+    # stale_read_generation is observable EXACTLY when the version is unmoved.
+    if zombie["outcome"] == OUTCOME_STALE_READ_GENERATION:
+        assert zombie["current_version"] == 1, results
+    else:
+        assert zombie["current_version"] == 2, results
+    # Deterministic half of the pin: after the peer's commit, the same zombie
+    # retrying its stale comparand is denied by the VERSION leg first.
+    with _connect(spike_pg, autocommit=True) as conn:
+        outcome, current = _arbitrate(conn, agent="zombie", expected_version=1)
+    assert (outcome, current) == (OUTCOME_VERSION_MISMATCH, 2)
+
+
+def test_race_pessimistic_holder_denies_optimistic_committers(spike_pg) -> None:
+    """A pessimistic EXCLUSIVE holder blocks every optimistic committer with
+    other_holder in the same atomic step: zero wins, version unmoved, no trace."""
+    _reset_rows(spike_pg)
+    with _connect(spike_pg, autocommit=True) as conn:
+        _grant(conn, "holder", "EXCLUSIVE", 0)
+
+    results, _observed = _race_committers(spike_pg, agents=["opt-a", "opt-b"], delays=(0.0, 0.0))
+    assert [r["outcome"] for r in results] == [OUTCOME_OTHER_HOLDER, OUTCOME_OTHER_HOLDER], results
+
+    with _connect(spike_pg, autocommit=True) as conn:
+        artifact, states = _snapshot(conn)
+    assert artifact == (1, 0, None, None), "a denied committer left a trace"
+    assert states == [("holder", "EXCLUSIVE", 0)]
+
+
+def test_race_phantom_grant_insert_vs_committer(spike_pg) -> None:
+    """A mid-race grant transition INSERTs a NEW agent_states row — the
+    phantom case only the anchor lock chain forces into view. The racing
+    committer still resolves to exactly one typed outcome, consistent with
+    the authoritative read."""
+    _reset_rows(spike_pg)
+    harness = ProcessRaceHarness(timeout_sec=60.0)
+    result = harness.race(
+        [
+            ContenderSpec(_u3_grant_transition_contender, args=(spike_pg, "newcomer", "EXCLUSIVE", None)),
+            ContenderSpec(
+                _u3_arbitrate_contender,
+                args=(spike_pg, "committer", "payload-committer", f"{_U3_APP_PREFIX}-0"),
+            ),
+        ]
+    )
+    for outcome in result.outcomes:
+        if outcome.error is not None:
+            raise outcome.error
+    committer = result.outcomes[1].value
+
+    with _connect(spike_pg, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(READ_ARTIFACT_SQL, (_ARTIFACT,))
+            version, _generation, content_hash, _token = cur.fetchone()
+            cur.execute(READ_AGENT_STATES_SQL, (_ARTIFACT,))
+            states = {agent: state for agent, state, _g in cur.fetchall()}
+    assert states.get("newcomer") == "EXCLUSIVE", "the grant transition must land either way"
+    if committer["outcome"] == OUTCOME_WIN:
+        # The committer beat the insert through the anchor chain.
+        assert (version, content_hash) == (2, "payload-committer"), (committer, version, content_hash)
+    elif committer["outcome"] == OUTCOME_OTHER_HOLDER:
+        # The insert committed first; the committer's fresh grant-leg read saw it.
+        assert (version, content_hash) == (1, None), (committer, version, content_hash)
+    else:
+        pytest.fail(f"the racing committer must resolve to a typed outcome, got {committer}")
+
+
+def test_statement_timeout_mid_function_is_a_safe_no_effect(spike_pg) -> None:
+    """KTD5/R10: a statement_timeout that fires INSIDE the function (blocked on
+    the anchor lock) cancels the WHOLE statement — no partial application, not
+    even the anchor bump. Distinguishable from an unknown outcome by SQLSTATE
+    57014 (query_canceled), which the findings report records as the
+    timeout-vs-indeterminate distinction."""
+    import psycopg  # noqa: PLC0415
+
+    _reset_rows(spike_pg)
+    blocker = _connect(spike_pg, autocommit=False)
+    try:
+        with blocker.cursor() as cur:
+            cur.execute(GRANT_TRANSITION_SQL, (_ARTIFACT, "blocker", "EXCLUSIVE", 0))  # anchor lock held
+        with _connect(spike_pg, autocommit=True, statement_timeout_ms=300) as victim:
+            with pytest.raises(psycopg.errors.QueryCanceled):
+                _arbitrate(victim, agent="victim", expected_version=1)
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+    with _connect(spike_pg, autocommit=True) as conn:
+        artifact, states = _snapshot(conn)
+        anchor = _anchor_count(conn)
+    assert artifact == (1, 0, None, None), "a cancelled arbitration mutated the artifact"
+    assert states == [], "a cancelled arbitration left a grant behind"
+    assert anchor == 0, "the whole statement must roll back — anchor bump included"
+
+
+def test_paired_contrast_function_denies_under_forced_interleaving(spike_pg) -> None:
+    """U2's core contrast: the SAME commit-across-a-blocked-peer shape that the
+    naive statement ADMITTED is DENIED by the function. Each arm blocks at its
+    own construction's serialization point (the naive arm on the artifact row,
+    the function at its first anchor write — the naive arm's absence from the
+    anchor chain IS its defect); in both, the blocked statement is provably
+    in-flight across the peer's EXCLUSIVE grant commit. This test also carries
+    R9's deterministic lock-wait observation for the suite."""
+    inconclusive: list[str] = []
+    for _attempt in range(_U2_ATTEMPTS):
+        _reset_rows(spike_pg)
+        harness = ProcessRaceHarness(timeout_sec=60.0)
+        result = harness.race(
+            [
+                ContenderSpec(_u3_grant_locker_contender, args=(spike_pg,)),
+                ContenderSpec(_u3_function_contender, args=(spike_pg,)),
+            ]
+        )
+        for outcome in result.outcomes:
+            if outcome.error is not None:
+                raise outcome.error
+        locker = result.outcomes[0].value
+        fn_arm = result.outcomes[1].value
+
+        if fn_arm.get("outcome") == "unknown":
+            inconclusive.append(f"driver error {fn_arm['error_type']} (unknown outcome)")
+            continue
+        if not locker["observed_blocked"]:
+            inconclusive.append("function backend never observed in a Lock wait")
+            continue
+
+        # The forcing held: the function was blocked across the grant commit,
+        # its post-wait statements took fresh snapshots, and the grant leg saw
+        # the committed EXCLUSIVE — the deny the naive construction cannot make.
+        assert fn_arm["outcome"] == OUTCOME_OTHER_HOLDER, fn_arm
+        with _connect(spike_pg, autocommit=True) as conn:
+            artifact, states = _snapshot(conn)
+        assert artifact == (1, 0, None, None), "the denied function arm left a trace"
+        assert states == [(_AGENT_A, "EXCLUSIVE", 0)]
+        return
+    pytest.fail(
+        "INCONCLUSIVE: the forced interleaving could not be established in "
+        f"{_U2_ATTEMPTS} attempts ({'; '.join(inconclusive)}). Rerun the spike."
+    )
+
+
+def test_mutant_without_grant_leg_admits_what_the_real_function_denies(spike_pg) -> None:
+    """The Verification Contract's teeth check: with the grant leg disabled the
+    other_holder scenario flips — the mutant ADMITS across a peer's EXCLUSIVE
+    grant where the real function denies. A spike that cannot fail proves
+    nothing; this proves it can."""
+    with _connect(spike_pg, autocommit=False) as conn:
+        with conn.cursor() as cur:
+            cur.execute(build_mutant_arbitration_ddl())
+        conn.commit()
+        _reset_rows(spike_pg)
+        _grant(conn, "holder", "EXCLUSIVE", 0)
+
+        outcome, _current = _arbitrate(conn, agent="writer", expected_version=1)
+        assert outcome == OUTCOME_OTHER_HOLDER, "the real function must deny across the peer grant"
+        with conn.cursor() as cur:
+            cur.execute(MUTANT_ARBITRATE_SQL, (_ARTIFACT, "writer", 1, "mutant-c", "mutant-t"))
+            mutant_outcome, mutant_version = cur.fetchone()
+        conn.commit()
+    assert (mutant_outcome, mutant_version) == (OUTCOME_WIN, 2), (
+        "the grant-leg mutant should have admitted — if it denies too, the other_holder "
+        "scenarios are not exercising the grant leg and the spike proves nothing"
     )

--- a/tests/conformance/test_pg_three_leg_spike.py
+++ b/tests/conformance/test_pg_three_leg_spike.py
@@ -78,19 +78,30 @@ def _connect(
 ):
     """A bounded-wait connection: connect + per-statement timeouts ALWAYS set
     (KTD5). Arbitration calls use ``autocommit=True`` so the single SELECT is
-    one self-contained transaction (KTD2); provisioning uses explicit commit."""
+    one self-contained transaction (KTD2); provisioning uses explicit commit.
+
+    A connect failure surfaces the exception TYPE only: the DSN carries the
+    password, driver connect errors may echo conninfo, and the harness
+    transports child tracebacks — so the scrub lives at the ONE connect site.
+    """
     import psycopg  # noqa: PLC0415 - lazy so collection never needs the extra
 
     kwargs: dict[str, object] = {}
     if application_name is not None:
         kwargs["application_name"] = application_name
-    return psycopg.connect(
-        dsn,
-        autocommit=autocommit,
-        connect_timeout=_CONNECT_TIMEOUT_SEC,
-        options=f"-c statement_timeout={statement_timeout_ms}",
-        **kwargs,
-    )
+    try:
+        return psycopg.connect(
+            dsn,
+            autocommit=autocommit,
+            connect_timeout=_CONNECT_TIMEOUT_SEC,
+            options=f"-c statement_timeout={statement_timeout_ms}",
+            **kwargs,
+        )
+    except Exception as exc:  # noqa: BLE001 - re-raised scrubbed
+        raise RuntimeError(
+            f"spike connect failed with {type(exc).__name__}; "
+            "details suppressed to avoid leaking DSN credentials"
+        ) from None
 
 
 @pytest.fixture(scope="module")
@@ -222,9 +233,12 @@ def test_expected_behind_yields_version_mismatch_without_mutation(conn) -> None:
     assert _anchor_count(conn) == anchor_before + 1, "the denied call still commits its anchor bump"
 
 
-def test_peer_exclusive_yields_other_holder_without_mutation(conn) -> None:
+@pytest.mark.parametrize("holder_state", ["EXCLUSIVE", "MODIFIED"])
+def test_peer_holder_yields_other_holder_without_mutation(conn, holder_state) -> None:
+    # BOTH halves of the M/E holder predicate must deny — a suite that only
+    # ever seeds EXCLUSIVE would stay green if MODIFIED fell out of the tuple.
     _seed(conn, version=1)
-    _grant(conn, _AGENT_B, "EXCLUSIVE", 0)
+    _grant(conn, _AGENT_B, holder_state, 0)
     before = _snapshot(conn)
 
     outcome, current = _arbitrate(conn, agent=_AGENT_A, expected_version=1)
@@ -348,19 +362,6 @@ _BLOCK_POLL_TIMEOUT_SEC = 10.0
 _FORCED_INTERLEAVING_ATTEMPTS = 3
 
 
-def _contender_connect(dsn: str, *, autocommit: bool, application_name: str | None = None):
-    """Contender-side connect with the DSN-scrubbing discipline: a failure
-    surfaces the exception TYPE only, because the harness transports child
-    tracebacks and a driver connect error may echo conninfo details."""
-    try:
-        return _connect(dsn, autocommit=autocommit, application_name=application_name)
-    except Exception as exc:  # noqa: BLE001 - re-raised scrubbed
-        raise RuntimeError(
-            f"spike contender connect failed with {type(exc).__name__}; "
-            "details suppressed to avoid leaking DSN credentials"
-        ) from None
-
-
 def _raise_contender_errors(result) -> None:
     """Surface the first child failure; a contender error is never a pass."""
     if result.errors:
@@ -392,8 +393,12 @@ def _await_backend_blocked(monitor_conn, application_name: str, timeout_sec: flo
 def _u2_locker_contender(ctx, dsn: str) -> dict:
     """Contender A: hold the artifact row lock, observe B blocked, then commit
     an EXCLUSIVE grant through the anchor lock chain while B waits."""
-    conn = _contender_connect(dsn, autocommit=False)
-    monitor = _contender_connect(dsn, autocommit=True)
+    conn = _connect(dsn, autocommit=False)
+    try:
+        monitor = _connect(dsn, autocommit=True)
+    except Exception:
+        conn.close()
+        raise
     try:
         ctx.barrier_wait()  # phase 1: both contenders are running
         with conn.cursor() as cur:
@@ -412,7 +417,7 @@ def _u2_locker_contender(ctx, dsn: str) -> dict:
 def _u2_naive_contender(ctx, dsn: str) -> dict:
     """Contender B: fire the naive single-statement CAS+grant-check and report
     whether it admitted (rowcount 1) or denied (rowcount 0)."""
-    conn = _contender_connect(dsn, autocommit=True, application_name=_NAIVE_APP_NAME)
+    conn = _connect(dsn, autocommit=True, application_name=_NAIVE_APP_NAME)
     try:
         ctx.barrier_wait()  # phase 1
         ctx.barrier_wait()  # phase 2: A holds the artifact row lock
@@ -492,7 +497,9 @@ def test_naive_single_statement_loses_the_grant_leg(spike_pg) -> None:
 
 # --- U3: cross-process affirmative demonstration ----------------------------
 #
-# Two-phase contenders per the shipped pattern: barrier 1 (everyone running),
+# Two-phase contenders per the shipped pattern (the harness Barrier is
+# reusable, and every contender in a race performs the same TWO waits, so the
+# rendezvous counts always match): barrier 1 (everyone running),
 # each contender pair-reads its comparands, barrier 2 (everyone holds the same
 # pre-race version), optional delay, then ONE arbitration call on its own
 # autocommit connection. Concurrent calls serialize on the anchor row lock;
@@ -551,7 +558,7 @@ def _u3_arbitrate_contender(ctx, dsn: str, agent: str, payload: str, app_name: s
     one arbitration SELECT on an autocommit connection (KTD2)."""
     import psycopg  # noqa: PLC0415
 
-    conn = _contender_connect(dsn, autocommit=True, application_name=app_name)
+    conn = _connect(dsn, autocommit=True, application_name=app_name)
     try:
         ctx.barrier_wait()  # phase 1: everyone is running
         with conn.cursor() as cur:
@@ -583,7 +590,7 @@ def _u3_arbitrate_contender(ctx, dsn: str, agent: str, payload: str, app_name: s
 def _u3_grant_transition_contender(ctx, dsn: str, agent: str, state: str, read_generation: int | None) -> dict:
     """Mid-race grant transition through the sanctioned anchor lock chain —
     INSERTs a NEW agent_states row, the phantom no row lock can see."""
-    conn = _contender_connect(dsn, autocommit=True, application_name=f"{_U3_APP_PREFIX}-grant")
+    conn = _connect(dsn, autocommit=True, application_name=f"{_U3_APP_PREFIX}-grant")
     try:
         ctx.barrier_wait()  # phase 1
         ctx.barrier_wait()  # phase 2
@@ -599,8 +606,12 @@ def _u3_grant_locker_contender(ctx, dsn: str) -> dict:
     lock + EXCLUSIVE upsert), observe the function-arm contender blocked on the
     anchor, then commit mid-flight — the same commit-across-a-blocked-peer
     shape as U2, at the construction's OWN serialization point."""
-    conn = _contender_connect(dsn, autocommit=False)
-    monitor = _contender_connect(dsn, autocommit=True)
+    conn = _connect(dsn, autocommit=False)
+    try:
+        monitor = _connect(dsn, autocommit=True)
+    except Exception:
+        conn.close()
+        raise
     try:
         ctx.barrier_wait()  # phase 1
         with conn.cursor() as cur:
@@ -619,7 +630,7 @@ def _u3_function_contender(ctx, dsn: str) -> dict:
     locker holds the anchor; blocks at the function's FIRST statement."""
     import psycopg  # noqa: PLC0415
 
-    conn = _contender_connect(dsn, autocommit=True, application_name=f"{_U3_APP_PREFIX}-fn")
+    conn = _connect(dsn, autocommit=True, application_name=f"{_U3_APP_PREFIX}-fn")
     try:
         ctx.barrier_wait()  # phase 1
         ctx.barrier_wait()  # phase 2: the locker holds the anchor lock
@@ -632,19 +643,6 @@ def _u3_function_contender(ctx, dsn: str) -> dict:
         return {"outcome": outcome, "current_version": current}
     finally:
         conn.close()
-
-
-def _uncontended_baseline_sec(dsn: str) -> float:
-    """Median of a few solo arbitration calls on freshly seeded rows — the
-    comparison floor for the loser-elapsed fallback signal (KTD6)."""
-    samples = []
-    with _connect(dsn, autocommit=True) as conn:
-        for i in range(3):
-            _reset_rows(dsn)
-            started = time.monotonic()
-            _arbitrate(conn, agent=f"baseline-{i}", expected_version=1)
-            samples.append(time.monotonic() - started)
-    return sorted(samples)[1]
 
 
 def _signal_lock_wait_or_warn(observed: bool, results: list[dict], baseline_sec: float) -> None:
@@ -697,7 +695,12 @@ def _assert_exactly_one_winner(dsn: str, results: list[dict], *, pre_version: in
     unknowns = [r for r in results if r["outcome"] == _OUTCOME_UNKNOWN]
     losers = [r for r in results if r["outcome"] not in (OUTCOME_WIN, _OUTCOME_UNKNOWN)]
 
-    assert version == pre_version + 1, f"exactly one write must land, got version {version}"
+    if version == pre_version and results and all(r["outcome"] == _OUTCOME_UNKNOWN for r in results):
+        pytest.fail(
+            "INCONCLUSIVE: every contender hit a driver error and no write landed "
+            f"({[r['error_type'] for r in results]}); rerun the spike — not a lost-update verdict"
+        )
+    assert version == pre_version + 1, f"exactly one write must land, got version {version}: {results}"
     assert len(wins) <= 1, f"two winners is a lost update: {results}"
     # Peer-committed ⇒ the version leg fires first (the shipped precedence
     # pin): every typed loser must see version_mismatch, never other_holder
@@ -713,34 +716,28 @@ def _assert_exactly_one_winner(dsn: str, results: list[dict], *, pre_version: in
         assert content_hash in {u["payload"] for u in unknowns}, results
 
 
-def test_race_two_contenders_exactly_one_winner(spike_pg) -> None:
-    _reset_rows(spike_pg)
-    baseline = _uncontended_baseline_sec(spike_pg)
+def test_race_two_contenders_exactly_one_winner(spike_pg, baseline_sec) -> None:
     _reset_rows(spike_pg)
     results, observed = _race_committers(spike_pg, agents=["r2-a", "r2-b"], delays=(0.0, 0.05))
     _assert_exactly_one_winner(spike_pg, results)
-    _signal_lock_wait_or_warn(observed, results, baseline)
+    _signal_lock_wait_or_warn(observed, results, baseline_sec)
 
 
-def test_race_four_contenders_exactly_one_winner(spike_pg) -> None:
-    _reset_rows(spike_pg)
-    baseline = _uncontended_baseline_sec(spike_pg)
+def test_race_four_contenders_exactly_one_winner(spike_pg, baseline_sec) -> None:
     _reset_rows(spike_pg)
     results, observed = _race_committers(
         spike_pg, agents=["r4-a", "r4-b", "r4-c", "r4-d"], delays=(0.0, 0.02, 0.04, 0.06)
     )
     _assert_exactly_one_winner(spike_pg, results)
-    _signal_lock_wait_or_warn(observed, results, baseline)
+    _signal_lock_wait_or_warn(observed, results, baseline_sec)
 
 
-def test_race_zero_delay_exactly_one_winner(spike_pg) -> None:
+def test_race_zero_delay_exactly_one_winner(spike_pg, baseline_sec) -> None:
     """Delays are never load-bearing: every assertion holds at all-zero."""
-    _reset_rows(spike_pg)
-    baseline = _uncontended_baseline_sec(spike_pg)
     _reset_rows(spike_pg)
     results, observed = _race_committers(spike_pg, agents=["z-a", "z-b"], delays=(0.0, 0.0))
     _assert_exactly_one_winner(spike_pg, results)
-    _signal_lock_wait_or_warn(observed, results, baseline)
+    _signal_lock_wait_or_warn(observed, results, baseline_sec)
 
 
 def test_race_fence_zombie_vs_fresh_peer(spike_pg) -> None:

--- a/tests/conformance/test_pg_three_leg_spike.py
+++ b/tests/conformance/test_pg_three_leg_spike.py
@@ -1,0 +1,277 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Postgres three-leg boundary spike — operator-run, research-only (U1–U3).
+
+Adjudicates the origin BRD's §9.2 mechanism claim with evidence: a
+``SECURITY DEFINER`` plpgsql function plus a written anchor row delivers the
+full three-leg deny (version-CAS, grant arbitration, read-generation fence) as
+one atomic step at READ COMMITTED — and the naive single-statement construction
+demonstrably loses the grant leg. Plan:
+``docs/plans/2026-09-01-1824-test-pg-three-leg-spike-plan.md``.
+
+Requires ``CCS_TEST_PG_DSN`` (owner DSN; a local throwaway container is the
+documented default) and the ``coherent-row`` extra. Without either, every test
+skips and the module still collects cleanly. Serial-only: provisioning DDL
+drops and recreates one shared schema, so the module is not xdist-safe.
+
+Driver-error hygiene: surfaced classifications carry the exception TYPE only —
+never the driver message, which may embed the DSN password (the shipped
+``CoherentRow._scrubbed`` discipline).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.conformance.pg_spike_sql import (
+    ARBITRATE_SQL,
+    BUMP_OWNER_GENERATION_SQL,
+    GRANT_TRANSITION_SQL,
+    INSERT_ANCHOR_SQL,
+    INSERT_ARTIFACT_SQL,
+    OUTCOME_CORRUPTION,
+    OUTCOME_OTHER_HOLDER,
+    OUTCOME_STALE_READ_GENERATION,
+    OUTCOME_VERSION_MISMATCH,
+    OUTCOME_WIN,
+    PAIR_READ_SQL,
+    READ_AGENT_STATES_SQL,
+    READ_ANCHOR_SQL,
+    READ_ARTIFACT_SQL,
+    SPIKE_SCHEMA,
+    build_spike_sql,
+)
+
+pytestmark = pytest.mark.real_substrate
+
+_ARTIFACT = "artifact-1"
+_AGENT_A = "agent-a"
+_AGENT_B = "agent-b"
+
+_CONNECT_TIMEOUT_SEC = 10
+_STATEMENT_TIMEOUT_MS = 15_000
+
+
+def _connect(dsn: str, *, autocommit: bool, statement_timeout_ms: int = _STATEMENT_TIMEOUT_MS):
+    """A bounded-wait connection: connect + per-statement timeouts ALWAYS set
+    (KTD5). Arbitration calls use ``autocommit=True`` so the single SELECT is
+    one self-contained transaction (KTD2); provisioning uses explicit commit."""
+    import psycopg  # noqa: PLC0415 - lazy so collection never needs the extra
+
+    return psycopg.connect(
+        dsn,
+        autocommit=autocommit,
+        connect_timeout=_CONNECT_TIMEOUT_SEC,
+        options=f"-c statement_timeout={statement_timeout_ms}",
+    )
+
+
+@pytest.fixture
+def spike_pg():
+    """Provision the spike schema + functions on the operator's Postgres.
+
+    Functions DDL (CREATE + REVOKE/GRANT) applies in ONE transaction (R6).
+    Fails loudly when the server's default isolation is not READ COMMITTED —
+    every claim this spike adjudicates is isolation-specific.
+    """
+    dsn = os.environ.get("CCS_TEST_PG_DSN")
+    if not dsn:
+        pytest.skip("set CCS_TEST_PG_DSN (owner DSN) to run the pg three-leg spike")
+    pytest.importorskip("psycopg", reason="the spike needs the coherent-row extra (psycopg v3)")
+
+    sql = build_spike_sql()
+    with _connect(dsn, autocommit=False) as conn:
+        with conn.cursor() as cur:
+            cur.execute(f"DROP SCHEMA IF EXISTS {SPIKE_SCHEMA} CASCADE")
+            cur.execute(sql.schema_ddl)
+            cur.execute(sql.functions_ddl)
+        conn.commit()
+        with conn.cursor() as cur:
+            cur.execute("SHOW transaction_isolation")
+            (isolation,) = cur.fetchone()
+        if isolation != "read committed":
+            pytest.fail(
+                f"spike requires the Postgres default READ COMMITTED, got {isolation!r}; "
+                "the construction's claims are isolation-specific — do not run it elsewhere"
+            )
+    try:
+        yield dsn
+    finally:
+        with _connect(dsn, autocommit=True) as conn, conn.cursor() as cur:
+            cur.execute(f"DROP SCHEMA IF EXISTS {SPIKE_SCHEMA} CASCADE")
+
+
+@pytest.fixture
+def conn(spike_pg):
+    """An autocommit connection for direct-call tests (KTD2's client shape)."""
+    with _connect(spike_pg, autocommit=True) as c:
+        yield c
+
+
+def _seed(conn, *, version: int = 1, owner_generation: int = 0) -> None:
+    """Single-threaded pre-race seeding (KTD4): artifact + anchor rows."""
+    with conn.cursor() as cur:
+        cur.execute(INSERT_ARTIFACT_SQL, (_ARTIFACT, version, owner_generation))
+        cur.execute(INSERT_ANCHOR_SQL, (_ARTIFACT,))
+
+
+def _grant(conn, agent: str, state: str, read_generation: int | None) -> None:
+    """Seed or change a grant through the sanctioned anchor lock chain."""
+    with conn.cursor() as cur:
+        cur.execute(GRANT_TRANSITION_SQL, (_ARTIFACT, agent, state, read_generation))
+
+
+def _arbitrate(conn, *, agent: str, expected_version: int, content_hash: str = "h", commit_token: str = "t"):
+    with conn.cursor() as cur:
+        cur.execute(ARBITRATE_SQL, (_ARTIFACT, agent, expected_version, content_hash, commit_token))
+        return cur.fetchone()
+
+
+def _snapshot(conn):
+    """Everything the no-mutation guarantee covers: the artifacts row and the
+    agent_states rows. The anchor row is deliberately EXCLUDED — a denied call
+    still commits its anchor bump by design (the lock chain IS a write)."""
+    with conn.cursor() as cur:
+        cur.execute(READ_ARTIFACT_SQL, (_ARTIFACT,))
+        artifact = cur.fetchone()
+        cur.execute(READ_AGENT_STATES_SQL, (_ARTIFACT,))
+        states = cur.fetchall()
+    return artifact, states
+
+
+def _anchor_count(conn) -> int:
+    with conn.cursor() as cur:
+        cur.execute(READ_ANCHOR_SQL, (_ARTIFACT,))
+        (count,) = cur.fetchone()
+    return count
+
+
+# --- U1: single-process leg proofs ------------------------------------------
+
+
+def test_win_bumps_version_and_lands_payload_and_grant(conn) -> None:
+    _seed(conn, version=1)
+    outcome, current = _arbitrate(conn, agent=_AGENT_A, expected_version=1, content_hash="c1", commit_token="tok1")
+    assert (outcome, current) == (OUTCOME_WIN, 2)
+    artifact, states = _snapshot(conn)
+    assert artifact == (2, 0, "c1", "tok1")
+    assert states == [(_AGENT_A, "MODIFIED", 0)], "the winner's grant lands in the same step"
+
+
+def test_expected_behind_yields_version_mismatch_without_mutation(conn) -> None:
+    _seed(conn, version=1)
+    assert _arbitrate(conn, agent=_AGENT_A, expected_version=1)[0] == OUTCOME_WIN  # version is now 2
+    before = _snapshot(conn)
+    anchor_before = _anchor_count(conn)
+
+    outcome, current = _arbitrate(conn, agent=_AGENT_B, expected_version=1, content_hash="loser")
+    assert (outcome, current) == (OUTCOME_VERSION_MISMATCH, 2)
+    assert _snapshot(conn) == before, "a denied CAS must not touch artifacts or agent_states"
+    assert _anchor_count(conn) == anchor_before + 1, "the denied call still commits its anchor bump"
+
+
+def test_peer_exclusive_yields_other_holder_without_mutation(conn) -> None:
+    _seed(conn, version=1)
+    _grant(conn, _AGENT_B, "EXCLUSIVE", 0)
+    before = _snapshot(conn)
+
+    outcome, current = _arbitrate(conn, agent=_AGENT_A, expected_version=1)
+    assert (outcome, current) == (OUTCOME_OTHER_HOLDER, 1)
+    assert _snapshot(conn) == before
+
+
+def test_superseded_generation_with_version_unmoved_yields_stale_read_generation(conn) -> None:
+    _seed(conn, version=1, owner_generation=0)
+    _grant(conn, _AGENT_A, "INVALID", 0)  # the zombie captured generation 0 at its acquire
+    with conn.cursor() as cur:
+        cur.execute(BUMP_OWNER_GENERATION_SQL, (_ARTIFACT,))  # the reclaim supersedes it
+    before = _snapshot(conn)
+
+    outcome, current = _arbitrate(conn, agent=_AGENT_A, expected_version=1)
+    assert (outcome, current) == (OUTCOME_STALE_READ_GENERATION, 1), "fence fires exactly when the version is unmoved"
+    assert _snapshot(conn) == before
+
+    # Precedence pin (R4): once a peer commit MOVES the version, the same
+    # zombie sees version_mismatch — the version leg fires first.
+    assert _arbitrate(conn, agent=_AGENT_B, expected_version=1)[0] == OUTCOME_WIN
+    outcome, current = _arbitrate(conn, agent=_AGENT_A, expected_version=1)
+    assert (outcome, current) == (OUTCOME_VERSION_MISMATCH, 2)
+
+
+def test_absent_read_generation_is_admitted(conn) -> None:
+    # Contract verbatim: ABSENT is ADMITTED — version-CAS arbitrates it.
+    _seed(conn, version=1, owner_generation=3)  # generations have moved; the writers never fenced
+    # (a) No agent_states row at all: the plain OCC writer.
+    outcome, current = _arbitrate(conn, agent=_AGENT_A, expected_version=1)
+    assert (outcome, current) == (OUTCOME_WIN, 2)
+    # (b) A row PRESENT with NULL read_generation: still absent, still admitted.
+    # First downgrade the winner's own MODIFIED grant (landed by the win path),
+    # so the grant leg is quiet and the fence disposition is what decides.
+    _grant(conn, _AGENT_A, "SHARED", None)
+    _grant(conn, _AGENT_B, "SHARED", None)
+    outcome, current = _arbitrate(conn, agent=_AGENT_B, expected_version=2)
+    assert (outcome, current) == (OUTCOME_WIN, 3)
+
+
+def test_corruption_ahead_and_outranks_other_holder(conn) -> None:
+    _seed(conn, version=1)
+    outcome, current = _arbitrate(conn, agent=_AGENT_A, expected_version=5)
+    assert (outcome, current) == (OUTCOME_CORRUPTION, 1)
+
+    # KTD8: precedence is only proven when legs genuinely COMPETE — corruption
+    # must outrank a simultaneously-true other_holder condition.
+    _grant(conn, _AGENT_B, "MODIFIED", 0)
+    before = _snapshot(conn)
+    outcome, current = _arbitrate(conn, agent=_AGENT_A, expected_version=5)
+    assert (outcome, current) == (OUTCOME_CORRUPTION, 1)
+    assert _snapshot(conn) == before
+
+
+def test_pair_read_returns_both_halves_from_one_statement(conn) -> None:
+    _seed(conn, version=1, owner_generation=0)
+    with conn.cursor() as cur:
+        cur.execute(PAIR_READ_SQL, (_ARTIFACT,))
+        assert cur.fetchone() == (1, 0)
+        # A committed generation bump between two separate calls IS visible —
+        # the atomicity claim lives in the single statement, not the session.
+        cur.execute(BUMP_OWNER_GENERATION_SQL, (_ARTIFACT,))
+        cur.execute(PAIR_READ_SQL, (_ARTIFACT,))
+        assert cur.fetchone() == (1, 1)
+
+
+def test_missing_artifact_is_a_loud_error_not_a_typed_outcome(conn) -> None:
+    import psycopg  # noqa: PLC0415
+
+    # No anchor row: the lock-chain entry itself refuses, loudly.
+    with pytest.raises(psycopg.Error) as excinfo:
+        _arbitrate(conn, agent=_AGENT_A, expected_version=1)
+    assert excinfo.value.sqlstate == "P0001"  # RAISE EXCEPTION
+
+    # Anchor present but artifact row missing: the STRICT pair-read refuses.
+    with conn.cursor() as cur:
+        cur.execute(INSERT_ANCHOR_SQL, (_ARTIFACT,))
+    with pytest.raises(psycopg.Error) as excinfo:
+        _arbitrate(conn, agent=_AGENT_A, expected_version=1)
+    assert excinfo.value.sqlstate == "P0002"  # NO_DATA_FOUND from SELECT ... INTO STRICT
+
+
+def test_function_hardening_search_path_pinned_and_no_public_execute(conn) -> None:
+    for fn in ("spike_commit_cas", "spike_grant_transition"):
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT prosecdef, proconfig, proacl::text[] FROM pg_proc "
+                "WHERE proname = %s AND pronamespace = %s::regnamespace",
+                (fn, SPIKE_SCHEMA),
+            )
+            row = cur.fetchone()
+        assert row is not None, fn
+        secdef, config, acl = row
+        assert secdef is True, f"{fn} must be SECURITY DEFINER"
+        assert config == [f"search_path={SPIKE_SCHEMA}, pg_temp"], f"{fn} search_path not pinned: {config}"
+        # A NULL proacl means PUBLIC keeps its default EXECUTE; after the R6
+        # revoke it must be non-NULL with no PUBLIC entry (grantee '' in acl text).
+        assert acl is not None, f"{fn} has default ACLs — the R6 revoke did not land"
+        assert not any(entry.startswith("=") for entry in acl), f"{fn} still grants PUBLIC: {acl}"

--- a/tests/conformance/test_pg_three_leg_spike.py
+++ b/tests/conformance/test_pg_three_leg_spike.py
@@ -37,6 +37,7 @@ from tests.conformance.pg_spike_sql import (
     GRANT_TRANSITION_SQL,
     INSERT_ANCHOR_SQL,
     INSERT_ARTIFACT_SQL,
+    LOCK_AGENT_STATE_ROW_SQL,
     LOCK_ARTIFACT_ROW_SQL,
     MUTANT_ARBITRATE_SQL,
     NAIVE_COMMIT_CAS_SQL,
@@ -51,6 +52,7 @@ from tests.conformance.pg_spike_sql import (
     READ_ARTIFACT_SQL,
     RESET_ROWS_SQL,
     SPIKE_SCHEMA,
+    build_bump_transition_ddl,
     build_mutant_arbitration_ddl,
     build_spike_sql,
 )
@@ -125,6 +127,7 @@ def spike_pg():
             cur.execute(f"DROP SCHEMA IF EXISTS {SPIKE_SCHEMA} CASCADE")
             cur.execute(sql.schema_ddl)
             cur.execute(sql.functions_ddl)
+            cur.execute(build_bump_transition_ddl())
         conn.commit()
         with conn.cursor() as cur:
             cur.execute("SHOW transaction_isolation")
@@ -320,7 +323,7 @@ def test_missing_artifact_is_a_loud_error_not_a_typed_outcome(conn) -> None:
 
 
 def test_function_hardening_search_path_pinned_and_no_public_execute(conn) -> None:
-    for fn in ("spike_commit_cas", "spike_grant_transition"):
+    for fn in ("spike_commit_cas", "spike_grant_transition", "spike_bump_owner_generation"):
         with conn.cursor() as cur:
             cur.execute(
                 "SELECT prosecdef, proconfig, proacl::text[] FROM pg_proc "
@@ -561,9 +564,16 @@ def _u3_arbitrate_contender(ctx, dsn: str, agent: str, payload: str, app_name: s
     conn = _connect(dsn, autocommit=True, application_name=app_name)
     try:
         ctx.barrier_wait()  # phase 1: everyone is running
-        with conn.cursor() as cur:
-            cur.execute(PAIR_READ_SQL, (_ARTIFACT,))
-            read_version, _generation = cur.fetchone()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(PAIR_READ_SQL, (_ARTIFACT,))
+                read_version, _generation = cur.fetchone()
+        except (psycopg.OperationalError, psycopg.InterfaceError) as exc:
+            # KTD5 covers the pre-race read too — but the phase-2 rendezvous
+            # must STILL happen before returning, or the sibling contenders
+            # strand at the barrier until the harness timeout.
+            ctx.barrier_wait()
+            return {"agent": agent, "payload": payload, "outcome": _OUTCOME_UNKNOWN, "error_type": type(exc).__name__}
         ctx.barrier_wait()  # phase 2: everyone holds the same pre-race state
         ctx.delay()
         started = time.monotonic()
@@ -601,11 +611,14 @@ def _u3_grant_transition_contender(ctx, dsn: str, agent: str, state: str, read_g
         conn.close()
 
 
-def _u3_grant_locker_contender(ctx, dsn: str) -> dict:
-    """Paired-contrast forcer: hold an UNCOMMITTED grant transition (anchor
-    lock + EXCLUSIVE upsert), observe the function-arm contender blocked on the
-    anchor, then commit mid-flight — the same commit-across-a-blocked-peer
-    shape as U2, at the construction's OWN serialization point."""
+def _u3_grant_locker_contender(ctx, dsn: str, agent: str, state: str, read_generation) -> dict:
+    """Forced-interleaving locker: hold an UNCOMMITTED grant transition (anchor
+    lock + the given upsert), observe the function-arm contender blocked on the
+    anchor, then commit mid-flight — the commit-across-a-blocked-peer shape at
+    the construction's OWN serialization point. The granted state decides which
+    leg the unblocked function lands on: an M/E grant forces other_holder; a
+    non-holder SHARED transition leaves the ladder to fall through to the
+    fence."""
     conn = _connect(dsn, autocommit=False)
     try:
         monitor = _connect(dsn, autocommit=True)
@@ -615,7 +628,7 @@ def _u3_grant_locker_contender(ctx, dsn: str) -> dict:
     try:
         ctx.barrier_wait()  # phase 1
         with conn.cursor() as cur:
-            cur.execute(GRANT_TRANSITION_SQL, (_ARTIFACT, _AGENT_A, "EXCLUSIVE", 0))  # uncommitted
+            cur.execute(GRANT_TRANSITION_SQL, (_ARTIFACT, agent, state, read_generation))  # uncommitted
         ctx.barrier_wait()  # phase 2: the anchor lock is provably held before B fires
         observed_blocked = _await_backend_blocked(monitor, f"{_U3_APP_PREFIX}-fn")
         conn.commit()  # B unblocks HERE, mid-flight across this grant commit
@@ -625,9 +638,10 @@ def _u3_grant_locker_contender(ctx, dsn: str) -> dict:
         conn.close()
 
 
-def _u3_function_contender(ctx, dsn: str) -> dict:
-    """Paired-contrast function arm: fires the arbitration function while the
-    locker holds the anchor; blocks at the function's FIRST statement."""
+def _u3_function_contender(ctx, dsn: str, agent: str) -> dict:
+    """Forced-interleaving function arm: fires the arbitration function as the
+    given agent while the locker holds the anchor; blocks at the function's
+    FIRST statement."""
     import psycopg  # noqa: PLC0415
 
     conn = _connect(dsn, autocommit=True, application_name=f"{_U3_APP_PREFIX}-fn")
@@ -636,13 +650,25 @@ def _u3_function_contender(ctx, dsn: str) -> dict:
         ctx.barrier_wait()  # phase 2: the locker holds the anchor lock
         try:
             with conn.cursor() as cur:
-                cur.execute(ARBITRATE_SQL, (_ARTIFACT, _AGENT_B, 1, "fn-c", "fn-t"))
+                cur.execute(ARBITRATE_SQL, (_ARTIFACT, agent, 1, "fn-c", "fn-t"))
                 outcome, current = cur.fetchone()
         except (psycopg.OperationalError, psycopg.InterfaceError) as exc:
             return {"outcome": _OUTCOME_UNKNOWN, "error_type": type(exc).__name__}
         return {"outcome": outcome, "current_version": current}
     finally:
         conn.close()
+
+
+def _fail_inconclusive_on_unknown(results) -> None:
+    """KTD5: an unknown driver outcome is never a semantic verdict. The
+    direct-assert races classify it INCONCLUSIVE — mirroring the forced
+    interleavings' rerun discipline — instead of failing a typed assertion."""
+    unknown = [r for r in results if r.get("outcome") == _OUTCOME_UNKNOWN]
+    if unknown:
+        pytest.fail(
+            "INCONCLUSIVE (not a semantic verdict): a contender hit a driver error "
+            f"({[r.get('error_type') for r in unknown]}); rerun the spike."
+        )
 
 
 def _signal_lock_wait_or_warn(observed: bool, results: list[dict], baseline_sec: float) -> None:
@@ -751,6 +777,7 @@ def test_race_fence_zombie_vs_fresh_peer(spike_pg) -> None:
             cur.execute(BUMP_OWNER_GENERATION_SQL, (_ARTIFACT,))  # the reclaim supersedes it
 
     results, _observed = _race_committers(spike_pg, agents=["zombie", "fresh"], delays=(0.0, 0.0))
+    _fail_inconclusive_on_unknown(results)
     zombie, fresh = results[0], results[1]
 
     # The fresh peer has NO read_generation — admit-on-absent, cross-process:
@@ -779,6 +806,7 @@ def test_race_pessimistic_holder_denies_optimistic_committers(spike_pg) -> None:
         _grant(conn, "holder", "EXCLUSIVE", 0)
 
     results, _observed = _race_committers(spike_pg, agents=["opt-a", "opt-b"], delays=(0.0, 0.0))
+    _fail_inconclusive_on_unknown(results)
     assert [r["outcome"] for r in results] == [OUTCOME_OTHER_HOLDER, OUTCOME_OTHER_HOLDER], results
 
     with _connect(spike_pg, autocommit=True) as conn:
@@ -805,6 +833,7 @@ def test_race_phantom_grant_insert_vs_committer(spike_pg) -> None:
     )
     _raise_contender_errors(result)
     committer = result.outcomes[1].value
+    _fail_inconclusive_on_unknown([committer])
 
     with _connect(spike_pg, autocommit=True) as conn:
         with conn.cursor() as cur:
@@ -851,6 +880,41 @@ def test_statement_timeout_mid_function_is_a_safe_no_effect(spike_pg) -> None:
     assert anchor == 0, "the whole statement must roll back — anchor bump included"
 
 
+def test_statement_timeout_after_anchor_bump_rolls_back_whole_statement(spike_pg) -> None:
+    """Round-2 review finding: the sibling test above blocks the victim at its
+    FIRST statement (the anchor), so its anchor-rollback claim is vacuously
+    true. Here the blocker holds a raw row lock on a seeded EXCLUSIVE peer's
+    agent_states row WITHOUT touching the anchor, so the victim EXECUTES its
+    anchor bump, passes the CAS, and blocks at the grant leg's FOR UPDATE —
+    the cancel then has a real intra-function write to roll back."""
+    import psycopg  # noqa: PLC0415
+
+    _reset_rows(spike_pg)
+    with _connect(spike_pg, autocommit=True) as seed_conn:
+        _grant(seed_conn, "holder", "EXCLUSIVE", 0)
+        anchor_before = _anchor_count(seed_conn)
+        before = _snapshot(seed_conn)
+
+    blocker = _connect(spike_pg, autocommit=False)
+    try:
+        with blocker.cursor() as cur:
+            # Deliberately OUTSIDE the anchor chain: the lock must not stop
+            # the victim's anchor bump, only its grant-leg FOR UPDATE.
+            cur.execute(LOCK_AGENT_STATE_ROW_SQL, (_ARTIFACT, "holder"))
+        with _connect(spike_pg, autocommit=True, statement_timeout_ms=300) as victim:
+            with pytest.raises(psycopg.errors.QueryCanceled):
+                _arbitrate(victim, agent="victim", expected_version=1)
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+    with _connect(spike_pg, autocommit=True) as conn:
+        assert _snapshot(conn) == before, "a cancelled arbitration mutated the decided rows"
+        assert _anchor_count(conn) == anchor_before, (
+            "the whole statement must roll back — the EXECUTED anchor bump included"
+        )
+
+
 def test_paired_contrast_function_denies_under_forced_interleaving(spike_pg) -> None:
     """U2's core contrast: the SAME commit-across-a-blocked-peer shape that the
     naive statement ADMITTED is DENIED by the function. Each arm blocks at its
@@ -865,8 +929,8 @@ def test_paired_contrast_function_denies_under_forced_interleaving(spike_pg) -> 
         harness = ProcessRaceHarness(timeout_sec=60.0)
         result = harness.race(
             [
-                ContenderSpec(_u3_grant_locker_contender, args=(spike_pg,)),
-                ContenderSpec(_u3_function_contender, args=(spike_pg,)),
+                ContenderSpec(_u3_grant_locker_contender, args=(spike_pg, _AGENT_A, "EXCLUSIVE", 0)),
+                ContenderSpec(_u3_function_contender, args=(spike_pg, _AGENT_B)),
             ]
         )
         _raise_contender_errors(result)
@@ -891,6 +955,53 @@ def test_paired_contrast_function_denies_under_forced_interleaving(spike_pg) -> 
         return
     pytest.fail(
         "INCONCLUSIVE: the forced interleaving could not be established in "
+        f"{_FORCED_INTERLEAVING_ATTEMPTS} attempts ({'; '.join(inconclusive)}). Rerun the spike."
+    )
+
+
+def test_forced_fence_zombie_deterministically_sees_stale_read_generation(spike_pg) -> None:
+    """Round-2 review finding: the free zombie-vs-fresh race certifies the
+    fence leg cross-process only when the zombie happens to arbitrate first.
+    This variant FORCES it: a non-holder SHARED transition holds the anchor
+    lock (creating no M/E holder and moving no version), the zombie provably
+    blocks at its anchor bump, the locker commits, and the zombie's post-wait
+    ladder must land on the fence leg — stale_read_generation,
+    deterministically."""
+    inconclusive: list[str] = []
+    for _attempt in range(_FORCED_INTERLEAVING_ATTEMPTS):
+        _reset_rows(spike_pg)
+        with _connect(spike_pg, autocommit=True) as conn:
+            _grant(conn, "zombie", "INVALID", 0)  # captured generation 0 at its acquire
+            with conn.cursor() as cur:
+                cur.execute(BUMP_OWNER_GENERATION_SQL, (_ARTIFACT,))  # the reclaim supersedes it
+        harness = ProcessRaceHarness(timeout_sec=60.0)
+        result = harness.race(
+            [
+                ContenderSpec(_u3_grant_locker_contender, args=(spike_pg, "bystander", "SHARED", None)),
+                ContenderSpec(_u3_function_contender, args=(spike_pg, "zombie")),
+            ]
+        )
+        _raise_contender_errors(result)
+        locker = result.outcomes[0].value
+        fn_arm = result.outcomes[1].value
+
+        if fn_arm.get("outcome") == _OUTCOME_UNKNOWN:
+            inconclusive.append(f"driver error {fn_arm['error_type']} (unknown outcome)")
+            continue
+        if not locker["observed_blocked"]:
+            inconclusive.append("zombie backend never observed in a Lock wait")
+            continue
+
+        # The forcing held: the zombie was blocked across the SHARED commit,
+        # its fresh post-wait reads saw version unmoved and no M/E peer, so
+        # only the fence can (and must) deny it.
+        assert fn_arm["outcome"] == OUTCOME_STALE_READ_GENERATION, fn_arm
+        with _connect(spike_pg, autocommit=True) as conn:
+            artifact, _states = _snapshot(conn)
+        assert artifact == (1, 1, None, None), "the fenced zombie left a trace"
+        return
+    pytest.fail(
+        "INCONCLUSIVE: the forced fence interleaving could not be established in "
         f"{_FORCED_INTERLEAVING_ATTEMPTS} attempts ({'; '.join(inconclusive)}). Rerun the spike."
     )
 

--- a/tests/conformance/test_pg_three_leg_spike.py
+++ b/tests/conformance/test_pg_three_leg_spike.py
@@ -23,6 +23,7 @@ never the driver message, which may embed the DSN password (the shipped
 from __future__ import annotations
 
 import os
+import statistics
 import threading
 import time
 import warnings
@@ -60,27 +61,43 @@ _ARTIFACT = "artifact-1"
 _AGENT_A = "agent-a"
 _AGENT_B = "agent-b"
 
+# Client-side classification of a driver error whose server outcome is
+# unresolved (KTD5) — a harness verdict, not a server outcome string.
+_OUTCOME_UNKNOWN = "unknown"
+
 _CONNECT_TIMEOUT_SEC = 10
 _STATEMENT_TIMEOUT_MS = 15_000
 
 
-def _connect(dsn: str, *, autocommit: bool, statement_timeout_ms: int = _STATEMENT_TIMEOUT_MS):
+def _connect(
+    dsn: str,
+    *,
+    autocommit: bool,
+    statement_timeout_ms: int = _STATEMENT_TIMEOUT_MS,
+    application_name: str | None = None,
+):
     """A bounded-wait connection: connect + per-statement timeouts ALWAYS set
     (KTD5). Arbitration calls use ``autocommit=True`` so the single SELECT is
     one self-contained transaction (KTD2); provisioning uses explicit commit."""
     import psycopg  # noqa: PLC0415 - lazy so collection never needs the extra
 
+    kwargs: dict[str, object] = {}
+    if application_name is not None:
+        kwargs["application_name"] = application_name
     return psycopg.connect(
         dsn,
         autocommit=autocommit,
         connect_timeout=_CONNECT_TIMEOUT_SEC,
         options=f"-c statement_timeout={statement_timeout_ms}",
+        **kwargs,
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def spike_pg():
-    """Provision the spike schema + functions on the operator's Postgres.
+    """Provision the spike schema + functions ONCE for the module (the schema
+    is immutable; per-test isolation is the row truncate below — the module is
+    declared serial, so module scope adds no parallelism hazard).
 
     Functions DDL (CREATE + REVOKE/GRANT) applies in ONE transaction (R6).
     Fails loudly when the server's default isolation is not READ COMMITTED —
@@ -113,11 +130,34 @@ def spike_pg():
             cur.execute(f"DROP SCHEMA IF EXISTS {SPIKE_SCHEMA} CASCADE")
 
 
+@pytest.fixture(autouse=True)
+def _clean_rows(spike_pg):
+    """Per-test isolation over the module-scoped schema: rows start empty."""
+    with _connect(spike_pg, autocommit=True) as c, c.cursor() as cur:
+        cur.execute(RESET_ROWS_SQL)
+
+
 @pytest.fixture
 def conn(spike_pg):
     """An autocommit connection for direct-call tests (KTD2's client shape)."""
     with _connect(spike_pg, autocommit=True) as c:
         yield c
+
+
+@pytest.fixture(scope="module")
+def baseline_sec(spike_pg) -> float:
+    """The uncontended arbitration-call floor for the loser-elapsed fallback
+    signal (KTD6) — a property of the server/DSN, measured once per module."""
+    samples = []
+    with _connect(spike_pg, autocommit=True) as c:
+        for i in range(3):
+            with c.cursor() as cur:
+                cur.execute(RESET_ROWS_SQL)
+            _seed(c)
+            started = time.monotonic()
+            _arbitrate(c, agent=f"baseline-{i}", expected_version=1)
+            samples.append(time.monotonic() - started)
+    return statistics.median(samples)
 
 
 def _seed(conn, *, version: int = 1, owner_generation: int = 0) -> None:
@@ -255,16 +295,14 @@ def test_missing_artifact_is_a_loud_error_not_a_typed_outcome(conn) -> None:
     import psycopg  # noqa: PLC0415
 
     # No anchor row: the lock-chain entry itself refuses, loudly.
-    with pytest.raises(psycopg.Error) as excinfo:
+    with pytest.raises(psycopg.errors.RaiseException):
         _arbitrate(conn, agent=_AGENT_A, expected_version=1)
-    assert excinfo.value.sqlstate == "P0001"  # RAISE EXCEPTION
 
     # Anchor present but artifact row missing: the STRICT pair-read refuses.
     with conn.cursor() as cur:
         cur.execute(INSERT_ANCHOR_SQL, (_ARTIFACT,))
-    with pytest.raises(psycopg.Error) as excinfo:
+    with pytest.raises(psycopg.errors.NoDataFound):  # SELECT ... INTO STRICT
         _arbitrate(conn, agent=_AGENT_A, expected_version=1)
-    assert excinfo.value.sqlstate == "P0002"  # NO_DATA_FOUND from SELECT ... INTO STRICT
 
 
 def test_function_hardening_search_path_pinned_and_no_public_execute(conn) -> None:
@@ -307,31 +345,26 @@ def test_function_hardening_search_path_pinned_and_no_public_execute(conn) -> No
 
 _NAIVE_APP_NAME = "ccs-spike-naive"
 _BLOCK_POLL_TIMEOUT_SEC = 10.0
-_U2_ATTEMPTS = 3
+_FORCED_INTERLEAVING_ATTEMPTS = 3
 
 
 def _contender_connect(dsn: str, *, autocommit: bool, application_name: str | None = None):
     """Contender-side connect with the DSN-scrubbing discipline: a failure
     surfaces the exception TYPE only, because the harness transports child
     tracebacks and a driver connect error may echo conninfo details."""
-    import psycopg  # noqa: PLC0415
-
-    kwargs: dict[str, object] = {}
-    if application_name is not None:
-        kwargs["application_name"] = application_name
     try:
-        return psycopg.connect(
-            dsn,
-            autocommit=autocommit,
-            connect_timeout=_CONNECT_TIMEOUT_SEC,
-            options=f"-c statement_timeout={_STATEMENT_TIMEOUT_MS}",
-            **kwargs,
-        )
+        return _connect(dsn, autocommit=autocommit, application_name=application_name)
     except Exception as exc:  # noqa: BLE001 - re-raised scrubbed
         raise RuntimeError(
             f"spike contender connect failed with {type(exc).__name__}; "
             "details suppressed to avoid leaking DSN credentials"
         ) from None
+
+
+def _raise_contender_errors(result) -> None:
+    """Surface the first child failure; a contender error is never a pass."""
+    if result.errors:
+        raise result.errors[0].error
 
 
 def _await_backend_blocked(monitor_conn, application_name: str, timeout_sec: float = _BLOCK_POLL_TIMEOUT_SEC) -> bool:
@@ -383,23 +416,22 @@ def _u2_naive_contender(ctx, dsn: str) -> dict:
     try:
         ctx.barrier_wait()  # phase 1
         ctx.barrier_wait()  # phase 2: A holds the artifact row lock
-        started = time.monotonic()
         try:
             with conn.cursor() as cur:
                 cur.execute(NAIVE_COMMIT_CAS_SQL, ("naive-c", "naive-t", _ARTIFACT, 1, _AGENT_B))
                 rowcount = cur.rowcount
         except Exception as exc:  # noqa: BLE001 - classified, scrubbed (KTD5)
-            return {"outcome": "unknown", "error_type": type(exc).__name__}
-        return {"rowcount": rowcount, "elapsed": time.monotonic() - started}
+            return {"outcome": _OUTCOME_UNKNOWN, "error_type": type(exc).__name__}
+        return {"rowcount": rowcount}
     finally:
         conn.close()
 
 
-def _reset_rows(dsn: str, *, version: int = 1, owner_generation: int = 0) -> None:
+def _reset_rows(dsn: str) -> None:
     with _connect(dsn, autocommit=True) as conn:
         with conn.cursor() as cur:
             cur.execute(RESET_ROWS_SQL)
-        _seed(conn, version=version, owner_generation=owner_generation)
+        _seed(conn)
 
 
 def test_naive_single_statement_loses_the_grant_leg(spike_pg) -> None:
@@ -408,7 +440,7 @@ def test_naive_single_statement_loses_the_grant_leg(spike_pg) -> None:
     should have denied it. This test PASSING means the naive construction
     FAILED in the predicted shape."""
     inconclusive: list[str] = []
-    for _attempt in range(_U2_ATTEMPTS):
+    for _attempt in range(_FORCED_INTERLEAVING_ATTEMPTS):
         _reset_rows(spike_pg)
         harness = ProcessRaceHarness(timeout_sec=60.0)
         result = harness.race(
@@ -417,13 +449,11 @@ def test_naive_single_statement_loses_the_grant_leg(spike_pg) -> None:
                 ContenderSpec(_u2_naive_contender, args=(spike_pg,)),
             ]
         )
-        for outcome in result.outcomes:
-            if outcome.error is not None:
-                raise outcome.error
+        _raise_contender_errors(result)
         locker = result.outcomes[0].value
         naive = result.outcomes[1].value
 
-        if naive.get("outcome") == "unknown":
+        if naive.get("outcome") == _OUTCOME_UNKNOWN:
             inconclusive.append(f"driver error {naive['error_type']} (unknown outcome)")
             continue
         if not locker["observed_blocked"]:
@@ -436,7 +466,7 @@ def test_naive_single_statement_loses_the_grant_leg(spike_pg) -> None:
                 cur.execute(READ_ARTIFACT_SQL, (_ARTIFACT,))
                 version, _gen, content_hash, _token = cur.fetchone()
                 cur.execute(READ_AGENT_STATES_SQL, (_ARTIFACT,))
-                states = dict((agent, state) for agent, state, _g in cur.fetchall())
+                states = {agent: state for agent, state, _g in cur.fetchall()}
         assert states.get(_AGENT_A) == "EXCLUSIVE", "scaffold broke: A's grant transition did not commit"
 
         if naive["rowcount"] == 0:
@@ -455,7 +485,7 @@ def test_naive_single_statement_loses_the_grant_leg(spike_pg) -> None:
         return
     pytest.fail(
         "INCONCLUSIVE (not a §9.2 refutation): the forced interleaving could not be "
-        f"established in {_U2_ATTEMPTS} attempts ({'; '.join(inconclusive)}). Rerun the spike; "
+        f"established in {_FORCED_INTERLEAVING_ATTEMPTS} attempts ({'; '.join(inconclusive)}). Rerun the spike; "
         "do not escalate an unforced run to the C-3 pause."
     )
 
@@ -537,7 +567,7 @@ def _u3_arbitrate_contender(ctx, dsn: str, agent: str, payload: str, app_name: s
         except (psycopg.OperationalError, psycopg.InterfaceError) as exc:
             # KTD5: the write MAY have landed server-side — classify, discard
             # the connection, and let the parent's authoritative read settle it.
-            return {"agent": agent, "payload": payload, "outcome": "unknown", "error_type": type(exc).__name__}
+            return {"agent": agent, "payload": payload, "outcome": _OUTCOME_UNKNOWN, "error_type": type(exc).__name__}
         return {
             "agent": agent,
             "payload": payload,
@@ -598,7 +628,7 @@ def _u3_function_contender(ctx, dsn: str) -> dict:
                 cur.execute(ARBITRATE_SQL, (_ARTIFACT, _AGENT_B, 1, "fn-c", "fn-t"))
                 outcome, current = cur.fetchone()
         except (psycopg.OperationalError, psycopg.InterfaceError) as exc:
-            return {"outcome": "unknown", "error_type": type(exc).__name__}
+            return {"outcome": _OUTCOME_UNKNOWN, "error_type": type(exc).__name__}
         return {"outcome": outcome, "current_version": current}
     finally:
         conn.close()
@@ -651,9 +681,7 @@ def _race_committers(dsn: str, *, agents: list[str], delays: tuple[float, ...]) 
                 for i, agent in enumerate(agents)
             ]
         )
-    for outcome in result.outcomes:
-        if outcome.error is not None:
-            raise outcome.error
+    _raise_contender_errors(result)
     return [o.value for o in result.outcomes], monitor.observed
 
 
@@ -666,8 +694,8 @@ def _assert_exactly_one_winner(dsn: str, results: list[dict], *, pre_version: in
             cur.execute(READ_ARTIFACT_SQL, (_ARTIFACT,))
             version, _generation, content_hash, _token = cur.fetchone()
     wins = [r for r in results if r["outcome"] == OUTCOME_WIN]
-    unknowns = [r for r in results if r["outcome"] == "unknown"]
-    losers = [r for r in results if r["outcome"] not in (OUTCOME_WIN, "unknown")]
+    unknowns = [r for r in results if r["outcome"] == _OUTCOME_UNKNOWN]
+    losers = [r for r in results if r["outcome"] not in (OUTCOME_WIN, _OUTCOME_UNKNOWN)]
 
     assert version == pre_version + 1, f"exactly one write must land, got version {version}"
     assert len(wins) <= 1, f"two winners is a lost update: {results}"
@@ -778,9 +806,7 @@ def test_race_phantom_grant_insert_vs_committer(spike_pg) -> None:
             ),
         ]
     )
-    for outcome in result.outcomes:
-        if outcome.error is not None:
-            raise outcome.error
+    _raise_contender_errors(result)
     committer = result.outcomes[1].value
 
     with _connect(spike_pg, autocommit=True) as conn:
@@ -837,7 +863,7 @@ def test_paired_contrast_function_denies_under_forced_interleaving(spike_pg) -> 
     in-flight across the peer's EXCLUSIVE grant commit. This test also carries
     R9's deterministic lock-wait observation for the suite."""
     inconclusive: list[str] = []
-    for _attempt in range(_U2_ATTEMPTS):
+    for _attempt in range(_FORCED_INTERLEAVING_ATTEMPTS):
         _reset_rows(spike_pg)
         harness = ProcessRaceHarness(timeout_sec=60.0)
         result = harness.race(
@@ -846,13 +872,11 @@ def test_paired_contrast_function_denies_under_forced_interleaving(spike_pg) -> 
                 ContenderSpec(_u3_function_contender, args=(spike_pg,)),
             ]
         )
-        for outcome in result.outcomes:
-            if outcome.error is not None:
-                raise outcome.error
+        _raise_contender_errors(result)
         locker = result.outcomes[0].value
         fn_arm = result.outcomes[1].value
 
-        if fn_arm.get("outcome") == "unknown":
+        if fn_arm.get("outcome") == _OUTCOME_UNKNOWN:
             inconclusive.append(f"driver error {fn_arm['error_type']} (unknown outcome)")
             continue
         if not locker["observed_blocked"]:
@@ -870,7 +894,7 @@ def test_paired_contrast_function_denies_under_forced_interleaving(spike_pg) -> 
         return
     pytest.fail(
         "INCONCLUSIVE: the forced interleaving could not be established in "
-        f"{_U2_ATTEMPTS} attempts ({'; '.join(inconclusive)}). Rerun the spike."
+        f"{_FORCED_INTERLEAVING_ATTEMPTS} attempts ({'; '.join(inconclusive)}). Rerun the spike."
     )
 
 

--- a/tests/conformance/test_pg_three_leg_spike.py
+++ b/tests/conformance/test_pg_three_leg_spike.py
@@ -23,15 +23,19 @@ never the driver message, which may embed the DSN password (the shipped
 from __future__ import annotations
 
 import os
+import time
 
 import pytest
 
+from ccs.testing.process_harness import ContenderSpec, ProcessRaceHarness
 from tests.conformance.pg_spike_sql import (
     ARBITRATE_SQL,
     BUMP_OWNER_GENERATION_SQL,
     GRANT_TRANSITION_SQL,
     INSERT_ANCHOR_SQL,
     INSERT_ARTIFACT_SQL,
+    LOCK_ARTIFACT_ROW_SQL,
+    NAIVE_COMMIT_CAS_SQL,
     OUTCOME_CORRUPTION,
     OUTCOME_OTHER_HOLDER,
     OUTCOME_STALE_READ_GENERATION,
@@ -41,6 +45,7 @@ from tests.conformance.pg_spike_sql import (
     READ_AGENT_STATES_SQL,
     READ_ANCHOR_SQL,
     READ_ARTIFACT_SQL,
+    RESET_ROWS_SQL,
     SPIKE_SCHEMA,
     build_spike_sql,
 )
@@ -275,3 +280,177 @@ def test_function_hardening_search_path_pinned_and_no_public_execute(conn) -> No
         # revoke it must be non-NULL with no PUBLIC entry (grantee '' in acl text).
         assert acl is not None, f"{fn} has default ACLs — the R6 revoke did not land"
         assert not any(entry.startswith("=") for entry in acl), f"{fn} still grants PUBLIC: {acl}"
+
+
+# --- U2: negative control — the naive construction loses the grant leg ------
+#
+# The decisive interleaving is FORCED, never hoped for (delay-free by design):
+#   1. Contender A takes the artifact's row lock with a non-version-bumping
+#      UPDATE inside an open transaction.
+#   2. Contender B fires the naive single statement and BLOCKS on that lock —
+#      observed directly in pg_stat_activity, so B is provably in-flight
+#      across A's commit (no scheduling coin-flip).
+#   3. A writes an EXCLUSIVE grant via the sanctioned transition helper (the
+#      anchor lock chain) and commits.
+#   4. B's row re-check re-evaluates the version qual against A's committed
+#      tuple, while the grant subquery keeps its pre-grant statement snapshot —
+#      §9.2 predicts the admit lands.
+#
+# Refutation predicate: a DENY under exactly this interleaving is a genuine
+# refutation of the origin's §9.2 mechanism claim (reported loudly, flags the
+# C-3 pause). A run where the forcing did not hold is INCONCLUSIVE — rerun,
+# never escalate. Never silently green either way.
+
+_NAIVE_APP_NAME = "ccs-spike-naive"
+_BLOCK_POLL_TIMEOUT_SEC = 10.0
+_U2_ATTEMPTS = 3
+
+
+def _contender_connect(dsn: str, *, autocommit: bool, application_name: str | None = None):
+    """Contender-side connect with the DSN-scrubbing discipline: a failure
+    surfaces the exception TYPE only, because the harness transports child
+    tracebacks and a driver connect error may echo conninfo details."""
+    import psycopg  # noqa: PLC0415
+
+    kwargs: dict[str, object] = {}
+    if application_name is not None:
+        kwargs["application_name"] = application_name
+    try:
+        return psycopg.connect(
+            dsn,
+            autocommit=autocommit,
+            connect_timeout=_CONNECT_TIMEOUT_SEC,
+            options=f"-c statement_timeout={_STATEMENT_TIMEOUT_MS}",
+            **kwargs,
+        )
+    except Exception as exc:  # noqa: BLE001 - re-raised scrubbed
+        raise RuntimeError(
+            f"spike contender connect failed with {type(exc).__name__}; "
+            "details suppressed to avoid leaking DSN credentials"
+        ) from None
+
+
+def _await_backend_blocked(monitor_conn, application_name: str, timeout_sec: float = _BLOCK_POLL_TIMEOUT_SEC) -> bool:
+    """True once a backend with ``application_name`` is observed in a Lock wait.
+
+    Must run on an AUTOCOMMIT connection: backend-status views are frozen at
+    first access within a transaction, so polling inside one would never see
+    the state change.
+    """
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        with monitor_conn.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM pg_stat_activity "
+                "WHERE application_name = %s AND wait_event_type = 'Lock'",
+                (application_name,),
+            )
+            (count,) = cur.fetchone()
+        if count:
+            return True
+        time.sleep(0.02)
+    return False
+
+
+def _u2_locker_contender(ctx, dsn: str) -> dict:
+    """Contender A: hold the artifact row lock, observe B blocked, then commit
+    an EXCLUSIVE grant through the anchor lock chain while B waits."""
+    conn = _contender_connect(dsn, autocommit=False)
+    monitor = _contender_connect(dsn, autocommit=True)
+    try:
+        ctx.barrier_wait()  # phase 1: both contenders are running
+        with conn.cursor() as cur:
+            cur.execute(LOCK_ARTIFACT_ROW_SQL, (_ARTIFACT,))  # row lock held; version untouched
+        ctx.barrier_wait()  # phase 2: the lock is provably held before B fires
+        observed_blocked = _await_backend_blocked(monitor, _NAIVE_APP_NAME)
+        with conn.cursor() as cur:
+            cur.execute(GRANT_TRANSITION_SQL, (_ARTIFACT, _AGENT_A, "EXCLUSIVE", 0))
+        conn.commit()  # B unblocks HERE, mid-flight across this grant commit
+        return {"observed_blocked": observed_blocked}
+    finally:
+        monitor.close()
+        conn.close()
+
+
+def _u2_naive_contender(ctx, dsn: str) -> dict:
+    """Contender B: fire the naive single-statement CAS+grant-check and report
+    whether it admitted (rowcount 1) or denied (rowcount 0)."""
+    conn = _contender_connect(dsn, autocommit=True, application_name=_NAIVE_APP_NAME)
+    try:
+        ctx.barrier_wait()  # phase 1
+        ctx.barrier_wait()  # phase 2: A holds the artifact row lock
+        started = time.monotonic()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(NAIVE_COMMIT_CAS_SQL, ("naive-c", "naive-t", _ARTIFACT, 1, _AGENT_B))
+                rowcount = cur.rowcount
+        except Exception as exc:  # noqa: BLE001 - classified, scrubbed (KTD5)
+            return {"outcome": "unknown", "error_type": type(exc).__name__}
+        return {"rowcount": rowcount, "elapsed": time.monotonic() - started}
+    finally:
+        conn.close()
+
+
+def _reset_rows(dsn: str, *, version: int = 1, owner_generation: int = 0) -> None:
+    with _connect(dsn, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(RESET_ROWS_SQL)
+        _seed(conn, version=version, owner_generation=owner_generation)
+
+
+def test_naive_single_statement_loses_the_grant_leg(spike_pg) -> None:
+    """R8 — and the origin §10 second-pass caveat this control discharges: the
+    naive arm must admit a write while a peer's committed EXCLUSIVE grant
+    should have denied it. This test PASSING means the naive construction
+    FAILED in the predicted shape."""
+    inconclusive: list[str] = []
+    for _attempt in range(_U2_ATTEMPTS):
+        _reset_rows(spike_pg)
+        harness = ProcessRaceHarness(timeout_sec=60.0)
+        result = harness.race(
+            [
+                ContenderSpec(_u2_locker_contender, args=(spike_pg,)),
+                ContenderSpec(_u2_naive_contender, args=(spike_pg,)),
+            ]
+        )
+        for outcome in result.outcomes:
+            if outcome.error is not None:
+                raise outcome.error
+        locker = result.outcomes[0].value
+        naive = result.outcomes[1].value
+
+        if naive.get("outcome") == "unknown":
+            inconclusive.append(f"driver error {naive['error_type']} (unknown outcome)")
+            continue
+        if not locker["observed_blocked"]:
+            inconclusive.append("naive backend never observed in a Lock wait")
+            continue
+
+        # The forcing held: B was provably blocked across A's grant commit.
+        with _connect(spike_pg, autocommit=True) as check:
+            with check.cursor() as cur:
+                cur.execute(READ_ARTIFACT_SQL, (_ARTIFACT,))
+                version, _gen, content_hash, _token = cur.fetchone()
+                cur.execute(READ_AGENT_STATES_SQL, (_ARTIFACT,))
+                states = dict((agent, state) for agent, state, _g in cur.fetchall())
+        assert states.get(_AGENT_A) == "EXCLUSIVE", "scaffold broke: A's grant transition did not commit"
+
+        if naive["rowcount"] == 0:
+            pytest.fail(
+                "SPIKE FINDING — §9.2 REFUTED: the naive single statement DENIED under the "
+                "forced interleaving (blocked across a committed EXCLUSIVE grant, then rejected). "
+                "The origin BRD's mechanism argument does not hold as stated; flag the C-3 pause "
+                "and record this in the findings report before any backend scoping."
+            )
+        # The predicted lost arbitration: the naive statement admitted a write
+        # while a peer held a committed EXCLUSIVE grant.
+        assert naive["rowcount"] == 1
+        assert version == 2 and content_hash == "naive-c", (
+            "the admitted write should be the naive contender's payload"
+        )
+        return
+    pytest.fail(
+        "INCONCLUSIVE (not a §9.2 refutation): the forced interleaving could not be "
+        f"established in {_U2_ATTEMPTS} attempts ({'; '.join(inconclusive)}). Rerun the spike; "
+        "do not escalate an unforced run to the C-3 pause."
+    )


### PR DESCRIPTION
## Summary

- Postgres at default READ COMMITTED can decide all three coherence legs — version-CAS, grant arbitration (no peer holds MODIFIED/EXCLUSIVE), and the read-generation fence — in ONE atomic step a client invokes as a single `SELECT`: a `SECURITY DEFINER` plpgsql function plus an actually-written per-artifact anchor row. This spike demonstrates it with cross-process races and records the construction's load-bearing facts.
- The obvious one-statement shape (`UPDATE ... WHERE version = ?` with an inline grant subquery) demonstrably CANNOT: under a forced, delay-free interleaving it admits a write across a peer's committed EXCLUSIVE grant, because its single statement snapshot predates the lock wait. That failure is reproduced deterministically as the suite's permanent negative control.
- Everything lands in the test tree (`tests/conformance/`); nothing ships in the package. The suite is operator-run behind the `real_substrate` marker against `CCS_TEST_PG_DSN` (documented default: a throwaway Postgres 16 container).

This continues the cross-process conformance work from #167, reusing its spawn harness and two-phase contender pattern unchanged. A production Postgres binding is deliberately out of scope — this settles feasibility only.

Design decisions worth reviewing:

- **The anchor row is the mechanism, not bookkeeping.** Every arbitration call and every grant transition first UPDATEs the artifact's anchor row, so they all serialize on one row lock — including INSERTs of new agent_states rows that row locks on existing rows cannot see. A denied call still commits its anchor bump by design; the no-mutation guarantee is scoped to the artifacts and agent_states rows and asserted at that scope.
- **The controls are forced, not hoped for.** Both interleaving tests hold a lock, observe the victim backend in a `pg_stat_activity` Lock wait, then commit a grant mid-block — no scheduling coin-flips, no load-bearing sleeps. A deny by the naive arm under that forcing would be reported loudly as a refutation; an unforced run reruns as inconclusive.
- **The suite can fail.** A mutant arbitration function with the grant leg stripped — emitted from the same template as the real one, so they cannot drift — must ADMIT where the real function denies, and both halves of the M/E holder predicate are proven to deny independently.
- **Indeterminate outcomes are classified, not solved.** Driver errors map to a typed `unknown` outcome (exception type only — never the message, which may embed DSN credentials) and the parent's authoritative read settles what landed; a mid-function `statement_timeout` is proven to roll back the whole statement, anchor bump included (SQLSTATE 57014, distinguishable from `unknown`).

## New concepts

**Statement snapshots vs. a forcing write at READ COMMITTED.** At READ COMMITTED, each *statement* takes a fresh snapshot, but everything inside one statement — subqueries included — shares one snapshot taken before any lock wait. When a blocked `UPDATE` resumes after the lock holder commits, Postgres re-evaluates only the target row's WHERE clause against the new tuple (the EvalPlanQual re-check); a `NOT EXISTS` subquery over *other* tables keeps the stale pre-wait snapshot. That is why the one-statement CAS+grant-check silently admits. The fix pattern: split the decision across statements inside one function *and* make every conflicting writer touch one shared row first (the anchor), so any concurrent decision must first wait on that row lock — and every statement after the wait sees the peer's committed state. Use it when a decision must observe concurrent writes to *other* rows/tables; skip it when a single-row compare-and-swap is the whole decision (plain version-CAS needs no anchor).

## Test Plan

- [x] Operator run: 22 spike tests green across repeated runs (PostgreSQL 16.15, Docker, READ COMMITTED asserted in-fixture)
- [x] Default suite without the DSN or the psycopg extra: 3084 passed; the spike module collects and deselects cleanly
- [x] Negative controls observed to fail in the predicted shape (naive arm admits; grant-leg mutant admits where the real function denies)
- [x] `ruff` and architecture checks clean; tracked diff touches only `tests/conformance/`
- [x] Multi-agent code review completed; 3 validated findings applied (9973565)
- [x] Second review round: 4 findings applied and adversarially re-verified (6057d61) — the timeout-rollback and cross-process fence certifications are now forced rather than coin-flip, driver-error classification is uniform across all races, and the generation-bump scaffold joins the anchor lock chain

## Known Residuals

Advisory-grade, deliberately not applied: the parent-side lock-wait monitor thread has no per-iteration error tolerance (a driver blip degrades the warn-only signal to an honest warning); multi-contender failure reporting surfaces the first error only (matches the shipped harness idiom); fixture setup drops a name-colliding `ccs_spike` schema on the operator DSN (throwaway-database usage is documented, not enforced).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — test-tree-only research spike; nothing ships in the package.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

