### PR TITLE
fix(test): wait for the in-flight drain in i6 instead of sampling it

### DIFF
--- a/tests/test_claude_code_coordinator_server.py
+++ b/tests/test_claude_code_coordinator_server.py
@@ -1553,6 +1553,36 @@ def test_handler_concurrency_limit_constant_matches_spec(client: _Client) -> Non
 # ----------------------------------------------------------------------
 
 
+def _await_in_flight_drain(
+    coordinator: CoordinatorHTTPServer, timeout_sec: float = 1.0,
+) -> None:
+    """Wait for the in-flight counter to reach zero, failing on timeout.
+
+    ``client.post`` returns as soon as the response body is read, but
+    ``release_handler_slot`` runs in the dispatcher's ``finally`` block
+    AFTER the response has been written. Between those two points the
+    counter still reads 1 from the client's point of view — a window of
+    microseconds on an idle machine, milliseconds on a loaded CI runner
+    (REL-03's lock around the watchdog counters widens it further).
+
+    Any test that samples the counter straight after a client call is
+    therefore racing the server thread. The contract under test is that
+    the finally block releases the slot — *eventually* zero, not zero by
+    the next bytecode op — so wait for the drain rather than sampling
+    it. Do NOT relax the assertion to ``<= 1`` instead: that stops
+    pinning the release, which is the whole property.
+    """
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        if coordinator._in_flight == 0:
+            return
+        time.sleep(0.010)
+    pytest.fail(
+        f"in-flight counter never drained: expected 0 within "
+        f"{timeout_sec}s, still at {coordinator._in_flight}"
+    )
+
+
 def test_i1_acquire_release_pair_balances_counter(tmp_path: Path) -> None:
     """Unit-level: acquire/release balance the in-flight counter; the
     drain condition is signalled on the zero transition."""
@@ -1652,36 +1682,27 @@ def test_i5_dispatch_pairs_acquire_with_release(client: _Client, coordinator) ->
     """Integration: a normal pre-read request increments and decrements
     the in-flight counter exactly once, leaving it at zero on return.
 
-    Polling rationale: client.post returns once the response body is read,
-    but ``release_handler_slot`` runs in the dispatcher's finally block
-    AFTER the response is sent. There's a microseconds-to-milliseconds
-    window where the counter is still 1 from the client's POV. Poll
-    briefly (up to 1s) instead of asserting immediately — the contract
-    is "eventually zero", not "zero by the next bytecode op". REL-03's
-    lock around watchdog counters widens this window slightly on slow
-    CI, surfacing the pre-existing race."""
+    The zero check waits for the drain — see :func:`_await_in_flight_drain`
+    for why sampling it straight after the response races the server
+    thread."""
     assert coordinator._in_flight == 0
     status, _ = client.post(
         "/hooks/pre-read",
         {"session_id": _sid("i5"), "path": "CLAUDE.md"},
     )
     assert status == 200
-    deadline = time.monotonic() + 1.0
-    while time.monotonic() < deadline:
-        if coordinator._in_flight == 0:
-            return
-        time.sleep(0.010)
-    pytest.fail(
-        f"in-flight counter never drained: expected 0 within 1s, "
-        f"still at {coordinator._in_flight}"
-    )
+    _await_in_flight_drain(coordinator)
 
 
 def test_i6_dispatch_decrements_even_when_handler_raises(
     client: _Client, coordinator, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Defensive: if a handler raises mid-dispatch (becoming a 500), the
-    finally block must still release the slot."""
+    finally block must still release the slot.
+
+    Same drain wait as i5: the 500 is written by the ``except`` arm and
+    the release happens in the ``finally`` that follows it, so the
+    client can observe the response before the decrement lands."""
     import ccs.adapters.claude_code.coordinator_server as mod
     original = mod._ROUTES[("POST", "/hooks/pre-read")]
 
@@ -1690,13 +1711,14 @@ def test_i6_dispatch_decrements_even_when_handler_raises(
 
     monkeypatch.setitem(mod._ROUTES, ("POST", "/hooks/pre-read"), raising_handler)
     try:
+        assert coordinator._in_flight == 0
         status, _ = client.post(
             "/hooks/pre-read",
             {"session_id": _sid("i6"), "path": "CLAUDE.md"},
         )
         assert status == 500
         # Counter must have been decremented despite the exception.
-        assert coordinator._in_flight == 0
+        _await_in_flight_drain(coordinator)
     finally:
         mod._ROUTES[("POST", "/hooks/pre-read")] = original
 


### PR DESCRIPTION
## Summary

- `test_i6_dispatch_decrements_even_when_handler_raises` sampled `coordinator._in_flight == 0` the instant the client read the 500 response, but `release_handler_slot()` runs in the dispatcher's `finally` block *after* the response is written. On a loaded runner the client wins that race — the observed CI failure was `assert 1 == 0` on Python 3.11 while 3.12 passed the identical suite (the same run also hit `ConnectionResetError` in the 32-thread `test_concurrent_pre_read_above_limit_returns_503`, so the runner was loaded).
- `c82749d` already fixed this for `test_i5` by polling for the drain; `i6` has the identical shape on the 500 path and was missed. That poll is now extracted into `_await_in_flight_drain()` and used from both, so the next test on this counter inherits the wait instead of re-discovering the race.
- The assertion is **not** weakened. It still pins "eventually exactly 0" — never `<= 1` — because the property under test is that the `finally` block releases the slot.

Survey of neighbouring tests: `i1`/`i2` call `acquire`/`release` directly with no HTTP in between, and `i3`/`i4` deliberately hold a slot open, so none of them can see this window. `_in_flight` is the only server state mutated *after* a response is written — `mark_request`, `record_401` and the per-endpoint counters all bump before the write — and it is referenced from no other test module.

## Test Plan

- [x] Race reproduced before the fix: injecting a 50 ms delay between the response write and the decrement makes the old `i6` fail while `i5` (already polling) passes.
- [x] Fix verified against that same widened window: both tests pass.
- [x] Assertion still pins the property: deleting `release_handler_slot()` from the dispatcher's `finally` makes both `i5` and `i6` fail.
- [x] 60 loaded runs of the concurrency subset (`i1`–`i6`, `rel01`, `concurrent_pre_read`) with 16 busy loops saturating 8 cores — 0 failures.
- [x] 3 full-file runs on Python 3.11.14 (the version that failed in CI) and 1 on 3.12 — 215 passed each.
- [x] `ruff check` and `tools/check_architecture.py` clean.

Test-only change; no source, docs, or user-facing surface touched.