### PR TITLE
refactor(diagnose): share the read-only state.db open, and stop it fabricating zeros

### DIFF
--- a/src/ccs/diagnose/_state_db.py
+++ b/src/ccs/diagnose/_state_db.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""Read-only open of a coordinator ``state.db``, shared by the offline readers.
+
+:mod:`ccs.diagnose.conflict_counters` and :mod:`ccs.diagnose.foreign_writes`
+are two reports over the same store, so the low-level open is the same fact
+twice, not the sanctioned per-backend duplication the two registries carry.
+Written out twice it drifts silently: a busy timeout re-derived from the
+registry's budget, or a tightening of the missing-file translation, would land
+in one report and leave the other answering on different terms.
+
+What deliberately stays with each caller is the per-table
+missing-versus-empty logic. The conflict reader maps an absent table and an
+empty one to the same zero and documents that as zero recorded conflicts; the
+foreign-write reader must keep the two apart, because a coverage claim depends
+on knowing whether the detector ever ran. Those are different contracts over
+the same connection, and merging them would cost one of them its honesty.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+__all__ = ["open_readonly_state_db"]
+
+BUSY_TIMEOUT_MS = 1500
+"""Matches the registry's own budget-derived value."""
+
+
+def open_readonly_state_db(path: Path) -> sqlite3.Connection:
+    """Open the coordinator store at ``path`` read-only, ready to query.
+
+    Raises ``FileNotFoundError`` when nothing is there — a report against a
+    store that does not exist is a caller error, never evidence of a quiet
+    month. Every other failure to open propagates, so a broken read cannot be
+    mistaken for an empty one. The caller owns the returned connection and
+    must close it.
+    """
+    # mode=ro + uri=True: without the explicit uri flag sqlite3 treats the
+    # string as a literal filename and can silently fall back to read-write.
+    # No pre-check stat: connect directly and translate the failure, so a
+    # missing file cannot slip through a check-to-open race window.
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    except sqlite3.OperationalError as exc:
+        if not path.exists():
+            raise FileNotFoundError(f"no coordinator database at {path}") from exc
+        raise
+    try:
+        # A transient writer lock must wait, never masquerade as an empty
+        # result — whatever "empty" means to the report being built.
+        conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+    except BaseException:
+        # The caller never received the handle, so it cannot close it.
+        conn.close()
+        raise
+    return conn

--- a/src/ccs/diagnose/_state_db.py
+++ b/src/ccs/diagnose/_state_db.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from urllib.parse import quote
 
 __all__ = ["open_readonly_state_db"]
 
@@ -34,16 +35,36 @@ def open_readonly_state_db(path: Path) -> sqlite3.Connection:
 
     Raises ``FileNotFoundError`` when nothing is there — a report against a
     store that does not exist is a caller error, never evidence of a quiet
-    month. Every other failure to open propagates, so a broken read cannot be
-    mistaken for an empty one. The caller owns the returned connection and
-    must close it.
+    month — and ``ValueError`` for a path carrying a NUL, which no filesystem
+    call would accept either. Every other failure to open propagates, so a
+    broken read cannot be mistaken for an empty one. The caller owns the
+    returned connection and must close it.
     """
+    # A NUL cannot survive the round trip: quote() renders it %00 and SQLite
+    # decodes it back into a C string that truncates there, which is the same
+    # open-a-different-file bug the encoding below exists to prevent. Python
+    # raises ValueError for a NUL in any real filesystem call, so raise it here
+    # rather than let the URI layer turn it into a silent wrong-file read.
+    if "\x00" in str(path):
+        raise ValueError(f"NUL byte in coordinator database path: {path!r}")
     # mode=ro + uri=True: without the explicit uri flag sqlite3 treats the
     # string as a literal filename and can silently fall back to read-write.
+    # quote() so the path is read as filename bytes and never as URI syntax:
+    # a '#' would otherwise start a fragment that swallows the query, taking
+    # mode=ro with it — SQLite then opens the truncated path read-WRITE,
+    # creates it, and the reader reports a store it never read as empty.
+    # safe="" because '/' left unescaped lets a leading '//' read as a URI
+    # authority, which is the same wrong-file hazard; SQLite decodes %2F back
+    # into a separator, so escaping it costs nothing. absolute() so a bare
+    # ":memory:" cannot resolve to SQLite's in-memory store and answer with a
+    # zero no database ever backed. surrogateescape so an undecodable
+    # filesystem byte still reaches the open and fails as FileNotFoundError,
+    # rather than escaping as UnicodeEncodeError past every documented type.
     # No pre-check stat: connect directly and translate the failure, so a
     # missing file cannot slip through a check-to-open race window.
+    uri = quote(str(path.absolute()), safe="", errors="surrogateescape")
     try:
-        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        conn = sqlite3.connect(f"file:{uri}?mode=ro", uri=True)
     except sqlite3.OperationalError as exc:
         if not path.exists():
             raise FileNotFoundError(f"no coordinator database at {path}") from exc

--- a/src/ccs/diagnose/conflict_counters.py
+++ b/src/ccs/diagnose/conflict_counters.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+from ._state_db import open_readonly_state_db
+
 __all__ = ["read_conflict_totals"]
 
 
@@ -38,32 +40,18 @@ def read_conflict_totals(db_path: str | Path) -> dict[tuple[str, str, str], int]
     database, a hot-WAL recovery failure, disk I/O — is re-raised rather than
     swallowed, so it can never masquerade as zero conflicts.
     """
-    path = Path(db_path)
-    # mode=ro + uri=True: without the explicit uri flag sqlite3 treats the
-    # string as a literal filename and can silently fall back to read-write.
-    # No pre-check stat: connect directly and translate the failure, so a
-    # missing file cannot slip through a check-to-open race window.
+    conn = open_readonly_state_db(Path(db_path))
     try:
-        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        rows = conn.execute(
+            "SELECT artifact_id, agent_id, reason, count FROM conflict_counters"
+        ).fetchall()
     except sqlite3.OperationalError as exc:
-        if not path.exists():
-            raise FileNotFoundError(f"no coordinator database at {path}") from exc
+        if "no such table" in str(exc):
+            return {}  # pre-instrumentation db: no table, zero recorded.
         raise
-    try:
-        # A transient writer lock must wait, never masquerade as zero; 1500
-        # matches the registry's own budget-derived value.
-        conn.execute("PRAGMA busy_timeout=1500")
-        try:
-            rows = conn.execute(
-                "SELECT artifact_id, agent_id, reason, count FROM conflict_counters"
-            ).fetchall()
-        except sqlite3.OperationalError as exc:
-            if "no such table" in str(exc):
-                return {}  # pre-instrumentation db: no table, zero recorded.
-            raise
-        return {
-            (art_hex, agent_hex, reason): count
-            for art_hex, agent_hex, reason, count in rows
-        }
     finally:
         conn.close()
+    return {
+        (art_hex, agent_hex, reason): count
+        for art_hex, agent_hex, reason, count in rows
+    }

--- a/src/ccs/diagnose/foreign_writes.py
+++ b/src/ccs/diagnose/foreign_writes.py
@@ -33,6 +33,8 @@ import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
+from ._state_db import open_readonly_state_db
+
 __all__ = [
     "COUNTS",
     "INSTRUMENTED_ZERO",
@@ -142,21 +144,8 @@ def read_foreign_write_report(db_path: str | Path) -> ForeignWriteReport:
     ``FileNotFoundError``: a report against a store that does not exist is a
     caller error, not evidence of zero foreign writes.
     """
-    path = Path(db_path)
-    # mode=ro + uri=True: without the explicit uri flag sqlite3 treats the
-    # string as a literal filename and can silently fall back to read-write.
-    # No pre-check stat: connect directly and translate the failure, so a
-    # missing file cannot slip through a check-to-open race window.
+    conn = open_readonly_state_db(Path(db_path))
     try:
-        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
-    except sqlite3.OperationalError as exc:
-        if not path.exists():
-            raise FileNotFoundError(f"no coordinator database at {path}") from exc
-        raise
-    try:
-        # A transient writer lock must wait, never masquerade as not-instrumented;
-        # 1500 matches the registry's own budget-derived value.
-        conn.execute("PRAGMA busy_timeout=1500")
         run_rows = _read_table(
             conn,
             "SELECT run_id, first_tick_unix, last_tick_unix, tick_count, "

--- a/tests/test_state_db.py
+++ b/tests/test_state_db.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2026 agent-coherence contributors.
+# The Coherence Protocol for AI Agents
+
+"""The shared read-only open, and the two promises it makes to both readers.
+
+``ccs.diagnose._state_db`` is the one place the offline readers open a
+coordinator ``state.db``, so its two guarantees are theirs: the handle is
+read-only, and a failure is loud. Both are stated in prose the readers repeat
+to their callers, and neither was pinned by a test — the readers' own suites
+build every path from ``tmp_path``, whose components never carry a character
+the URI layer treats as syntax.
+
+That gap hid a real defect. The store path is interpolated into a SQLite URI
+whose query string is the only thing that makes the handle read-only, so a path
+containing ``#``, ``?`` or ``%`` was parsed as URI syntax rather than as
+filename bytes: SQLite opened a different file, ``mode=ro`` was displaced into
+the fragment and silently lost, and ``read_conflict_totals`` answered ``{}`` for
+a store that held real conflicts. A fabricated zero is the exact failure this
+subsystem exists to prevent, and the suite stayed green through all of it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from ccs.diagnose import _state_db
+from ccs.diagnose._state_db import BUSY_TIMEOUT_MS, open_readonly_state_db
+from ccs.diagnose.conflict_counters import read_conflict_totals
+from ccs.diagnose.foreign_writes import INSTRUMENTED_ZERO, read_foreign_write_report
+
+# Characters the URI layer treats as syntax: '#' starts a fragment, '?' starts
+# the query, '%' introduces an escape. A space is the ordinary case that must
+# keep working alongside them.
+URI_HOSTILE_NAMES = ["proj#1", "proj?x", "proj%2e", "proj dir"]
+
+
+def _seed_conflict_row(db: Path) -> None:
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE conflict_counters "
+        "(artifact_id TEXT, agent_id TEXT, reason TEXT, count INT)"
+    )
+    conn.execute("INSERT INTO conflict_counters VALUES ('aa', 'bb', 'version_mismatch', 7)")
+    conn.commit()
+    conn.close()
+
+
+def _seed_observation_row(db: Path) -> None:
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE foreign_write_observations (run_id TEXT, first_tick_unix REAL, "
+        "last_tick_unix REAL, tick_count INT, covered_count INT)"
+    )
+    conn.execute(
+        "CREATE TABLE foreign_write_counters (artifact_id TEXT, foreign_count INT, "
+        "mediated_count INT, lag_suppressed_count INT)"
+    )
+    conn.execute("INSERT INTO foreign_write_observations VALUES ('r1', 10.0, 20.0, 5, 1)")
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# A path is filename bytes, never URI syntax
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dirname", URI_HOSTILE_NAMES)
+def test_a_uri_reserved_character_in_the_path_still_reads_the_real_store(
+    tmp_path: Path, dirname: str
+) -> None:
+    """The worst failure this subsystem has: a reader that answers "zero" about
+    a store it never opened. Unencoded, '#' truncated the path and SQLite
+    created and read an empty database beside the real one, so the count-7 row
+    below came back as ``{}`` — indistinguishable from an honestly quiet month.
+    """
+    db = tmp_path / dirname / "state.db"
+    db.parent.mkdir()
+    _seed_conflict_row(db)
+
+    assert read_conflict_totals(db) == {("aa", "bb", "version_mismatch"): 7}
+
+
+@pytest.mark.parametrize("dirname", URI_HOSTILE_NAMES)
+def test_a_uri_reserved_character_in_the_path_keeps_the_detector_state(
+    tmp_path: Path, dirname: str
+) -> None:
+    """The same displacement on the sibling reader: a store the detector really
+    ran against must not read as one it never ran against."""
+    db = tmp_path / dirname / "state.db"
+    db.parent.mkdir()
+    _seed_observation_row(db)
+
+    assert read_foreign_write_report(db).state == INSTRUMENTED_ZERO
+
+
+@pytest.mark.parametrize("dirname", URI_HOSTILE_NAMES)
+def test_a_uri_reserved_character_in_the_path_stays_read_only(
+    tmp_path: Path, dirname: str
+) -> None:
+    """``mode=ro`` lives in the URI query string, so anything that displaces the
+    query silently hands back a writable handle to a store the caller was
+    promised would not be touched."""
+    db = tmp_path / dirname / "state.db"
+    db.parent.mkdir()
+    _seed_conflict_row(db)
+
+    conn = open_readonly_state_db(db)
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            conn.execute("CREATE TABLE proof_of_write (x)")
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("dirname", URI_HOSTILE_NAMES)
+def test_a_uri_reserved_character_in_the_path_creates_no_stray_file(
+    tmp_path: Path, dirname: str
+) -> None:
+    """A truncated path does not fail loudly — SQLite creates the shorter name.
+    Asserted on the parent directory, where the stray sibling appeared."""
+    db = tmp_path / dirname / "state.db"
+    db.parent.mkdir()
+    _seed_conflict_row(db)
+    before = sorted(p.name for p in tmp_path.iterdir())
+
+    read_conflict_totals(db)
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == before
+
+
+def test_a_missing_store_under_a_reserved_character_path_still_raises(
+    tmp_path: Path,
+) -> None:
+    """Encoding must not cost the missing-file translation: an absent store is a
+    caller error, never evidence of zero."""
+    with pytest.raises(FileNotFoundError):
+        read_conflict_totals(tmp_path / "proj#1" / "nope.db")
+
+
+# ---------------------------------------------------------------------------
+# Shapes that must not resolve to a store the caller did not name
+# ---------------------------------------------------------------------------
+
+
+def test_a_nul_byte_in_the_path_is_rejected_rather_than_truncated(
+    tmp_path: Path,
+) -> None:
+    """Percent-encoding alone re-creates the very bug it fixes here: a NUL
+    survives as %00, SQLite decodes it, and the C string truncates there — so
+    a path ending '.../state.db\x00.evil' would read the real store and report
+    it as the caller's. Python raises ValueError for a NUL in any real
+    filesystem call; the URI layer must not quietly succeed instead."""
+    db = tmp_path / "state.db"
+    _seed_conflict_row(db)
+
+    with pytest.raises(ValueError, match="NUL byte"):
+        read_conflict_totals(Path(f"{db}\x00.evil"))
+
+
+def test_an_in_memory_path_is_not_a_store_and_never_reads_as_zero() -> None:
+    """':memory:' is SQLite's in-memory store, so an unqualified path reaching
+    the URI intact answers {} for a database that never existed — a zero with
+    nothing behind it, which is the one answer this reader may not invent."""
+    with pytest.raises(FileNotFoundError):
+        read_conflict_totals(Path(":memory:"))
+
+
+def test_a_leading_double_slash_is_not_read_as_a_uri_authority(
+    tmp_path: Path,
+) -> None:
+    """'//host/path' is authority syntax to the URI parser. Left unescaped it
+    strips to '/path', so the reader opens a store one level up from the name
+    it was given and reports it as that name's."""
+    db = tmp_path / "state.db"
+    _seed_conflict_row(db)
+
+    with pytest.raises(FileNotFoundError):
+        read_conflict_totals(Path(f"//localhost{db}"))
+
+
+def test_an_undecodable_filesystem_byte_still_raises_file_not_found(
+    tmp_path: Path,
+) -> None:
+    """POSIX filenames are bytes, and Python surfaces an undecodable one as a
+    surrogate. Strict encoding would raise UnicodeEncodeError straight past
+    both readers' documented failure types; the open must still be attempted so
+    the answer stays FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        read_conflict_totals(tmp_path / "\udcff.db")
+
+
+# ---------------------------------------------------------------------------
+# The handle the caller never received must not leak
+# ---------------------------------------------------------------------------
+
+
+def test_the_busy_timeout_is_applied_to_the_returned_handle(tmp_path: Path) -> None:
+    db = tmp_path / "state.db"
+    sqlite3.connect(db).close()
+
+    conn = open_readonly_state_db(db)
+    try:
+        assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == BUSY_TIMEOUT_MS
+    finally:
+        conn.close()
+
+
+def test_the_connection_is_closed_when_the_busy_timeout_pragma_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The PRAGMA used to run inside each caller's ``try``/``finally``, so a
+    failure there already closed the handle. Moving it into the helper keeps
+    that only because of the cleanup guard — without it the caller cannot close
+    a handle it never received, and the failure leaks it."""
+    db = tmp_path / "state.db"
+    sqlite3.connect(db).close()
+    closed: list[str] = []
+    real_connect = sqlite3.connect
+
+    class _PragmaRejectingConnection(sqlite3.Connection):
+        def execute(self, *args: object, **kwargs: object) -> sqlite3.Cursor:
+            raise sqlite3.OperationalError("pragma rejected")
+
+        def close(self) -> None:
+            closed.append("closed")
+            super().close()
+
+    monkeypatch.setattr(
+        _state_db.sqlite3,
+        "connect",
+        lambda *a, **k: real_connect(*a, factory=_PragmaRejectingConnection, **k),
+    )
+
+    with pytest.raises(sqlite3.OperationalError, match="pragma rejected"):
+        open_readonly_state_db(db)
+
+    assert closed == ["closed"], "the orphaned handle must be closed, not leaked"
+
+
+def test_the_connection_is_closed_when_the_pragma_raises_a_base_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard catches BaseException, not Exception, and the breadth is the
+    point: a Ctrl-C landing on the PRAGMA is exactly when a handle the caller
+    never received would leak. Narrowing the guard passes every ordinary-error
+    test, so this is the one that fails."""
+    db = tmp_path / "state.db"
+    sqlite3.connect(db).close()
+    closed: list[str] = []
+    real_connect = sqlite3.connect
+
+    class _InterruptingConnection(sqlite3.Connection):
+        def execute(self, *args: object, **kwargs: object) -> sqlite3.Cursor:
+            raise KeyboardInterrupt
+
+        def close(self) -> None:
+            closed.append("closed")
+            super().close()
+
+    monkeypatch.setattr(
+        _state_db.sqlite3,
+        "connect",
+        lambda *a, **k: real_connect(*a, factory=_InterruptingConnection, **k),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        open_readonly_state_db(db)
+
+    assert closed == ["closed"], "an interrupt must not leak the handle either"

--- a/tests/test_state_db.py
+++ b/tests/test_state_db.py
@@ -17,6 +17,15 @@ filename bytes: SQLite opened a different file, ``mode=ro`` was displaced into
 the fragment and silently lost, and ``read_conflict_totals`` answered ``{}`` for
 a store that held real conflicts. A fabricated zero is the exact failure this
 subsystem exists to prevent, and the suite stayed green through all of it.
+
+The older tests were not weak — their input domain could not express the bug.
+``tmp_path`` yields only ``[A-Za-z0-9/_-]``, so no assertion added over that
+fixture could have failed. The rule this file exists to carry forward: when a
+fixture generates the input, the fixture silently decides which bugs are
+reachable, so a path-taking API has to be tested on paths the platform allows
+and the fixture never emits. ``URI_HOSTILE_NAMES`` below is that set for a
+directory component; the tests after it cover the shapes that are not
+directory names at all — a NUL, a ``//`` authority, and ``:memory:``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
> Supersedes #180, which GitHub auto-closed when its base `feat/foreign-write-detection` was deleted after #182 merged. The refactor itself never landed, so this re-targets `dev` and carries the same work plus the fix below.

## Summary

- `conflict_counters.py` and `foreign_writes.py` are two reports over the same store, and both carried the same low-level open verbatim — the `mode=ro` URI connect, the missing-file translation, and `PRAGMA busy_timeout=1500`. That is one backend's plumbing written twice, not the sanctioned per-backend duplication the two registries carry.
- Extracts `open_readonly_state_db()` into a private `_state_db` module, following the `_labels.py` convention already in this package: private module, plain symbol.
- Both readers now open with one line.
- Fixes a pre-existing defect the consolidation exposed, and pins the helper's contract with its own test file.

## What deliberately did NOT move

The per-table missing-versus-empty logic stays with each caller, because the two contracts genuinely differ:

| | absent table | empty table |
|---|---|---|
| `read_conflict_totals` | `{}` | `{}` — collapsed on purpose, documented as zero recorded conflicts |
| `read_foreign_write_report` | `not-instrumented` | `not-instrumented` — keyed on the observation **row**, so a ticked-but-clean store is `instrumented-zero` |

Merging those would cost the foreign-write reader its honesty: a coverage claim depends on knowing whether the detector ever ran, so an absent observation row and a clean one cannot collapse.

## The defect this consolidation exposed

The store path was interpolated straight into the SQLite URI, whose query string is the only thing making the handle read-only. A path containing `#` was therefore parsed as URI *syntax*, not filename bytes. Reproduced on a store at `.../proj#1/state.db` holding a real conflict row:

- `PRAGMA database_list` showed SQLite had opened `.../proj` — the named `state.db` was never opened
- `PRAGMA query_only` was `0` and a `CREATE TABLE` committed — `mode=ro` was displaced into the fragment and silently lost
- a stray SQLite file appeared beside the intended one
- `read_conflict_totals` returned `{}` for the store that still held its count-7 row

That last one is a fabricated zero: the exact failure both modules' docstrings promise cannot happen. The expression was verbatim in both readers before this PR, so the bug is not new — but consolidating to one call site is what makes it a one-line fix, so it is fixed here.

The path is now percent-encoded, with three shapes that survive naive encoding closed alongside it:

| shape | before | after |
|---|---|---|
| `#`, `?`, `%` in a path | wrong file, writable, fabricated zero | correct file, read-only |
| NUL (`state.db\x00.evil`) | `ValueError` (loud) | `ValueError` — `%00` would otherwise decode back and truncate |
| `//host/path` | wrong file, no error | `FileNotFoundError` |
| `:memory:` | `{}` for a database that never existed | `FileNotFoundError` |

`quote(str(path.absolute()), safe="", errors="surrogateescape")` rather than `Path.as_uri()`, which raises on the relative `.coherence/state.db` form `docs/guide.md` documents.

## On the cleanup guard

An earlier revision of this description called the guard around the `PRAGMA` a new behaviour. It is not, and that heading was wrong. The `PRAGMA` previously ran inside each caller's `try/finally: conn.close()`, so a failure there already closed the handle; moving it into the helper *preserves* that only because of the guard, since the caller cannot close a handle it never received. Net observable behaviour is unchanged. It is now tested, including its `BaseException` breadth — narrowing it to `Exception` passes every ordinary-error test, so that case has its own.

## Why the existing suite never caught this

Worth stating plainly, because it is the more reusable half of this PR: the two reader suites were not weak. Their **input domain could not express the bug**.

`tmp_path` yields `/private/var/folders/.../pytest-of-<user>/pytest-N/<testname>N` — alphanumerics, `/`, `-`, `_`. Not one component can contain `#`, `?` or `%`. `test_the_reader_does_not_modify_the_store` asserts the exact property that was being violated and still passed, because it asserts it over a path the fixture cannot make hostile. No assertion strengthening, coverage target, or mutation score over that fixture would have caught this.

The rule, recorded in the new test file's docstring so it outlives this PR: when a fixture generates the input, the fixture silently decides which bugs are reachable — so a path-taking API has to be tested on paths the platform allows and the fixture never emits.

Two cheap checks that would have caught it earlier, both now present: assert the safety property *behaviourally* (a write on the handle must raise) rather than structurally (bytes unchanged), and mutate the **input generator**, not just the implementation.

## Test Plan

New `tests/test_state_db.py` (24 tests) owns the shared helper's contract, which nothing covered before: both readers' suites build every path from `tmp_path`, whose components never carry a character the URI layer treats as syntax.

- [x] `pytest -q tests/test_state_db.py` — 24 passed
- [x] `pytest -q tests/test_conflict_instrumentation.py tests/test_foreign_write_report.py` — 41 passed
- [x] `ruff check src/ tests/` — clean
- [x] `python tools/check_architecture.py` — passed (`diagnose` is `interface`; the new module imports stdlib only, no new cycle)
- [x] Full suite — 3907 passed, 3 skipped
- [x] Every new test mutation-checked. Reverting the encode fails 15; dropping the NUL guard, `safe=""`, `absolute()`, `surrogateescape`, or the `BaseException` breadth each fails exactly 1.
- [x] Legitimate path forms verified unregressed: absolute, the documented relative form, spaces, non-ASCII, `..` components, symlinks

## Known residual

`src/ccs/coordinator/sqlite_registry.py:1705` builds its read-only URI the same unencoded way and makes the same never-creates-the-file promise. Out of scope for this PR (different layer), untouched here, and worth its own change.

Note that `dev` currently carries the URI defect in **both** readers, since the shared helper does not exist there yet — so this PR removes two live instances of it, not one.

