### PR TITLE
fix(packaging): ship the HTML report templates in the wheel and sdist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to `agent-coherence` are documented here. The format follows
 
 Alpha — APIs may change before `v1.0`.
 
+## [Unreleased]
+
+### Fixed
+
+- **The HTML report templates now ship in the distribution.** `ccs-compare`
+  and `ccs-diagnose` read their templates off the filesystem beside the
+  module (`Path(__file__).with_name("templates")`), but `pyproject.toml`
+  declared no `package-data`, so neither `comparison_report.html` nor
+  `diagnose_report.html` was written into the wheel or the sdist. A source
+  checkout always has the files, which is why the test suite never saw it;
+  anyone installing from PyPI hit a bare `FileNotFoundError` the moment a
+  report rendered. Both templates are now declared and verified present in
+  both artifacts.
+
+  The declaration has to name the subdirectory (`"ccs.output" =
+  ["templates/*.html"]`) — setuptools globs each pattern against the owning
+  package's directory with `glob(recursive=True)`, so a bare `"*"` stops at
+  the path separator and never reaches inside `templates/`. A new guard,
+  `tests/test_packaging_data_files.py`, enumerates every non-`.py` file
+  under `src/ccs/` and fails if any of them is left undeclared, so the next
+  asset added anywhere in the tree fails in CI rather than in a user's
+  install. It replays setuptools' own `find_data_files` algorithm from
+  `pyproject.toml` — no wheel build, no setuptools import — and a companion
+  test pins that replay against the real build backend wherever setuptools
+  is importable.
+
 ## [0.14.1] - 2026-09-05
 
 **Four correctness fixes to the read-generation fence and the effect gate, plus the conflict-outcome instrumentation that makes a deny countable.** Every fix in this release closes a window in which a revoked or preempted writer's work was silently admitted; the instrumentation exists so the next thirty days can say how often that happens in the wild, rather than leaving it to argument.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,12 @@ stale-write-guard-fs = "ccs.mcp.server:main"
 # `python tools/check_release_readiness.py`. Maintainers run the same path.
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0", "ruff>=0.4"]
+# ``setuptools`` is already the build backend; naming it here as well puts it
+# in the *test* environment, where tests/test_packaging_data_files.py pins its
+# package-data replay against the real thing. Neither a modern venv nor
+# GitHub's setup-python leaves it importable on 3.12, so without this the
+# cross-check silently skips everywhere and the pin never actually holds.
+dev = ["pytest>=7.0", "ruff>=0.4", "setuptools>=68.0"]
 # The packaged conformance corpus (ccs.testing.substrate_conformance) imports
 # and runs WITHOUT pytest; this extra adds it so scenario skips report as
 # skips when a foreign implementation runs the corpus under its test suite.
@@ -145,6 +150,21 @@ version = { attr = "ccs.__version__" }
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+# The HTML report templates are read off the filesystem at runtime
+# (``Path(__file__).with_name("templates")`` in ccs/output/report.py and
+# ccs/diagnose/render.py), so they MUST ride the wheel — without them an
+# installed-from-PyPI ``ccs-diagnose``/``ccs-compare`` raises FileNotFoundError
+# the moment it renders. Discovery alone does not carry them: ``templates/`` is
+# found as a namespace package, but a package with no matching data pattern
+# ships nothing. Nor would a bare ``"*"`` under the catch-all key reach the
+# files — setuptools globs every pattern against the owning package's directory
+# with ``glob(recursive=True)``, where ``*`` stops at a path separator, so the
+# subdirectory has to be named. tests/test_packaging_data_files.py fails if any
+# future non-.py asset under src/ccs/ is left undeclared here.
+[tool.setuptools.package-data]
+"ccs.diagnose" = ["templates/*.html"]
+"ccs.output" = ["templates/*.html"]
 
 [project.urls]
 Homepage = "https://github.com/Cohexa-ai/agent-coherence"

--- a/tests/test_packaging_data_files.py
+++ b/tests/test_packaging_data_files.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Guard: every non-Python asset under ``src/ccs/`` ships in the distribution.
+
+``ccs/output/report.py`` and ``ccs/diagnose/render.py`` read their HTML
+templates off the filesystem next to the module. Nothing in the import system
+notices when such a file is missing from the wheel — the failure surfaces only
+at render time, in the installed-from-PyPI environment, as a bare
+``FileNotFoundError``. The repo's own test run never sees it, because a source
+checkout always has the file.
+
+So this module asserts the packaging *declaration* instead of the built
+artifact: it replays setuptools' own ``build_py.find_data_files`` algorithm
+against ``pyproject.toml`` and fails if any asset in the tree is left
+undeclared. That runs in a plain ``pytest -q`` with no wheel build and no
+setuptools import; ``test_replayed_data_files_match_setuptools`` pins the
+replay to the real backend wherever setuptools happens to be importable.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import tomllib
+from glob import glob
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+SRC_ROOT = REPO_ROOT / "src"
+
+# setuptools always folds these two in on top of the declared patterns
+# (``setuptools.command.build_py._IMPLICIT_DATA_FILES``), so a ``py.typed``
+# added later is covered without anyone touching pyproject.toml.
+_IMPLICIT_DATA_PATTERNS = ("*.pyi", "py.typed")
+
+
+def _iter_packages(src_root: Path) -> list[str]:
+    """Dotted names of every directory setuptools would treat as a package.
+
+    ``[tool.setuptools.packages.find]`` runs with ``namespaces = true`` by
+    default under pyproject.toml, so discovery is NOT gated on ``__init__.py``
+    — ``ccs.output.templates`` is itself a (namespace) package. Enumerating
+    every directory therefore matches the backend, and keeps this replay from
+    rejecting a valid ``"ccs.output.templates" = ["*.html"]`` declaration.
+    ``test_replayed_data_files_match_setuptools`` is what holds that claim
+    honest: if setuptools disagreed about any package, the two resolved sets
+    would part ways there.
+    """
+    return sorted(
+        str(directory.relative_to(src_root)).replace(os.sep, ".")
+        for directory in src_root.glob("**/")
+        if directory != src_root and "__pycache__" not in directory.parts
+    )
+
+
+def _patterns_for(spec: dict[str, list[str]], package: str, implicit: tuple[str, ...] = ()) -> list[str]:
+    """Patterns ``spec`` applies to ``package``, joined to its directory.
+
+    ``implicit`` carries setuptools' built-in includes; the exclude side
+    passes none, matching ``exclude_data_files``, which does not fold them in.
+    """
+    package_dir = SRC_ROOT / Path(*package.split("."))
+    raw = [*implicit, *spec.get("", []), *spec.get(package, [])]
+    return [os.path.join(str(package_dir), *pattern.split("/")) for pattern in raw]
+
+
+def _included_files(patterns: list[str]) -> set[str]:
+    """Files matched by include patterns — setuptools' ``find_data_files``.
+
+    ``glob(..., recursive=True)`` is the call it makes, so ``*`` stops at a
+    path separator and only an explicit ``**`` descends. That is precisely why
+    a bare ``"*"`` never reaches ``templates/comparison_report.html``.
+    """
+    return {hit for pattern in patterns for hit in glob(pattern, recursive=True) if os.path.isfile(hit)}
+
+
+def _excluded_files(patterns: list[str], candidates: set[str]) -> set[str]:
+    """Files dropped by exclude patterns — setuptools' ``exclude_data_files``.
+
+    Note the asymmetry with the include side: excludes are ``fnmatch``ed
+    against the already-globbed paths rather than re-globbed, so here a ``*``
+    *does* cross a path separator.
+    """
+    return {hit for pattern in patterns for hit in fnmatch.filter(sorted(candidates), pattern)}
+
+
+def _declared_data_files() -> set[Path]:
+    """Every file the packaging config declares as package data."""
+    config = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    setuptools_table = config.get("tool", {}).get("setuptools", {})
+    package_data = setuptools_table.get("package-data", {})
+    exclude_data = setuptools_table.get("exclude-package-data", {})
+
+    declared: set[Path] = set()
+    for package in _iter_packages(SRC_ROOT):
+        included = _included_files(_patterns_for(package_data, package, _IMPLICIT_DATA_PATTERNS))
+        declared |= {Path(hit) for hit in included - _excluded_files(_patterns_for(exclude_data, package), included)}
+    return declared
+
+
+def _shipped_assets() -> set[Path]:
+    """Every non-Python, non-cache file living under ``src/ccs/``."""
+    return {
+        path
+        for path in (SRC_ROOT / "ccs").glob("**/*")
+        if path.is_file() and path.suffix != ".py" and "__pycache__" not in path.parts
+    }
+
+
+def test_every_non_python_asset_is_declared_package_data() -> None:
+    """A new asset that nobody declared fails here, not in a user's install."""
+    undeclared = sorted(path.relative_to(REPO_ROOT) for path in _shipped_assets() - _declared_data_files())
+
+    assert not undeclared, (
+        "These files live under src/ccs/ but would NOT ship in the wheel or sdist:\n"
+        + "\n".join(f"  - {path}" for path in undeclared)
+        + "\n\nAnything read at runtime via Path(__file__) must be declared, or an\n"
+        "installed-from-PyPI import raises FileNotFoundError. Add the owning\n"
+        "package to [tool.setuptools.package-data] in pyproject.toml, naming the\n"
+        'subdirectory explicitly (e.g. "ccs.output" = ["templates/*.html"]) — a\n'
+        'bare "*" is globbed against the package directory and stops at the\n'
+        "path separator, so it never reaches a file one level down."
+    )
+
+
+def test_the_html_templates_are_declared() -> None:
+    """The two templates whose absence this guard was written for."""
+    declared = _declared_data_files()
+
+    for relative in (
+        "ccs/diagnose/templates/diagnose_report.html",
+        "ccs/output/templates/comparison_report.html",
+    ):
+        assert SRC_ROOT / relative in declared, f"{relative} is not declared package data"
+
+
+def test_replayed_data_files_match_setuptools(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the replay above to what the real build backend resolves.
+
+    The ``dev`` extra installs setuptools precisely so this runs in CI. It
+    still degrades to a skip rather than an error, because the guard above
+    must keep working in a bare venv — neither a fresh ``python -m venv`` nor
+    GitHub's setup-python leaves setuptools importable on 3.12, so a hard
+    requirement here would take the whole module down with it.
+    """
+    setuptools = pytest.importorskip("setuptools", reason="build backend not installed in this env")
+    from setuptools.config.pyprojecttoml import apply_configuration
+
+    # setuptools resolves package_dir and the dynamic version relative to cwd.
+    monkeypatch.chdir(REPO_ROOT)
+    distribution = setuptools.Distribution()
+    apply_configuration(distribution, str(PYPROJECT_PATH))
+
+    # ``include_package_data`` defaults on under pyproject.toml, and its leg of
+    # find_data_files shells out to egg_info to read SOURCES.txt — which would
+    # write *.egg-info into the working tree mid-test. Both sides of this
+    # comparison are the *declared* patterns, which is the thing under guard;
+    # the red-state build confirmed the manifest leg contributes nothing here
+    # (no MANIFEST.in, no revision-control plugin).
+    distribution.include_package_data = False
+
+    build_py = distribution.get_command_obj("build_py")
+    build_py.ensure_finalized()
+    # setuptools reports source dirs relative to cwd; this comparison is
+    # against absolute paths, so anchor them back on the repo root.
+    resolved = {
+        (REPO_ROOT / source_dir / name).resolve()
+        for _package, source_dir, _build_dir, names in build_py.data_files
+        for name in names
+    }
+
+    assert resolved == _declared_data_files()


### PR DESCRIPTION
## Summary

- `ccs/output/report.py` and `ccs/diagnose/render.py` read their HTML templates off the filesystem beside the module (`Path(__file__).with_name("templates")`), but `pyproject.toml` declared no `package-data` and there is no `MANIFEST.in` — so neither template was written into the wheel or the sdist. A source checkout always has the files, which is why the suite never caught it; installing from PyPI and rendering a report raised a bare `FileNotFoundError`.
- Declares both templates as package data. The declaration must name the subdirectory: setuptools globs each pattern against the owning package's directory with `glob(recursive=True)`, so a bare `"*"` stops at the path separator and never reaches one level down.
- Adds `tests/test_packaging_data_files.py`, which enumerates every non-`.py` file under `src/ccs/` and fails if any is left undeclared — so the *next* asset added anywhere in the tree fails in CI rather than in a user's install.

## The guard

It asserts the packaging **declaration**, not a built artifact: it replays setuptools' own `build_py.find_data_files` algorithm against `pyproject.toml`, so it needs no wheel build and no `setuptools` import, and runs in a plain `pytest -q`.

`test_replayed_data_files_match_setuptools` pins that replay to the real build backend, so drift between the two gets caught before a release. Writing it surfaced three things worth recording:

- **Neither a fresh `python -m venv` nor GitHub's setup-python leaves setuptools importable on 3.12.** I first wrote the pin as `importorskip` and assumed CI would have it; the junit output from this PR's own first CI run showed it skipping there too, i.e. never actually running anywhere. `setuptools` is therefore added to the `dev` extra — it is already the build backend, and this puts it in the *test* environment where the pin needs it. It stays a skip rather than a hard requirement so the main guard still works in a bare venv.
- `[tool.setuptools.packages.find]` defaults to `namespaces = true` under pyproject.toml, so `ccs.output.templates` **is** discovered as a package (23 packages, not 21). Discovery alone still ships nothing — the data pattern is what carries the file.
- The include and exclude sides are asymmetric: includes are `glob(recursive=True)`-ed, excludes are `fnmatch`-ed against the already-globbed paths. The replay mirrors both.

## Verification

Before / after, same build command:

| artifact | before | after |
|---|---|---|
| wheel | 128 entries, **0** templates | 130 entries, **2** templates |
| sdist | **0** templates | **2** templates |
| wheel built *from* the sdist | — | **2** templates |

Installing the pre-fix wheel into a clean venv reproduced the defect exactly:

```
FileNotFoundError: [Errno 2] No such file or directory:
  '.../site-packages/ccs/output/templates/comparison_report.html'
```

The same call reads the template after the fix. `setuptools` lands only as `Requires-Dist: setuptools>=68.0; extra == "dev"` — not a runtime dependency.

The guard was mutation-tested red before being trusted — it fails on the original defect (no `package-data`), on the `"*" = ["*"]` trap, on a new asset dropped into an existing package, on one dropped into a brand-new directory, and on an `exclude-package-data` entry that cancels an include.

## Test plan

- [x] `pytest -q` — 3131 passed / 31 skipped in a bare venv; 3767 passed / 15 skipped in a `.[dev,diagnose,mcp]` env matching CI
- [x] `ruff check src/ tests/` — clean
- [x] `python tools/check_architecture.py` — passed
- [x] New guard verified both red and green, with and without setuptools installed
- [x] `python -m build` re-run and artifact contents inspected

No source behaviour changes; a packaging declaration, one new test module, and a CHANGELOG entry under Fixed.