### PR TITLE
refactor(tests): share the both-registries fixture, and pin its contract

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ matrix that exercises bare-install paths.
 from __future__ import annotations
 
 import importlib.util
+from pathlib import Path
 
 import pytest
 
@@ -87,3 +88,28 @@ def _neutralize_v090_first_use_warning():
 
     _service._V090_FIRST_USE_WARNED = True
     yield
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+def registry(request, tmp_path: Path):
+    """Both registry implementations, identically — the parametrization IS the
+    parity harness for registry-level surfaces.
+
+    Shared here rather than per-module because the instrumentation suites
+    (conflict counters, foreign-write counters) assert the same contract across
+    both arms and had drifted into byte-identical local copies. Modules that
+    define their own ``registry`` still shadow this one, so the pre-existing
+    per-module fixtures keep their own param ids and teardown idiom.
+    """
+    # Imported in-body, matching this file's existing idiom: a module-level
+    # `ccs` import would fail conftest import outright, before the
+    # `collect_ignore_glob` guards above ever get a chance to skip gracefully.
+    from ccs.coordinator.registry import ArtifactRegistry
+    from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
+
+    if request.param == "memory":
+        yield ArtifactRegistry()
+    else:
+        reg = SqliteArtifactRegistry(tmp_path / "state.db")
+        yield reg
+        reg.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,21 +95,26 @@ def registry(request, tmp_path: Path):
     """Both registry implementations, identically — the parametrization IS the
     parity harness for registry-level surfaces.
 
-    Shared here rather than per-module because the instrumentation suites
-    (conflict counters, foreign-write counters) assert the same contract across
-    both arms and had drifted into byte-identical local copies. Modules that
-    define their own ``registry`` still shadow this one, so the pre-existing
-    per-module fixtures keep their own param ids and teardown idiom.
+    Shared here rather than per-module because the conflict-counter suite and
+    the foreign-write-counter suite that follows it assert the same contract
+    across both arms, from what had become byte-identical local copies. Modules
+    that define their own ``registry`` shadow this one, so the pre-existing
+    per-module fixtures keep their own param ids and teardown idiom;
+    ``tests/test_registry_fixture_contract.py`` pins both halves of that split.
+
+    The sqlite arm's filename is deliberately its own: consumers put their own
+    sqlite files in the same ``tmp_path``, and the tree's default ``state.db``
+    is a name two coordinator suites already reserve for raw-sqlite probes.
     """
-    # Imported in-body, matching this file's existing idiom: a module-level
-    # `ccs` import would fail conftest import outright, before the
-    # `collect_ignore_glob` guards above ever get a chance to skip gracefully.
+    # Deferred like the ``ccs`` imports in the hooks above, so importing this
+    # conftest stays free of the package under test. Nothing here needs `ccs`
+    # until a test actually requests the fixture.
     from ccs.coordinator.registry import ArtifactRegistry
     from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
 
     if request.param == "memory":
         yield ArtifactRegistry()
     else:
-        reg = SqliteArtifactRegistry(tmp_path / "state.db")
+        reg = SqliteArtifactRegistry(tmp_path / "shared-registry-arm.db")
         yield reg
         reg.close()

--- a/tests/test_conflict_instrumentation.py
+++ b/tests/test_conflict_instrumentation.py
@@ -21,7 +21,6 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from ccs.coordinator.registry import ArtifactRegistry
 from ccs.coordinator.sqlite_registry import SqliteArtifactRegistry
 from ccs.core.states import MESIState
 from ccs.core.types import Artifact, CommitAllEntry, ConflictDetail, MultiCommitConflict
@@ -30,16 +29,6 @@ from ccs.diagnose.conflict_counters import read_conflict_totals
 
 def _mk_artifact() -> Artifact:
     return Artifact(name=f"{uuid4().hex}.md", version=1, content_hash="seed")
-
-
-@pytest.fixture(params=["memory", "sqlite"])
-def registry(request, tmp_path: Path):
-    if request.param == "memory":
-        yield ArtifactRegistry()
-    else:
-        reg = SqliteArtifactRegistry(tmp_path / "state.db")
-        yield reg
-        reg.close()
 
 
 def _seed(reg, artifact: Artifact, *agents: UUID) -> None:

--- a/tests/test_registry_fixture_contract.py
+++ b/tests/test_registry_fixture_contract.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""The `registry` fixture contract: who owns it, and under which param ids.
+
+``tests/conftest.py`` defines a tree-wide ``registry`` fixture. Nine modules
+define their own and shadow it. That shadowing is load-bearing and, until this
+module existed, entirely unasserted: pytest resolves the nearest fixture
+silently, so a module that loses its local definition does not fail — it binds
+to the shared one and keeps passing.
+
+Two things break quietly when that happens. The seven modules whose arms are
+id'd ``in_memory`` would silently start reporting ``memory``, invalidating any
+``-k`` filter and every stored test id. And a module would start exercising a
+registry built by different code than its own fixture built, while still
+reporting green.
+
+These are structural assertions over the test tree's own source, so they need
+no optional extra and can never skip.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import NamedTuple
+
+TESTS_ROOT = Path(__file__).parent
+
+# Modules that own a local ``registry`` fixture, mapped to its param ids
+# (``None`` = not parametrized). A module dropping out of this map has lost its
+# local fixture and now silently resolves the shared one.
+EXPECTED_LOCAL_FIXTURES: dict[str, tuple[str, ...] | None] = {
+    "adapters/test_workspace_versioner.py": None,
+    "coordinator/test_last_observed_version.py": ("in_memory", "sqlite"),
+    "coordinator/test_workspace_checkpoints.py": ("in_memory", "sqlite"),
+    "coordinator/test_workspace_registration.py": ("in_memory", "sqlite"),
+    "test_commit_all_registry.py": ("memory", "sqlite"),
+    "test_fencing.py": ("in_memory", "sqlite"),
+    "test_fetch_peer_leg_fence.py": ("in_memory", "sqlite"),
+    "test_registry_lock_coverage.py": ("in_memory", "sqlite"),
+    "test_zombie_revoke.py": ("in_memory", "sqlite"),
+}
+
+# Modules that deliberately resolve the shared fixture from conftest.
+EXPECTED_SHARED_CONSUMERS: frozenset[str] = frozenset({
+    "test_conflict_instrumentation.py",
+})
+
+SHARED_PARAM_IDS: tuple[str, ...] = ("memory", "sqlite")
+
+# The shared fixture's sqlite filename must belong to it alone. `state.db` is
+# the tree's generic default (~77 uses) and two coordinator suites reserve it
+# for raw-sqlite probes while routing their own registry arm to `parity-arm.db`
+# — a shared fixture using either name would alias a consumer's own path inside
+# one `tmp_path`.
+SHARED_DB_FILENAME = "shared-registry-arm.db"
+
+
+def _fixture_params(node: ast.FunctionDef) -> tuple[bool, tuple[str, ...] | None]:
+    """Return (is_registry_fixture, param_ids) for one function definition."""
+    is_fixture = False
+    params: tuple[str, ...] | None = None
+    for dec in node.decorator_list:
+        call = dec if isinstance(dec, ast.Call) else None
+        target = call.func if call else dec
+        if isinstance(target, ast.Attribute) and target.attr == "fixture":
+            is_fixture = True
+        elif isinstance(target, ast.Name) and target.id == "fixture":
+            is_fixture = True
+        if call and is_fixture:
+            for kw in call.keywords:
+                if kw.arg == "params" and isinstance(kw.value, (ast.List, ast.Tuple)):
+                    params = tuple(
+                        e.value for e in kw.value.elts if isinstance(e, ast.Constant)
+                    )
+    return is_fixture, params
+
+
+class RegistryFixtureSurface(NamedTuple):
+    """Where the `registry` name resolves, across one test tree."""
+
+    local: dict[str, tuple[str, ...] | None]
+    """Modules defining their own fixture, mapped to its param ids."""
+
+    consumers: frozenset[str]
+    """Modules requesting `registry` that resolve the shared conftest one."""
+
+
+def scan_registry_fixtures(tests_root: Path) -> RegistryFixtureSurface:
+    """Map the `registry` fixture surface of a test tree from its source.
+
+    Takes the root as an argument so the scan can be exercised against a
+    mutated copy of the tree — a guard that has never been shown to fail is
+    not a guard.
+    """
+    local: dict[str, tuple[str, ...] | None] = {}
+    consumers: set[str] = set()
+    for path in sorted(tests_root.rglob("*.py")):
+        rel = path.relative_to(tests_root).as_posix()
+        tree = ast.parse(path.read_text())
+        defines = False
+        uses = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            if node.name == "registry":
+                is_fixture, params = _fixture_params(node)
+                if is_fixture:
+                    defines = True
+                    local[rel] = params
+            elif node.name.startswith("test") and "registry" in (
+                a.arg for a in node.args.args
+            ):
+                uses = True
+        if uses and not defines:
+            consumers.add(rel)
+    return RegistryFixtureSurface(local=local, consumers=frozenset(consumers))
+
+
+def test_local_registry_fixtures_still_shadow_the_shared_one() -> None:
+    """A module that loses its local fixture binds to the shared one silently.
+
+    Pytest resolves the nearest `registry` and reports nothing, so only this
+    pinned inventory turns that into a failure.
+    """
+    found = scan_registry_fixtures(TESTS_ROOT).local
+    found.pop("conftest.py", None)
+    assert found == EXPECTED_LOCAL_FIXTURES
+
+
+def test_only_declared_modules_resolve_the_shared_registry_fixture() -> None:
+    """Requesting `registry` without a local fixture is no longer an error.
+
+    Before conftest owned the name, that was a fixture-not-found failure. Now
+    it silently succeeds, so the consumer set is pinned instead.
+    """
+    assert scan_registry_fixtures(TESTS_ROOT).consumers == EXPECTED_SHARED_CONSUMERS
+
+
+def test_shared_registry_fixture_keeps_its_param_ids() -> None:
+    """The shared fixture's ids are part of every consumer's test id."""
+    local = scan_registry_fixtures(TESTS_ROOT).local
+    assert local["conftest.py"] == SHARED_PARAM_IDS
+
+
+def test_shared_registry_fixture_owns_its_sqlite_filename() -> None:
+    """The shared fixture's db name must not collide inside a shared tmp_path.
+
+    Consumers put their own sqlite files in the same `tmp_path`; a name the
+    rest of the tree also uses would let the fixture's arm alias a consumer's
+    raw-probe database.
+    """
+    conftest = (TESTS_ROOT / "conftest.py").read_text()
+    assert f'"{SHARED_DB_FILENAME}"' in conftest
+
+    # conftest.py declares it; this module names it as the pinned constant.
+    owners = {"conftest.py", Path(__file__).name}
+    others = [
+        path.relative_to(TESTS_ROOT).as_posix()
+        for path in sorted(TESTS_ROOT.rglob("*.py"))
+        if path.name not in owners and f'"{SHARED_DB_FILENAME}"' in path.read_text()
+    ]
+    assert others == []

--- a/tests/test_registry_fixture_contract.py
+++ b/tests/test_registry_fixture_contract.py
@@ -3,7 +3,7 @@
 
 """The `registry` fixture contract: who owns it, and under which param ids.
 
-``tests/conftest.py`` defines a tree-wide ``registry`` fixture. Nine modules
+``tests/conftest.py`` defines a tree-wide ``registry`` fixture. Ten modules
 define their own and shadow it. That shadowing is load-bearing and, until this
 module existed, entirely unasserted: pytest resolves the nearest fixture
 silently, so a module that loses its local definition does not fail — it binds
@@ -38,6 +38,7 @@ EXPECTED_LOCAL_FIXTURES: dict[str, tuple[str, ...] | None] = {
     "test_commit_all_registry.py": ("memory", "sqlite"),
     "test_fencing.py": ("in_memory", "sqlite"),
     "test_fetch_peer_leg_fence.py": ("in_memory", "sqlite"),
+    "test_foreign_write_instrumentation.py": ("memory", "sqlite"),
     "test_registry_lock_coverage.py": ("in_memory", "sqlite"),
     "test_zombie_revoke.py": ("in_memory", "sqlite"),
 }


### PR DESCRIPTION
## Summary

- `tests/test_conflict_instrumentation.py` declared its own parametrized `registry` fixture, and a second instrumentation suite in flight declares a byte-identical one. This moves the single definition into `tests/conftest.py` rather than letting a third copy appear.
- Collected test ids are unchanged. The shared fixture keeps the `memory` / `sqlite` param ids the module already used, so nothing about what runs, or how it is named, moves.
- `tests/test_registry_fixture_contract.py` pins the invariant the first commit relied on but never asserted.

## Why the second commit exists

Moving a fixture into `tests/conftest.py` makes the name tree-wide, and the safety argument for that was "nine other modules define their own `registry` and shadow it." Nothing asserted it. Pytest resolves the nearest fixture silently, so a module that loses its local definition does not fail — it binds to the shared one and keeps passing, against a registry built by different code. For the seven modules whose arms are id'd `in_memory`, it would also silently rename every collected test id and break any `-k` filter written against them.

The new module pins that split from the test tree's own source: which modules own a local fixture and under which param ids, which modules resolve the shared one, and that the shared arm's ids hold. Its scan takes the tree root as an argument, so each guard was run against a mutated copy — all four fail on their own mutant (a dropped fixture, an `in_memory` -> `memory` rename, a shared-id drift, a filename collision). They are structural assertions over source, so no missing optional extra can make them skip in CI.

Two corrections in the same commit:

- The in-body import comment claimed a module-level `ccs` import "would fail conftest import outright." That is false — `ccs` is the core package, the `collect_ignore_glob` guards cover only the optional extras, and the fixture's sole consumer already imports `ccs` at module level. The placement is fine and matches the hooks above; only its stated reason was wrong.
- The sqlite arm no longer writes `state.db`. That is the tree's generic default (~77 uses) and the name `tests/coordinator/test_last_observed_version.py` and `tests/coordinator/test_workspace_checkpoints.py` reserve for raw-sqlite probes while deliberately routing their own registry arm to `parity-arm.db`. A shared fixture using it would alias a consumer's own database inside one `tmp_path` — latent today, live the moment either suite adopts the shared fixture.

## Scope note

Nine modules keep their local `registry` fixture and shadow the shared one. Seven id their arms `in_memory` rather than `memory`; adopting the shared fixture there would rewrite every one of their test ids. `tests/test_commit_all_registry.py` is the one clean candidate — same param ids; only its `with SqliteArtifactRegistry(...)` teardown differs from the manual `close()`. Left alone: a rename of that size is worth making deliberately, not as a side effect of removing a duplicate. The new contract test pins the current split either way, so any such migration has to be explicit.

## Test plan

- [x] `pytest -q tests/test_conflict_instrumentation.py` — **27 passed** (9 `[memory]` + 9 `[sqlite]` + 9 unparametrized); collected ids diffed byte-for-byte against the pre-change list, identical.
- [x] `pytest -q tests/test_registry_fixture_contract.py` — 4 passed; each guard separately shown to fail against a mutated copy of the tree.
- [x] All ten modules that use a `registry` fixture, plus the new contract module — 409 passed.
- [x] Full `pytest -q` — **3812 passed, 4 skipped, 0 failures**, run against the exact tree at `3b607b8`.
- [x] `ruff check tests/` clean; `tools/check_architecture.py` passed.

An earlier revision of this description claimed "29 passed" for the first item. That number was inferred, not measured; the module collects 27. The id-equality claim it backed is unaffected and independently confirmed.