### PR TITLE
refactor(diagnose): share the read-only state.db open

### DIFF
--- a/src/ccs/diagnose/_state_db.py
+++ b/src/ccs/diagnose/_state_db.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Read-only open of a coordinator ``state.db``, shared by the offline readers.
+
+:mod:`ccs.diagnose.conflict_counters` and :mod:`ccs.diagnose.foreign_writes`
+are two reports over the same store, so the low-level open is the same fact
+twice, not the sanctioned per-backend duplication the two registries carry.
+Written out twice it drifts silently: a busy timeout re-derived from the
+registry's budget, or a tightening of the missing-file translation, would land
+in one report and leave the other answering on different terms.
+
+What deliberately stays with each caller is the per-table
+missing-versus-empty logic. The conflict reader maps an absent table and an
+empty one to the same zero and documents that as zero recorded conflicts; the
+foreign-write reader must keep the two apart, because a coverage claim depends
+on knowing whether the detector ever ran. Those are different contracts over
+the same connection, and merging them would cost one of them its honesty.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+__all__ = ["open_readonly_state_db"]
+
+BUSY_TIMEOUT_MS = 1500
+"""Matches the registry's own budget-derived value."""
+
+
+def open_readonly_state_db(path: Path) -> sqlite3.Connection:
+    """Open the coordinator store at ``path`` read-only, ready to query.
+
+    Raises ``FileNotFoundError`` when nothing is there — a report against a
+    store that does not exist is a caller error, never evidence of a quiet
+    month. Every other failure to open propagates, so a broken read cannot be
+    mistaken for an empty one. The caller owns the returned connection and
+    must close it.
+    """
+    # mode=ro + uri=True: without the explicit uri flag sqlite3 treats the
+    # string as a literal filename and can silently fall back to read-write.
+    # No pre-check stat: connect directly and translate the failure, so a
+    # missing file cannot slip through a check-to-open race window.
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    except sqlite3.OperationalError as exc:
+        if not path.exists():
+            raise FileNotFoundError(f"no coordinator database at {path}") from exc
+        raise
+    try:
+        # A transient writer lock must wait, never masquerade as an empty
+        # result — whatever "empty" means to the report being built.
+        conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+    except BaseException:
+        # The caller never received the handle, so it cannot close it.
+        conn.close()
+        raise
+    return conn

--- a/src/ccs/diagnose/conflict_counters.py
+++ b/src/ccs/diagnose/conflict_counters.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+from ._state_db import open_readonly_state_db
+
 __all__ = ["read_conflict_totals"]
 
 
@@ -38,32 +40,18 @@ def read_conflict_totals(db_path: str | Path) -> dict[tuple[str, str, str], int]
     database, a hot-WAL recovery failure, disk I/O — is re-raised rather than
     swallowed, so it can never masquerade as zero conflicts.
     """
-    path = Path(db_path)
-    # mode=ro + uri=True: without the explicit uri flag sqlite3 treats the
-    # string as a literal filename and can silently fall back to read-write.
-    # No pre-check stat: connect directly and translate the failure, so a
-    # missing file cannot slip through a check-to-open race window.
+    conn = open_readonly_state_db(Path(db_path))
     try:
-        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        rows = conn.execute(
+            "SELECT artifact_id, agent_id, reason, count FROM conflict_counters"
+        ).fetchall()
     except sqlite3.OperationalError as exc:
-        if not path.exists():
-            raise FileNotFoundError(f"no coordinator database at {path}") from exc
+        if "no such table" in str(exc):
+            return {}  # pre-instrumentation db: no table, zero recorded.
         raise
-    try:
-        # A transient writer lock must wait, never masquerade as zero; 1500
-        # matches the registry's own budget-derived value.
-        conn.execute("PRAGMA busy_timeout=1500")
-        try:
-            rows = conn.execute(
-                "SELECT artifact_id, agent_id, reason, count FROM conflict_counters"
-            ).fetchall()
-        except sqlite3.OperationalError as exc:
-            if "no such table" in str(exc):
-                return {}  # pre-instrumentation db: no table, zero recorded.
-            raise
-        return {
-            (art_hex, agent_hex, reason): count
-            for art_hex, agent_hex, reason, count in rows
-        }
     finally:
         conn.close()
+    return {
+        (art_hex, agent_hex, reason): count
+        for art_hex, agent_hex, reason, count in rows
+    }

--- a/src/ccs/diagnose/foreign_writes.py
+++ b/src/ccs/diagnose/foreign_writes.py
@@ -33,6 +33,8 @@ import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
+from ._state_db import open_readonly_state_db
+
 __all__ = [
     "COUNTS",
     "INSTRUMENTED_ZERO",
@@ -142,21 +144,8 @@ def read_foreign_write_report(db_path: str | Path) -> ForeignWriteReport:
     ``FileNotFoundError``: a report against a store that does not exist is a
     caller error, not evidence of zero foreign writes.
     """
-    path = Path(db_path)
-    # mode=ro + uri=True: without the explicit uri flag sqlite3 treats the
-    # string as a literal filename and can silently fall back to read-write.
-    # No pre-check stat: connect directly and translate the failure, so a
-    # missing file cannot slip through a check-to-open race window.
+    conn = open_readonly_state_db(Path(db_path))
     try:
-        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
-    except sqlite3.OperationalError as exc:
-        if not path.exists():
-            raise FileNotFoundError(f"no coordinator database at {path}") from exc
-        raise
-    try:
-        # A transient writer lock must wait, never masquerade as not-instrumented;
-        # 1500 matches the registry's own budget-derived value.
-        conn.execute("PRAGMA busy_timeout=1500")
         run_rows = _read_table(
             conn,
             "SELECT run_id, first_tick_unix, last_tick_unix, tick_count, "


### PR DESCRIPTION
## Summary

- `conflict_counters.py` and `foreign_writes.py` are two reports over the same store, and both carried the same low-level open verbatim — the `mode=ro` URI connect, the missing-file translation, and `PRAGMA busy_timeout=1500`. That is one backend's plumbing written twice, not the sanctioned per-backend duplication the two registries carry.
- Extracts `open_readonly_state_db()` into a private `_state_db` module, following the `_labels.py` convention already in this package: private module, plain symbol.
- Both readers now open with one line. Nothing about either report's behaviour changes.

## What deliberately did NOT move

The per-table missing-versus-empty logic stays with each caller, because the two contracts genuinely differ:

| | absent table | empty table |
|---|---|---|
| `read_conflict_totals` | `{}` | `{}` — collapsed on purpose, documented as zero recorded conflicts |
| `read_foreign_write_report` | `not-instrumented` | `not-instrumented` — keyed on the observation **row**, so a ticked-but-clean store is `instrumented-zero` |

Merging those would cost the foreign-write reader its honesty: a coverage claim depends on knowing whether the detector ever ran, so an absent observation row and a clean one cannot collapse.

## One behaviour addition

The helper closes the connection if the `PRAGMA` itself raises. It previously ran inside each caller's `try/finally`, so moving it out would otherwise leak a handle the caller never received. Verified with a fault-injected pragma.

## Test Plan

- [x] `pytest -q tests/test_conflict_instrumentation.py tests/test_foreign_write_report.py` — 41 passed
- [x] `ruff check src/ tests/` — clean
- [x] `python tools/check_architecture.py` — passed (`diagnose` is `interface`; the new module imports stdlib only, no new cycle)
- [x] Wider blast radius (detector + instrumentation suites, registry lock coverage) — 231 passed
- [x] Full suite — 3870 passed, 3 skipped
- [x] Contracts probed directly: both readers' absent/empty behaviour, `FileNotFoundError` on a missing file, `busy_timeout` reads back as 1500, writes rejected, no handle leak on pragma failure

Stacked on `feat/foreign-write-detection`; rebased onto `27b36fa` so the `_OUTCOME_COLUMNS` / `covered_count` work in that commit is preserved intact.