### PR TITLE
fix(adapters): create .coherence at 0700 from the pre-spawn policy write

### DIFF
--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -519,7 +519,14 @@ class CoherentVolume:
         if not self._managed:
             return
         coherence_dir = self._root / ".coherence"
-        coherence_dir.mkdir(parents=True, exist_ok=True)
+        # This write runs BEFORE the lifecycle creates the directory, so on a
+        # fresh workspace it is the creator. The lifecycle requires 0700 here
+        # (state.db, hook.secret and the pidfile live inside) and re-tightens
+        # anything looser with a warning — a default-mode mkdir would earn every
+        # brand-new workspace that warning for a directory we made a moment
+        # earlier. An existing directory is left as-is (mkdir never chmods);
+        # re-tightening stays the lifecycle's job.
+        coherence_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
         self._merge_yaml_list(coherence_dir / "tracked.yaml", self._managed)
         self._merge_yaml_list(coherence_dir / "strict_mode.yaml", self._managed)
 

--- a/src/ccs/adapters/substrate.py
+++ b/src/ccs/adapters/substrate.py
@@ -395,7 +395,12 @@ def _write_strict_policy(coherence_dir: Path, managed: tuple[str, ...]) -> None:
     for a peer commit to invalidate this reader's cached view."""
     if not managed:
         return
-    coherence_dir.mkdir(parents=True, exist_ok=True)
+    # Runs BEFORE the lifecycle creates the directory, so on a fresh workspace
+    # this is the creator: match the 0700 the lifecycle requires, or every new
+    # workspace spawns with a "tightened existing .coherence directory" warning
+    # about a directory this call made a moment earlier. An existing directory
+    # is left as-is (mkdir never chmods); re-tightening is the lifecycle's job.
+    coherence_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     for name in ("tracked.yaml", "strict_mode.yaml"):
         _merge_yaml_list(coherence_dir / name, managed)
 

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import builtins
 import io
+import logging
 import os
 import subprocess
 import threading
@@ -75,6 +76,32 @@ def test_unmanaged_paths_get_no_strict(tmp_path: Path, fast_cfg: LifecycleConfig
         assert vol.is_attached
         assert vol.strict_mode_active() is False
     finally:
+        stop_coordinator(tmp_path)
+
+
+def test_fresh_workspace_coherence_dir_is_0700_without_tighten_warning(
+    tmp_path: Path, fast_cfg: LifecycleConfig, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The pre-spawn policy write creates ``.coherence/`` itself, ahead of the
+    lifecycle. It must create it at the 0700 the lifecycle requires; otherwise
+    every brand-new workspace spawns with a "tightened existing .coherence
+    directory" warning that blames the operator for a directory the volume
+    created a moment earlier. umask is pinned to 022 so a permissive default
+    ``mkdir`` is observable regardless of the host's setting."""
+    prior_umask = os.umask(0o022)
+    try:
+        caplog.set_level(logging.WARNING, logger="ccs.adapters.claude_code.lifecycle")
+        vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+        assert vol.is_attached
+        assert ((tmp_path / ".coherence").stat().st_mode & 0o777) == 0o700
+        tightened = [
+            r.getMessage()
+            for r in caplog.records
+            if "tightened existing .coherence directory" in r.getMessage()
+        ]
+        assert tightened == []
+    finally:
+        os.umask(prior_umask)
         stop_coordinator(tmp_path)
 
 

--- a/tests/adapters/test_substrate_cross_agent.py
+++ b/tests/adapters/test_substrate_cross_agent.py
@@ -19,6 +19,8 @@ token-identity logic both real bindings use.
 from __future__ import annotations
 
 import hashlib
+import logging
+import os
 from pathlib import Path
 
 import pytest
@@ -197,6 +199,33 @@ def _agent(
 
 def _session(tmp_path: Path, fast_cfg: LifecycleConfig) -> SubstrateCoordinatorSession:
     return SubstrateCoordinatorSession(tmp_path, managed=("**",), config=fast_cfg)
+
+
+# --- spawn: the pre-spawn policy write creates .coherence/ at 0700 ----------
+
+
+def test_spawn_creates_coherence_dir_at_0700_without_tighten_warning(
+    tmp_path: Path, fast_cfg: LifecycleConfig, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The strict-policy write creates ``.coherence/`` ahead of the lifecycle
+    and must do so at the 0700 the lifecycle requires; otherwise every fresh
+    workspace spawns with a "tightened existing .coherence directory" warning
+    about a directory the session itself created a moment earlier. umask is
+    pinned to 022 so a permissive default ``mkdir`` is observable."""
+    prior_umask = os.umask(0o022)
+    try:
+        caplog.set_level(logging.WARNING, logger="ccs.adapters.claude_code.lifecycle")
+        _session(tmp_path, fast_cfg)
+        assert ((tmp_path / ".coherence").stat().st_mode & 0o777) == 0o700
+        tightened = [
+            r.getMessage()
+            for r in caplog.records
+            if "tightened existing .coherence directory" in r.getMessage()
+        ]
+        assert tightened == []
+    finally:
+        os.umask(prior_umask)
+        stop_coordinator(tmp_path)
 
 
 # --- happy: pull invalidation before act (LOAD-BEARING) ---------------------


### PR DESCRIPTION
## Summary
- `CoherentVolume._write_policy_yaml` and `substrate._write_strict_policy` create `.coherence/` before the coordinator lifecycle does, via a default-mode `mkdir`. Under umask 022 that is 0755, so `lifecycle._ensure_coherence_dir` re-tightened it and logged a "tightened existing .coherence directory" warning on every brand-new workspace.
- Both sites now create the directory at `0o700`. `exist_ok` behaviour is unchanged: an existing directory is left as-is, and the lifecycle remains the one that re-tightens a genuinely loose pre-existing directory.
- No other `src/` site creates `.coherence` with the default mode: the lifecycle, `auth.ensure_secret`, and the workspace CLI already pass 0700 or route through `_ensure_coherence_dir`.
- Follow-up: the pending session-handoff example pre-creates `.coherence` at 0700 as a workaround for this; that helper line becomes redundant once this lands.

## Test plan
- [x] New regression tests, one per adapter, pin umask to 022, construct over a fresh workspace, and assert the directory is 0700 with no tighten warning captured on the lifecycle logger. Both failed before the fix and pass after.
- [x] Full suite from the branch: 3836 passed, 48 skipped.
- [x] `ruff check` clean on the touched files.
