### PR TITLE
fix(coherent-volume): wait, don't spin, between denied comparand reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,47 @@ Alpha — APIs may change before `v1.0`.
 
 ### Fixed
 
+- **`write_cas` now waits, rather than spins, while a peer's committed write
+  reaches disk.** The OCC comparand read fails closed when the coordinator
+  records a version whose bytes are not on disk yet — the transient window
+  between a peer's confirmed CAS and its `_atomic_write` landing. Consecutive
+  denied reads were bounded by count (`MAX_CAS_REACQUIRES`) with no delay
+  between them, which made that bound a proxy for CPU scheduling rather than
+  for a wedged view: measured, nine undelayed re-reads burn through in **37 ms**
+  of wall clock, all of it emergent from local HTTP round-trip latency and
+  chosen by nobody. Any peer descheduled inside that window for longer than
+  37 ms raised `ViewWedged` even though the view would have cleared moments
+  later. On a loaded CI runner that is unremarkable, and it reddened the
+  two-writer `examples/concurrent_writers` demo intermittently — on the same
+  commit that passed on a less contended job.
+
+  The count bound is unchanged; a capped-exponential wait now separates the
+  denied re-reads (`DENIED_READ_BACKOFF_BASE_SEC` 2 ms, doubling to
+  `DENIED_READ_BACKOFF_CAP_SEC` 50 ms). The waiting matters more than the extra
+  time it buys: an undelayed loser **competes for CPU with the very peer whose
+  disk write unblocks it**, so sleeping removes the cause rather than merely
+  outlasting it — with a 50 ms stall injected into the winner, the patched loop
+  converges in five polls where the undelayed one burned all nine and still
+  wedged. Tolerance for one streak moves from ~40 ms to ~280 ms; a genuinely
+  never-clearing view (a foreign edit, a wedged coordinator) still fails closed
+  with `ViewWedged`, and the fail-closed guarantee is untouched — no write lands,
+  so no update was ever at risk. A clean read resets the streak, so a single call
+  that alternates streaks with lost races stays bounded but by ~1.9 s in
+  aggregate rather than by one schedule.
+
+  This distinction is the general one: the sibling commit budget counts
+  *contention losses*, where an iteration count is exactly the right unit, while
+  a poll of a transient that clears on **another** writer's progress has to be
+  denominated in time. A new guard,
+  `test_write_cas_waits_between_denied_comparand_reads`, records the waits the
+  loop actually requests and pins the **sequence** against the schedule, plus a
+  non-degeneracy check on the two constants. Pinning only an elapsed floor was
+  not enough and is the interesting part: the floor is computed from the same
+  constants it guards, so zeroing the base makes the assertion `>= 0` and the
+  whole fix could be reverted with the test still green. The sequence form fails
+  on all of it — a removed wait, a zeroed or inverted constant, a schedule
+  flattened to the cap, and an off-by-one in the exponent.
+
 - **The HTML report templates now ship in the distribution.** `ccs-compare`
   and `ccs-diagnose` read their templates off the filesystem beside the
   module (`Path(__file__).with_name("templates")`), but `pyproject.toml`

--- a/src/ccs/adapters/coherent_volume.py
+++ b/src/ccs/adapters/coherent_volume.py
@@ -38,6 +38,7 @@ import io
 import logging
 import os
 import threading
+import time
 import urllib.error
 import uuid
 import warnings
@@ -120,11 +121,34 @@ class _ReadResult(NamedTuple):
 #   a silent drop). A stale-denied comparand read never POSTs, so it does NOT
 #   consume this budget.
 # - CONSECUTIVE stale-denied comparand reads are bounded at
-#   ``MAX_CAS_REACQUIRES + 1``; on exhaustion ``write_cas`` raises
+#   ``MAX_CAS_REACQUIRES + 1``, WITH a capped-exponential wait between re-reads
+#   (the transient clears on a peer's progress, so the poll yields to it — see
+#   ``DENIED_READ_BACKOFF_BASE_SEC``); on exhaustion ``write_cas`` raises
 #   :class:`~ccs.core.exceptions.CoherenceError` (a view that never clears —
 #   wedged coordinator / perpetually lagging disk — must not spin). A clean
 #   read resets the streak.
 MAX_CAS_REACQUIRES = 8
+
+# A stale-denied comparand read has two causes. One is LOCAL and clears on the
+# ``_remint()`` alone (this instance is ``INVALID``). The other is a TRANSIENT that
+# clears only on ANOTHER writer's progress: the window between a peer's confirmed
+# CAS and its ``_atomic_write`` landing on disk. Because the second cause is the one
+# a streak is made of, the denied-read retry must WAIT, not spin.
+# Polling it with no delay made the streak bound a proxy for CPU scheduling luck
+# rather than for a wedged view: measured, 9 undelayed re-reads burn through in
+# ~37ms of wall clock, so a peer descheduled inside that window (routine on a
+# loaded 2-vCPU CI runner) wedged the loser even though the view would have
+# cleared moments later. Worse, the undelayed loser COMPETES for CPU with
+# the very peer whose disk write unblocks it. A capped-exponential wait between
+# denied re-reads yields to that peer and denominates the bound in time, so the
+# streak still fails closed on a genuinely never-clearing view (foreign edit,
+# wedged coordinator) without going red on scheduler jitter.
+# The schedule below bounds ONE streak (8 waits, 212ms). A clean read resets the
+# streak, so a single ``write_cas`` call that alternates streaks with lost CAS races
+# can traverse up to ``MAX_CAS_REACQUIRES + 1`` of them — the per-call wait is
+# bounded, but by ~1.9s in aggregate, not by one schedule.
+DENIED_READ_BACKOFF_BASE_SEC = 0.002
+DENIED_READ_BACKOFF_CAP_SEC = 0.05
 
 # SB-23 content-CAS deny message. Byte-stable (no path/hash interpolation) so a
 # model's retry loop sees identical text each attempt (KTD-P), and distinct from
@@ -893,8 +917,17 @@ class CoherentVolume:
         landed but its disk write hasn't) does NOT consume the commit budget;
         instead CONSECUTIVE denied reads are separately bounded (also at
         ``MAX_CAS_REACQUIRES + 1``) and raise ``ViewWedged`` (a ``CoherenceError``
-        subclass) if the view never clears. Both terminals are the honest fail-closed outcome,
-        **never** a silent lost update: the invariant this method guarantees is
+        subclass) if the view never clears. That poll WAITS between re-reads
+        (capped-exponential, :data:`DENIED_READ_BACKOFF_BASE_SEC` →
+        :data:`DENIED_READ_BACKOFF_CAP_SEC`) rather than spinning: the transient
+        clears on a PEER's progress, so the waiting writer must yield the CPU to
+        it instead of racing it — an undelayed poll made this bound a proxy for
+        scheduler luck (a measured ~37ms of wall clock) rather than for a wedged
+        view. That schedule bounds ONE streak (212ms); a clean read resets the
+        streak, so a call that alternates streaks with lost races can traverse up
+        to ``MAX_CAS_REACQUIRES + 1`` of them (~1.9s in aggregate).
+        Both terminals are the honest fail-closed outcome, **never** a silent
+        lost update: the invariant this method guarantees is
         *final == start + every applied delta, OR a typed raise* — a successful
         return always means the update landed.
 
@@ -993,6 +1026,14 @@ class CoherentVolume:
                         "landed (fail-closed)."
                     )
                 self._remint()
+                # WAIT, don't spin: yield the CPU to the peer whose disk write
+                # clears this view (see DENIED_READ_BACKOFF_BASE_SEC).
+                time.sleep(
+                    min(
+                        DENIED_READ_BACKOFF_BASE_SEC * (2 ** (denied_streak - 1)),
+                        DENIED_READ_BACKOFF_CAP_SEC,
+                    )
+                )
                 continue
             denied_streak = 0
 

--- a/tests/adapters/test_coherent_volume.py
+++ b/tests/adapters/test_coherent_volume.py
@@ -17,16 +17,21 @@ import logging
 import os
 import subprocess
 import threading
+import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+import ccs.adapters.coherent_volume as coherent_volume_module
 from ccs.adapters.claude_code.lifecycle import (
     LifecycleConfig,
     ensure_coordinator,
     stop_coordinator,
 )
 from ccs.adapters.coherent_volume import (
+    DENIED_READ_BACKOFF_BASE_SEC,
+    DENIED_READ_BACKOFF_CAP_SEC,
     MAX_CAS_REACQUIRES,
     CoherentVolume,
     coherent_workspace,
@@ -38,6 +43,7 @@ from ccs.core.exceptions import (
     CoherenceDegradedWarning,
     CoherenceError,
     StaleView,
+    ViewWedged,
 )
 
 
@@ -1813,3 +1819,70 @@ def test_write_cas_on_foreign_edit_wedges_not_stale_view(
         assert target.read_bytes() == b"foreign-v2"  # foreign edit intact (not clobbered)
     finally:
         stop_coordinator(tmp_path)
+
+
+def test_write_cas_waits_between_denied_comparand_reads(
+    tmp_path: Path, fast_cfg: LifecycleConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The denied comparand read polls a TRANSIENT that clears on ANOTHER writer's
+    progress (the window between a peer's confirmed CAS and its disk write), so the
+    poll must WAIT — yielding the CPU to that peer — not spin.
+
+    Regression for the intermittent concurrent-writers demo red (2026-09-09): with
+    no wait, the streak bound was denominated in local HTTP round trips, so it
+    bought only ~40ms of wall clock and a peer descheduled inside that window
+    (routine on a loaded CI runner) wedged the loser even though the view would
+    have cleared moments later.
+
+    Pins the SCHEDULE, not a scalar floor. An ``elapsed >= sum(schedule)`` assertion
+    derives its own threshold from these same constants, so it moves with them:
+    zeroing the base makes the bound ``>= 0`` and the fix can be reverted with the
+    test still green (measured — the zeroed mutant passed). The recorded sequence
+    plus the non-degeneracy assertions below fail on every reachable mutant: a
+    removed wait, a zeroed or inverted constant, a schedule flattened to the cap,
+    and an off-by-one in the exponent.
+    """
+    # Without this the rest is vacuous: a zeroed base makes every entry 0.0, so the
+    # recorded sequence still matches and the elapsed floor still holds.
+    assert DENIED_READ_BACKOFF_BASE_SEC > 0
+    assert DENIED_READ_BACKOFF_CAP_SEC >= DENIED_READ_BACKOFF_BASE_SEC
+    schedule = [
+        min(DENIED_READ_BACKOFF_BASE_SEC * 2**i, DENIED_READ_BACKOFF_CAP_SEC)
+        for i in range(MAX_CAS_REACQUIRES)  # one wait per denied read before the bound trips
+    ]
+
+    # Record what the loop asks to wait, and still wait it. ``time`` is used nowhere
+    # else in the adapter, so shimming that module-level name leaves the real
+    # time.sleep untouched for every other caller, the coordinator client included.
+    waits: list[float] = []
+
+    def recording_sleep(seconds: float) -> None:
+        waits.append(seconds)
+        time.sleep(seconds)
+
+    monkeypatch.setattr(
+        coherent_volume_module, "time", SimpleNamespace(sleep=recording_sleep)
+    )
+
+    target = _seed_file(tmp_path, content=b"v1")
+    vol = CoherentVolume(tmp_path, managed=("data/**",), config=fast_cfg)
+    try:
+        vol.read("data/x.txt")
+        target.write_bytes(b"foreign-v2")  # a denied view that never clears
+        waits.clear()  # only the write_cas call's own waits are the subject
+        started = time.perf_counter()
+        with pytest.raises(ViewWedged):
+            vol.write_cas("data/x.txt", lambda cur: cur + b"-cas")
+        elapsed = time.perf_counter() - started
+        observed = list(waits)
+    finally:
+        stop_coordinator(tmp_path)
+
+    assert observed == schedule, (
+        f"denied-read backoff schedule changed: waited {observed}, expected {schedule}"
+    )
+    # And the waits were real wall clock, not merely requested.
+    assert elapsed >= sum(schedule), (
+        f"write_cas wedged after {elapsed:.3f}s but its own backoff schedule is "
+        f"{sum(schedule):.3f}s — the recorded waits did not actually elapse"
+    )


### PR DESCRIPTION
## Summary

- `write_cas` could raise `ViewWedged` on a perfectly healthy view whenever a peer writer
  was descheduled at the wrong moment for more than **~37 ms**. Nothing was ever at risk
  (the terminal is fail-closed — no write lands), but the failure was spurious, and on a
  loaded CI runner a 37 ms deschedule is unremarkable: it reddened
  `tests/test_concurrent_writers_demo.py::test_fixed_invariant_holds_across_runs`
  intermittently, with the py3.12 job failing while py3.11 passed on the same commit.
- The wedge bound is now denominated in time instead of in scheduler luck. A
  capped-exponential wait (2 ms doubling to a 50 ms cap) separates the denied re-reads;
  one streak's tolerance moves ~40 ms -> ~280 ms.
- The count bound is unchanged, and the sibling commit-CAS budget — which genuinely counts
  contention losses, where an iteration count is the right unit — is untouched.

## Root cause

The stale-denied comparand read polls a transient that clears on **another** writer's
progress: the window between a peer's confirmed CAS and its `_atomic_write` reaching disk.
It polled with no delay, and `_remint()` is pure-local (a `uuid4` and a dict clear), so the
consecutive-denied streak bound was effectively denominated in local HTTP round trips.
Nine of them burn through in 0.037 s. Nobody chose 37 ms; it emerged from RTT.

The yielding matters more than the extra time it buys. An undelayed loser **competes for
CPU with the very peer whose disk write unblocks it**, so waiting removes the cause rather
than merely outlasting it: with a 50 ms stall injected into the winner, the patched loop
converges in five polls where the undelayed one burned all nine and still wedged.

`MAX_CAS_REACQUIRES` bounds two things that differ in kind. Counting iterations is correct
for the commit budget, where each iteration is a peer legitimately winning the version. It
is the wrong unit for a poll whose condition clears on someone else's progress.

## Test Plan

- [x] New guard `test_write_cas_waits_between_denied_comparand_reads` records the waits the
      loop requests and pins the **sequence** against the schedule, plus a non-degeneracy
      check on the two constants.
- [x] Mutant battery — all five fail, unmutated passes: base constant zeroed (which reverts
      the fix), off-by-one in the exponent, schedule flattened to the cap, wait removed
      entirely, cap below base.
- [x] Full suite 3271 passed via `pytest -q --ignore=tests/mcp`. The single failure,
      `test_packaging_data_files`, is pre-existing and caused by untracked local-only
      `CLAUDE.md` files; `tests/mcp` needs the `mcp` extra, which CI installs and this venv
      lacks.
- [x] Target test x5 under 24-way CPU oversubscription: green. Separately stress-tested 20
      rounds under full CPU saturation with 0 wedges.
- [x] `ruff check` clean on both changed Python files.
- [x] No documented behavior changed, so no guide update: the guide's "a loser just
      re-reads and retries" stays accurate.

An earlier revision of the guard asserted only `elapsed >= sum(schedule)`. Review caught
that this cannot discriminate — the floor is computed from the same constants it guards, so
zeroing the base makes the bound `>= 0` and the whole fix could be reverted with the test
still green. That mutant was run and did pass. The sequence form replaced it.

## Unapplied review findings

From a six-reviewer pass. Recorded, deliberately not applied here:

- [ ] P2 — `src/ccs/adapters/coherent_volume.py:145` — the 50 ms cap leaves this poll's lag
      model an order of magnitude under the coordinator's own ~5 s foreign-deny lag window.
      Not retuned: 20 rounds under full CPU saturation produced 0 wedges, so there is no
      evidence of need, and raising it slows every genuine wedge terminal.
- [ ] P3 — `src/ccs/adapters/coherent_volume.py:144` — the 2 ms first wait exceeds a
      sub-millisecond `_atomic_write`, adding ~30-50% to the single-retry recovery. Not
      lowered: a 0.5 ms base pulls one streak's total to ~113 ms, against the point of the
      change.
- [ ] Test gap — nothing asserts the *benefit*: that a transient clearing mid-streak now
      converges to a CAS win where the undelayed loop wedged. The shipped guard drives a
      permanent foreign edit, which can never clear. Doing this well needs an
      `Event`-gated peer hold rather than a wall-clock one, so it is not rushed in here — a
      wall-clock version would risk the very flake class this PR removes.
- [ ] Test gap — nothing pins the wait's *absence* from the commit-conflict branch and the
      win path; a mutant adding the same wait after the conflict re-mint passes the suite.
- [ ] Test gap — no coverage of a denied-streak reset mid-retry, i.e. that backoff restarts
      at the base rather than continuing to grow across episodes.

Assessed and cleared during that pass, kept as residual risks: effective tolerance is still
`212 ms + up to 9x RTT`, so RTT coupling is reduced ~7x but not eliminated; there is no
jitter, so losers wake in lockstep (judged speculative at this scale — a loser can lose at
most N-1 CAS rounds against a budget of 9); no lease, grant, heartbeat, idle-shutdown or
MCP deadline is crossed, all being orders of magnitude larger; `_single_op_guard` detects
and raises rather than blocking, so nothing waits on it across the wait; and the three
constants elsewhere that "mirror" `MAX_CAS_REACQUIRES` bound structurally different,
non-backoff-shaped loops that needed no matching change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
