### PR TITLE
feat(examples): add the session-handoff demo over a shared scratch file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `agent-coherence` are documented here. The format follows
 
 Alpha — APIs may change before `v1.0`.
 
+## [Unreleased]
+
+### Added
+
+- **Session-handoff demo** (`examples/session_handoff`): two sessions on one
+  host — each a real OS process — share a scratch file and hand work off through
+  a checkpoint. It runs the workaround described in
+  [anthropics/claude-code#60082](https://github.com/anthropics/claude-code/issues/60082)
+  the way people actually run it and pins what the file does under it: plain file
+  I/O loses the second session's line with nothing raised; through
+  `CoherentVolume` the stale write is denied and both lines survive; a control arm
+  with the guard pointed elsewhere shows the loss return. The handoff act shows
+  both honest outcomes of a rewind — clean when the handing-off session has
+  stopped, a bounded `conflict` (never a clobber) when it is still writing.
+  Offline, deterministic, no keys: `python -m examples.session_handoff.main`.
+
 ## [0.14.1] - 2026-09-05
 
 **Four correctness fixes to the read-generation fence and the effect gate, plus the conflict-outcome instrumentation that makes a deny countable.** Every fix in this release closes a window in which a revoked or preempted writer's work was silently admitted; the instrumentation exists so the next thirty days can say how often that happens in the wild, rather than leaving it to argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Alpha — APIs may change before `v1.0`.
   `CoherentVolume` the stale write is denied and both lines survive; a control arm
   with the guard pointed elsewhere shows the loss return. The handoff act shows
   both honest outcomes of a rewind — clean when the handing-off session has
-  stopped, a bounded `conflict` (never a clobber) when it is still writing.
+  stopped writing, a bounded `conflict` (never a clobber) when it is still writing.
   Offline, deterministic, no keys: `python -m examples.session_handoff.main`.
 
 ## [0.14.1] - 2026-09-05

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1291,6 +1291,7 @@ Correctness demos lead; the token-savings / hit-rate demos follow.
 | Effect gate | `python -m examples.effect_gate.main` | `gate()` holds an effect on a stale input; `--baseline` shows the stale fire (offline, no keys) |
 | MCP stale-write guard | `python -m examples.mcp_stale_write_guard.main` | Red→green stale-write deny through the MCP server tools (offline, no keys) |
 | Workspace versioning & restore | `python -m examples.workspace_versioning.main` | Checkpoint a mixed file + S3 workspace, then restore it with per-member honesty (`restored` / `conflict` / delete leg / forward-only skip); `--baseline` shows the unrecoverable loss first (offline, no keys) |
+| Session handoff | `python -m examples.session_handoff.main` | Two sessions, each a real OS process, share a scratch file and hand off through a checkpoint: plain file I/O loses the second session's line with nothing raised; `CoherentVolume` denies the stale write and both lines survive; a rewind lands cleanly when the handing-off session stopped and concludes `conflict` when it is still writing (offline, no keys) |
 | Conversations stale-read | `python -m examples.conversations_stale_read.main` | Two agents share one conversation; client-cache invalidation (offline, no keys) |
 | Cross-host (experimental) | `python examples/cross_host/main.py` | Stale-write deny + effect ordering across a host boundary (local smoke; Docker runner in `examples/cross_host/`) |
 | LangGraph planner | `python -m examples.langgraph_planner.main` | 4-agent, 1 artifact, 75% hit rate |

--- a/examples/session_handoff/README.md
+++ b/examples/session_handoff/README.md
@@ -1,0 +1,68 @@
+# Session handoff demo
+
+Two agent sessions on one machine share a scratch file, `handoff/notes.md`, so
+that "a teammate picks up exactly where you left off" — the workaround people
+describe in [anthropics/claude-code#60082](https://github.com/anthropics/claude-code/issues/60082).
+This demo runs that workaround as two **real OS processes** and shows what the
+file does under it: without coordination, the second session's write quietly
+erases the first session's line; with `CoherentVolume` on the file, the stale
+write is denied and both lines survive. It then hands work off through a
+checkpoint and shows the two honest outcomes of a rewind — clean when the
+handing-off session has stopped, a bounded `conflict` (never a clobber) when it
+is still typing.
+
+Offline, deterministic, no API keys. Every act runs the same read→write
+sequence; only the coordination differs.
+
+## Prerequisites
+
+- Python 3.11+
+- From the repo root: `pip install -e .` (pulls `pyyaml`)
+- Run from the repo root
+
+```bash
+python -m examples.session_handoff.main
+```
+
+Exits `0` only if **all five** hold:
+
+| Act | Sequence | What it pins |
+|-----|----------|--------------|
+| **RED** — plain file I/O | A posts status → B reads, appends its pickup line → A (never re-read) writes its updated status | B's line is **gone**; nothing raised |
+| **GREEN** — `handoff/**` guarded | the same sequence through `CoherentVolume` | A's stale write is **denied** (`StaleView`); A reacquires and rebuilds; both lines survive *exactly* |
+| **CONTROL** — guard pointed elsewhere | the GREEN code with `other/**` as the strict glob | the loss returns — green depends on the deny, not on the re-read |
+| **HANDOFF** — A stopped | A checkpoints, writes once more, stops → B restores the checkpoint → A writes again | restore lands in **one attempt**, disk rewound; A's next write is **denied**, and `reacquire` shows the handoff bytes |
+| **HANDOFF** — A still working | A checkpoints and keeps editing → B restores | restore concludes **`conflict`** after its bounded budget; A's latest edit survives, nothing clobbered |
+
+## Scope, honestly
+
+- **Single host.** Both sessions run on one machine — the shape people are
+  actually using: a shared scratch file between two sessions on the same box.
+  Nothing here makes a cross-host claim.
+- **The workspace half only.** A handoff has two halves: the conversation and
+  the workspace. Only Anthropic can share the conversation; this demo covers the
+  workspace — the file the sessions coordinate through and the checkpoint one
+  hands the other.
+- **Sequenced, not raced.** Each act runs its steps in a fixed order so the
+  result is byte-identical every run. That is also the right model for a
+  handoff: the loss in RED needs no timing window at all — a session that never
+  re-reads before writing loses the other's line every time. In the last act a
+  deterministic stand-in plays "A keeps typing", one edit per restore read.
+- **File members are detection-guarded, never substrate-arbitrated.** The
+  file's version check is the adapter's own detection of a foreign edit; the
+  filesystem does not arbitrate. It catches the stale write and reports the
+  conflict — that is the whole claim.
+- **`restore` is a forward write of old bytes.** It writes the checkpointed
+  content back as a new version; history is never rewritten, and a restore that
+  meets a live writer stops and says so rather than overwriting.
+
+## See also
+
+- [`examples/mcp_stale_write_guard`](../mcp_stale_write_guard) — the same deny
+  through the MCP server's tool contract, which is what a Claude Code session
+  actually calls.
+- [`examples/workspace_versioning`](../workspace_versioning) — the full restore
+  surface across files and S3 objects, with per-member outcomes.
+
+Comparing notes on multi-agent coherence?
+https://github.com/Cohexa-ai/agent-coherence/discussions

--- a/examples/session_handoff/README.md
+++ b/examples/session_handoff/README.md
@@ -8,7 +8,7 @@ file does under it: without coordination, the second session's write quietly
 erases the first session's line; with `CoherentVolume` on the file, the stale
 write is denied and both lines survive. It then hands work off through a
 checkpoint and shows the two honest outcomes of a rewind — clean when the
-handing-off session has stopped, a bounded `conflict` (never a clobber) when it
+handing-off session has stopped writing, a bounded `conflict` (never a clobber) when it
 is still typing.
 
 Offline, deterministic, no API keys. Every act runs the same read→write
@@ -31,7 +31,7 @@ Exits `0` only if **all five** hold:
 | **RED** — plain file I/O | A posts status → B reads, appends its pickup line → A (never re-read) writes its updated status | B's line is **gone**; nothing raised |
 | **GREEN** — `handoff/**` guarded | the same sequence through `CoherentVolume` | A's stale write is **denied** (`StaleView`); A reacquires and rebuilds; both lines survive *exactly* |
 | **CONTROL** — guard pointed elsewhere | the GREEN code with `other/**` as the strict glob | the loss returns — green depends on the deny, not on the re-read |
-| **HANDOFF** — A stopped | A checkpoints, writes once more, stops → B restores the checkpoint → A writes again | restore lands in **one attempt**, disk rewound; A's next write is **denied**, and `reacquire` shows the handoff bytes |
+| **HANDOFF** — A stopped writing | A checkpoints, writes once more, stops writing → B restores the checkpoint → A writes again | restore lands in **one attempt**, disk rewound; A's next write is **denied**, and `reacquire` shows the handoff bytes |
 | **HANDOFF** — A still working | A checkpoints and keeps editing → B restores | restore concludes **`conflict`** after its bounded budget; A's latest edit survives, nothing clobbered |
 
 ## Scope, honestly
@@ -55,6 +55,10 @@ Exits `0` only if **all five** hold:
 - **`restore` is a forward write of old bytes.** It writes the checkpointed
   content back as a new version; history is never rewritten, and a restore that
   meets a live writer stops and says so rather than overwriting.
+- **Both sessions stay open.** In this demo the coordinator runs inside the
+  first session's process, so that session stays open — idle, not exited —
+  while the other one works. A handing-off session that exits, and a teammate
+  who attaches afterwards, is a different shape and is not shown here.
 
 ## See also
 

--- a/examples/session_handoff/__init__.py
+++ b/examples/session_handoff/__init__.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Session-handoff demo: two sessions on one host share a scratch file.
+
+Two long-lived agent sessions — each a REAL OS process holding its own
+``CoherentVolume`` — coordinate through one shared scratch file,
+``handoff/notes.md``, and hand work off asynchronously via a checkpoint. The
+first session to construct its volume spawns the local coordinator; later
+sessions attach to the same one. Offline, deterministic, no API keys.
+
+This module holds only the shared constants so a spawned session process can
+import it cheaply; the process primitive lives in :mod:`.sessions`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from uuid import NAMESPACE_URL, uuid5
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+# Every spawned session process must import ``ccs`` too (the coordinator itself
+# serves in-thread inside the first session's child, so it inherits this path);
+# propagate the src path so the demo runs from a bare checkout (harmless when
+# installed).
+_pp = os.environ.get("PYTHONPATH", "")
+if str(SRC_ROOT) not in _pp.split(os.pathsep):
+    os.environ["PYTHONPATH"] = f"{SRC_ROOT}{os.pathsep}{_pp}" if _pp else str(SRC_ROOT)
+
+from ccs.adapters.claude_code.lifecycle import LifecycleConfig  # noqa: E402
+
+#: The one shared scratch file both sessions read and write.
+NOTES = "handoff/notes.md"
+
+A_STATUS_1 = b"status: migrating tables 1-3\n"
+B_PICKUP = b"pickup: B taking tables 4-6\n"
+A_STATUS_2 = b"status: migrating tables 1-4\n"
+
+#: Strict glob covering ``NOTES`` — the guarded arm.
+GUARDED = ("handoff/**",)
+#: CONTROL: the strict glob deliberately leaves ``NOTES`` outside it, so the
+#: same sequence runs with the deny disabled.
+UNGUARDED = ("other/**",)
+
+#: Stable owner identity for the demo's checkpoint manifests.
+OWNER = uuid5(NAMESPACE_URL, "agent-coherence.examples.session_handoff")
+
+#: Snappy local spawn for a one-command demo. ``idle_shutdown_sec=0`` DISABLES
+#: idle shutdown so the coordinator cannot self-stop mid-run.
+DEMO_CFG = LifecycleConfig(
+    idle_shutdown_sec=0,
+    sweep_interval_sec=0.1,
+    port_file_retry_attempts=40,
+    port_file_retry_interval_sec=0.05,
+    connect_retry_attempts=20,
+    connect_retry_interval_sec=0.05,
+)

--- a/examples/session_handoff/broken.py
+++ b/examples/session_handoff/broken.py
@@ -35,10 +35,6 @@ def new_workspace(act: str) -> Path:
     """Fresh temp workspace for one act, with the notes directory in place."""
     workspace = Path(tempfile.mkdtemp(prefix=f"session_handoff_{act}_"))
     (workspace / NOTES).parent.mkdir(parents=True, exist_ok=True)
-    # The coordinator requires ``.coherence/`` at 0700; the pre-spawn config write
-    # would otherwise create it at 0755, and the coordinator would tighten it and
-    # warn on stderr every act.
-    (workspace / ".coherence").mkdir(mode=0o700)
     return workspace
 
 

--- a/examples/session_handoff/broken.py
+++ b/examples/session_handoff/broken.py
@@ -84,10 +84,14 @@ def run_broken() -> dict[str, object]:
         finally:
             b.close()
     finally:
-        # The workspace is removed even when spawning A itself failed.
-        if a is not None:
-            a.close()
-        shutil.rmtree(workspace, ignore_errors=True)
+        # The workspace is removed even when spawning A itself failed, and even
+        # when close() itself escapes -- an interrupt landing in teardown must
+        # not cost the caller its temp directory.
+        try:
+            if a is not None:
+                a.close()
+        finally:
+            shutil.rmtree(workspace, ignore_errors=True)
     return {
         "act": "red",
         "final": final,

--- a/examples/session_handoff/broken.py
+++ b/examples/session_handoff/broken.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""RED: the handoff as people actually run it — plain file I/O, no coordination.
+
+Session A is mid-task and posts its status to the shared notes file. Teammate
+B picks up: reads the notes and appends its pickup line. A — still working,
+and never re-reading — writes its updated status from the notes it read
+earlier. B's line is gone, and nothing complained. That is the lost update
+over a shared scratch file, here across two REAL OS processes; ``fixed.py``
+runs the same sequence through ``CoherentVolume`` and shows it denied and
+recovered.
+
+This module also hosts the small story vocabulary the other acts reuse
+(``EXPECTED``, ``new_workspace``, ``render_notes``, ``verdict_line``) so every
+act renders its trace the same way.
+
+Deterministic and offline — sequenced, not raced.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+from examples.session_handoff import A_STATUS_1, A_STATUS_2, B_PICKUP, NOTES, UNGUARDED
+from examples.session_handoff.sessions import Session
+
+#: What the notes file holds when BOTH sessions' lines survive.
+EXPECTED = A_STATUS_2 + B_PICKUP
+
+
+def new_workspace(act: str) -> Path:
+    """Fresh temp workspace for one act, with the notes directory in place."""
+    workspace = Path(tempfile.mkdtemp(prefix=f"session_handoff_{act}_"))
+    (workspace / NOTES).parent.mkdir(parents=True, exist_ok=True)
+    return workspace
+
+
+def render_notes(data: bytes) -> str:
+    """One-line rendering of notes-file bytes for the trace (lines joined by ' | ')."""
+    return " | ".join(data.decode().splitlines()) or "<empty>"
+
+
+def verdict_line(final: bytes) -> str:
+    """Closing trace line: what the notes file holds, and whether B's line made it."""
+    if final == EXPECTED:
+        outcome = "both lines survive"
+    elif B_PICKUP not in final:
+        outcome = "B's pickup line is GONE"
+    else:
+        outcome = "unexpected content"
+    return f"notes.md    {render_notes(final)}   ({outcome})"
+
+
+def run_broken() -> dict[str, object]:
+    """Sequenced raw read→write with no coordination; A's second write erases B's line.
+
+    Returns a structured trace so the runner and tests can assert the lost update
+    without parsing prose.
+    """
+    workspace = new_workspace("red")
+    trace: list[str] = []
+    # A Session always carries a volume; this act never touches it. Leaving NOTES
+    # outside the strict glob keeps the arm honest: nothing is coordinating it.
+    a = Session(workspace, "A", UNGUARDED)
+    try:
+        b = Session(workspace, "B", UNGUARDED)
+        try:
+            a.raw_write(A_STATUS_1)
+            trace.append(f"A raw_write {render_notes(A_STATUS_1)}")
+            seen = b.raw_read()
+            trace.append(f"B raw_read  -> {render_notes(seen)}")
+            b.raw_write(seen + B_PICKUP)
+            trace.append(f"B raw_write {render_notes(seen + B_PICKUP)}")
+            # A is still working and never re-read: its update is built from the
+            # notes as they were BEFORE B's pickup, so B's line is not in it.
+            a.raw_write(A_STATUS_2)
+            trace.append(f"A raw_write {render_notes(A_STATUS_2)}   (from its earlier read; never re-read)")
+            final = (workspace / NOTES).read_bytes()
+            trace.append(verdict_line(final))
+        finally:
+            b.close()
+    finally:
+        a.close()
+        shutil.rmtree(workspace, ignore_errors=True)
+    return {
+        "act": "red",
+        "final": final,
+        "expected": EXPECTED,
+        "b_line_present": B_PICKUP in final,
+        "lost": final != EXPECTED,
+        # Plain file I/O has no deny surface, so nothing can complain here; the
+        # key exists so all three acts share one result vocabulary.
+        "raised": None,
+        "trace": trace,
+    }

--- a/examples/session_handoff/broken.py
+++ b/examples/session_handoff/broken.py
@@ -66,10 +66,11 @@ def run_broken() -> dict[str, object]:
     """
     workspace = new_workspace("red")
     trace: list[str] = []
-    # A Session always carries a volume; this act never touches it. Leaving NOTES
-    # outside the strict glob keeps the arm honest: nothing is coordinating it.
-    a = Session(workspace, "A", UNGUARDED)
+    a: Session | None = None
     try:
+        # A Session always carries a volume; this act never touches it. Leaving NOTES
+        # outside the strict glob keeps the arm honest: nothing is coordinating it.
+        a = Session(workspace, "A", UNGUARDED)
         b = Session(workspace, "B", UNGUARDED)
         try:
             a.raw_write(A_STATUS_1)
@@ -87,7 +88,9 @@ def run_broken() -> dict[str, object]:
         finally:
             b.close()
     finally:
-        a.close()
+        # The workspace is removed even when spawning A itself failed.
+        if a is not None:
+            a.close()
         shutil.rmtree(workspace, ignore_errors=True)
     return {
         "act": "red",

--- a/examples/session_handoff/broken.py
+++ b/examples/session_handoff/broken.py
@@ -35,6 +35,10 @@ def new_workspace(act: str) -> Path:
     """Fresh temp workspace for one act, with the notes directory in place."""
     workspace = Path(tempfile.mkdtemp(prefix=f"session_handoff_{act}_"))
     (workspace / NOTES).parent.mkdir(parents=True, exist_ok=True)
+    # The coordinator requires ``.coherence/`` at 0700; the pre-spawn config write
+    # would otherwise create it at 0755, and the coordinator would tighten it and
+    # warn on stderr every act.
+    (workspace / ".coherence").mkdir(mode=0o700)
     return workspace
 
 

--- a/examples/session_handoff/fixed.py
+++ b/examples/session_handoff/fixed.py
@@ -44,8 +44,9 @@ def _run_handoff(act: str, managed: tuple[str, ...]) -> dict[str, object]:
     """
     workspace = new_workspace(act)
     trace: list[str] = []
-    a = Session(workspace, "A", managed)  # first session: spawns the coordinator
+    a: Session | None = None
     try:
+        a = Session(workspace, "A", managed)  # first session: spawns the coordinator
         b = Session(workspace, "B", managed)  # attaches to A's coordinator
         try:
             _post_status_and_pick_up(a, b, trace)
@@ -56,7 +57,9 @@ def _run_handoff(act: str, managed: tuple[str, ...]) -> dict[str, object]:
         finally:
             b.close()
     finally:
-        a.close()
+        # The workspace is removed even when spawning A itself failed.
+        if a is not None:
+            a.close()
         shutil.rmtree(workspace, ignore_errors=True)
     return {
         "act": act,

--- a/examples/session_handoff/fixed.py
+++ b/examples/session_handoff/fixed.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""GREEN and CONTROL: the same handoff, routed through ``CoherentVolume``.
+
+GREEN (``run_guarded``): both sessions manage ``handoff/**``. B's pickup write
+invalidates A's view, so A's stale status write is DENIED (``StaleView``); A
+``reacquire``s, sees B's line, and writes its updated status on top of it.
+Both lines survive.
+
+CONTROL (``run_control``): the identical code path with the strict glob pointed
+elsewhere (``other/**``), so ``handoff/notes.md`` sits outside it and the deny
+is off. A's stale write lands and B's line is lost again — GREEN depends on
+the deny, not on the re-read.
+
+Sequenced, not raced: deterministic by construction. Each session is a real OS
+process (see ``sessions.py``): the first spawns the coordinator, the second
+attaches to it.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+from examples.session_handoff import A_STATUS_1, A_STATUS_2, B_PICKUP, GUARDED, NOTES, UNGUARDED
+from examples.session_handoff.broken import EXPECTED, new_workspace, render_notes, verdict_line
+from examples.session_handoff.sessions import Session, SessionDenied
+
+
+def run_guarded() -> dict[str, object]:
+    """GREEN: strict on ``handoff/**`` — A's stale write is denied, then recovered."""
+    return _run_handoff("green", GUARDED)
+
+
+def run_control() -> dict[str, object]:
+    """CONTROL: strict glob elsewhere — the deny is off, so the loss returns."""
+    return _run_handoff("control", UNGUARDED)
+
+
+def _run_handoff(act: str, managed: tuple[str, ...]) -> dict[str, object]:
+    """A posts status, B picks up, A writes from its earlier view; A recovers iff denied.
+
+    Returns a structured trace mirroring ``run_broken`` for side-by-side asserts.
+    """
+    workspace = new_workspace(act)
+    trace: list[str] = []
+    a = Session(workspace, "A", managed)  # first session: spawns the coordinator
+    try:
+        b = Session(workspace, "B", managed)  # attaches to A's coordinator
+        try:
+            _post_status_and_pick_up(a, b, trace)
+            denial = _write_stale_status(a, trace)
+            recovered = denial is not None and _recover(a, trace)
+            final = (workspace / NOTES).read_bytes()
+            trace.append(verdict_line(final))
+        finally:
+            b.close()
+    finally:
+        a.close()
+        shutil.rmtree(workspace, ignore_errors=True)
+    return {
+        "act": act,
+        "final": final,
+        "expected": EXPECTED,
+        "b_line_present": B_PICKUP in final,
+        "lost": final != EXPECTED,
+        "denied": denial is not None,
+        "denial_exc": denial.exc_name if denial else None,
+        "denial_message": denial.message if denial else None,
+        "recovered": recovered,
+        "trace": trace,
+    }
+
+
+def _post_status_and_pick_up(a: Session, b: Session, trace: list[str]) -> None:
+    """A posts its status; B reads it and appends its pickup line (A's view goes stale)."""
+    a.write(A_STATUS_1)
+    trace.append(f"A write     {render_notes(A_STATUS_1)}")
+    seen = b.read()
+    trace.append(f"B read      -> {render_notes(seen)}")
+    b.write(seen + B_PICKUP)
+    trace.append(f"B write     {render_notes(seen + B_PICKUP)}   (A's view of the notes is now stale)")
+
+
+def _write_stale_status(a: Session, trace: list[str]) -> SessionDenied | None:
+    """A — still working, never re-read — writes its updated status from its earlier view."""
+    try:
+        a.write(A_STATUS_2)
+    except SessionDenied as denied:
+        # Only the exception NAME goes in the trace: the coordinator's reason text
+        # carries a session-id hash and a timestamp, which would make the trace
+        # differ run to run. The verbatim reason travels in ``denial_message``.
+        trace.append(f"A write     {render_notes(A_STATUS_2)}   -> DENIED {denied.exc_name}")
+        return denied
+    trace.append(f"A write     {render_notes(A_STATUS_2)}   (landed; B's line overwritten, nothing raised)")
+    return None
+
+
+def _recover(a: Session, trace: list[str]) -> bool:
+    """After the deny: a mandatory fresh read, then A's update rebuilt FROM those bytes."""
+    fresh = a.reacquire()
+    trace.append(f"A reacquire -> {render_notes(fresh)}")
+    # Rebuild from the fresh bytes rather than from memory: swap A's own status
+    # line, keep everything else (B's pickup line) exactly as it is on disk.
+    updated = fresh.replace(A_STATUS_1, A_STATUS_2, 1)
+    a.write(updated)
+    trace.append(f"A write     {render_notes(updated)}")
+    return True

--- a/examples/session_handoff/fixed.py
+++ b/examples/session_handoff/fixed.py
@@ -22,9 +22,20 @@ from __future__ import annotations
 
 import shutil
 
+from ccs.adapters.claude_code.hook_payloads import STRICT_MODE_DENY_REASON_TEMPLATE
 from examples.session_handoff import A_STATUS_1, A_STATUS_2, B_PICKUP, GUARDED, NOTES, UNGUARDED
 from examples.session_handoff.broken import EXPECTED, new_workspace, render_notes, verdict_line
 from examples.session_handoff.sessions import Session, SessionDenied
+
+#: The coordinator renders every strict-mode deny from one public template; its
+#: fixed lead-in is how a trace can tell a coordinator deny from the file's own
+#: version check (which raises the same ``StaleView`` with a different reason).
+COORDINATOR_DENY_PREFIX = STRICT_MODE_DENY_REASON_TEMPLATE.split("{", 1)[0]
+
+
+def denied_by_coordinator(message: str | None) -> bool:
+    """True when a deny reason came from the coordinator, not from the file's own version check."""
+    return bool(message) and message.startswith(COORDINATOR_DENY_PREFIX)
 
 
 def run_guarded() -> dict[str, object]:

--- a/examples/session_handoff/fixed.py
+++ b/examples/session_handoff/fixed.py
@@ -68,10 +68,14 @@ def _run_handoff(act: str, managed: tuple[str, ...]) -> dict[str, object]:
         finally:
             b.close()
     finally:
-        # The workspace is removed even when spawning A itself failed.
-        if a is not None:
-            a.close()
-        shutil.rmtree(workspace, ignore_errors=True)
+        # The workspace is removed even when spawning A itself failed, and even
+        # when close() itself escapes -- an interrupt landing in teardown must
+        # not cost the caller its temp directory.
+        try:
+            if a is not None:
+                a.close()
+        finally:
+            shutil.rmtree(workspace, ignore_errors=True)
     return {
         "act": act,
         "final": final,

--- a/examples/session_handoff/handoff.py
+++ b/examples/session_handoff/handoff.py
@@ -9,7 +9,8 @@ status write. B picks the checkpoint up and restores it, rewinding the notes to
 the handoff point. What happens next depends on one thing — whether A has
 stopped.
 
-HANDOFF-a (``run_handoff_stopped``): A stopped after that last write. B's
+HANDOFF-a (``run_handoff_stopped``): A has stopped writing after that last
+write (its process stays open — it hosts the coordinator B is attached to). B's
 restore lands cleanly (``restored``, one attempt) and the disk holds the handoff
 bytes again. A finds out only when it next writes: the restore went through the
 versioner's own ledger, never through A's live coordinator view, so A's next
@@ -54,7 +55,7 @@ _Story = Callable[[Path, Session, Session], dict[str, object]]
 
 
 def run_handoff_stopped() -> dict[str, object]:
-    """HANDOFF-a: A stops after the handoff; B's restore rewinds, A learns on its next write."""
+    """HANDOFF-a: A stops writing after the handoff; B's restore rewinds, A learns on its next write."""
     return _with_two_sessions("handoff_stopped", _stopped_story)
 
 
@@ -86,7 +87,7 @@ def _stopped_story(workspace: Path, a: Session, b: Session) -> dict[str, object]
     checkpoint = _post_and_checkpoint(a, "handoff-1", trace)
     checkpoint_id = str(checkpoint["checkpoint_id"])
     a.write(A_STATUS_2)
-    trace.append(f"A write     {render_notes(A_STATUS_2)}   (one more status, then A stops)")
+    trace.append(f"A write     {render_notes(A_STATUS_2)}   (one more status, then A stops writing)")
     members = _pick_up(b, checkpoint_id, trace)
     leg = _single_leg(b.restore(checkpoint_id), trace)
     disk_after_restore = _notes_on_disk(workspace, trace)

--- a/examples/session_handoff/handoff.py
+++ b/examples/session_handoff/handoff.py
@@ -63,23 +63,21 @@ def run_handoff_racing() -> dict[str, object]:
     return _with_two_sessions("handoff_racing", _racing_story)
 
 
-def still_working_bytes(edit: int) -> bytes:
-    """The notes bytes after the racing source's ``edit``-th edit (mirrors ``_StillWorkingSource``)."""
-    return f"status: still working, edit {edit}\n".encode()
-
-
 def _with_two_sessions(act: str, story: _Story) -> dict[str, object]:
     """Fresh workspace, A then B, the story, then B then A closed (reverse creation order)."""
     workspace = new_workspace(act)
-    a = Session(workspace, "A", GUARDED)  # first session: spawns the coordinator
+    a: Session | None = None
     try:
+        a = Session(workspace, "A", GUARDED)  # first session: spawns the coordinator
         b = Session(workspace, "B", GUARDED)  # attaches to A's coordinator
         try:
             return story(workspace, a, b)
         finally:
             b.close()
     finally:
-        a.close()
+        # The workspace is removed even when spawning A itself failed.
+        if a is not None:
+            a.close()
         shutil.rmtree(workspace, ignore_errors=True)
 
 

--- a/examples/session_handoff/handoff.py
+++ b/examples/session_handoff/handoff.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""HANDOFF: A hands work to B through a checkpoint, and the rewind has two outcomes.
+
+Both acts open the same way. A posts its status to the shared notes file,
+checkpoints it (``handoff-1`` / ``handoff-2``), and keeps working: one more
+status write. B picks the checkpoint up and restores it, rewinding the notes to
+the handoff point. What happens next depends on one thing — whether A has
+stopped.
+
+HANDOFF-a (``run_handoff_stopped``): A stopped after that last write. B's
+restore lands cleanly (``restored``, one attempt) and the disk holds the handoff
+bytes again. A finds out only when it next writes: the restore went through the
+versioner's own ledger, never through A's live coordinator view, so A's next
+``write`` re-hashes the disk against the hash it last observed, sees a foreign
+change, and is DENIED (``StaleView``). A ``reacquire``s and reads the handoff
+bytes. Restoring file members while a live session runs bypasses its grants —
+the session learns on its next access.
+
+HANDOFF-b (``run_handoff_racing``): A is STILL WORKING while B restores. Every
+read the restore takes is followed by one more edit from A, so the restore's
+version-CAS is beaten each time (the disk no longer matches what the ledger just
+observed), re-drives from a fresh read, and is beaten again — until the bounded
+re-drive budget exhausts into ``conflict``. A's latest edit survives on disk,
+nothing was clobbered, and B is told. The surprising half: a restore is not an
+overwrite.
+
+Sequenced, not raced: the racing source stands in for A's continued edits
+deterministically, one edit per restore read. Each session is a real OS process
+(see ``sessions.py``): the first spawns the coordinator, the second attaches.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+
+from ccs.adapters.workspace import MAX_RESTORE_LEG_REDRIVES
+from examples.session_handoff import A_STATUS_1, A_STATUS_2, GUARDED, NOTES
+from examples.session_handoff.broken import new_workspace, render_notes
+from examples.session_handoff.sessions import Session, SessionDenied
+
+#: What A tries to write after the rewind: its own last status plus a fresh note.
+A_STATUS_3 = A_STATUS_2 + b"note: added indexes\n"
+
+#: Leg iterations a contended restore is allowed: the first attempt plus every
+#: re-drive. Exhaustion is the ``conflict`` outcome — never a raise, never a
+#: livelock — so this is also the racing act's exact ``attempts`` value.
+RACING_ATTEMPTS = MAX_RESTORE_LEG_REDRIVES + 1
+
+_Story = Callable[[Path, Session, Session], dict[str, object]]
+
+
+def run_handoff_stopped() -> dict[str, object]:
+    """HANDOFF-a: A stops after the handoff; B's restore rewinds, A learns on its next write."""
+    return _with_two_sessions("handoff_stopped", _stopped_story)
+
+
+def run_handoff_racing() -> dict[str, object]:
+    """HANDOFF-b: A is still working during B's restore; the restore concludes ``conflict``."""
+    return _with_two_sessions("handoff_racing", _racing_story)
+
+
+def still_working_bytes(edit: int) -> bytes:
+    """The notes bytes after the racing source's ``edit``-th edit (mirrors ``_StillWorkingSource``)."""
+    return f"status: still working, edit {edit}\n".encode()
+
+
+def _with_two_sessions(act: str, story: _Story) -> dict[str, object]:
+    """Fresh workspace, A then B, the story, then B then A closed (reverse creation order)."""
+    workspace = new_workspace(act)
+    a = Session(workspace, "A", GUARDED)  # first session: spawns the coordinator
+    try:
+        b = Session(workspace, "B", GUARDED)  # attaches to A's coordinator
+        try:
+            return story(workspace, a, b)
+        finally:
+            b.close()
+    finally:
+        a.close()
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def _stopped_story(workspace: Path, a: Session, b: Session) -> dict[str, object]:
+    trace: list[str] = []
+    checkpoint = _post_and_checkpoint(a, "handoff-1", trace)
+    checkpoint_id = str(checkpoint["checkpoint_id"])
+    a.write(A_STATUS_2)
+    trace.append(f"A write     {render_notes(A_STATUS_2)}   (one more status, then A stops)")
+    members = _pick_up(b, checkpoint_id, trace)
+    leg = _single_leg(b.restore(checkpoint_id), trace)
+    disk_after_restore = _notes_on_disk(workspace, trace)
+    denial = _write_after_rewind(a, trace)
+    reacquired = _reacquire(a, trace)
+    return {
+        "act": "handoff_stopped",
+        **_restore_fields(checkpoint_id, members, leg),
+        "disk_after_restore": disk_after_restore,
+        "a_denied": denial is not None,
+        "a_denial_exc": denial.exc_name if denial else None,
+        "a_denial_message": denial.message if denial else None,
+        "a_reacquired": reacquired,
+        "trace": trace,
+    }
+
+
+def _racing_story(workspace: Path, a: Session, b: Session) -> dict[str, object]:
+    trace: list[str] = []
+    checkpoint = _post_and_checkpoint(a, "handoff-2", trace)
+    checkpoint_id = str(checkpoint["checkpoint_id"])
+    a.write(A_STATUS_2)
+    trace.append(f"A write     {render_notes(A_STATUS_2)}   (A is still working)")
+    # ``racing=True`` stands in for A continuing to edit while B restores: every
+    # read the restore takes is followed by one more edit on disk.
+    leg = _single_leg(b.restore(checkpoint_id, racing=True), trace)
+    disk_after_restore = _notes_on_disk(workspace, trace)
+    return {
+        "act": "handoff_racing",
+        **_restore_fields(checkpoint_id, list(checkpoint["members"]), leg),
+        "disk_after_restore": disk_after_restore,
+        "restore_landed": disk_after_restore == A_STATUS_1,
+        "trace": trace,
+    }
+
+
+def _post_and_checkpoint(a: Session, name: str, trace: list[str]) -> dict:
+    """A posts its status and checkpoints the notes under ``name``."""
+    a.write(A_STATUS_1)
+    trace.append(f"A write     {render_notes(A_STATUS_1)}")
+    checkpoint = a.checkpoint(name)
+    # Only the NAME enters the trace: the checkpoint id is a uuid, fresh every run.
+    trace.append(f"A checkpoint {name}")
+    return checkpoint
+
+
+def _pick_up(b: Session, checkpoint_id: str, trace: list[str]) -> list[dict]:
+    """B lists what A left behind: one trace line per checkpoint member."""
+    members = b.members(checkpoint_id)
+    for row in members:
+        trace.append(f"B members   {row['member_path']} ({row['restore_tier']}, {row['pin_state']})")
+    return members
+
+
+def _single_leg(report: dict, trace: list[str]) -> dict:
+    """The restore report's one member leg, traced as B's restore line."""
+    (leg,) = report["members"]
+    # ``detail`` stays out of the trace: it is engine vocabulary, not the story.
+    trace.append(f"B restore   -> {leg['outcome']} (attempts={leg['attempts']})")
+    return leg
+
+
+def _notes_on_disk(workspace: Path, trace: list[str]) -> bytes:
+    """What the notes file holds after B's restore, with the verdict the bytes earn."""
+    data = (workspace / NOTES).read_bytes()
+    if data == A_STATUS_1:
+        verdict = "rewound to the handoff point"
+    else:
+        verdict = "NOT rewound; A's latest edit survives"
+    trace.append(f"notes.md    {render_notes(data)}   ({verdict})")
+    return data
+
+
+def _write_after_rewind(a: Session, trace: list[str]) -> SessionDenied | None:
+    """A's next write, built from its own last write — stale against the restored disk."""
+    try:
+        a.write(A_STATUS_3)
+    except SessionDenied as denied:
+        # Name only in the trace, as GREEN does; the reason travels in ``a_denial_message``.
+        trace.append(f"A write     {render_notes(A_STATUS_3)}   -> DENIED {denied.exc_name}")
+        return denied
+    trace.append(f"A write     {render_notes(A_STATUS_3)}   (landed over the restored bytes; nothing raised)")
+    return None
+
+
+def _reacquire(a: Session, trace: list[str]) -> bytes:
+    """After the deny: a mandatory fresh read, which is how A learns about the rewind."""
+    fresh = a.reacquire()
+    trace.append(f"A reacquire -> {render_notes(fresh)}")
+    return fresh
+
+
+def _restore_fields(checkpoint_id: str, members: list[dict], leg: dict) -> dict[str, object]:
+    """The result keys both acts share: what was checkpointed and how the one leg concluded."""
+    return {
+        "checkpoint_id": checkpoint_id,
+        "members": members,
+        "outcome": leg["outcome"],
+        "attempts": leg["attempts"],
+        "detail": leg["detail"],
+    }

--- a/examples/session_handoff/handoff.py
+++ b/examples/session_handoff/handoff.py
@@ -76,10 +76,14 @@ def _with_two_sessions(act: str, story: _Story) -> dict[str, object]:
         finally:
             b.close()
     finally:
-        # The workspace is removed even when spawning A itself failed.
-        if a is not None:
-            a.close()
-        shutil.rmtree(workspace, ignore_errors=True)
+        # The workspace is removed even when spawning A itself failed, and even
+        # when close() itself escapes -- an interrupt landing in teardown must
+        # not cost the caller its temp directory.
+        try:
+            if a is not None:
+                a.close()
+        finally:
+            shutil.rmtree(workspace, ignore_errors=True)
 
 
 def _stopped_story(workspace: Path, a: Session, b: Session) -> dict[str, object]:

--- a/examples/session_handoff/main.py
+++ b/examples/session_handoff/main.py
@@ -24,18 +24,13 @@ under the ``__main__`` guard at the bottom.
 
 from __future__ import annotations
 
-import sys
 from collections.abc import Callable
-from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-SRC_ROOT = REPO_ROOT / "src"
-if str(SRC_ROOT) not in sys.path:
-    sys.path.insert(0, str(SRC_ROOT))
-
+from ccs.core.exceptions import RESTORE_OUTCOME_CONFLICT, RESTORE_OUTCOME_RESTORED
 from examples.session_handoff import A_STATUS_1, A_STATUS_2, broken, fixed, handoff
 from examples.session_handoff.broken import EXPECTED
-from examples.session_handoff.handoff import RACING_ATTEMPTS, still_working_bytes
+from examples.session_handoff.handoff import RACING_ATTEMPTS
+from examples.session_handoff.sessions import still_working_bytes
 
 #: (result key, act runner, title line) — in the order the story is told: loss first.
 _ACTS: tuple[tuple[str, Callable[[], dict], str], ...] = (
@@ -100,7 +95,7 @@ def _control_checks(control: dict) -> dict[str, bool]:
 def _stopped_checks(stopped: dict) -> dict[str, bool]:
     return {
         "HANDOFF  A stopped: B's restore lands in one attempt; the disk is rewound": (
-            stopped["outcome"] == "restored"
+            stopped["outcome"] == RESTORE_OUTCOME_RESTORED
             and stopped["attempts"] == 1
             and stopped["disk_after_restore"] == A_STATUS_1
         ),
@@ -115,7 +110,7 @@ def _stopped_checks(stopped: dict) -> dict[str, bool]:
 def _racing_checks(racing: dict) -> dict[str, bool]:
     return {
         f"HANDOFF  A still working: restore concludes conflict after {RACING_ATTEMPTS} attempts; A's edit survives": (
-            racing["outcome"] == "conflict"
+            racing["outcome"] == RESTORE_OUTCOME_CONFLICT
             and racing["attempts"] == RACING_ATTEMPTS
             and racing["disk_after_restore"] == still_working_bytes(RACING_ATTEMPTS)
             and not racing["restore_landed"]

--- a/examples/session_handoff/main.py
+++ b/examples/session_handoff/main.py
@@ -6,11 +6,13 @@
 Runs five acts, each with two REAL OS processes, and exits 0 only if ALL hold:
   - RED       — plain file I/O → A's second write erases B's pickup line; nothing raised.
   - GREEN     — the same sequence through ``CoherentVolume`` → A's stale write is
-                DENIED (``StaleView``); A reacquires and both lines survive EXACTLY.
+                DENIED by the coordinator (``StaleView``); A reacquires and both
+                lines survive EXACTLY.
   - CONTROL   — the green code with the guard pointed elsewhere → the loss returns,
                 proving green depends on the deny, not on the re-read.
   - HANDOFF a — A checkpoints, writes once more, stops; B restores → the disk rewinds
-                in one attempt and A learns on its NEXT write (denied, then reacquire).
+                in one attempt and A learns on its NEXT write (denied by the file's
+                own version check, then reacquire).
   - HANDOFF b — A is STILL WORKING while B restores → the restore concludes a bounded
                 ``conflict``; A's latest edit survives; nothing was clobbered.
 
@@ -37,7 +39,7 @@ _ACTS: tuple[tuple[str, Callable[[], dict], str], ...] = (
     ("red", broken.run_broken, "RED — plain file I/O, no coordination"),
     ("green", fixed.run_guarded, "GREEN — the same sequence through CoherentVolume (handoff/** guarded)"),
     ("control", fixed.run_control, "CONTROL — the same code with the guard pointed elsewhere (other/**)"),
-    ("stopped", handoff.run_handoff_stopped, "HANDOFF — A hands off through a checkpoint, then stops"),
+    ("stopped", handoff.run_handoff_stopped, "HANDOFF — A hands off through a checkpoint, then stops writing"),
     ("racing", handoff.run_handoff_racing, "HANDOFF — A hands off through a checkpoint, and is still working"),
 )
 
@@ -72,8 +74,10 @@ def _red_checks(red: dict) -> dict[str, bool]:
 
 def _green_checks(green: dict) -> dict[str, bool]:
     return {
-        "GREEN    A's stale write is denied (StaleView)": (
-            bool(green["denied"]) and green["denial_exc"] == "StaleView"
+        "GREEN    A's stale write is denied by the coordinator (StaleView)": (
+            bool(green["denied"])
+            and green["denial_exc"] == "StaleView"
+            and fixed.denied_by_coordinator(green["denial_message"])
         ),
         "GREEN    A reacquires and rebuilds; both lines survive (exact)": (
             bool(green["recovered"]) and green["final"] == EXPECTED and not green["lost"]
@@ -94,14 +98,16 @@ def _control_checks(control: dict) -> dict[str, bool]:
 
 def _stopped_checks(stopped: dict) -> dict[str, bool]:
     return {
-        "HANDOFF  A stopped: B's restore lands in one attempt; the disk is rewound": (
+        "HANDOFF  A stopped writing: B's restore lands in one attempt; the disk is rewound": (
             stopped["outcome"] == RESTORE_OUTCOME_RESTORED
             and stopped["attempts"] == 1
             and stopped["disk_after_restore"] == A_STATUS_1
         ),
-        "HANDOFF  A stopped: A's next write is denied (StaleView); reacquire shows the handoff bytes": (
+        "HANDOFF  A stopped writing: A's next write is denied by the file's own version check (StaleView); "
+        "reacquire shows the handoff bytes": (
             bool(stopped["a_denied"])
             and stopped["a_denial_exc"] == "StaleView"
+            and not fixed.denied_by_coordinator(stopped["a_denial_message"])
             and stopped["a_reacquired"] == A_STATUS_1
         ),
     }

--- a/examples/session_handoff/main.py
+++ b/examples/session_handoff/main.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Session handoff — loss first, then guarded: two sessions on one host, one shared notes file.
+
+Runs five acts, each with two REAL OS processes, and exits 0 only if ALL hold:
+  - RED       — plain file I/O → A's second write erases B's pickup line; nothing raised.
+  - GREEN     — the same sequence through ``CoherentVolume`` → A's stale write is
+                DENIED (``StaleView``); A reacquires and both lines survive EXACTLY.
+  - CONTROL   — the green code with the guard pointed elsewhere → the loss returns,
+                proving green depends on the deny, not on the re-read.
+  - HANDOFF a — A checkpoints, writes once more, stops; B restores → the disk rewinds
+                in one attempt and A learns on its NEXT write (denied, then reacquire).
+  - HANDOFF b — A is STILL WORKING while B restores → the restore concludes a bounded
+                ``conflict``; A's latest edit survives; nothing was clobbered.
+
+Constructed, deterministic, offline (a local coordinator; loopback only, no network).
+
+    python -m examples.session_handoff.main
+
+Every session is a spawned child that re-imports this module, so all work stays
+under the ``__main__`` guard at the bottom.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from examples.session_handoff import A_STATUS_1, A_STATUS_2, broken, fixed, handoff
+from examples.session_handoff.broken import EXPECTED
+from examples.session_handoff.handoff import RACING_ATTEMPTS, still_working_bytes
+
+#: (result key, act runner, title line) — in the order the story is told: loss first.
+_ACTS: tuple[tuple[str, Callable[[], dict], str], ...] = (
+    ("red", broken.run_broken, "RED — plain file I/O, no coordination"),
+    ("green", fixed.run_guarded, "GREEN — the same sequence through CoherentVolume (handoff/** guarded)"),
+    ("control", fixed.run_control, "CONTROL — the same code with the guard pointed elsewhere (other/**)"),
+    ("stopped", handoff.run_handoff_stopped, "HANDOFF — A hands off through a checkpoint, then stops"),
+    ("racing", handoff.run_handoff_racing, "HANDOFF — A hands off through a checkpoint, and is still working"),
+)
+
+
+def _show_act(title: str, result: dict) -> None:
+    """One act's title line and its trace, indented."""
+    print(title)
+    for line in result["trace"]:
+        print(f"  {line}")
+    if result.get("a_denial_message"):
+        # Only the HANDOFF reason is printed: it is a fixed string. GREEN's reason
+        # embeds a session hash and a timestamp, so it never reaches stdout.
+        print(f"  deny reason A saw: {result['a_denial_message']}")
+    print()
+
+
+def _run_acts() -> dict[str, dict]:
+    results: dict[str, dict] = {}
+    for key, run, title in _ACTS:
+        results[key] = run()
+        _show_act(title, results[key])
+    return results
+
+
+def _red_checks(red: dict) -> dict[str, bool]:
+    return {
+        "RED      plain file I/O: B's pickup line is gone and nothing raised": (
+            red["raised"] is None and red["final"] == A_STATUS_2 and not red["b_line_present"] and bool(red["lost"])
+        ),
+    }
+
+
+def _green_checks(green: dict) -> dict[str, bool]:
+    return {
+        "GREEN    A's stale write is denied (StaleView)": (
+            bool(green["denied"]) and green["denial_exc"] == "StaleView"
+        ),
+        "GREEN    A reacquires and rebuilds; both lines survive (exact)": (
+            bool(green["recovered"]) and green["final"] == EXPECTED and not green["lost"]
+        ),
+    }
+
+
+def _control_checks(control: dict) -> dict[str, bool]:
+    return {
+        "CONTROL  with the guard off, the loss returns": (
+            not control["denied"]
+            and bool(control["lost"])
+            and not control["b_line_present"]
+            and control["final"] == A_STATUS_2
+        ),
+    }
+
+
+def _stopped_checks(stopped: dict) -> dict[str, bool]:
+    return {
+        "HANDOFF  A stopped: B's restore lands in one attempt; the disk is rewound": (
+            stopped["outcome"] == "restored"
+            and stopped["attempts"] == 1
+            and stopped["disk_after_restore"] == A_STATUS_1
+        ),
+        "HANDOFF  A stopped: A's next write is denied (StaleView); reacquire shows the handoff bytes": (
+            bool(stopped["a_denied"])
+            and stopped["a_denial_exc"] == "StaleView"
+            and stopped["a_reacquired"] == A_STATUS_1
+        ),
+    }
+
+
+def _racing_checks(racing: dict) -> dict[str, bool]:
+    return {
+        f"HANDOFF  A still working: restore concludes conflict after {RACING_ATTEMPTS} attempts; A's edit survives": (
+            racing["outcome"] == "conflict"
+            and racing["attempts"] == RACING_ATTEMPTS
+            and racing["disk_after_restore"] == still_working_bytes(RACING_ATTEMPTS)
+            and not racing["restore_landed"]
+        ),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    # ``argv`` is accepted for parity with the other demos' runners; there are no
+    # flags — RED always runs first (loss first, then the guard).
+    print("session handoff — two sessions on one host, one shared notes file (loss first, then guarded).")
+    print("Same read→write sequence each time; only the coordination differs.\n")
+
+    results = _run_acts()
+
+    # Exact pins, not inequalities: a green that merely "differs from the broken
+    # value" could still be wrong.
+    checks = {
+        **_red_checks(results["red"]),
+        **_green_checks(results["green"]),
+        **_control_checks(results["control"]),
+        **_stopped_checks(results["stopped"]),
+        **_racing_checks(results["racing"]),
+    }
+    for label, passed in checks.items():
+        print(f"  [{'ok' if passed else 'FAIL'}] {label}")
+
+    ok = all(checks.values())
+    print("\nGREEN" if ok else "\nRED — a check failed; do not trust this build")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/session_handoff/sessions.py
+++ b/examples/session_handoff/sessions.py
@@ -9,9 +9,10 @@ sessions are therefore two processes, exactly as two agent sessions on one
 host would be; the first child to construct its volume spawns the coordinator
 (an in-process serving thread) and every later child attaches to it.
 
-Commands cross a spawn-context queue pair and come back typed: a typed
-coordinator deny — ``StaleView`` or ``CommitPreempted`` — surfaces in the parent
-as :class:`SessionDenied`; anything else the child raises, including any other
+Commands cross a spawn-context queue pair and come back typed: one of the
+volume's typed denies — ``StaleView`` or ``CommitPreempted``, from the
+coordinator or from the file's own version check — surfaces in the parent as
+:class:`SessionDenied`; anything else the child raises, including any other
 ``CoherenceError`` (an unreachable coordinator, an unknown checkpoint), surfaces
 as :class:`SessionError` carrying the child's traceback. Checkpoint and restore
 run in the child too, over a per-command ``WorkspaceVersioner`` — the ledger
@@ -51,8 +52,9 @@ _KIND_ERROR = "error"
 
 
 class SessionDenied(Exception):
-    """The child's coordinator denied the operation: a typed deny, ``StaleView``
-    or ``CommitPreempted``. Every other child-side failure is a :class:`SessionError`."""
+    """One of the volume's typed denies — ``StaleView`` or ``CommitPreempted`` —
+    raised by the coordinator or by the file's own version check. Every other
+    child-side failure is a :class:`SessionError`."""
 
     def __init__(self, exc_name: str, message: str) -> None:
         super().__init__(f"{exc_name}: {message}")
@@ -146,7 +148,12 @@ class Session:
         try:
             if self._proc.is_alive():
                 self._cmd_q.put(("stop",))
-                with suppress(SessionError):
+                # Both channel types, because the wait is not correlated to the
+                # command: an interrupt that abandoned an earlier reply leaves it
+                # in the queue, and this wait collects THAT instead of the stop
+                # reply. Teardown must swallow it either way -- callers run
+                # close() and their workspace cleanup from one ``finally``.
+                with suppress(SessionError, SessionDenied):
                     self._await_reply("stop", _STOP_TIMEOUT_SEC)
             self._proc.join(timeout=_JOIN_TIMEOUT_SEC)
         finally:

--- a/examples/session_handoff/sessions.py
+++ b/examples/session_handoff/sessions.py
@@ -215,6 +215,11 @@ class Session:
 # --- child side ---------------------------------------------------------------
 
 
+def still_working_bytes(edit: int) -> bytes:
+    """The notes bytes after the racing source's ``edit``-th edit — the one place this format lives."""
+    return f"status: still working, edit {edit}\n".encode()
+
+
 class _StillWorkingSource:
     """Wrap a ``WorkingTreeSource``: every read of ``NOTES`` is followed by a
     fresh edit to the disk file — the handing-off session is still typing. The
@@ -231,7 +236,7 @@ class _StillWorkingSource:
         observed = self._inner.read_with_version(path)
         if path == NOTES:
             self._edits += 1
-            (self._workspace / NOTES).write_bytes(f"status: still working, edit {self._edits}\n".encode())
+            (self._workspace / NOTES).write_bytes(still_working_bytes(self._edits))
         return observed
 
     def write_cas_at(self, path: str, expected_version: int, new_content: bytes) -> None:
@@ -358,7 +363,9 @@ def _session_main(
                 value = _dispatch(op, args, state)
             reply_q.put((_KIND_OK, value, None, None, None))
         except CoherenceError as exc:
-            reply_q.put((_KIND_DENIED, None, type(exc).__name__, str(exc), traceback.format_exc()))
+            # A deny carries no traceback: the parent raises SessionDenied from the
+            # name and message alone, so formatting one here would only be discarded.
+            reply_q.put((_KIND_DENIED, None, type(exc).__name__, str(exc), None))
         except BaseException as exc:  # noqa: BLE001 - the channel carries everything
             reply_q.put((_KIND_ERROR, None, type(exc).__name__, str(exc), traceback.format_exc()))
             if op == "stop":

--- a/examples/session_handoff/sessions.py
+++ b/examples/session_handoff/sessions.py
@@ -9,10 +9,11 @@ sessions are therefore two processes, exactly as two agent sessions on one
 host would be; the first child to construct its volume spawns the coordinator
 (an in-process serving thread) and every later child attaches to it.
 
-Commands cross a spawn-context queue pair and come back typed: a coordinator
-deny (any ``CoherenceError``, e.g. ``StaleView``) surfaces in the parent as
-:class:`SessionDenied`; anything else the child raises surfaces as
-:class:`SessionError` carrying the child's traceback. Checkpoint and restore
+Commands cross a spawn-context queue pair and come back typed: a typed
+coordinator deny — ``StaleView`` or ``CommitPreempted`` — surfaces in the parent
+as :class:`SessionDenied`; anything else the child raises, including any other
+``CoherenceError`` (an unreachable coordinator, an unknown checkpoint), surfaces
+as :class:`SessionError` carrying the child's traceback. Checkpoint and restore
 run in the child too, over a per-command ``WorkspaceVersioner`` — the ledger
 is opened, used, and closed inside each command, never held across commands.
 
@@ -42,6 +43,7 @@ _REPLY_TIMEOUT_SEC = 60.0
 _STOP_TIMEOUT_SEC = 30.0
 _JOIN_TIMEOUT_SEC = 10.0
 _POLL_SEC = 0.05
+_PARENT_WATCH_SEC = 1.0
 
 _KIND_OK = "ok"
 _KIND_DENIED = "denied"
@@ -49,7 +51,8 @@ _KIND_ERROR = "error"
 
 
 class SessionDenied(Exception):
-    """The child's coordinator denied the operation (a ``CoherenceError``)."""
+    """The child's coordinator denied the operation: a typed deny, ``StaleView``
+    or ``CommitPreempted``. Every other child-side failure is a :class:`SessionError`."""
 
     def __init__(self, exc_name: str, message: str) -> None:
         super().__init__(f"{exc_name}: {message}")
@@ -338,17 +341,37 @@ def _dispatch(op: str, args: tuple[Any, ...], state: dict[str, Any]) -> Any:
     raise ValueError(f"unknown session command {op!r}")
 
 
+def _next_command(cmd_q: Any) -> tuple[Any, ...] | None:  # pragma: no cover - runs in the spawned child
+    """Wait for the next command; ``None`` once the parent process is gone.
+
+    A waiting ``get`` still returns the moment a command lands; the timeout only
+    bounds how long the child goes without checking that its parent is alive.
+    """
+    while True:
+        with suppress(queue.Empty):
+            return tuple(cmd_q.get(timeout=_PARENT_WATCH_SEC))
+        parent = multiprocessing.parent_process()
+        if parent is None or not parent.is_alive():
+            return None
+
+
 def _session_main(
     cmd_q: Any, reply_q: Any, workspace_str: str, role: str, managed: tuple[str, ...]
 ) -> None:  # pragma: no cover - runs in the spawned child
     # Imported here so the child pays for the volume runtime only once alive.
     from ccs.adapters.claude_code.lifecycle import stop_coordinator
     from ccs.adapters.coherent_volume import CoherentVolume
-    from ccs.core.exceptions import CoherenceError
+    from ccs.core.exceptions import CommitPreempted, StaleView
 
     state: dict[str, Any] = {"workspace": Path(workspace_str), "role": role, "volume": None}
     while True:
-        command = cmd_q.get()
+        command = _next_command(cmd_q)
+        if command is None:
+            # ``daemon=True`` reaps this child only through the parent's atexit
+            # hook, which a hard kill (SIGKILL, OOM, CI timeout) never runs; an
+            # unbounded ``get`` would then block forever holding the coordinator.
+            stop_coordinator(state["workspace"])
+            return
         op, args = command[0], tuple(command[1:])
         try:
             if op == "stop":
@@ -362,7 +385,10 @@ def _session_main(
             else:
                 value = _dispatch(op, args, state)
             reply_q.put((_KIND_OK, value, None, None, None))
-        except CoherenceError as exc:
+        except (StaleView, CommitPreempted) as exc:
+            # Only the volume's typed denies are denies; any other CoherenceError
+            # (unreachable coordinator, CheckpointUnknown, ...) is a failure and
+            # keeps its traceback via the branch below.
             # A deny carries no traceback: the parent raises SessionDenied from the
             # name and message alone, so formatting one here would only be discarded.
             reply_q.put((_KIND_DENIED, None, type(exc).__name__, str(exc), None))

--- a/examples/session_handoff/sessions.py
+++ b/examples/session_handoff/sessions.py
@@ -1,0 +1,365 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""The ``Session`` primitive: one agent session = one real OS process.
+
+A :class:`Session` lives in the demo's parent process and drives a long-lived
+spawned child that holds ONE ``CoherentVolume`` over the shared workspace. Two
+sessions are therefore two processes, exactly as two agent sessions on one
+host would be; the first child to construct its volume spawns the coordinator
+(an in-process serving thread) and every later child attaches to it.
+
+Commands cross a spawn-context queue pair and come back typed: a coordinator
+deny (any ``CoherenceError``, e.g. ``StaleView``) surfaces in the parent as
+:class:`SessionDenied`; anything else the child raises surfaces as
+:class:`SessionError` carrying the child's traceback. Checkpoint and restore
+run in the child too, over a per-command ``WorkspaceVersioner`` — the ledger
+is opened, used, and closed inside each command, never held across commands.
+
+Teardown order matters: close sessions in reverse creation order. Closing the
+FIRST session stops the coordinator its child spawned, which attached sessions
+still need.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import queue
+import time
+import traceback
+from contextlib import contextmanager, suppress
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid5
+
+from ccs.adapters.workspace import WorkspaceVersioner
+from ccs.cli.workspace import RetainedContentResolver, WorkingTreeSource
+from ccs.coordinator.service import CoordinatorService
+from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+from examples.session_handoff import DEMO_CFG, NOTES, OWNER
+
+_REPLY_TIMEOUT_SEC = 60.0
+_STOP_TIMEOUT_SEC = 30.0
+_JOIN_TIMEOUT_SEC = 10.0
+_POLL_SEC = 0.05
+
+_KIND_OK = "ok"
+_KIND_DENIED = "denied"
+_KIND_ERROR = "error"
+
+
+class SessionDenied(Exception):
+    """The child's coordinator denied the operation (a ``CoherenceError``)."""
+
+    def __init__(self, exc_name: str, message: str) -> None:
+        super().__init__(f"{exc_name}: {message}")
+        self.exc_name = exc_name
+        self.message = message
+
+
+class SessionError(Exception):
+    """Any other child-side failure, with the child's traceback attached."""
+
+    def __init__(self, exc_name: str, message: str, traceback_text: str) -> None:
+        super().__init__(f"{exc_name}: {message}")
+        self.exc_name = exc_name
+        self.message = message
+        self.traceback = traceback_text
+
+
+class Session:
+    """Parent-side handle on one spawned session process.
+
+    Constructing a ``Session`` spawns its child and eagerly builds the child's
+    ``CoherentVolume`` (the ``init`` command), so the first ``Session`` created
+    is the one whose child spawns the coordinator.
+    """
+
+    def __init__(self, workspace: Path, role: str, managed: tuple[str, ...]) -> None:
+        self.role = role
+        self._workspace = Path(workspace).resolve()
+        self._closed = False
+        ctx = multiprocessing.get_context("spawn")
+        self._cmd_q = ctx.Queue()
+        self._reply_q = ctx.Queue()
+        self._proc = ctx.Process(
+            target=_session_main,
+            args=(self._cmd_q, self._reply_q, str(self._workspace), role, tuple(managed)),
+            daemon=True,
+        )
+        self._proc.start()
+        try:
+            self._call("init")
+        except BaseException:
+            self._terminate()
+            self._release_queues()
+            self._closed = True
+            raise
+
+    # -- identity -----------------------------------------------------------
+
+    @property
+    def pid(self) -> int:
+        """OS pid of the child process."""
+        return int(self._proc.pid or 0)
+
+    # -- plain file I/O (no CoherentVolume; the unguarded baseline) -----------
+
+    def raw_read(self) -> bytes:
+        return self._call("raw_read")
+
+    def raw_write(self, data: bytes) -> None:
+        self._call("raw_write", bytes(data))
+
+    # -- CoherentVolume ------------------------------------------------------
+
+    def read(self) -> bytes:
+        return self._call("read")
+
+    def write(self, data: bytes) -> None:
+        self._call("write", bytes(data))
+
+    def reacquire(self) -> bytes:
+        return self._call("reacquire")
+
+    # -- checkpoint / restore -------------------------------------------------
+
+    def checkpoint(self, name: str) -> dict:
+        return self._call("checkpoint", name)
+
+    def members(self, checkpoint_id: str) -> list[dict]:
+        return self._call("members", checkpoint_id)
+
+    def restore(self, checkpoint_id: str, *, racing: bool = False) -> dict:
+        return self._call("restore", checkpoint_id, bool(racing))
+
+    # -- lifecycle -------------------------------------------------------------
+
+    def close(self) -> None:
+        """Stop the child (and, in the spawner, the coordinator); never hangs."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self._proc.is_alive():
+                self._cmd_q.put(("stop",))
+                with suppress(SessionError):
+                    self._await_reply("stop", _STOP_TIMEOUT_SEC)
+            self._proc.join(timeout=_JOIN_TIMEOUT_SEC)
+        finally:
+            if self._proc.is_alive():
+                self._terminate()
+            self._release_queues()
+
+    def __enter__(self) -> "Session":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    # -- the channel -----------------------------------------------------------
+
+    def _call(self, op: str, *args: Any) -> Any:
+        if self._closed:
+            raise SessionError("RuntimeError", f"session {self.role!r} is closed", "")
+        self._cmd_q.put((op, *args))
+        return self._await_reply(op, _REPLY_TIMEOUT_SEC)
+
+    def _await_reply(self, op: str, timeout_sec: float) -> Any:
+        """Bounded wait; a dead or hung child is a typed ``SessionError``, never a stall."""
+        deadline = time.monotonic() + timeout_sec
+        while True:
+            with suppress(queue.Empty):
+                return self._unpack(self._reply_q.get(timeout=_POLL_SEC))
+            if not self._proc.is_alive():
+                raise SessionError(
+                    "ChildExited",
+                    f"session {self.role!r} exited (code {self._proc.exitcode}) before answering {op!r}",
+                    "",
+                )
+            if time.monotonic() >= deadline:
+                self._terminate()
+                raise SessionError(
+                    "TimeoutError",
+                    f"session {self.role!r} did not answer {op!r} within {timeout_sec}s; terminated",
+                    "",
+                )
+
+    @staticmethod
+    def _unpack(reply: tuple[Any, ...]) -> Any:
+        kind, value, exc_name, exc_str, tb_text = reply
+        if kind == _KIND_OK:
+            return value
+        if kind == _KIND_DENIED:
+            raise SessionDenied(exc_name, exc_str)
+        raise SessionError(exc_name, exc_str, tb_text or "")
+
+    def _terminate(self) -> None:
+        if not self._proc.is_alive():
+            return
+        self._proc.terminate()
+        self._proc.join(timeout=5.0)
+        if self._proc.is_alive():  # pragma: no cover - stubborn child
+            self._proc.kill()
+            self._proc.join(timeout=5.0)
+
+    def _release_queues(self) -> None:
+        # cancel_join_thread first: a queue whose feeder still holds an item the
+        # (dead) child never consumed would otherwise block close() forever.
+        for q in (self._cmd_q, self._reply_q):
+            with suppress(Exception):
+                q.cancel_join_thread()
+                q.close()
+
+
+# --- child side ---------------------------------------------------------------
+
+
+class _StillWorkingSource:
+    """Wrap a ``WorkingTreeSource``: every read of ``NOTES`` is followed by a
+    fresh edit to the disk file — the handing-off session is still typing. The
+    restorer's comparand is therefore stale by the time it CASes; the leg
+    re-drives, reads again, and is beaten again, until the bounded budget
+    exhausts into the honest absorbing ``conflict`` (nothing clobbered)."""
+
+    def __init__(self, inner: WorkingTreeSource, workspace: Path) -> None:
+        self._inner = inner
+        self._workspace = workspace
+        self._edits = 0
+
+    def read_with_version(self, path: str) -> tuple[bytes, int]:
+        observed = self._inner.read_with_version(path)
+        if path == NOTES:
+            self._edits += 1
+            (self._workspace / NOTES).write_bytes(f"status: still working, edit {self._edits}\n".encode())
+        return observed
+
+    def write_cas_at(self, path: str, expected_version: int, new_content: bytes) -> None:
+        # Spelled out rather than left to __getattr__: the restore pre-flight
+        # checks the FileRestoreTarget protocol statically, which never sees
+        # attributes that only resolve through __getattr__.
+        self._inner.write_cas_at(path, expected_version, new_content)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
+def _open_registry(workspace: Path) -> SqliteArtifactRegistry:
+    return SqliteArtifactRegistry(workspace / ".coherence" / "workspace.db", retain_versions=True)
+
+
+@contextmanager
+def _versioner(workspace: Path, role: str, *, racing: bool = False) -> Iterator[WorkspaceVersioner]:
+    """Per-command versioner over the workspace ledger: open → use → close."""
+    registry = _open_registry(workspace)
+    try:
+        service = CoordinatorService(registry)
+        source: Any = WorkingTreeSource(workspace, registry, uuid5(OWNER, role))
+        if racing:
+            source = _StillWorkingSource(source, workspace)
+        resolver = RetainedContentResolver(registry)
+        versioner = WorkspaceVersioner(service=service, owner=OWNER, file_resolver=resolver)
+        versioner.add_file_member(source, NOTES)
+        yield versioner
+    finally:
+        registry.close()
+
+
+def _member_row(member: Any) -> dict:
+    return {
+        "member_path": member.member_path,
+        "restore_tier": member.restore_tier,
+        "pin_state": member.pin_state,
+    }
+
+
+def _checkpoint(workspace: Path, role: str, name: str) -> dict:
+    with _versioner(workspace, role) as versioner:
+        result = versioner.checkpoint(name)
+    return {
+        "checkpoint_id": result.record.checkpoint_id,
+        "members": [_member_row(m) for m in result.members],
+    }
+
+
+def _members(workspace: Path, checkpoint_id: str) -> list[dict]:
+    registry = _open_registry(workspace)
+    try:
+        return [_member_row(m) for m in registry.get_checkpoint_members(checkpoint_id)]
+    finally:
+        registry.close()
+
+
+def _restore(workspace: Path, role: str, checkpoint_id: str, *, racing: bool) -> dict:
+    with _versioner(workspace, role, racing=racing) as versioner:
+        report = versioner.restore(checkpoint_id)
+    return {
+        "members": [
+            {
+                "member_path": m.member_path,
+                "outcome": m.outcome,
+                "attempts": m.attempts,
+                "detail": m.detail,
+            }
+            for m in report.members
+        ]
+    }
+
+
+def _dispatch(op: str, args: tuple[Any, ...], state: dict[str, Any]) -> Any:
+    workspace: Path = state["workspace"]
+    role: str = state["role"]
+    if op == "raw_read":
+        return (workspace / NOTES).read_bytes()
+    if op == "raw_write":
+        (workspace / NOTES).write_bytes(args[0])
+        return None
+    if op == "checkpoint":
+        return _checkpoint(workspace, role, args[0])
+    if op == "members":
+        return _members(workspace, args[0])
+    if op == "restore":
+        return _restore(workspace, role, args[0], racing=args[1])
+    volume = state["volume"]
+    if volume is None:
+        raise RuntimeError("session volume is not initialised")
+    if op == "read":
+        return volume.read(NOTES)
+    if op == "write":
+        volume.write(NOTES, args[0])
+        return None
+    if op == "reacquire":
+        return volume.reacquire(NOTES)
+    raise ValueError(f"unknown session command {op!r}")
+
+
+def _session_main(
+    cmd_q: Any, reply_q: Any, workspace_str: str, role: str, managed: tuple[str, ...]
+) -> None:  # pragma: no cover - runs in the spawned child
+    # Imported here so the child pays for the volume runtime only once alive.
+    from ccs.adapters.claude_code.lifecycle import stop_coordinator
+    from ccs.adapters.coherent_volume import CoherentVolume
+    from ccs.core.exceptions import CoherenceError
+
+    state: dict[str, Any] = {"workspace": Path(workspace_str), "role": role, "volume": None}
+    while True:
+        command = cmd_q.get()
+        op, args = command[0], tuple(command[1:])
+        try:
+            if op == "stop":
+                # ``stop_coordinator`` only knows coordinators spawned in THIS
+                # process: True in the spawner's child, a no-op False elsewhere.
+                reply_q.put((_KIND_OK, stop_coordinator(state["workspace"]), None, None, None))
+                return
+            if op == "init":
+                state["volume"] = CoherentVolume(state["workspace"], managed=managed, config=DEMO_CFG)
+                value = None
+            else:
+                value = _dispatch(op, args, state)
+            reply_q.put((_KIND_OK, value, None, None, None))
+        except CoherenceError as exc:
+            reply_q.put((_KIND_DENIED, None, type(exc).__name__, str(exc), traceback.format_exc()))
+        except BaseException as exc:  # noqa: BLE001 - the channel carries everything
+            reply_q.put((_KIND_ERROR, None, type(exc).__name__, str(exc), traceback.format_exc()))
+            if op == "stop":
+                return

--- a/tests/test_session_handoff_demo.py
+++ b/tests/test_session_handoff_demo.py
@@ -130,3 +130,51 @@ def test_control_with_guard_off_loses_again() -> None:
     assert result["b_line_present"] is False
     assert result["lost"] is True
     assert result["trace"] and all(isinstance(line, str) for line in result["trace"])
+
+
+# --- the fourth act: HANDOFF (A stopped / A still working) -------------------------------
+
+
+def test_handoff_stopped_rewinds_and_a_learns_on_next_write() -> None:
+    from examples.session_handoff.handoff import run_handoff_stopped
+
+    result = run_handoff_stopped()
+
+    assert result["act"] == "handoff_stopped"
+    assert isinstance(result["checkpoint_id"], str) and result["checkpoint_id"]
+    assert len(result["members"]) == 1
+    assert result["members"][0]["member_path"] == NOTES
+    assert result["members"][0]["restore_tier"] == "restorable-unpinned"
+    assert result["members"][0]["pin_state"] == "held"
+    assert result["outcome"] == "restored"
+    assert result["attempts"] == 1
+    assert result["detail"]
+    assert result["disk_after_restore"] == A_STATUS_1  # rewound to the handoff point
+    assert result["a_denied"] is True  # A learns on its NEXT write, not at restore time
+    assert result["a_denial_exc"] == "StaleView"
+    assert result["a_denial_message"]
+    assert result["a_reacquired"] == A_STATUS_1
+    assert result["trace"] and all(isinstance(line, str) for line in result["trace"])
+    assert result["checkpoint_id"] not in "\n".join(result["trace"])  # the uuid never enters the trace
+
+
+def test_handoff_racing_concludes_conflict_not_clobber() -> None:
+    from ccs.adapters.workspace import MAX_RESTORE_LEG_REDRIVES
+    from examples.session_handoff.handoff import RACING_ATTEMPTS, run_handoff_racing, still_working_bytes
+
+    result = run_handoff_racing()
+
+    # The leg budget admits the initial attempt plus every re-drive, then concludes.
+    assert RACING_ATTEMPTS == MAX_RESTORE_LEG_REDRIVES + 1
+    assert result["act"] == "handoff_racing"
+    assert isinstance(result["checkpoint_id"], str) and result["checkpoint_id"]
+    assert len(result["members"]) == 1 and result["members"][0]["member_path"] == NOTES
+    assert result["outcome"] == "conflict"
+    assert result["attempts"] == RACING_ATTEMPTS
+    assert "re-drive budget exhausted" in result["detail"]
+    # One racing edit per admitted attempt, so the last edit index equals the attempt count.
+    assert still_working_bytes(RACING_ATTEMPTS) == f"status: still working, edit {RACING_ATTEMPTS}\n".encode()
+    assert result["disk_after_restore"] == still_working_bytes(RACING_ATTEMPTS)
+    assert result["restore_landed"] is False  # A's work survives; nothing was clobbered
+    assert result["trace"] and all(isinstance(line, str) for line in result["trace"])
+    assert result["checkpoint_id"] not in "\n".join(result["trace"])

--- a/tests/test_session_handoff_demo.py
+++ b/tests/test_session_handoff_demo.py
@@ -178,3 +178,12 @@ def test_handoff_racing_concludes_conflict_not_clobber() -> None:
     assert result["restore_landed"] is False  # A's work survives; nothing was clobbered
     assert result["trace"] and all(isinstance(line, str) for line in result["trace"])
     assert result["checkpoint_id"] not in "\n".join(result["trace"])
+
+
+# --- the runner: all five acts under one exit code -----------------------------------------
+
+
+def test_session_handoff_demo_exits_zero() -> None:
+    from examples.session_handoff.main import main
+
+    assert main([]) == 0

--- a/tests/test_session_handoff_demo.py
+++ b/tests/test_session_handoff_demo.py
@@ -80,3 +80,53 @@ def test_two_sessions_are_distinct_processes(workspace: Path) -> None:
     with Session(workspace, "A", GUARDED) as a, Session(workspace, "B", GUARDED) as b:
         assert a.pid != b.pid
         assert os.getpid() not in {a.pid, b.pid}
+
+
+# --- the three acts: RED, GREEN, CONTROL -------------------------------------------------
+
+
+def test_red_loses_the_pickup_line() -> None:
+    from examples.session_handoff.broken import run_broken
+
+    result = run_broken()
+
+    assert result["act"] == "red"
+    assert result["raised"] is None  # plain file I/O: nothing complained
+    assert result["final"] == A_STATUS_2  # B's pickup line is gone
+    assert result["expected"] == A_STATUS_2 + B_PICKUP
+    assert result["b_line_present"] is False
+    assert result["lost"] is True
+    assert result["trace"] and all(isinstance(line, str) for line in result["trace"])
+
+
+def test_green_denies_then_both_lines_survive() -> None:
+    from examples.session_handoff.fixed import run_guarded
+
+    result = run_guarded()
+
+    assert result["act"] == "green"
+    assert result["denied"] is True
+    assert result["denial_exc"] == "StaleView"
+    assert result["denial_message"]  # the coordinator's reason travels verbatim
+    assert result["recovered"] is True
+    assert result["final"] == A_STATUS_2 + B_PICKUP  # EXACT bytes: both lines survive
+    assert result["expected"] == A_STATUS_2 + B_PICKUP
+    assert result["b_line_present"] is True
+    assert result["lost"] is False
+    assert result["trace"] and all(isinstance(line, str) for line in result["trace"])
+
+
+def test_control_with_guard_off_loses_again() -> None:
+    from examples.session_handoff.fixed import run_control
+
+    result = run_control()
+
+    assert result["act"] == "control"
+    assert result["denied"] is False  # NOTES sits outside the strict glob: no deny
+    assert result["denial_exc"] is None
+    assert result["denial_message"] is None
+    assert result["recovered"] is False
+    assert result["final"] == A_STATUS_2  # the loss returns
+    assert result["b_line_present"] is False
+    assert result["lost"] is True
+    assert result["trace"] and all(isinstance(line, str) for line in result["trace"])

--- a/tests/test_session_handoff_demo.py
+++ b/tests/test_session_handoff_demo.py
@@ -10,8 +10,10 @@ on: a deny crosses the process boundary as a typed ``SessionDenied`` — and eac
 act's deny is pinned to the mechanism that produced it (the coordinator, or the
 file's own version check after an out-of-band rewind); any other child failure,
 including a non-deny ``CoherenceError``, crosses as a typed ``SessionError``
-carrying the child's traceback; raw file I/O bypasses the guard entirely (the
-negative control); and the two sessions really are distinct processes.
+carrying the child's traceback; a dead or hung child is bounded rather than a
+stall, and teardown swallows whatever reply it finds; raw file I/O bypasses the
+guard entirely (the negative control); and the two sessions really are distinct
+processes.
 """
 
 from __future__ import annotations
@@ -26,7 +28,13 @@ from ccs.core.exceptions import RESTORE_OUTCOME_CONFLICT, RESTORE_OUTCOME_RESTOR
 from examples.session_handoff import A_STATUS_1, A_STATUS_2, B_PICKUP, GUARDED, NOTES
 from examples.session_handoff.broken import new_workspace
 from examples.session_handoff.fixed import denied_by_coordinator
-from examples.session_handoff.sessions import Session, SessionDenied, SessionError
+from examples.session_handoff.sessions import (
+    _JOIN_TIMEOUT_SEC,
+    _KIND_DENIED,
+    Session,
+    SessionDenied,
+    SessionError,
+)
 
 
 @pytest.fixture
@@ -125,6 +133,87 @@ def test_session_non_deny_coherence_error_surfaces_as_session_error(workspace: P
         assert err.value.traceback and "CheckpointUnknown" in err.value.traceback
     finally:
         a.close()
+
+
+def test_close_tolerates_an_abandoned_reply(workspace: Path) -> None:
+    """Teardown must not re-raise a reply left over from an abandoned command.
+
+    An interrupt inside ``_await_reply`` abandons that command's reply in the
+    queue; ``close()``'s own wait then collects it instead of the ``stop``
+    reply. Nothing may escape teardown: every act calls ``close()`` and
+    ``shutil.rmtree`` from the SAME ``finally``, so a raise here would skip the
+    workspace cleanup. A deny is the reply that used to escape -- it is not a
+    ``SessionError``, so the guard did not cover it.
+    """
+    a = Session(workspace, "A", GUARDED)
+    # The exact tuple the child puts for a typed deny (sessions.py `_session_main`).
+    a._reply_q.put((_KIND_DENIED, None, "StaleView", "stale read denied: handoff/notes.md", None))
+
+    a.close()  # must not raise
+
+    assert not a._proc.is_alive()  # the child is still reaped
+
+
+def test_dead_child_surfaces_as_child_exited(workspace: Path) -> None:
+    """A child that died surfaces as a typed ``SessionError``, never a stall."""
+    a = Session(workspace, "A", GUARDED)
+    try:
+        a._proc.kill()
+        a._proc.join(timeout=_JOIN_TIMEOUT_SEC)
+
+        with pytest.raises(SessionError) as err:
+            a.read()
+        assert err.value.exc_name == "ChildExited"
+        assert "before answering 'read'" in err.value.message
+    finally:
+        a.close()
+
+
+def test_unanswered_command_times_out_and_terminates_the_child(workspace: Path) -> None:
+    """A hung child hits the bounded deadline, is terminated, and raises."""
+    a = Session(workspace, "A", GUARDED)
+    try:
+        # No command was sent, so no reply is coming -- the parent's view of a
+        # child wedged mid-command. The wait must be bounded, not a stall.
+        with pytest.raises(SessionError) as err:
+            a._await_reply("probe", 0.5)
+        assert err.value.exc_name == "TimeoutError"
+        assert not a._proc.is_alive()  # the deadline branch terminates the child
+    finally:
+        a.close()
+
+
+def test_act_removes_its_workspace_when_close_escapes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An act's temp workspace is removed even when teardown itself raises.
+
+    ``close()`` swallows both channel types, but an interrupt landing in
+    teardown is a ``BaseException`` and must keep propagating. Cleanup may not
+    depend on that: it runs from its own ``finally``, so the caller loses the
+    interrupt's meaning but never its temp directory.
+    """
+    from examples.session_handoff import broken, sessions
+
+    created: list[Path] = []
+    real_new_workspace = broken.new_workspace
+    real_close = sessions.Session.close
+
+    def recording_new_workspace(act: str) -> Path:
+        made = real_new_workspace(act)
+        created.append(made)
+        return made
+
+    def close_then_interrupt(self: sessions.Session) -> None:
+        real_close(self)  # the child is still reaped
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(broken, "new_workspace", recording_new_workspace)
+    monkeypatch.setattr(sessions.Session, "close", close_then_interrupt)
+
+    with pytest.raises(KeyboardInterrupt):
+        broken.run_broken()
+
+    assert created, "the act never created a workspace"
+    assert not created[0].exists()  # removed despite teardown raising
 
 
 # --- the three acts: RED, GREEN, CONTROL -------------------------------------------------

--- a/tests/test_session_handoff_demo.py
+++ b/tests/test_session_handoff_demo.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Session-handoff demo: the ``Session`` process primitive.
+
+Each ``Session`` drives a real spawned OS process holding one ``CoherentVolume``
+over a shared workspace; the first session created spawns the coordinator and
+later ones attach. These tests pin the channel contract the demo's acts build
+on: a coordinator deny crosses the process boundary as a typed
+``SessionDenied``, raw file I/O bypasses the guard entirely (the negative
+control), and the two sessions really are distinct processes.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from examples.session_handoff import A_STATUS_1, A_STATUS_2, B_PICKUP, GUARDED, NOTES
+from examples.session_handoff.sessions import Session, SessionDenied
+
+
+@pytest.fixture
+def workspace() -> Path:
+    root = Path(tempfile.mkdtemp(prefix="session_handoff_test_"))
+    (root / NOTES).parent.mkdir(parents=True, exist_ok=True)
+    try:
+        yield root
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_session_write_denial_surfaces_as_session_denied(workspace: Path) -> None:
+    a = Session(workspace, "A", GUARDED)
+    try:
+        b = Session(workspace, "B", GUARDED)
+        try:
+            a.write(A_STATUS_1)
+            assert b.read() == A_STATUS_1  # B now holds a SHARED view
+            a.write(A_STATUS_2)  # A's second commit invalidates B
+
+            with pytest.raises(SessionDenied) as denied:
+                b.write(B_PICKUP)  # B writes from its stale view -> denied
+            assert denied.value.exc_name == "StaleView"
+            assert denied.value.message  # the coordinator's reason travels verbatim
+            assert (workspace / NOTES).read_bytes() == A_STATUS_2  # nothing clobbered
+
+            assert b.reacquire() == A_STATUS_2  # fresh mandatory read
+            b.write(B_PICKUP)  # recovered write lands
+            assert (workspace / NOTES).read_bytes() == B_PICKUP
+        finally:
+            b.close()
+    finally:
+        a.close()
+
+
+def test_session_raw_io_bypasses_the_guard(workspace: Path) -> None:
+    a = Session(workspace, "A", GUARDED)
+    try:
+        b = Session(workspace, "B", GUARDED)
+        try:
+            a.raw_write(A_STATUS_1)
+            assert b.raw_read() == A_STATUS_1
+            a.raw_write(A_STATUS_2)
+
+            b.raw_write(B_PICKUP)  # no exception: the stale write silently wins
+
+            assert (workspace / NOTES).read_bytes() == B_PICKUP
+        finally:
+            b.close()
+    finally:
+        a.close()
+
+
+def test_two_sessions_are_distinct_processes(workspace: Path) -> None:
+    with Session(workspace, "A", GUARDED) as a, Session(workspace, "B", GUARDED) as b:
+        assert a.pid != b.pid
+        assert os.getpid() not in {a.pid, b.pid}

--- a/tests/test_session_handoff_demo.py
+++ b/tests/test_session_handoff_demo.py
@@ -15,19 +15,19 @@ from __future__ import annotations
 
 import os
 import shutil
-import tempfile
 from pathlib import Path
 
 import pytest
 
+from ccs.core.exceptions import RESTORE_OUTCOME_CONFLICT, RESTORE_OUTCOME_RESTORED
 from examples.session_handoff import A_STATUS_1, A_STATUS_2, B_PICKUP, GUARDED, NOTES
+from examples.session_handoff.broken import new_workspace
 from examples.session_handoff.sessions import Session, SessionDenied
 
 
 @pytest.fixture
 def workspace() -> Path:
-    root = Path(tempfile.mkdtemp(prefix="session_handoff_test_"))
-    (root / NOTES).parent.mkdir(parents=True, exist_ok=True)
+    root = new_workspace("test")
     try:
         yield root
     finally:
@@ -146,7 +146,7 @@ def test_handoff_stopped_rewinds_and_a_learns_on_next_write() -> None:
     assert result["members"][0]["member_path"] == NOTES
     assert result["members"][0]["restore_tier"] == "restorable-unpinned"
     assert result["members"][0]["pin_state"] == "held"
-    assert result["outcome"] == "restored"
+    assert result["outcome"] == RESTORE_OUTCOME_RESTORED
     assert result["attempts"] == 1
     assert result["detail"]
     assert result["disk_after_restore"] == A_STATUS_1  # rewound to the handoff point
@@ -160,7 +160,8 @@ def test_handoff_stopped_rewinds_and_a_learns_on_next_write() -> None:
 
 def test_handoff_racing_concludes_conflict_not_clobber() -> None:
     from ccs.adapters.workspace import MAX_RESTORE_LEG_REDRIVES
-    from examples.session_handoff.handoff import RACING_ATTEMPTS, run_handoff_racing, still_working_bytes
+    from examples.session_handoff.handoff import RACING_ATTEMPTS, run_handoff_racing
+    from examples.session_handoff.sessions import still_working_bytes
 
     result = run_handoff_racing()
 
@@ -169,7 +170,7 @@ def test_handoff_racing_concludes_conflict_not_clobber() -> None:
     assert result["act"] == "handoff_racing"
     assert isinstance(result["checkpoint_id"], str) and result["checkpoint_id"]
     assert len(result["members"]) == 1 and result["members"][0]["member_path"] == NOTES
-    assert result["outcome"] == "conflict"
+    assert result["outcome"] == RESTORE_OUTCOME_CONFLICT
     assert result["attempts"] == RACING_ATTEMPTS
     assert "re-drive budget exhausted" in result["detail"]
     # One racing edit per admitted attempt, so the last edit index equals the attempt count.

--- a/tests/test_session_handoff_demo.py
+++ b/tests/test_session_handoff_demo.py
@@ -6,9 +6,12 @@
 Each ``Session`` drives a real spawned OS process holding one ``CoherentVolume``
 over a shared workspace; the first session created spawns the coordinator and
 later ones attach. These tests pin the channel contract the demo's acts build
-on: a coordinator deny crosses the process boundary as a typed
-``SessionDenied``, raw file I/O bypasses the guard entirely (the negative
-control), and the two sessions really are distinct processes.
+on: a deny crosses the process boundary as a typed ``SessionDenied`` — and each
+act's deny is pinned to the mechanism that produced it (the coordinator, or the
+file's own version check after an out-of-band rewind); any other child failure,
+including a non-deny ``CoherenceError``, crosses as a typed ``SessionError``
+carrying the child's traceback; raw file I/O bypasses the guard entirely (the
+negative control); and the two sessions really are distinct processes.
 """
 
 from __future__ import annotations
@@ -22,7 +25,8 @@ import pytest
 from ccs.core.exceptions import RESTORE_OUTCOME_CONFLICT, RESTORE_OUTCOME_RESTORED
 from examples.session_handoff import A_STATUS_1, A_STATUS_2, B_PICKUP, GUARDED, NOTES
 from examples.session_handoff.broken import new_workspace
-from examples.session_handoff.sessions import Session, SessionDenied
+from examples.session_handoff.fixed import denied_by_coordinator
+from examples.session_handoff.sessions import Session, SessionDenied, SessionError
 
 
 @pytest.fixture
@@ -47,6 +51,8 @@ def test_session_write_denial_surfaces_as_session_denied(workspace: Path) -> Non
                 b.write(B_PICKUP)  # B writes from its stale view -> denied
             assert denied.value.exc_name == "StaleView"
             assert denied.value.message  # the coordinator's reason travels verbatim
+            # The coordinator denied, not the file's own version check.
+            assert denied_by_coordinator(denied.value.message)
             assert (workspace / NOTES).read_bytes() == A_STATUS_2  # nothing clobbered
 
             assert b.reacquire() == A_STATUS_2  # fresh mandatory read
@@ -82,6 +88,45 @@ def test_two_sessions_are_distinct_processes(workspace: Path) -> None:
         assert os.getpid() not in {a.pid, b.pid}
 
 
+def test_session_unknown_command_surfaces_as_session_error(workspace: Path) -> None:
+    a = Session(workspace, "A", GUARDED)
+    try:
+        with pytest.raises(SessionError) as err:
+            a._call("bogus_op")  # the cheapest deterministic route into the child's error branch
+        assert err.value.exc_name == "ValueError"
+        assert "unknown session command" in err.value.message
+        assert err.value.traceback and "ValueError" in err.value.traceback  # the child's traceback crosses
+
+        a.raw_write(A_STATUS_1)  # the child loop survives a failed command
+        assert a.raw_read() == A_STATUS_1
+    finally:
+        a.close()
+
+
+def test_session_call_after_close_raises_session_error(workspace: Path) -> None:
+    a = Session(workspace, "A", GUARDED)
+    a.close()
+
+    with pytest.raises(SessionError) as err:
+        a.read()
+    assert err.value.exc_name == "RuntimeError"
+    assert "closed" in err.value.message
+
+    a.close()  # closing twice is a no-op
+
+
+def test_session_non_deny_coherence_error_surfaces_as_session_error(workspace: Path) -> None:
+    a = Session(workspace, "A", GUARDED)
+    try:
+        a.write(A_STATUS_1)  # the ledger exists before the lookup
+        with pytest.raises(SessionError) as err:
+            a.restore("00000000-0000-0000-0000-000000000000")
+        assert err.value.exc_name == "CheckpointUnknown"  # a CoherenceError, but not a typed deny
+        assert err.value.traceback and "CheckpointUnknown" in err.value.traceback
+    finally:
+        a.close()
+
+
 # --- the three acts: RED, GREEN, CONTROL -------------------------------------------------
 
 
@@ -108,6 +153,7 @@ def test_green_denies_then_both_lines_survive() -> None:
     assert result["denied"] is True
     assert result["denial_exc"] == "StaleView"
     assert result["denial_message"]  # the coordinator's reason travels verbatim
+    assert denied_by_coordinator(result["denial_message"])
     assert result["recovered"] is True
     assert result["final"] == A_STATUS_2 + B_PICKUP  # EXACT bytes: both lines survive
     assert result["expected"] == A_STATUS_2 + B_PICKUP
@@ -153,6 +199,8 @@ def test_handoff_stopped_rewinds_and_a_learns_on_next_write() -> None:
     assert result["a_denied"] is True  # A learns on its NEXT write, not at restore time
     assert result["a_denial_exc"] == "StaleView"
     assert result["a_denial_message"]
+    # The restore bypassed A's live view; A's own version check catches it, not the coordinator.
+    assert not denied_by_coordinator(result["a_denial_message"])
     assert result["a_reacquired"] == A_STATUS_1
     assert result["trace"] and all(isinstance(line, str) for line in result["trace"])
     assert result["checkpoint_id"] not in "\n".join(result["trace"])  # the uuid never enters the trace


### PR DESCRIPTION
## Summary

`examples/session_handoff` shows two agent sessions on one machine — each a real OS process — sharing one scratch file and handing work off through a checkpoint, and pins what the file does under that workaround: plain file I/O loses the second session's line with nothing raised; through `CoherentVolume` the stale write is denied and both lines survive; a checkpoint restore lands cleanly when the handing-off session has stopped writing, and concludes a bounded `conflict` — never a clobber — when it is still writing. `python -m examples.session_handoff.main` exits 0 only if every exact pin holds; it is offline, needs no keys, and prints byte-identical output on every run.

Related: https://github.com/anthropics/claude-code/issues/60082 — this covers the workspace half of that handoff (the shared file and the checkpoint), not the conversation.

## Design decisions

- **Two real OS processes, not two volume objects in one process.** The second `CoherentVolume` attaches to the coordinator the first one spawned. That is what makes the "two sessions" claim honest, and it is also why both sessions stay open in the demo: the first session's process hosts the coordinator, so the handing-off session stops writing rather than exiting. The README says so under "Scope, honestly"; a session that exits with a teammate attaching afterwards is a different shape and is not claimed.
- **Sequenced, not raced.** Every act runs its steps in a fixed order, so stdout is byte-identical run to run. The lost update in RED needs no timing window: a session that never re-reads before writing loses the other's line every time. In the last act a deterministic stand-in (`_StillWorkingSource`) plays "A keeps typing", one edit per restore read, so the restore's version check is beaten exactly `MAX_RESTORE_LEG_REDRIVES + 1` times before it concludes `conflict`.
- **CONTROL uses the shipped scope knob.** The strict glob is pointed at `other/**`, so the same code runs with the deny off and the loss returns. Green depends on the deny, not on the re-read. No new flag.
- **Each pin names the mechanism that denied.** GREEN's deny must carry the coordinator's public deny reason; the post-rewind deny in HANDOFF-a must come from the file's own version check (`fixed.denied_by_coordinator`). The adapter's local content check alone reproduces every other GREEN signal, so without this a regression in cross-process invalidation would have kept the demo green.
- **The process primitive types its channel.** Only the volume's typed denies (`StaleView`, `CommitPreempted`) cross as `SessionDenied`; anything else the child raises — an unreachable coordinator, an unknown checkpoint — crosses as `SessionError` with the child's traceback. A child whose parent is gone exits and stops its coordinator, so a hard-killed run leaves no orphan listening on loopback.
- **Teardown is total, and cleanup does not depend on it.** `close()` swallows both channel types, which covers everything the channel can deliver, because the reply wait is not correlated to the command that triggered it — an interrupt abandons a reply and the next wait collects it. Each act's `shutil.rmtree` then sits in its own `finally`, so a `BaseException` escaping teardown still cannot cost the caller its temp workspace.
- **Nothing under `src/` changes.** The top-level README is deliberately untouched: it has no examples registry. The demo is documented in its own README, the `docs/guide.md` examples table, and the changelog.

Session-settled decisions carried from planning: two real OS processes (user-directed, over two volumes in one process); all acts including the checkpoint handoff (user-directed, over scratch-file acts only); a demo-grade example rather than a production build (user-directed).

## Validation

- `python -m examples.session_handoff.main`: exit 0; two consecutive runs produce byte-identical stdout (3166 bytes) and empty stderr; loopback only (a run with socket connects monkeypatched to raise still exits 0); no stray child or coordinator process and no leftover temp workspace afterwards; a `kill -9` of the parent leaves no orphans.
- `tests/test_session_handoff_demo.py` (16 tests): the channel contract — a deny crosses as typed `SessionDenied` and is pinned to the mechanism that produced it; an unknown command, a call after close, and a `CheckpointUnknown` cross as typed `SessionError` with the child's traceback; raw file I/O bypasses the guard; the two sessions are distinct pids — plus each act's exact result keys and `main([]) == 0`. Four of the sixteen cover teardown and the bounded wait: teardown with a reply left over from an abandoned command, workspace cleanup when teardown itself raises, and the dead-child and timeout branches. Spawn-heavy: about 30 processes and a minute and a half locally.
- Full suite: 3795 passed, 13 skipped. The two failures in `tests/test_claude_code_e2e.py` (`test_e2e_subprocess_spawn_then_status`, `test_e2e_subprocess_idempotent_second_spawn`) require the `agent-coherence-coordinator` console script on PATH, which the local shell lacked; that file is untouched here and the tests pass where the package is installed. `ruff check`, `ruff format --check`, and the architecture check are clean.
- Code review, two rounds. The first was a full multi-lens pass over the whole PR (correctness, adversarial, testing, maintainability, reliability, project standards, prior learnings): five P2/P3 findings, no P0/P1, all applied in `7dcc3ce` and `6fee2c7`. The second reviewed only the teardown fix and found one further P2 — that swallowing both channel types still left the interrupt route open — which `6fee2c7` closes with the per-act `finally`. Every fix in that commit was proven red before green, the workspace-cleanup one on a scratch copy of the tree.

## Known residuals

Advisory; none blocking.

- `examples/session_handoff/main.py` — the HANDOFF-a line prints the adapter's stale-write deny reason verbatim; a wording change in `src/` changes demo stdout (every pin still holds).
- `examples/session_handoff/sessions.py:176` — the reply wait is not correlated to the command it is waiting for, so a desynchronized channel would answer one command with another's reply. Two reviewers raised this independently and both judged it unreachable for current callers: every path that abandons a reply ends at a teardown that now tolerates any reply. Closing it properly means a channel protocol change — a sequence number or an op echo in the reply tuple — which is a design call rather than a bug fix.
- P3 `examples/session_handoff/sessions.py:233` — `_StillWorkingSource` repeats the shape of `examples/workspace_versioning`'s `_SustainedForeignWriter` against a different protocol; two small self-contained copies are acceptable for example code.
- P3 `examples/session_handoff/sessions.py:254` — the comment on `write_cas_at` says the restore pre-flight's Protocol check is static; that holds on Python 3.12 (`getattr_static`), while 3.11 traverses `__getattr__`. The code is correct on both.
- `examples/session_handoff/handoff.py` — the racing act's "A is still working" stdout line does not say the edits come from a stand-in inside B's restore process; the README does.
- `tests/test_session_handoff_demo.py` — no slow marker; adds about a minute and a half of spawn-heavy time to the default suite. Determinism (byte-identical stdout, empty stderr) and process hygiene are verified by hand, not pinned in-suite, matching the sibling demo tests.
- Cross-process concurrent access to the same `.coherence/workspace.db` is not exercised; each act is sequential.

## Post-Deploy Monitoring & Validation

- No runtime rollout: this adds an example and its tests; nothing under `src/` changes. No additional operational monitoring is required beyond CI.
- Signal to watch: the Tests job on Python 3.11 and 3.12 for `tests/test_session_handoff_demo.py`. It is spawn-heavy, so a timeout or a flaky spawn on a constrained runner is the failure signal; the mitigation is a slow marker or a longer per-test timeout, not a logic change.
- Rollback: revert the merge commit. The change is confined to `examples/session_handoff`, one test module, one guide-table row, and a changelog entry.
- Validation window: this PR's CI run and the first release that ships it. Owner: the repository maintainer.
